### PR TITLE
refactor(linter): split linter fact stores

### DIFF
--- a/crates/shuck-linter/src/facts/arithmetic.rs
+++ b/crates/shuck-linter/src/facts/arithmetic.rs
@@ -1,4 +1,6 @@
-fn collect_zsh_option_map_arithmetic_suppressed_subscripts(
+use super::*;
+
+pub(crate) fn collect_zsh_option_map_arithmetic_suppressed_subscripts(
     command: &Command,
     semantic: &SemanticModel,
     command_scope: ScopeId,
@@ -42,7 +44,7 @@ fn collect_zsh_option_map_arithmetic_suppressed_subscripts(
     }
 }
 
-fn collect_zsh_option_map_suppressed_subscripts_in_expr(
+pub(crate) fn collect_zsh_option_map_suppressed_subscripts_in_expr(
     expression: Option<&ArithmeticExprNode>,
     semantic: &SemanticModel,
     command_scope: ScopeId,
@@ -154,7 +156,7 @@ fn collect_zsh_option_map_suppressed_subscripts_in_expr(
     }
 }
 
-fn collect_zsh_option_map_suppressed_subscripts_in_lvalue(
+pub(crate) fn collect_zsh_option_map_suppressed_subscripts_in_lvalue(
     target: &ArithmeticLvalue,
     semantic: &SemanticModel,
     command_scope: ScopeId,
@@ -185,7 +187,7 @@ fn collect_zsh_option_map_suppressed_subscripts_in_lvalue(
     }
 }
 
-fn arithmetic_index_uses_zsh_option_map_key_semantics(
+pub(crate) fn arithmetic_index_uses_zsh_option_map_key_semantics(
     semantic: &SemanticModel,
     command_scope: ScopeId,
     owner_name: &Name,
@@ -215,12 +217,11 @@ fn arithmetic_index_uses_zsh_option_map_key_semantics(
         semantic.visible_binding_for_lookup(owner_name, command_scope, index.span),
         owner_name,
         source,
-    )
-        && semantic.shell_profile().dialect == shuck_parser::parser::ShellDialect::Zsh
+    ) && semantic.shell_profile().dialect == shuck_parser::parser::ShellDialect::Zsh
         && zsh_option_map_subscript_key(owner_name.as_str(), index.span.slice(source))
 }
 
-fn zsh_option_map_binding_permits_implicit_assoc_key(
+pub(crate) fn zsh_option_map_binding_permits_implicit_assoc_key(
     semantic: &SemanticModel,
     binding: Option<&Binding>,
     owner_name: &Name,
@@ -229,7 +230,10 @@ fn zsh_option_map_binding_permits_implicit_assoc_key(
     let Some(binding) = binding else {
         return true;
     };
-    if binding.attributes.contains(shuck_semantic::BindingAttributes::ASSOC) {
+    if binding
+        .attributes
+        .contains(shuck_semantic::BindingAttributes::ASSOC)
+    {
         return true;
     }
 
@@ -239,7 +243,11 @@ fn zsh_option_map_binding_permits_implicit_assoc_key(
         )
 }
 
-fn zsh_option_map_binding_origin(owner_name: &Name, binding: &Binding, source: &str) -> bool {
+pub(crate) fn zsh_option_map_binding_origin(
+    owner_name: &Name,
+    binding: &Binding,
+    source: &str,
+) -> bool {
     match &binding.origin {
         shuck_semantic::BindingOrigin::Assignment {
             definition_span, ..
@@ -257,7 +265,7 @@ fn zsh_option_map_binding_origin(owner_name: &Name, binding: &Binding, source: &
     }
 }
 
-fn zsh_option_map_binding_has_prior_assoc_lookup_blocker(
+pub(crate) fn zsh_option_map_binding_has_prior_assoc_lookup_blocker(
     semantic: &SemanticModel,
     owner_name: &Name,
     binding: &Binding,
@@ -272,7 +280,7 @@ fn zsh_option_map_binding_has_prior_assoc_lookup_blocker(
     })
 }
 
-fn zsh_option_map_binding_blocks_assoc_lookup(binding: &Binding) -> bool {
+pub(crate) fn zsh_option_map_binding_blocks_assoc_lookup(binding: &Binding) -> bool {
     binding
         .attributes
         .contains(shuck_semantic::BindingAttributes::LOCAL)
@@ -285,18 +293,21 @@ fn zsh_option_map_binding_blocks_assoc_lookup(binding: &Binding) -> bool {
         )
 }
 
-fn zsh_option_map_assignment_target(owner_name: &Name, text: &str) -> bool {
+pub(crate) fn zsh_option_map_assignment_target(owner_name: &Name, text: &str) -> bool {
     let Some(rest) = text.strip_prefix(owner_name.as_str()) else {
         return false;
     };
-    let Some(subscript) = rest.strip_prefix('[').and_then(|rest| rest.strip_suffix(']')) else {
+    let Some(subscript) = rest
+        .strip_prefix('[')
+        .and_then(|rest| rest.strip_suffix(']'))
+    else {
         return false;
     };
 
     zsh_option_map_subscript_key(owner_name.as_str(), subscript)
 }
 
-fn zsh_option_map_subscript_key(owner_name: &str, text: &str) -> bool {
+pub(crate) fn zsh_option_map_subscript_key(owner_name: &str, text: &str) -> bool {
     if owner_name != "OPTS" {
         return false;
     }
@@ -322,7 +333,7 @@ fn zsh_option_map_subscript_key(owner_name: &str, text: &str) -> bool {
             .all(|ch| ch == '-' || ch == '_' || ch.is_ascii_alphanumeric())
 }
 
-fn collect_base_prefix_spans_in_command_parts(
+pub(crate) fn collect_base_prefix_spans_in_command_parts(
     command: &Command,
     source: &str,
     spans: &mut Vec<(Span, ArithmeticLiteralKind)>,
@@ -466,7 +477,7 @@ fn collect_base_prefix_spans_in_command_parts(
     }
 }
 
-fn collect_base_prefix_spans_in_assignment(
+pub(crate) fn collect_base_prefix_spans_in_assignment(
     assignment: &Assignment,
     source: &str,
     spans: &mut Vec<(Span, ArithmeticLiteralKind)>,
@@ -491,13 +502,17 @@ fn collect_base_prefix_spans_in_assignment(
     }
 }
 
-fn collect_base_prefix_spans_in_word(word: &Word, source: &str, spans: &mut Vec<(Span, ArithmeticLiteralKind)>) {
+pub(crate) fn collect_base_prefix_spans_in_word(
+    word: &Word,
+    source: &str,
+    spans: &mut Vec<(Span, ArithmeticLiteralKind)>,
+) {
     for part in &word.parts {
         collect_base_prefix_spans_in_word_part(part, source, spans);
     }
 }
 
-fn collect_base_prefix_spans_in_word_part(
+pub(crate) fn collect_base_prefix_spans_in_word_part(
     part: &WordPartNode,
     source: &str,
     spans: &mut Vec<(Span, ArithmeticLiteralKind)>,
@@ -569,7 +584,7 @@ fn collect_base_prefix_spans_in_word_part(
     }
 }
 
-fn collect_base_prefix_spans_in_parameter_expansion(
+pub(crate) fn collect_base_prefix_spans_in_parameter_expansion(
     parameter: &shuck_ast::ParameterExpansion,
     source: &str,
     spans: &mut Vec<(Span, ArithmeticLiteralKind)>,
@@ -640,7 +655,7 @@ fn collect_base_prefix_spans_in_parameter_expansion(
     }
 }
 
-fn collect_base_prefix_spans_in_arithmetic_parameter_expansion(
+pub(crate) fn collect_base_prefix_spans_in_arithmetic_parameter_expansion(
     parameter: &shuck_ast::ParameterExpansion,
     source: &str,
     spans: &mut Vec<(Span, ArithmeticLiteralKind)>,
@@ -711,7 +726,7 @@ fn collect_base_prefix_spans_in_arithmetic_parameter_expansion(
     }
 }
 
-fn collect_base_prefix_spans_in_zsh_target(
+pub(crate) fn collect_base_prefix_spans_in_zsh_target(
     target: &shuck_ast::ZshExpansionTarget,
     source: &str,
     spans: &mut Vec<(Span, ArithmeticLiteralKind)>,
@@ -730,7 +745,7 @@ fn collect_base_prefix_spans_in_zsh_target(
     }
 }
 
-fn collect_base_prefix_spans_in_arithmetic_zsh_target(
+pub(crate) fn collect_base_prefix_spans_in_arithmetic_zsh_target(
     target: &shuck_ast::ZshExpansionTarget,
     source: &str,
     spans: &mut Vec<(Span, ArithmeticLiteralKind)>,
@@ -749,7 +764,11 @@ fn collect_base_prefix_spans_in_arithmetic_zsh_target(
     }
 }
 
-fn collect_base_prefix_spans_in_pattern(pattern: &Pattern, source: &str, spans: &mut Vec<(Span, ArithmeticLiteralKind)>) {
+pub(crate) fn collect_base_prefix_spans_in_pattern(
+    pattern: &Pattern,
+    source: &str,
+    spans: &mut Vec<(Span, ArithmeticLiteralKind)>,
+) {
     for (part, _) in pattern.parts_with_spans() {
         match part {
             PatternPart::Group { patterns, .. } => {
@@ -766,11 +785,15 @@ fn collect_base_prefix_spans_in_pattern(pattern: &Pattern, source: &str, spans: 
     }
 }
 
-fn collect_base_prefix_spans_in_var_ref(reference: &VarRef, source: &str, spans: &mut Vec<(Span, ArithmeticLiteralKind)>) {
+pub(crate) fn collect_base_prefix_spans_in_var_ref(
+    reference: &VarRef,
+    source: &str,
+    spans: &mut Vec<(Span, ArithmeticLiteralKind)>,
+) {
     collect_base_prefix_spans_in_subscript(reference.subscript.as_deref(), source, spans);
 }
 
-fn collect_base_prefix_spans_in_subscript(
+pub(crate) fn collect_base_prefix_spans_in_subscript(
     subscript: Option<&Subscript>,
     source: &str,
     spans: &mut Vec<(Span, ArithmeticLiteralKind)>,
@@ -780,7 +803,7 @@ fn collect_base_prefix_spans_in_subscript(
     }
 }
 
-fn collect_base_prefix_spans_in_arithmetic(
+pub(crate) fn collect_base_prefix_spans_in_arithmetic(
     expression: &ArithmeticExprNode,
     source: &str,
     spans: &mut Vec<(Span, ArithmeticLiteralKind)>,
@@ -823,7 +846,7 @@ fn collect_base_prefix_spans_in_arithmetic(
     }
 }
 
-fn collect_base_prefix_spans_in_arithmetic_lvalue(
+pub(crate) fn collect_base_prefix_spans_in_arithmetic_lvalue(
     target: &ArithmeticLvalue,
     source: &str,
     spans: &mut Vec<(Span, ArithmeticLiteralKind)>,
@@ -836,13 +859,17 @@ fn collect_base_prefix_spans_in_arithmetic_lvalue(
     }
 }
 
-fn collect_base_prefix_spans_in_arithmetic_word(word: &Word, source: &str, spans: &mut Vec<(Span, ArithmeticLiteralKind)>) {
+pub(crate) fn collect_base_prefix_spans_in_arithmetic_word(
+    word: &Word,
+    source: &str,
+    spans: &mut Vec<(Span, ArithmeticLiteralKind)>,
+) {
     for part in &word.parts {
         collect_base_prefix_spans_in_arithmetic_word_part(part, source, spans);
     }
 }
 
-fn collect_base_prefix_spans_in_arithmetic_word_part(
+pub(crate) fn collect_base_prefix_spans_in_arithmetic_word_part(
     part: &WordPartNode,
     source: &str,
     spans: &mut Vec<(Span, ArithmeticLiteralKind)>,
@@ -935,7 +962,7 @@ fn collect_base_prefix_spans_in_arithmetic_word_part(
     }
 }
 
-fn collect_base_prefix_spans_in_fragment(
+pub(crate) fn collect_base_prefix_spans_in_fragment(
     word: Option<&Word>,
     text: Option<&SourceText>,
     source: &str,
@@ -960,7 +987,7 @@ fn collect_base_prefix_spans_in_fragment(
     collect_base_prefix_spans_in_word(word, source, spans);
 }
 
-fn collect_base_prefix_spans_in_arithmetic_fragment(
+pub(crate) fn collect_base_prefix_spans_in_arithmetic_fragment(
     word: Option<&Word>,
     text: Option<&SourceText>,
     source: &str,
@@ -982,7 +1009,7 @@ fn collect_base_prefix_spans_in_arithmetic_fragment(
     collect_base_prefix_spans_in_arithmetic_word(word, source, spans);
 }
 
-fn collect_base_prefix_spans_in_text(
+pub(crate) fn collect_base_prefix_spans_in_text(
     span: Span,
     source: &str,
     spans: &mut Vec<(Span, ArithmeticLiteralKind)>,
@@ -1035,7 +1062,7 @@ fn collect_base_prefix_spans_in_text(
     }
 }
 
-fn collect_leading_zero_integer_spans_in_text(
+pub(crate) fn collect_leading_zero_integer_spans_in_text(
     span: Span,
     source: &str,
     spans: &mut Vec<(Span, ArithmeticLiteralKind)>,
@@ -1088,7 +1115,7 @@ fn collect_leading_zero_integer_spans_in_text(
     }
 }
 
-fn contains_leading_zero_integer(text: &str) -> bool {
+pub(crate) fn contains_leading_zero_integer(text: &str) -> bool {
     let bytes = text.as_bytes();
     bytes.windows(2).enumerate().any(|(index, window)| {
         window[0] == b'0'
@@ -1107,7 +1134,10 @@ fn contains_leading_zero_integer(text: &str) -> bool {
     })
 }
 
-fn build_double_paren_grouping_spans(commands: &[CommandFact<'_>], source: &str) -> Vec<Span> {
+pub(crate) fn build_double_paren_grouping_spans(
+    commands: &[CommandFact<'_>],
+    source: &str,
+) -> Vec<Span> {
     commands
         .iter()
         .filter_map(|fact| match fact.command() {
@@ -1119,7 +1149,7 @@ fn build_double_paren_grouping_spans(commands: &[CommandFact<'_>], source: &str)
         .collect()
 }
 
-fn collect_arithmetic_update_operator_spans_in_command(
+pub(crate) fn collect_arithmetic_update_operator_spans_in_command(
     command: &Command,
     semantic: &SemanticModel,
     semantic_artifacts: &LinterSemanticArtifacts<'_>,
@@ -1331,7 +1361,7 @@ fn collect_arithmetic_update_operator_spans_in_command(
     }
 }
 
-fn collect_arithmetic_update_operator_spans_in_assignment(
+pub(crate) fn collect_arithmetic_update_operator_spans_in_assignment(
     assignment: &Assignment,
     semantic: &SemanticModel,
     semantic_artifacts: &LinterSemanticArtifacts<'_>,
@@ -1388,7 +1418,7 @@ fn collect_arithmetic_update_operator_spans_in_assignment(
     }
 }
 
-fn collect_arithmetic_update_operator_spans_in_assignment_target(
+pub(crate) fn collect_arithmetic_update_operator_spans_in_assignment_target(
     reference: &VarRef,
     semantic: &SemanticModel,
     scope: ScopeId,
@@ -1407,7 +1437,10 @@ fn collect_arithmetic_update_operator_spans_in_assignment_target(
     });
 }
 
-fn var_ref_subscript_has_assoc_semantics(reference: &VarRef, semantic: &SemanticModel) -> bool {
+pub(crate) fn var_ref_subscript_has_assoc_semantics(
+    reference: &VarRef,
+    semantic: &SemanticModel,
+) -> bool {
     let Some(subscript) = reference.subscript.as_deref() else {
         return false;
     };
@@ -1428,7 +1461,7 @@ fn var_ref_subscript_has_assoc_semantics(reference: &VarRef, semantic: &Semantic
     var_ref_name_has_visible_assoc_binding_at(reference, semantic, scope)
 }
 
-fn var_ref_subscript_has_assoc_semantics_in_scope(
+pub(crate) fn var_ref_subscript_has_assoc_semantics_in_scope(
     reference: &VarRef,
     semantic: &SemanticModel,
     scope: ScopeId,
@@ -1452,16 +1485,15 @@ fn var_ref_subscript_has_assoc_semantics_in_scope(
     var_ref_name_has_visible_assoc_binding_at(reference, semantic, scope)
 }
 
-fn var_ref_name_has_visible_assoc_binding_at(
+pub(crate) fn var_ref_name_has_visible_assoc_binding_at(
     reference: &VarRef,
     semantic: &SemanticModel,
     scope: ScopeId,
 ) -> bool {
-    semantic
-        .assoc_binding_visible_for_lookup(&reference.name, scope, reference.name_span)
+    semantic.assoc_binding_visible_for_lookup(&reference.name, scope, reference.name_span)
 }
 
-fn collect_arithmetic_update_operator_spans_in_word(
+pub(crate) fn collect_arithmetic_update_operator_spans_in_word(
     word: &Word,
     semantic: &SemanticModel,
     source: &str,
@@ -1470,7 +1502,7 @@ fn collect_arithmetic_update_operator_spans_in_word(
     collect_arithmetic_update_operator_spans_from_parts(&word.parts, semantic, source, spans);
 }
 
-fn collect_arithmetic_update_operator_spans_in_pattern(
+pub(crate) fn collect_arithmetic_update_operator_spans_in_pattern(
     pattern: &Pattern,
     semantic: &SemanticModel,
     source: &str,
@@ -1496,7 +1528,7 @@ fn collect_arithmetic_update_operator_spans_in_pattern(
     }
 }
 
-fn collect_arithmetic_update_operator_spans_in_conditional_expr(
+pub(crate) fn collect_arithmetic_update_operator_spans_in_conditional_expr(
     expression: &ConditionalExpr,
     semantic: &SemanticModel,
     source: &str,
@@ -1536,7 +1568,7 @@ fn collect_arithmetic_update_operator_spans_in_conditional_expr(
     }
 }
 
-fn collect_arithmetic_update_operator_spans_in_heredoc_body(
+pub(crate) fn collect_arithmetic_update_operator_spans_in_heredoc_body(
     parts: &[shuck_ast::HeredocBodyPartNode],
     semantic: &SemanticModel,
     semantic_artifacts: &LinterSemanticArtifacts<'_>,
@@ -1584,7 +1616,7 @@ fn collect_arithmetic_update_operator_spans_in_heredoc_body(
     }
 }
 
-fn collect_arithmetic_update_operator_spans_in_nested_command_body(
+pub(crate) fn collect_arithmetic_update_operator_spans_in_nested_command_body(
     body: &StmtSeq,
     semantic_artifacts: &LinterSemanticArtifacts<'_>,
     semantic: &SemanticModel,
@@ -1623,7 +1655,7 @@ fn collect_arithmetic_update_operator_spans_in_nested_command_body(
         });
 }
 
-fn collect_arithmetic_update_operator_spans_in_subscript(
+pub(crate) fn collect_arithmetic_update_operator_spans_in_subscript(
     subscript: Option<&Subscript>,
     source: &str,
     spans: &mut Vec<Span>,
@@ -1642,7 +1674,7 @@ fn collect_arithmetic_update_operator_spans_in_subscript(
     }
 }
 
-fn collect_arithmetic_update_operator_spans_in_subscript_words(
+pub(crate) fn collect_arithmetic_update_operator_spans_in_subscript_words(
     subscript: &Subscript,
     semantic: &SemanticModel,
     semantic_artifacts: &LinterSemanticArtifacts<'_>,
@@ -1660,7 +1692,7 @@ fn collect_arithmetic_update_operator_spans_in_subscript_words(
     });
 }
 
-fn collect_arithmetic_update_operator_spans(
+pub(crate) fn collect_arithmetic_update_operator_spans(
     expression: Option<&ArithmeticExprNode>,
     source: &str,
     spans: &mut Vec<Span>,
@@ -1730,7 +1762,7 @@ fn collect_arithmetic_update_operator_spans(
     }
 }
 
-fn collect_arithmetic_lvalue_update_operator_spans(
+pub(crate) fn collect_arithmetic_lvalue_update_operator_spans(
     target: &ArithmeticLvalue,
     source: &str,
     spans: &mut Vec<Span>,
@@ -1796,7 +1828,7 @@ impl ArithmeticUpdateOperatorFixFact {
     }
 }
 
-fn build_arithmetic_update_operator_fix_facts(
+pub(in crate::facts) fn build_arithmetic_update_operator_fix_facts(
     spans: &[Span],
     source: &str,
 ) -> Vec<ArithmeticUpdateOperatorFixFact> {
@@ -1839,7 +1871,12 @@ fn arithmetic_update_operator_fix_fact(
 fn arithmetic_prefix_update_operand_span(operator_span: Span, source: &str) -> Option<Span> {
     let start = operator_span.end.offset;
     let end = scan_arithmetic_lvalue_end(source, start)?;
-    (end > start).then(|| Span::from_positions(operator_span.end, operator_span.end.advanced_by(&source[start..end])))
+    (end > start).then(|| {
+        Span::from_positions(
+            operator_span.end,
+            operator_span.end.advanced_by(&source[start..end]),
+        )
+    })
 }
 
 fn arithmetic_postfix_update_operand_span(operator_span: Span, source: &str) -> Option<Span> {
@@ -1981,7 +2018,12 @@ fn position_at_offset_on_same_line(anchor: Position, offset: usize) -> Position 
     }
 }
 
-fn find_operator_span(expression_span: Span, source: &str, operator: &str, first: bool) -> Span {
+pub(crate) fn find_operator_span(
+    expression_span: Span,
+    source: &str,
+    operator: &str,
+    first: bool,
+) -> Span {
     let expression = expression_span.slice(source);
     let offset = if first {
         let Some(offset) = expression.find(operator) else {
@@ -1998,7 +2040,7 @@ fn find_operator_span(expression_span: Span, source: &str, operator: &str, first
     Span::from_positions(start, start.advanced_by(operator))
 }
 
-fn double_paren_grouping_anchor(span: Span, source: &str) -> Option<Span> {
+pub(crate) fn double_paren_grouping_anchor(span: Span, source: &str) -> Option<Span> {
     let text = span.slice(source);
     let anchor_start = if let Some(stripped) = text.strip_prefix("((") {
         let body_start =

--- a/crates/shuck-linter/src/facts/arrays.rs
+++ b/crates/shuck-linter/src/facts/arrays.rs
@@ -1,7 +1,10 @@
-fn build_plain_unindexed_array_reference_facts(
+use super::*;
+
+pub(crate) fn build_plain_unindexed_array_reference_facts(
     facts: &LinterFacts<'_>,
 ) -> Vec<PlainUnindexedArrayReferenceFact> {
     let candidate_references = facts
+        .words
         .plain_unindexed_reference_spans
         .iter()
         .copied()
@@ -20,7 +23,7 @@ fn build_plain_unindexed_array_reference_facts(
         .collect()
 }
 
-struct PlainUnindexedArrayReferenceContext<'a, 'src> {
+pub(crate) struct PlainUnindexedArrayReferenceContext<'a, 'src> {
     facts: &'a LinterFacts<'src>,
     semantic: &'a SemanticModel,
     simple_command_ancestors_by_offset: FxHashMap<usize, Vec<SimpleCommandAncestor>>,
@@ -84,8 +87,11 @@ impl<'a, 'src> PlainUnindexedArrayReferenceContext<'a, 'src> {
         reference: &Reference,
         policy: shuck_semantic::ArrayReferencePolicy,
     ) -> bool {
-        if self.facts.shell != ShellDialect::Zsh
-            || matches!(policy, shuck_semantic::ArrayReferencePolicy::RequiresExplicitSelector)
+        if self.facts.source_facts.shell != ShellDialect::Zsh
+            || matches!(
+                policy,
+                shuck_semantic::ArrayReferencePolicy::RequiresExplicitSelector
+            )
         {
             return false;
         }
@@ -106,7 +112,7 @@ impl<'a, 'src> PlainUnindexedArrayReferenceContext<'a, 'src> {
         &self,
         reference: &Reference,
     ) -> shuck_semantic::ArrayReferencePolicy {
-        if self.facts.shell != ShellDialect::Zsh {
+        if self.facts.source_facts.shell != ShellDialect::Zsh {
             return shuck_semantic::ArrayReferencePolicy::RequiresExplicitSelector;
         }
 
@@ -134,20 +140,21 @@ impl<'a, 'src> PlainUnindexedArrayReferenceContext<'a, 'src> {
         !matches!(
             self.array_reference_policy(reference),
             shuck_semantic::ArrayReferencePolicy::RequiresExplicitSelector
+        ) && matches!(
+            reference.kind,
+            shuck_semantic::ReferenceKind::ConditionalOperand
         )
-            && matches!(reference.kind, shuck_semantic::ReferenceKind::ConditionalOperand)
     }
 
     fn reference_is_zsh_presence_test(&self, reference: &Reference) -> bool {
         !matches!(
             self.array_reference_policy(reference),
             shuck_semantic::ArrayReferencePolicy::RequiresExplicitSelector
-        )
-            && self
-                .facts
-                .presence_test_references(&reference.name)
-                .iter()
-                .any(|test| test.reference_id() == reference.id)
+        ) && self
+            .facts
+            .presence_test_references(&reference.name)
+            .iter()
+            .any(|test| test.reference_id() == reference.id)
     }
 
     fn reference_has_prior_presence_test(&mut self, reference: &Reference) -> bool {
@@ -207,7 +214,11 @@ impl<'a, 'src> PlainUnindexedArrayReferenceContext<'a, 'src> {
         *self
             .resolved_binding_ids
             .entry(reference_id)
-            .or_insert_with(|| self.semantic.resolved_binding(reference_id).map(|binding| binding.id))
+            .or_insert_with(|| {
+                self.semantic
+                    .resolved_binding(reference_id)
+                    .map(|binding| binding.id)
+            })
     }
 
     fn same_command_candidate_writer_bindings(&mut self, name: &Name) -> &[BindingId] {
@@ -282,16 +293,16 @@ impl<'a, 'src> PlainUnindexedArrayReferenceContext<'a, 'src> {
 }
 
 #[derive(Clone, Copy)]
-struct SimpleCommandAncestor {
+pub(crate) struct SimpleCommandAncestor {
     id: CommandId,
     assignment_only: bool,
 }
 
-fn span_is_within(outer: Span, inner: Span) -> bool {
+pub(crate) fn span_is_within(outer: Span, inner: Span) -> bool {
     outer.start.offset <= inner.start.offset && inner.end.offset <= outer.end.offset
 }
 
-fn loop_header_word_quote(facts: &LinterFacts<'_>, span: Span) -> Option<WordQuote> {
+pub(crate) fn loop_header_word_quote(facts: &LinterFacts<'_>, span: Span) -> Option<WordQuote> {
     facts
         .for_headers()
         .iter()
@@ -306,14 +317,20 @@ fn loop_header_word_quote(facts: &LinterFacts<'_>, span: Span) -> Option<WordQuo
         .map(|word| word.classification().quote)
 }
 
-fn binding_suppresses_same_command_array_read(binding: &Binding, assignment_only: bool) -> bool {
+pub(crate) fn binding_suppresses_same_command_array_read(
+    binding: &Binding,
+    assignment_only: bool,
+) -> bool {
     matches!(binding.kind, BindingKind::MapfileTarget)
         || (matches!(binding.kind, BindingKind::ReadTarget)
             && binding.attributes.contains(BindingAttributes::ARRAY))
         || (matches!(binding.kind, BindingKind::ArrayAssignment) && assignment_only)
 }
 
-fn collect_use_replacement_expansion_spans(parts: &[WordPartNode], spans: &mut Vec<Span>) {
+pub(crate) fn collect_use_replacement_expansion_spans(
+    parts: &[WordPartNode],
+    spans: &mut Vec<Span>,
+) {
     for part in parts {
         match &part.kind {
             WordPart::DoubleQuoted { .. }
@@ -347,7 +364,7 @@ fn collect_use_replacement_expansion_spans(parts: &[WordPartNode], spans: &mut V
     }
 }
 
-fn parameter_uses_replacement_operator(parameter: &ParameterExpansion) -> bool {
+pub(crate) fn parameter_uses_replacement_operator(parameter: &ParameterExpansion) -> bool {
     let ParameterExpansionSyntax::Bourne(syntax) = &parameter.syntax else {
         return false;
     };
@@ -370,8 +387,11 @@ fn parameter_uses_replacement_operator(parameter: &ParameterExpansion) -> bool {
     }
 }
 
-
-fn collect_broken_assoc_key_spans(command: &Command, source: &str, spans: &mut Vec<Span>) {
+pub(crate) fn collect_broken_assoc_key_spans(
+    command: &Command,
+    source: &str,
+    spans: &mut Vec<Span>,
+) {
     for assignment in command_assignments(command) {
         collect_broken_assoc_key_spans_in_assignment(assignment, source, spans);
     }
@@ -384,7 +404,7 @@ fn collect_broken_assoc_key_spans(command: &Command, source: &str, spans: &mut V
     }
 }
 
-fn collect_broken_assoc_key_spans_in_assignment(
+pub(crate) fn collect_broken_assoc_key_spans_in_assignment(
     assignment: &Assignment,
     source: &str,
     spans: &mut Vec<Span>,
@@ -406,7 +426,7 @@ fn collect_broken_assoc_key_spans_in_assignment(
     }
 }
 
-fn has_unclosed_assoc_key_prefix(word: &Word, source: &str) -> bool {
+pub(crate) fn has_unclosed_assoc_key_prefix(word: &Word, source: &str) -> bool {
     let text = word.span.slice(source);
     if !text.starts_with('[') {
         return false;
@@ -478,7 +498,7 @@ fn has_unclosed_assoc_key_prefix(word: &Word, source: &str) -> bool {
     saw_equals
 }
 
-fn collect_comma_array_assignment_spans(
+pub(crate) fn collect_comma_array_assignment_spans(
     command: &Command,
     source: &str,
     shell: ShellDialect,
@@ -501,7 +521,7 @@ fn collect_comma_array_assignment_spans(
     }
 }
 
-fn collect_ifs_literal_backslash_assignment_value_spans(
+pub(crate) fn collect_ifs_literal_backslash_assignment_value_spans(
     command: &Command,
     source: &str,
     spans: &mut Vec<Span>,
@@ -522,7 +542,7 @@ fn collect_ifs_literal_backslash_assignment_value_spans(
     }
 }
 
-fn ifs_literal_backslash_assignment_value_span(
+pub(crate) fn ifs_literal_backslash_assignment_value_span(
     assignment: &Assignment,
     source: &str,
 ) -> Option<Span> {
@@ -542,7 +562,7 @@ fn ifs_literal_backslash_assignment_value_span(
         .then_some(word.span)
 }
 
-fn comma_array_assignment_span(
+pub(crate) fn comma_array_assignment_span(
     assignment: &Assignment,
     source: &str,
     shell: ShellDialect,
@@ -558,7 +578,7 @@ fn comma_array_assignment_span(
     compound_assignment_paren_span(assignment, source)
 }
 
-fn array_value_has_unquoted_comma(
+pub(crate) fn array_value_has_unquoted_comma(
     assignment: &Assignment,
     array: &shuck_ast::ArrayExpr,
     source: &str,
@@ -575,7 +595,10 @@ fn array_value_has_unquoted_comma(
     })
 }
 
-fn assignment_target_has_assoc_context(assignment: &Assignment, semantic: &SemanticModel) -> bool {
+pub(crate) fn assignment_target_has_assoc_context(
+    assignment: &Assignment,
+    semantic: &SemanticModel,
+) -> bool {
     semantic
         .binding_for_definition_span(assignment.target.name_span)
         .is_some_and(|binding| {
@@ -596,7 +619,10 @@ fn assignment_target_has_assoc_context(assignment: &Assignment, semantic: &Seman
             })
 }
 
-fn zsh_option_map_value_allows_comma(value: &shuck_ast::ArrayValueWord, source: &str) -> bool {
+pub(crate) fn zsh_option_map_value_allows_comma(
+    value: &shuck_ast::ArrayValueWord,
+    source: &str,
+) -> bool {
     let Some(text) = static_word_text(value, source) else {
         return false;
     };
@@ -609,7 +635,7 @@ fn zsh_option_map_value_allows_comma(value: &shuck_ast::ArrayValueWord, source: 
     parts.len() > 1 && parts.iter().copied().all(zsh_option_alias_part)
 }
 
-fn zsh_option_alias_part(part: &str) -> bool {
+pub(crate) fn zsh_option_alias_part(part: &str) -> bool {
     part.starts_with('-')
         && part.len() > 1
         && part
@@ -618,7 +644,10 @@ fn zsh_option_alias_part(part: &str) -> bool {
             .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_'))
 }
 
-fn compound_assignment_paren_span(assignment: &Assignment, source: &str) -> Option<Span> {
+pub(crate) fn compound_assignment_paren_span(
+    assignment: &Assignment,
+    source: &str,
+) -> Option<Span> {
     let AssignmentValue::Compound(_) = &assignment.value else {
         return None;
     };

--- a/crates/shuck-linter/src/facts/assignments.rs
+++ b/crates/shuck-linter/src/facts/assignments.rs
@@ -1,3 +1,5 @@
+use super::*;
+
 #[derive(Debug, Clone)]
 pub struct DeclarationAssignmentProbe {
     kind: DeclarationKind,
@@ -44,7 +46,7 @@ pub struct BindingValueFact<'a> {
 }
 
 #[derive(Debug, Clone)]
-enum BindingValueKind<'a> {
+pub(crate) enum BindingValueKind<'a> {
     Scalar(&'a Word),
     Loop(Box<[&'a Word]>),
 }
@@ -129,7 +131,7 @@ impl<'a> BindingValueFact<'a> {
 }
 
 #[cfg_attr(shuck_profiling, inline(never))]
-fn build_bare_command_name_assignment_spans<'a>(
+pub(crate) fn build_bare_command_name_assignment_spans<'a>(
     commands: &[CommandFact<'a>],
     word_nodes: &[WordNode<'a>],
     word_occurrences: &[WordOccurrence],
@@ -151,7 +153,7 @@ fn build_bare_command_name_assignment_spans<'a>(
 }
 
 #[cfg_attr(shuck_profiling, inline(never))]
-fn build_assignment_like_command_name_spans<'a>(
+pub(crate) fn build_assignment_like_command_name_spans<'a>(
     commands: &[CommandFact<'a>],
     source: &str,
 ) -> Vec<Span> {
@@ -164,7 +166,7 @@ fn build_assignment_like_command_name_spans<'a>(
     spans
 }
 
-fn collect_assignment_like_command_name_spans_in_command(
+pub(crate) fn collect_assignment_like_command_name_spans_in_command(
     fact: &CommandFact<'_>,
     source: &str,
     spans: &mut Vec<Span>,
@@ -193,13 +195,17 @@ fn collect_assignment_like_command_name_spans_in_command(
     }
 }
 
-fn collect_assignment_like_command_name_span(word: &Word, source: &str, spans: &mut Vec<Span>) {
+pub(crate) fn collect_assignment_like_command_name_span(
+    word: &Word,
+    source: &str,
+    spans: &mut Vec<Span>,
+) {
     if let Some(span) = assignment_like_command_name_span(word, source) {
         spans.push(span);
     }
 }
 
-fn assignment_like_command_name_span(word: &Word, source: &str) -> Option<Span> {
+pub(crate) fn assignment_like_command_name_span(word: &Word, source: &str) -> Option<Span> {
     let prefix = leading_literal_word_prefix(word, source);
     let target_end = prefix.find("+=").or_else(|| prefix.find('='))?;
     let target = &prefix[..target_end];
@@ -214,7 +220,7 @@ fn assignment_like_command_name_span(word: &Word, source: &str) -> Option<Span> 
     }
 }
 
-fn zsh_declaration_brace_assignment_target(
+pub(crate) fn zsh_declaration_brace_assignment_target(
     word: &Word,
     source: &str,
     behavior: &ShellBehaviorAt<'_>,
@@ -234,7 +240,7 @@ fn zsh_declaration_brace_assignment_target(
         .any(|brace| brace.expands() && brace.span.end.offset <= target_end_offset)
 }
 
-fn bare_command_name_assignment_span<'a>(
+pub(crate) fn bare_command_name_assignment_span<'a>(
     command: &CommandFact<'a>,
     word_nodes: &[WordNode<'a>],
     word_occurrences: &[WordOccurrence],
@@ -278,7 +284,8 @@ fn bare_command_name_assignment_span<'a>(
         WordFactContext::Expansion(ExpansionContext::AssignmentValue),
     )?;
     let analysis = occurrence_analysis(word_nodes, fact);
-    if analysis.quote != WordQuote::Unquoted || analysis.literalness != WordLiteralness::FixedLiteral
+    if analysis.quote != WordQuote::Unquoted
+        || analysis.literalness != WordLiteralness::FixedLiteral
     {
         return None;
     }
@@ -295,7 +302,7 @@ fn bare_command_name_assignment_span<'a>(
     })
 }
 
-fn anchored_assignment_command_span(
+pub(crate) fn anchored_assignment_command_span(
     command: &CommandFact<'_>,
     assignment: &Assignment,
     source: &str,
@@ -327,7 +334,7 @@ fn anchored_assignment_command_span(
     }
 }
 
-fn assignment_target_span(assignment: &Assignment) -> Span {
+pub(crate) fn assignment_target_span(assignment: &Assignment) -> Span {
     assignment.target.subscript.as_deref().map_or_else(
         || assignment.target.name_span,
         |subscript| {
@@ -339,7 +346,10 @@ fn assignment_target_span(assignment: &Assignment) -> Span {
     )
 }
 
-fn is_bare_command_name_assignment_value(text: &str, zsh_options: Option<&ZshOptionState>) -> bool {
+pub(crate) fn is_bare_command_name_assignment_value(
+    text: &str,
+    zsh_options: Option<&ZshOptionState>,
+) -> bool {
     let text = zsh_literal_assignment_value_for_command_name_check(text, zsh_options);
     matches!(
         text,
@@ -449,7 +459,7 @@ fn is_bare_command_name_assignment_value(text: &str, zsh_options: Option<&ZshOpt
     )
 }
 
-fn zsh_literal_assignment_value_for_command_name_check<'a>(
+pub(crate) fn zsh_literal_assignment_value_for_command_name_check<'a>(
     text: &'a str,
     zsh_options: Option<&ZshOptionState>,
 ) -> &'a str {
@@ -466,10 +476,10 @@ fn zsh_literal_assignment_value_for_command_name_check<'a>(
 }
 
 #[derive(Debug, Default)]
-struct EnvPrefixScopeSpans {
-    assignment_scope_spans: Vec<Span>,
-    expansion_scope_spans: Vec<Span>,
-    expansion_fix_facts: Vec<EnvPrefixExpansionFixFact>,
+pub(crate) struct EnvPrefixScopeSpans {
+    pub(crate) assignment_scope_spans: Vec<Span>,
+    pub(crate) expansion_scope_spans: Vec<Span>,
+    pub(crate) expansion_fix_facts: Vec<EnvPrefixExpansionFixFact>,
 }
 
 #[derive(Debug, Clone)]
@@ -494,7 +504,7 @@ impl EnvPrefixExpansionFixFact {
 }
 
 #[cfg_attr(shuck_profiling, inline(never))]
-fn build_env_prefix_scope_spans(
+pub(crate) fn build_env_prefix_scope_spans(
     source: &str,
     semantic: &SemanticModel,
     commands: &[CommandFact<'_>],
@@ -686,14 +696,17 @@ fn build_env_prefix_scope_spans(
     scope_spans
         .expansion_scope_spans
         .sort_by_key(|span| (span.start.offset, span.end.offset));
-    scope_spans
-        .expansion_fix_facts
-        .sort_by_key(|fact| (fact.diagnostic_span.start.offset, fact.diagnostic_span.end.offset));
+    scope_spans.expansion_fix_facts.sort_by_key(|fact| {
+        (
+            fact.diagnostic_span.start.offset,
+            fact.diagnostic_span.end.offset,
+        )
+    });
     scope_spans
 }
 
 #[derive(Debug, Clone)]
-struct EnvPrefixExpansionFixSeed {
+pub(crate) struct EnvPrefixExpansionFixSeed {
     assignment_spans: Vec<Span>,
     delete_span: Span,
 }
@@ -708,13 +721,16 @@ impl EnvPrefixExpansionFixSeed {
     }
 }
 
-fn env_prefix_expansion_fix_seed(
+pub(crate) fn env_prefix_expansion_fix_seed(
     source: &str,
     assignments: &[Assignment],
 ) -> Option<EnvPrefixExpansionFixSeed> {
     let first_assignment = assignments.first()?;
     let last_assignment = assignments.last()?;
-    let prefix = source.get(line_start_offset(source, first_assignment.span.start.offset)..first_assignment.span.start.offset)?;
+    let prefix = source.get(
+        line_start_offset(source, first_assignment.span.start.offset)
+            ..first_assignment.span.start.offset,
+    )?;
     if !prefix.bytes().all(|byte| matches!(byte, b' ' | b'\t')) {
         return None;
     }
@@ -733,13 +749,13 @@ fn env_prefix_expansion_fix_seed(
     })
 }
 
-fn line_start_offset(source: &str, offset: usize) -> usize {
+pub(crate) fn line_start_offset(source: &str, offset: usize) -> usize {
     source[..offset]
         .rfind('\n')
         .map_or(0, |newline| newline + '\n'.len_utf8())
 }
 
-fn skip_env_prefix_separator(source: &str, start: Position) -> Option<Position> {
+pub(crate) fn skip_env_prefix_separator(source: &str, start: Position) -> Option<Position> {
     let mut position = start;
     let mut tail = source.get(start.offset..)?;
     while let Some(ch) = tail.chars().next() {
@@ -764,14 +780,14 @@ fn skip_env_prefix_separator(source: &str, start: Position) -> Option<Position> 
 }
 
 #[derive(Debug, Clone, Copy)]
-struct BrokenLegacyBracketTail {
+pub(crate) struct BrokenLegacyBracketTail {
     assignment_index: usize,
     synthetic_word_count: usize,
 }
 
-type EnvPrefixReferenceSpanVisitor<'a> = dyn FnMut(Span) -> ControlFlow<()> + 'a;
+pub(crate) type EnvPrefixReferenceSpanVisitor<'a> = dyn FnMut(Span) -> ControlFlow<()> + 'a;
 
-fn command_is_assignment_only(fact: &CommandFact<'_>, source: &str) -> bool {
+pub(crate) fn command_is_assignment_only(fact: &CommandFact<'_>, source: &str) -> bool {
     match fact.command() {
         Command::Simple(command) if !command.assignments.is_empty() => {
             fact.literal_name() == Some("")
@@ -788,7 +804,7 @@ fn command_is_assignment_only(fact: &CommandFact<'_>, source: &str) -> bool {
     }
 }
 
-fn broken_legacy_bracket_tail(
+pub(crate) fn broken_legacy_bracket_tail(
     command: &SimpleCommand,
     source: &str,
 ) -> Option<BrokenLegacyBracketTail> {
@@ -808,7 +824,7 @@ fn broken_legacy_bracket_tail(
     })
 }
 
-fn assignment_is_broken_legacy_bracket_arithmetic(assignment: &Assignment) -> bool {
+pub(crate) fn assignment_is_broken_legacy_bracket_arithmetic(assignment: &Assignment) -> bool {
     let AssignmentValue::Scalar(word) = &assignment.value else {
         return false;
     };
@@ -825,7 +841,7 @@ fn assignment_is_broken_legacy_bracket_arithmetic(assignment: &Assignment) -> bo
     )
 }
 
-fn assignment_mentions_name_outside_nested_commands(
+pub(crate) fn assignment_mentions_name_outside_nested_commands(
     semantic: &SemanticModel,
     command_span: Span,
     assignment: &Assignment,
@@ -841,7 +857,7 @@ fn assignment_mentions_name_outside_nested_commands(
     .is_break()
 }
 
-fn command_body_mentions_name_outside_nested_commands(
+pub(crate) fn command_body_mentions_name_outside_nested_commands(
     semantic: &SemanticModel,
     fact: &CommandFact<'_>,
     source: &str,
@@ -857,7 +873,7 @@ fn command_body_mentions_name_outside_nested_commands(
     .is_break()
 }
 
-pub(super) fn simple_command_body_words<'a>(
+pub(crate) fn simple_command_body_words<'a>(
     command: &'a SimpleCommand,
     source: &'a str,
 ) -> impl Iterator<Item = &'a Word> {
@@ -868,7 +884,7 @@ pub(super) fn simple_command_body_words<'a>(
         .skip(skip)
 }
 
-fn broken_legacy_bracket_tail_mentions_name(
+pub(crate) fn broken_legacy_bracket_tail_mentions_name(
     semantic: &SemanticModel,
     command_span: Span,
     command: &SimpleCommand,
@@ -886,7 +902,7 @@ fn broken_legacy_bracket_tail_mentions_name(
     .is_break()
 }
 
-fn visit_assignment_reference_spans_outside_nested_commands(
+pub(crate) fn visit_assignment_reference_spans_outside_nested_commands(
     semantic: &SemanticModel,
     command_span: Span,
     assignment: &Assignment,
@@ -902,7 +918,7 @@ fn visit_assignment_reference_spans_outside_nested_commands(
     )
 }
 
-fn visit_command_body_reference_spans_outside_nested_commands(
+pub(crate) fn visit_command_body_reference_spans_outside_nested_commands(
     semantic: &SemanticModel,
     fact: &CommandFact<'_>,
     source: &str,
@@ -967,7 +983,7 @@ fn visit_command_body_reference_spans_outside_nested_commands(
     ControlFlow::Continue(())
 }
 
-fn visit_broken_legacy_bracket_tail_reference_spans(
+pub(crate) fn visit_broken_legacy_bracket_tail_reference_spans(
     semantic: &SemanticModel,
     command_span: Span,
     command: &SimpleCommand,
@@ -982,7 +998,7 @@ fn visit_broken_legacy_bracket_tail_reference_spans(
     visit_named_command_reference_spans_in_subspan(semantic, command_span, span, name, visit)
 }
 
-fn broken_legacy_bracket_tail_span(
+pub(crate) fn broken_legacy_bracket_tail_span(
     command: &SimpleCommand,
     tail: BrokenLegacyBracketTail,
 ) -> Option<Span> {
@@ -994,7 +1010,7 @@ fn broken_legacy_bracket_tail_span(
     Some(Span::from_positions(first.span.start, last.span.end))
 }
 
-fn builtin_words(command: &BuiltinCommand) -> Vec<&Word> {
+pub(crate) fn builtin_words(command: &BuiltinCommand) -> Vec<&Word> {
     let mut words = Vec::new();
     match command {
         BuiltinCommand::Break(command) => {
@@ -1025,7 +1041,7 @@ fn builtin_words(command: &BuiltinCommand) -> Vec<&Word> {
     words
 }
 
-fn visit_named_command_reference_spans_in_subspan(
+pub(crate) fn visit_named_command_reference_spans_in_subspan(
     semantic: &SemanticModel,
     command_span: Span,
     subspan: Span,
@@ -1033,7 +1049,8 @@ fn visit_named_command_reference_spans_in_subspan(
     visit: &mut EnvPrefixReferenceSpanVisitor<'_>,
 ) -> ControlFlow<()> {
     for reference in semantic.references_in_command_span(command_span, subspan) {
-        if &reference.name == name && reference_kind_counts_as_env_prefix_command_read(reference.kind)
+        if &reference.name == name
+            && reference_kind_counts_as_env_prefix_command_read(reference.kind)
         {
             visit(reference.span)?;
         }
@@ -1042,7 +1059,9 @@ fn visit_named_command_reference_spans_in_subspan(
     ControlFlow::Continue(())
 }
 
-fn reference_kind_counts_as_env_prefix_command_read(kind: shuck_semantic::ReferenceKind) -> bool {
+pub(crate) fn reference_kind_counts_as_env_prefix_command_read(
+    kind: shuck_semantic::ReferenceKind,
+) -> bool {
     matches!(
         kind,
         shuck_semantic::ReferenceKind::Expansion
@@ -1058,7 +1077,7 @@ fn reference_kind_counts_as_env_prefix_command_read(kind: shuck_semantic::Refere
     )
 }
 
-fn assignment_is_identity_self_copy(assignment: &Assignment) -> bool {
+pub(crate) fn assignment_is_identity_self_copy(assignment: &Assignment) -> bool {
     if assignment.append {
         return false;
     }
@@ -1069,14 +1088,14 @@ fn assignment_is_identity_self_copy(assignment: &Assignment) -> bool {
     word_is_identity_self_copy(word, &assignment.target.name)
 }
 
-fn word_is_identity_self_copy(word: &Word, name: &Name) -> bool {
+pub(crate) fn word_is_identity_self_copy(word: &Word, name: &Name) -> bool {
     let [part] = word.parts.as_slice() else {
         return false;
     };
     word_part_is_identity_self_copy(&part.kind, name)
 }
 
-fn word_part_is_identity_self_copy(part: &WordPart, name: &Name) -> bool {
+pub(crate) fn word_part_is_identity_self_copy(part: &WordPart, name: &Name) -> bool {
     match part {
         WordPart::Variable(variable) => variable == name,
         WordPart::DoubleQuoted { parts, .. } => {
@@ -1090,7 +1109,10 @@ fn word_part_is_identity_self_copy(part: &WordPart, name: &Name) -> bool {
     }
 }
 
-fn parameter_is_plain_access_to_name(parameter: &ParameterExpansion, name: &Name) -> bool {
+pub(crate) fn parameter_is_plain_access_to_name(
+    parameter: &ParameterExpansion,
+    name: &Name,
+) -> bool {
     match &parameter.syntax {
         ParameterExpansionSyntax::Bourne(BourneParameterExpansion::Access { reference })
             if reference.subscript.is_none() =>
@@ -1107,7 +1129,11 @@ fn parameter_is_plain_access_to_name(parameter: &ParameterExpansion, name: &Name
     }
 }
 
-fn push_fact_span(span: Span, spans: &mut Vec<Span>, seen: &mut FxHashSet<FactSpan>) -> bool {
+pub(crate) fn push_fact_span(
+    span: Span,
+    spans: &mut Vec<Span>,
+    seen: &mut FxHashSet<FactSpan>,
+) -> bool {
     let key = FactSpan::new(span);
     if seen.insert(key) {
         spans.push(span);
@@ -1117,7 +1143,7 @@ fn push_fact_span(span: Span, spans: &mut Vec<Span>, seen: &mut FxHashSet<FactSp
     }
 }
 
-fn push_env_prefix_expansion_fact(
+pub(crate) fn push_env_prefix_expansion_fact(
     span: Span,
     fix_seed: Option<&EnvPrefixExpansionFixSeed>,
     spans: &mut Vec<Span>,
@@ -1133,8 +1159,7 @@ fn push_env_prefix_expansion_fact(
     }
 }
 
-
-fn build_plus_equals_assignment_spans(commands: &[CommandFact<'_>]) -> Vec<Span> {
+pub(crate) fn build_plus_equals_assignment_spans(commands: &[CommandFact<'_>]) -> Vec<Span> {
     let mut spans = Vec::new();
 
     for fact in commands {
@@ -1144,7 +1169,10 @@ fn build_plus_equals_assignment_spans(commands: &[CommandFact<'_>]) -> Vec<Span>
     spans
 }
 
-fn collect_plus_equals_assignment_spans_in_command(command: &Command, spans: &mut Vec<Span>) {
+pub(crate) fn collect_plus_equals_assignment_spans_in_command(
+    command: &Command,
+    spans: &mut Vec<Span>,
+) {
     match command {
         Command::Simple(command) => {
             collect_plus_equals_assignment_spans_in_assignments(&command.assignments, spans);
@@ -1178,7 +1206,7 @@ fn collect_plus_equals_assignment_spans_in_command(command: &Command, spans: &mu
     }
 }
 
-fn collect_plus_equals_assignment_spans_in_assignments(
+pub(crate) fn collect_plus_equals_assignment_spans_in_assignments(
     assignments: &[Assignment],
     spans: &mut Vec<Span>,
 ) {
@@ -1187,7 +1215,7 @@ fn collect_plus_equals_assignment_spans_in_assignments(
     }
 }
 
-fn collect_plus_equals_assignment_span(assignment: &Assignment, spans: &mut Vec<Span>) {
+pub(crate) fn collect_plus_equals_assignment_span(assignment: &Assignment, spans: &mut Vec<Span>) {
     if !assignment.append {
         return;
     }
@@ -1202,7 +1230,7 @@ fn collect_plus_equals_assignment_span(assignment: &Assignment, spans: &mut Vec<
 }
 
 #[cfg_attr(shuck_profiling, inline(never))]
-fn build_nonpersistent_assignment_spans(
+pub(crate) fn build_nonpersistent_assignment_spans(
     semantic: &SemanticModel,
     semantic_analysis: &SemanticAnalysis<'_>,
     commands: &[CommandFact<'_>],
@@ -1220,8 +1248,8 @@ fn build_nonpersistent_assignment_spans(
             scope: read.scope,
         })
         .collect();
-    let analysis = semantic.analyze_nonpersistent_assignments(
-        &NonpersistentAssignmentAnalysisContext {
+    let analysis =
+        semantic.analyze_nonpersistent_assignments(&NonpersistentAssignmentAnalysisContext {
             options: NonpersistentAssignmentAnalysisOptions {
                 suppress_bash_pipefail_pipeline_side_effects,
                 require_return_use_same_execution_context: suppress_zsh_nested_subshell_noise,
@@ -1229,8 +1257,7 @@ fn build_nonpersistent_assignment_spans(
             },
             commands: command_contexts,
             extra_reads: prompt_runtime_reads,
-        },
-    );
+        });
     let mut candidate_effects = Vec::new();
     for effect in analysis.effects {
         if arithmetic_only_suppressed_subscript_spans
@@ -1327,7 +1354,7 @@ fn build_nonpersistent_assignment_spans(
     }
 }
 
-fn nonpersistent_assignment_reaches_later_use(
+pub(crate) fn nonpersistent_assignment_reaches_later_use(
     semantic: &SemanticModel,
     effect: &shuck_semantic::NonpersistentAssignmentEffect,
 ) -> bool {
@@ -1351,7 +1378,7 @@ fn nonpersistent_assignment_reaches_later_use(
     true
 }
 
-fn zsh_later_use_is_parameter_subscript_flag(source: &str, span: Span) -> bool {
+pub(crate) fn zsh_later_use_is_parameter_subscript_flag(source: &str, span: Span) -> bool {
     if span.start.offset + 1 != span.end.offset {
         return false;
     }
@@ -1382,7 +1409,7 @@ fn zsh_later_use_is_parameter_subscript_flag(source: &str, span: Span) -> bool {
     true
 }
 
-fn nonpersistent_reset_site_covers_later_use(
+pub(crate) fn nonpersistent_reset_site_covers_later_use(
     semantic: &SemanticModel,
     semantic_analysis: &SemanticAnalysis<'_>,
     effect: &shuck_semantic::NonpersistentAssignmentEffect,
@@ -1416,19 +1443,20 @@ fn nonpersistent_reset_site_covers_later_use(
     }
 
     let assignment_scope = semantic.binding(effect.assignment_binding).scope;
-    let entry = semantic_analysis
-        .flow_entry_block_for_binding_scopes(&[assignment_scope], effect.later_use_span.start.offset);
-    later_use_blocks
-        .iter()
-        .copied()
-        .all(|target| semantic_analysis.blocks_cover_all_paths_to_block(entry, target, &reset_blocks))
+    let entry = semantic_analysis.flow_entry_block_for_binding_scopes(
+        &[assignment_scope],
+        effect.later_use_span.start.offset,
+    );
+    later_use_blocks.iter().copied().all(|target| {
+        semantic_analysis.blocks_cover_all_paths_to_block(entry, target, &reset_blocks)
+    })
 }
 
-fn span_contains(outer: Span, inner: Span) -> bool {
+pub(crate) fn span_contains(outer: Span, inner: Span) -> bool {
     outer.start.offset <= inner.start.offset && inner.end.offset <= outer.end.offset
 }
 
-fn build_subshell_loop_assignment_report_spans(
+pub(crate) fn build_subshell_loop_assignment_report_spans(
     commands: &[CommandFact<'_>],
 ) -> FxHashMap<FactSpan, Span> {
     let mut spans = FxHashMap::default();
@@ -1456,11 +1484,11 @@ fn build_subshell_loop_assignment_report_spans(
     spans
 }
 
-fn leading_keyword_span(command_span: Span, keyword: &str) -> Span {
+pub(crate) fn leading_keyword_span(command_span: Span, keyword: &str) -> Span {
     Span::from_positions(command_span.start, command_span.start.advanced_by(keyword))
 }
 
-fn subshell_assignment_report_span(
+pub(crate) fn subshell_assignment_report_span(
     binding: &Binding,
     loop_assignment_spans: &FxHashMap<FactSpan, Span>,
 ) -> Span {
@@ -1474,20 +1502,20 @@ fn subshell_assignment_report_span(
 }
 
 #[derive(Debug, Default)]
-struct NonpersistentAssignmentSpans {
-    subshell_assignment_sites: Vec<NamedSpan>,
-    subshell_later_use_sites: Vec<NamedSpan>,
+pub(crate) struct NonpersistentAssignmentSpans {
+    pub(crate) subshell_assignment_sites: Vec<NamedSpan>,
+    pub(crate) subshell_later_use_sites: Vec<NamedSpan>,
 }
 
 #[derive(Debug, Clone)]
-struct NonpersistentAssignmentExtraResetSite {
+pub(crate) struct NonpersistentAssignmentExtraResetSite {
     name: Name,
     span: Span,
     flow_span: Span,
     command_id: CommandId,
 }
 
-fn build_nonpersistent_assignment_extra_reset_sites(
+pub(crate) fn build_nonpersistent_assignment_extra_reset_sites(
     semantic: &SemanticModel,
     semantic_analysis: &SemanticAnalysis<'_>,
     commands: &[CommandFact<'_>],
@@ -1516,7 +1544,8 @@ fn build_nonpersistent_assignment_extra_reset_sites(
             continue;
         };
         let can_call_relevant_helper = helper_function_names.contains(command_name);
-        let can_set_reply_by_name = needs_reply_reset && zsh_helper_name_can_set_reply(command_name);
+        let can_set_reply_by_name =
+            needs_reply_reset && zsh_helper_name_can_set_reply(command_name);
         if !can_call_relevant_helper && !can_set_reply_by_name {
             continue;
         }
@@ -1528,7 +1557,8 @@ fn build_nonpersistent_assignment_extra_reset_sites(
             && reply_function_names
                 .as_ref()
                 .is_some_and(|names| names.contains(command_name));
-        let resolved_function_scope = (can_call_relevant_helper || reply_name_may_resolve_to_function)
+        let resolved_function_scope = (can_call_relevant_helper
+            || reply_name_may_resolve_to_function)
             .then(|| resolved_function_scope_for_command(semantic, semantic_analysis, command))
             .flatten();
 
@@ -1560,11 +1590,13 @@ fn build_nonpersistent_assignment_extra_reset_sites(
 
         let flow_span = reset_flow_span_for_command(semantic, semantic_analysis, command, source);
         if let Some(names) = names {
-            resets.extend(names.iter().cloned().map(|name| NonpersistentAssignmentExtraResetSite {
-                name,
-                span: call_name_span,
-                flow_span,
-                command_id: command.id(),
+            resets.extend(names.iter().cloned().map(|name| {
+                NonpersistentAssignmentExtraResetSite {
+                    name,
+                    span: call_name_span,
+                    flow_span,
+                    command_id: command.id(),
+                }
             }));
         }
 
@@ -1599,7 +1631,12 @@ fn build_nonpersistent_assignment_extra_reset_sites(
             .cmp(right.name.as_str())
             .then_with(|| left.span.start.offset.cmp(&right.span.start.offset))
             .then_with(|| left.span.end.offset.cmp(&right.span.end.offset))
-            .then_with(|| left.flow_span.start.offset.cmp(&right.flow_span.start.offset))
+            .then_with(|| {
+                left.flow_span
+                    .start
+                    .offset
+                    .cmp(&right.flow_span.start.offset)
+            })
             .then_with(|| left.flow_span.end.offset.cmp(&right.flow_span.end.offset))
             .then_with(|| left.command_id.index().cmp(&right.command_id.index()))
     });
@@ -1612,7 +1649,7 @@ fn build_nonpersistent_assignment_extra_reset_sites(
     resets
 }
 
-fn reset_flow_span_for_command(
+pub(crate) fn reset_flow_span_for_command(
     semantic: &SemanticModel,
     semantic_analysis: &SemanticAnalysis<'_>,
     command: &CommandFact<'_>,
@@ -1645,7 +1682,7 @@ fn reset_flow_span_for_command(
     pipeline_span.unwrap_or(command_span)
 }
 
-fn zsh_reply_helper_reset_span(command: &CommandFact<'_>) -> Option<Span> {
+pub(crate) fn zsh_reply_helper_reset_span(command: &CommandFact<'_>) -> Option<Span> {
     let name = command.effective_or_literal_name()?;
     if !zsh_helper_name_can_set_reply(name) {
         return None;
@@ -1654,11 +1691,11 @@ fn zsh_reply_helper_reset_span(command: &CommandFact<'_>) -> Option<Span> {
     Some(command.body_name_word()?.span)
 }
 
-fn zsh_helper_name_can_set_reply(name: &str) -> bool {
+pub(crate) fn zsh_helper_name_can_set_reply(name: &str) -> bool {
     (name.starts_with('.') && name != "." && name != "..") || name.starts_with('_')
 }
 
-fn helper_output_names_by_scope(
+pub(crate) fn helper_output_names_by_scope(
     semantic: &SemanticModel,
     semantic_analysis: &SemanticAnalysis<'_>,
     needed_names: &FxHashSet<Name>,
@@ -1690,7 +1727,7 @@ fn helper_output_names_by_scope(
     names_by_scope
 }
 
-fn helper_function_names_for_scopes(
+pub(crate) fn helper_function_names_for_scopes(
     semantic: &SemanticModel,
     semantic_analysis: &SemanticAnalysis<'_>,
     helper_output_names_by_scope: &FxHashMap<ScopeId, Vec<Name>>,
@@ -1719,7 +1756,7 @@ fn helper_function_names_for_scopes(
     function_names
 }
 
-fn function_definition_names(semantic: &SemanticModel) -> FxHashSet<Name> {
+pub(crate) fn function_definition_names(semantic: &SemanticModel) -> FxHashSet<Name> {
     semantic
         .bindings()
         .iter()
@@ -1728,7 +1765,7 @@ fn function_definition_names(semantic: &SemanticModel) -> FxHashSet<Name> {
         .collect()
 }
 
-fn helper_binding_can_reset_parent_scope(
+pub(crate) fn helper_binding_can_reset_parent_scope(
     semantic: &SemanticModel,
     semantic_analysis: &SemanticAnalysis<'_>,
     binding: &Binding,
@@ -1751,11 +1788,9 @@ fn helper_binding_can_reset_parent_scope(
         | BindingKind::GetoptsTarget
         | BindingKind::ZparseoptsTarget
         | BindingKind::ArithmeticAssignment => true,
-        BindingKind::Declaration(_) => {
-            binding
-                .attributes
-                .contains(BindingAttributes::DECLARATION_INITIALIZED)
-        }
+        BindingKind::Declaration(_) => binding
+            .attributes
+            .contains(BindingAttributes::DECLARATION_INITIALIZED),
         BindingKind::LoopVariable
         | BindingKind::FunctionDefinition
         | BindingKind::Nameref
@@ -1763,7 +1798,7 @@ fn helper_binding_can_reset_parent_scope(
     }
 }
 
-fn binding_command_is_unconditional_in_function(
+pub(crate) fn binding_command_is_unconditional_in_function(
     semantic: &SemanticModel,
     semantic_analysis: &SemanticAnalysis<'_>,
     binding: &Binding,
@@ -1775,7 +1810,7 @@ fn binding_command_is_unconditional_in_function(
     command_is_unconditional_in_function(semantic, semantic_analysis, current)
 }
 
-fn command_is_unconditional_in_function(
+pub(crate) fn command_is_unconditional_in_function(
     semantic: &SemanticModel,
     semantic_analysis: &SemanticAnalysis<'_>,
     mut current: CommandId,
@@ -1801,7 +1836,7 @@ fn command_is_unconditional_in_function(
     true
 }
 
-fn command_has_reachable_cfg_block(
+pub(crate) fn command_has_reachable_cfg_block(
     semantic: &SemanticModel,
     semantic_analysis: &SemanticAnalysis<'_>,
     command_id: CommandId,
@@ -1812,7 +1847,7 @@ fn command_has_reachable_cfg_block(
         .any(|block| !semantic_analysis.block_is_unreachable(*block))
 }
 
-fn zsh_set_a_outparam_positions_by_scope(
+pub(crate) fn zsh_set_a_outparam_positions_by_scope(
     semantic: &SemanticModel,
     semantic_analysis: &SemanticAnalysis<'_>,
     commands: &[CommandFact<'_>],
@@ -1848,7 +1883,7 @@ fn zsh_set_a_outparam_positions_by_scope(
     positions_by_scope
 }
 
-fn zsh_set_a_outparam_positions(args: &[&Word], source: &str) -> Vec<usize> {
+pub(crate) fn zsh_set_a_outparam_positions(args: &[&Word], source: &str) -> Vec<usize> {
     let mut positions = Vec::new();
     let mut saw_array_flag = false;
 
@@ -1870,7 +1905,7 @@ fn zsh_set_a_outparam_positions(args: &[&Word], source: &str) -> Vec<usize> {
     positions
 }
 
-fn positional_outparam_index_from_word_text(text: &str) -> Option<usize> {
+pub(crate) fn positional_outparam_index_from_word_text(text: &str) -> Option<usize> {
     positional_outparam_index(text).or_else(|| {
         text.strip_prefix('"')
             .and_then(|inner| inner.strip_suffix('"'))
@@ -1878,7 +1913,7 @@ fn positional_outparam_index_from_word_text(text: &str) -> Option<usize> {
     })
 }
 
-fn positional_outparam_index(text: &str) -> Option<usize> {
+pub(crate) fn positional_outparam_index(text: &str) -> Option<usize> {
     let parameter = text
         .strip_prefix("${")
         .and_then(|inner| inner.strip_suffix('}'))
@@ -1887,7 +1922,7 @@ fn positional_outparam_index(text: &str) -> Option<usize> {
     (index > 0).then_some(index)
 }
 
-fn resolved_function_scope_for_command(
+pub(crate) fn resolved_function_scope_for_command(
     semantic: &SemanticModel,
     semantic_analysis: &SemanticAnalysis<'_>,
     command: &CommandFact<'_>,
@@ -1917,7 +1952,7 @@ fn resolved_function_scope_for_command(
     Some((scope, name_span))
 }
 
-fn fallback_function_binding_is_callable_from_function_body(
+pub(crate) fn fallback_function_binding_is_callable_from_function_body(
     semantic: &SemanticModel,
     semantic_analysis: &SemanticAnalysis<'_>,
     command: &CommandFact<'_>,
@@ -1944,7 +1979,7 @@ fn fallback_function_binding_is_callable_from_function_body(
     )
 }
 
-fn function_scope_may_run_before_offset(
+pub(crate) fn function_scope_may_run_before_offset(
     semantic: &SemanticModel,
     semantic_analysis: &SemanticAnalysis<'_>,
     function_scope: ScopeId,
@@ -1956,20 +1991,23 @@ fn function_scope_may_run_before_offset(
         .is_some_and(|(_, bindings)| {
             bindings.iter().copied().any(|function_binding| {
                 let name = &semantic.binding(function_binding).name;
-                semantic_analysis
-                    .resolved_function_call_sites(name)
-                    .any(|(site, resolved_binding)| {
+                semantic_analysis.resolved_function_call_sites(name).any(
+                    |(site, resolved_binding)| {
                         resolved_binding == function_binding && site.name_span.start.offset < offset
-                    })
+                    },
+                )
             })
         })
 }
 
-fn command_is_inside_function_body(semantic: &SemanticModel, scope: ScopeId) -> bool {
+pub(crate) fn command_is_inside_function_body(semantic: &SemanticModel, scope: ScopeId) -> bool {
     enclosing_function_scope(semantic, scope).is_some()
 }
 
-fn enclosing_function_scope(semantic: &SemanticModel, scope: ScopeId) -> Option<ScopeId> {
+pub(crate) fn enclosing_function_scope(
+    semantic: &SemanticModel,
+    scope: ScopeId,
+) -> Option<ScopeId> {
     if matches!(semantic.scope_kind(scope), ScopeKind::Function(_)) {
         return Some(scope);
     }
@@ -1979,12 +2017,15 @@ fn enclosing_function_scope(semantic: &SemanticModel, scope: ScopeId) -> Option<
         .find(|scope| matches!(semantic.scope_kind(*scope), ScopeKind::Function(_)))
 }
 
-fn command_runs_in_persistent_shell_context(
+pub(crate) fn command_runs_in_persistent_shell_context(
     semantic: &SemanticModel,
     command: &CommandFact<'_>,
     source: &str,
 ) -> bool {
-    if matches!(command.stmt().terminator, Some(StmtTerminator::Background(_))) {
+    if matches!(
+        command.stmt().terminator,
+        Some(StmtTerminator::Background(_))
+    ) {
         return false;
     }
 
@@ -2001,7 +2042,7 @@ fn command_runs_in_persistent_shell_context(
         && zsh_pipeline_tail_runs_in_current_shell(command, semantic, source)
 }
 
-fn zsh_pipeline_tail_runs_in_current_shell(
+pub(crate) fn zsh_pipeline_tail_runs_in_current_shell(
     command: &CommandFact<'_>,
     semantic: &SemanticModel,
     source: &str,
@@ -2012,7 +2053,9 @@ fn zsh_pipeline_tail_runs_in_current_shell(
     if command
         .shell_behavior()
         .zsh_options()
-        .is_some_and(|options| *options == ZshOptionState::for_emulate(shuck_semantic::ZshEmulationMode::Sh))
+        .is_some_and(|options| {
+            *options == ZshOptionState::for_emulate(shuck_semantic::ZshEmulationMode::Sh)
+        })
     {
         return false;
     }
@@ -2021,7 +2064,7 @@ fn zsh_pipeline_tail_runs_in_current_shell(
         || command_is_textual_pipeline_tail_operand(command.span(), source)
 }
 
-fn command_is_pipeline_tail_operand(
+pub(crate) fn command_is_pipeline_tail_operand(
     semantic: &SemanticModel,
     mut current: CommandId,
     source: &str,
@@ -2043,7 +2086,7 @@ fn command_is_pipeline_tail_operand(
     saw_pipeline_parent
 }
 
-fn binary_child_pipe_tail_relation(
+pub(crate) fn binary_child_pipe_tail_relation(
     semantic: &SemanticModel,
     parent: CommandId,
     child: CommandId,
@@ -2061,7 +2104,7 @@ fn binary_child_pipe_tail_relation(
     text_ends_with_pipeline_operator(before_child).then_some(true)
 }
 
-fn command_is_textual_pipeline_tail_operand(command_span: Span, source: &str) -> bool {
+pub(crate) fn command_is_textual_pipeline_tail_operand(command_span: Span, source: &str) -> bool {
     let before_command = &source[..command_span.start.offset];
     let before_command = before_command.trim_end();
     if !text_ends_with_pipeline_operator(before_command) {
@@ -2073,15 +2116,15 @@ fn command_is_textual_pipeline_tail_operand(command_span: Span, source: &str) ->
     !after_command.starts_with('|')
 }
 
-fn text_ends_with_pipeline_operator(text: &str) -> bool {
+pub(crate) fn text_ends_with_pipeline_operator(text: &str) -> bool {
     text.ends_with("|&") || (text.ends_with('|') && !text.ends_with("||"))
 }
 
-fn text_starts_with_pipeline_operator(text: &str) -> Option<()> {
+pub(crate) fn text_starts_with_pipeline_operator(text: &str) -> Option<()> {
     (text.starts_with("|&") || (text.starts_with('|') && !text.starts_with("||"))).then_some(())
 }
 
-fn reset_site_control_ancestors_contain_later_use(
+pub(crate) fn reset_site_control_ancestors_contain_later_use(
     semantic: &SemanticModel,
     command_id: CommandId,
     later_use_span: Span,
@@ -2106,7 +2149,7 @@ fn reset_site_control_ancestors_contain_later_use(
     true
 }
 
-fn reset_site_is_always_run_binary_operand(
+pub(crate) fn reset_site_is_always_run_binary_operand(
     semantic: &SemanticModel,
     parent: CommandId,
     child: CommandId,
@@ -2118,7 +2161,7 @@ fn reset_site_is_always_run_binary_operand(
     semantic.command_syntax_span(parent).start == semantic.command_syntax_span(child).start
 }
 
-fn command_kind_may_skip_child(kind: CommandKind) -> bool {
+pub(crate) fn command_kind_may_skip_child(kind: CommandKind) -> bool {
     match kind {
         CommandKind::Binary => true,
         CommandKind::Compound(
@@ -2149,7 +2192,7 @@ fn command_kind_may_skip_child(kind: CommandKind) -> bool {
     }
 }
 
-fn build_nonpersistent_assignment_command_contexts(
+pub(crate) fn build_nonpersistent_assignment_command_contexts(
     commands: &[CommandFact<'_>],
 ) -> Vec<NonpersistentAssignmentCommandContext> {
     commands
@@ -2170,13 +2213,13 @@ fn build_nonpersistent_assignment_command_contexts(
         .collect()
 }
 
-struct PromptRuntimeRead {
+pub(crate) struct PromptRuntimeRead {
     name: Name,
     span: Span,
     scope: ScopeId,
 }
 
-fn build_prompt_runtime_read_spans(
+pub(crate) fn build_prompt_runtime_read_spans(
     commands: &[CommandFact<'_>],
     source: &str,
 ) -> Vec<PromptRuntimeRead> {
@@ -2199,7 +2242,7 @@ fn build_prompt_runtime_read_spans(
     reads
 }
 
-fn collect_prompt_runtime_reads_from_assignment(
+pub(crate) fn collect_prompt_runtime_reads_from_assignment(
     assignment: &Assignment,
     scope: ScopeId,
     source: &str,
@@ -2222,7 +2265,7 @@ fn collect_prompt_runtime_reads_from_assignment(
     }
 }
 
-fn escaped_braced_parameter_names(text: &str) -> Vec<String> {
+pub(crate) fn escaped_braced_parameter_names(text: &str) -> Vec<String> {
     let mut names = Vec::new();
     let mut index = 0;
 
@@ -2253,7 +2296,7 @@ fn escaped_braced_parameter_names(text: &str) -> Vec<String> {
 }
 
 #[cfg_attr(shuck_profiling, inline(never))]
-fn build_innermost_command_ids_by_offset(
+pub(crate) fn build_innermost_command_ids_by_offset(
     commands: &[CommandFact<'_>],
     mut offsets: Vec<usize>,
 ) -> CommandOffsetLookup {
@@ -2297,17 +2340,17 @@ fn build_innermost_command_ids_by_offset(
 }
 
 #[derive(Debug, Default, Clone)]
-struct CommandOffsetLookup {
+pub(crate) struct CommandOffsetLookup {
     entries: Vec<CommandOffsetLookupEntry>,
 }
 
 #[derive(Debug, Clone, Copy)]
-struct CommandOffsetLookupEntry {
+pub(crate) struct CommandOffsetLookupEntry {
     offset: usize,
     id: CommandId,
 }
 
-fn precomputed_command_id_for_offset(
+pub(crate) fn precomputed_command_id_for_offset(
     command_ids_by_offset: &CommandOffsetLookup,
     offset: usize,
 ) -> Option<CommandId> {
@@ -2319,12 +2362,12 @@ fn precomputed_command_id_for_offset(
 }
 
 #[derive(Debug, Clone, Copy)]
-struct OpenCommand {
+pub(crate) struct OpenCommand {
     end_offset: usize,
     id: CommandId,
 }
 
-fn pop_finished_commands(active_commands: &mut Vec<OpenCommand>, offset: usize) {
+pub(crate) fn pop_finished_commands(active_commands: &mut Vec<OpenCommand>, offset: usize) {
     while active_commands
         .last()
         .is_some_and(|command| command.end_offset < offset)
@@ -2333,7 +2376,10 @@ fn pop_finished_commands(active_commands: &mut Vec<OpenCommand>, offset: usize) 
     }
 }
 
-fn build_dollar_question_after_command_spans(commands: &StmtSeq, source: &str) -> Vec<Span> {
+pub(crate) fn build_dollar_question_after_command_spans(
+    commands: &StmtSeq,
+    source: &str,
+) -> Vec<Span> {
     let mut spans = Vec::new();
     BodyShapeAnalyzer::new(source).visit_status_available_sites(commands, true, &mut |site| {
         match site {
@@ -2355,8 +2401,7 @@ fn build_dollar_question_after_command_spans(commands: &StmtSeq, source: &str) -
     spans
 }
 
-
-fn build_declaration_assignment_probes<'a>(
+pub(crate) fn build_declaration_assignment_probes<'a>(
     command: &'a Command,
     normalized: &NormalizedCommand<'a>,
     semantic: &SemanticModel,
@@ -2377,11 +2422,7 @@ fn build_declaration_assignment_probes<'a>(
                     readonly_flag: declaration.readonly_flag,
                     target_name: assignment.target.name.as_str().into(),
                     target_name_span: assignment.target.name_span,
-                    has_command_substitution: word_has_command_substitution(
-                        word,
-                        source,
-                        behavior,
-                    ),
+                    has_command_substitution: word_has_command_substitution(word, source, behavior),
                     status_capture: word_is_standalone_status_capture(word),
                 })
             })
@@ -2429,7 +2470,7 @@ fn build_declaration_assignment_probes<'a>(
         .collect()
 }
 
-fn declaration_kind_from_semantic(builtin: DeclarationBuiltin) -> DeclarationKind {
+pub(crate) fn declaration_kind_from_semantic(builtin: DeclarationBuiltin) -> DeclarationKind {
     match builtin {
         DeclarationBuiltin::Export => DeclarationKind::Export,
         DeclarationBuiltin::Local => DeclarationKind::Local,
@@ -2439,7 +2480,7 @@ fn declaration_kind_from_semantic(builtin: DeclarationBuiltin) -> DeclarationKin
     }
 }
 
-fn semantic_declaration_readonly_flag(declaration: &Declaration) -> bool {
+pub(crate) fn semantic_declaration_readonly_flag(declaration: &Declaration) -> bool {
     if !matches!(
         declaration.builtin,
         DeclarationBuiltin::Local | DeclarationBuiltin::Declare | DeclarationBuiltin::Typeset
@@ -2457,28 +2498,27 @@ fn semantic_declaration_readonly_flag(declaration: &Declaration) -> bool {
     })
 }
 
-fn word_for_declaration_value_span(command: &Command, span: Span) -> Option<&Word> {
+pub(crate) fn word_for_declaration_value_span(command: &Command, span: Span) -> Option<&Word> {
     let Command::Simple(command) = command else {
         return None;
     };
 
-    command
-        .args
-        .iter()
-        .find(|word| span.start.offset >= word.span.start.offset && span.end.offset <= word.span.end.offset)
+    command.args.iter().find(|word| {
+        span.start.offset >= word.span.start.offset && span.end.offset <= word.span.end.offset
+    })
 }
 
-fn word_span_is_standalone_status_capture(word: &Word, span: Span) -> bool {
+pub(crate) fn word_span_is_standalone_status_capture(word: &Word, span: Span) -> bool {
     let parts = word_parts_in_span(word, span);
     matches!(parts.as_slice(), [part] if part_is_standalone_status_capture(&part.kind))
 }
 
-fn word_span_is_standalone_status_or_pid_capture(word: &Word, span: Span) -> bool {
+pub(crate) fn word_span_is_standalone_status_or_pid_capture(word: &Word, span: Span) -> bool {
     let parts = word_parts_in_span(word, span);
     matches!(parts.as_slice(), [part] if part_is_standalone_status_or_pid_capture(&part.kind))
 }
 
-fn word_parts_in_span(word: &Word, span: Span) -> Vec<&WordPartNode> {
+pub(crate) fn word_parts_in_span(word: &Word, span: Span) -> Vec<&WordPartNode> {
     word.parts
         .iter()
         .filter(|part| {
@@ -2487,7 +2527,7 @@ fn word_parts_in_span(word: &Word, span: Span) -> Vec<&WordPartNode> {
         .collect()
 }
 
-fn part_is_standalone_status_capture(part: &WordPart) -> bool {
+pub(crate) fn part_is_standalone_status_capture(part: &WordPart) -> bool {
     match part {
         WordPart::Variable(name) => name.as_str() == "?",
         WordPart::DoubleQuoted { parts, .. } => {
@@ -2502,11 +2542,11 @@ fn part_is_standalone_status_capture(part: &WordPart) -> bool {
     }
 }
 
-fn word_is_standalone_status_or_pid_capture(word: &Word) -> bool {
+pub(crate) fn word_is_standalone_status_or_pid_capture(word: &Word) -> bool {
     matches!(word.parts.as_slice(), [part] if part_is_standalone_status_or_pid_capture(&part.kind))
 }
 
-fn part_is_standalone_status_or_pid_capture(part: &WordPart) -> bool {
+pub(crate) fn part_is_standalone_status_or_pid_capture(part: &WordPart) -> bool {
     match part {
         WordPart::Variable(name) => matches!(name.as_str(), "?" | "!"),
         WordPart::DoubleQuoted { parts, .. } => {
@@ -2524,7 +2564,7 @@ fn part_is_standalone_status_or_pid_capture(part: &WordPart) -> bool {
     }
 }
 
-fn word_has_command_substitution(
+pub(crate) fn word_has_command_substitution(
     word: &Word,
     source: &str,
     behavior: &ShellBehaviorAt<'_>,
@@ -2533,13 +2573,13 @@ fn word_has_command_substitution(
         .has_command_substitution()
 }
 
-fn word_zsh_selectorless_subscript_value_base_names(word: &Word, source: &str) -> Box<[Name]> {
+pub(crate) fn word_zsh_selectorless_subscript_value_base_names(
+    word: &Word,
+    source: &str,
+) -> Box<[Name]> {
     let mut base_names = Vec::new();
-    if word_part_nodes_are_zsh_selectorless_subscript_value(
-        &word.parts,
-        source,
-        &mut base_names,
-    ) && !base_names.is_empty()
+    if word_part_nodes_are_zsh_selectorless_subscript_value(&word.parts, source, &mut base_names)
+        && !base_names.is_empty()
     {
         base_names.into_boxed_slice()
     } else {
@@ -2547,7 +2587,7 @@ fn word_zsh_selectorless_subscript_value_base_names(word: &Word, source: &str) -
     }
 }
 
-fn word_part_nodes_are_zsh_selectorless_subscript_value(
+pub(crate) fn word_part_nodes_are_zsh_selectorless_subscript_value(
     parts: &[WordPartNode],
     source: &str,
     base_names: &mut Vec<Name>,
@@ -2564,18 +2604,14 @@ fn word_part_nodes_are_zsh_selectorless_subscript_value(
             base_names.push(name.clone());
             continue;
         }
-        if !word_part_is_zsh_selectorless_subscript_value(
-            &part.kind,
-            source,
-            base_names,
-        ) {
+        if !word_part_is_zsh_selectorless_subscript_value(&part.kind, source, base_names) {
             return false;
         }
     }
     true
 }
 
-fn word_part_is_zsh_selectorless_subscript_value(
+pub(crate) fn word_part_is_zsh_selectorless_subscript_value(
     part: &WordPart,
     source: &str,
     base_names: &mut Vec<Name>,
@@ -2611,14 +2647,14 @@ fn word_part_is_zsh_selectorless_subscript_value(
     }
 }
 
-fn literal_starts_with_zsh_subscript(text: &str) -> bool {
+pub(crate) fn literal_starts_with_zsh_subscript(text: &str) -> bool {
     let Some(rest) = text.strip_prefix('[') else {
         return false;
     };
     rest.contains(']')
 }
 
-fn parameter_is_zsh_selectorless_subscript_value(
+pub(crate) fn parameter_is_zsh_selectorless_subscript_value(
     parameter: &ParameterExpansion,
     base_names: &mut Vec<Name>,
 ) -> bool {
@@ -2662,14 +2698,14 @@ fn parameter_is_zsh_selectorless_subscript_value(
     }
 }
 
-fn var_ref_has_selectorless_subscript(reference: &VarRef) -> bool {
+pub(crate) fn var_ref_has_selectorless_subscript(reference: &VarRef) -> bool {
     reference
         .subscript
         .as_deref()
         .is_some_and(|subscript| subscript.selector().is_none())
 }
 
-fn advance_escaped_char_boundary(text: &str, start: usize) -> usize {
+pub(crate) fn advance_escaped_char_boundary(text: &str, start: usize) -> usize {
     let next = start + '\\'.len_utf8();
     if next >= text.len() {
         return next;
@@ -2678,7 +2714,7 @@ fn advance_escaped_char_boundary(text: &str, start: usize) -> usize {
     next + text[next..].chars().next().map_or(0, char::len_utf8)
 }
 
-fn collect_binding_values<'a>(
+pub(crate) fn collect_binding_values<'a>(
     command: &'a Command,
     semantic: &SemanticModel,
     source: &str,
@@ -2796,14 +2832,14 @@ fn collect_binding_values<'a>(
     }
 }
 
-fn binding_value_definition_id_for_span(
+pub(crate) fn binding_value_definition_id_for_span(
     semantic: &SemanticModel,
     span: Span,
 ) -> Option<BindingId> {
     semantic.binding_for_definition_span(span)
 }
 
-fn binding_value_visible_id_for_name(
+pub(crate) fn binding_value_visible_id_for_name(
     semantic: &SemanticModel,
     name: &Name,
     span: Span,
@@ -2813,7 +2849,7 @@ fn binding_value_visible_id_for_name(
         .map(|binding| binding.id)
 }
 
-fn annotate_conditional_assignment_value_paths<'a>(
+pub(crate) fn annotate_conditional_assignment_value_paths<'a>(
     semantic: &SemanticModel,
     lists: &[ListFact<'a>],
     binding_values: &mut FxHashMap<BindingId, BindingValueFact<'a>>,
@@ -2865,7 +2901,7 @@ fn annotate_conditional_assignment_value_paths<'a>(
     }
 }
 
-fn list_has_conditional_assignment_shortcuts(list: &ListFact<'_>) -> bool {
+pub(crate) fn list_has_conditional_assignment_shortcuts(list: &ListFact<'_>) -> bool {
     if list.mixed_short_circuit_kind() == Some(MixedShortCircuitKind::AssignmentTernary) {
         return true;
     }

--- a/crates/shuck-linter/src/facts/body_shape.rs
+++ b/crates/shuck-linter/src/facts/body_shape.rs
@@ -1,3 +1,5 @@
+use super::*;
+
 // Shared body-shape predicates for condition/status facts.
 //
 // This file owns repeated command/body shape questions, but it intentionally leaves diagnostic span
@@ -8,12 +10,12 @@
 /// Keep this focused on repeated structural questions across condition/status facts. If a predicate
 /// needs command-specific wording, exact fix spans, or assignment policy, expose only the shared
 /// shape here and keep the payload-specific decision in the owning fact.
-pub(super) struct BodyShapeAnalyzer<'source> {
+pub(crate) struct BodyShapeAnalyzer<'source> {
     source: &'source str,
 }
 
 /// A syntax payload where the previous command status is available for inspection.
-pub(super) enum StatusAvailableSite<'a> {
+pub(crate) enum StatusAvailableSite<'a> {
     /// A simple command whose test-style operands can inspect `$?`.
     SimpleTest(&'a SimpleCommand),
     /// A `[[ ... ]]` expression whose operands can inspect `$?`.
@@ -24,19 +26,19 @@ pub(super) enum StatusAvailableSite<'a> {
 
 impl<'source> BodyShapeAnalyzer<'source> {
     /// Creates an analyzer bound to the source text used by syntax classifiers.
-    pub(super) fn new(source: &'source str) -> Self {
+    pub(crate) fn new(source: &'source str) -> Self {
         Self { source }
     }
 
     /// Returns whether any statement in `commands` or its nested bodies terminates in a test.
-    pub(super) fn sequence_tail_contains_nested_test_command(&self, commands: &[Stmt]) -> bool {
+    pub(crate) fn sequence_tail_contains_nested_test_command(&self, commands: &[Stmt]) -> bool {
         commands
             .iter()
             .any(|stmt| self.stmt_or_nested_sequence_contains_test_command(stmt))
     }
 
     /// Returns whether `stmt` itself or a nested statement sequence contains a terminal test.
-    pub(super) fn stmt_or_nested_sequence_contains_test_command(&self, stmt: &Stmt) -> bool {
+    pub(crate) fn stmt_or_nested_sequence_contains_test_command(&self, stmt: &Stmt) -> bool {
         if stmt_terminals_are_test_commands(stmt, self.source) {
             return true;
         }
@@ -46,76 +48,75 @@ impl<'source> BodyShapeAnalyzer<'source> {
                 self.stmt_or_nested_sequence_contains_test_command(&command.left)
                     || self.stmt_or_nested_sequence_contains_test_command(&command.right)
             }
-            Command::Compound(command) => match command {
-                CompoundCommand::If(command) => {
-                    condition_terminals_are_test_commands(&command.condition, self.source)
-                        || command
-                            .then_branch
-                            .iter()
-                            .any(|stmt| self.stmt_or_nested_sequence_contains_test_command(stmt))
-                        || command.elif_branches.iter().any(|(condition, branch)| {
-                            condition_terminals_are_test_commands(condition, self.source)
-                                || branch.iter().any(|stmt| {
+            Command::Compound(command) => {
+                match command {
+                    CompoundCommand::If(command) => {
+                        condition_terminals_are_test_commands(&command.condition, self.source)
+                            || command.then_branch.iter().any(|stmt| {
+                                self.stmt_or_nested_sequence_contains_test_command(stmt)
+                            })
+                            || command.elif_branches.iter().any(|(condition, branch)| {
+                                condition_terminals_are_test_commands(condition, self.source)
+                                    || branch.iter().any(|stmt| {
+                                        self.stmt_or_nested_sequence_contains_test_command(stmt)
+                                    })
+                            })
+                            || command.else_branch.as_ref().is_some_and(|branch| {
+                                branch.iter().any(|stmt| {
                                     self.stmt_or_nested_sequence_contains_test_command(stmt)
                                 })
-                        })
-                        || command.else_branch.as_ref().is_some_and(|branch| {
-                            branch
-                                .iter()
-                                .any(|stmt| self.stmt_or_nested_sequence_contains_test_command(stmt))
-                        })
-                }
-                CompoundCommand::While(command) => {
-                    condition_terminals_are_test_commands(&command.condition, self.source)
-                        || command
-                            .body
-                            .iter()
-                            .any(|stmt| self.stmt_or_nested_sequence_contains_test_command(stmt))
-                }
-                CompoundCommand::Until(command) => {
-                    condition_terminals_are_test_commands(&command.condition, self.source)
-                        || command
-                            .body
-                            .iter()
-                            .any(|stmt| self.stmt_or_nested_sequence_contains_test_command(stmt))
-                }
-                CompoundCommand::For(command) => command
-                    .body
-                    .iter()
-                    .any(|stmt| self.stmt_or_nested_sequence_contains_test_command(stmt)),
-                CompoundCommand::Select(command) => command
-                    .body
-                    .iter()
-                    .any(|stmt| self.stmt_or_nested_sequence_contains_test_command(stmt)),
-                CompoundCommand::BraceGroup(body) | CompoundCommand::Subshell(body) => body
-                    .iter()
-                    .any(|stmt| self.stmt_or_nested_sequence_contains_test_command(stmt)),
-                CompoundCommand::Time(command) => command
-                    .command
-                    .as_ref()
-                    .is_some_and(|stmt| self.stmt_or_nested_sequence_contains_test_command(stmt)),
-                CompoundCommand::Always(command) => {
-                    command
+                            })
+                    }
+                    CompoundCommand::While(command) => {
+                        condition_terminals_are_test_commands(&command.condition, self.source)
+                            || command.body.iter().any(|stmt| {
+                                self.stmt_or_nested_sequence_contains_test_command(stmt)
+                            })
+                    }
+                    CompoundCommand::Until(command) => {
+                        condition_terminals_are_test_commands(&command.condition, self.source)
+                            || command.body.iter().any(|stmt| {
+                                self.stmt_or_nested_sequence_contains_test_command(stmt)
+                            })
+                    }
+                    CompoundCommand::For(command) => command
                         .body
                         .iter()
-                        .any(|stmt| self.stmt_or_nested_sequence_contains_test_command(stmt))
-                        || command
-                            .always_body
+                        .any(|stmt| self.stmt_or_nested_sequence_contains_test_command(stmt)),
+                    CompoundCommand::Select(command) => command
+                        .body
+                        .iter()
+                        .any(|stmt| self.stmt_or_nested_sequence_contains_test_command(stmt)),
+                    CompoundCommand::BraceGroup(body) | CompoundCommand::Subshell(body) => body
+                        .iter()
+                        .any(|stmt| self.stmt_or_nested_sequence_contains_test_command(stmt)),
+                    CompoundCommand::Time(command) => {
+                        command.command.as_ref().is_some_and(|stmt| {
+                            self.stmt_or_nested_sequence_contains_test_command(stmt)
+                        })
+                    }
+                    CompoundCommand::Always(command) => {
+                        command
+                            .body
                             .iter()
                             .any(|stmt| self.stmt_or_nested_sequence_contains_test_command(stmt))
+                            || command.always_body.iter().any(|stmt| {
+                                self.stmt_or_nested_sequence_contains_test_command(stmt)
+                            })
+                    }
+                    CompoundCommand::Case(command) => command.cases.iter().any(|case| {
+                        case.body
+                            .iter()
+                            .any(|stmt| self.stmt_or_nested_sequence_contains_test_command(stmt))
+                    }),
+                    CompoundCommand::Conditional(_)
+                    | CompoundCommand::Repeat(_)
+                    | CompoundCommand::Foreach(_)
+                    | CompoundCommand::ArithmeticFor(_)
+                    | CompoundCommand::Arithmetic(_)
+                    | CompoundCommand::Coproc(_) => false,
                 }
-                CompoundCommand::Case(command) => command.cases.iter().any(|case| {
-                    case.body
-                        .iter()
-                        .any(|stmt| self.stmt_or_nested_sequence_contains_test_command(stmt))
-                }),
-                CompoundCommand::Conditional(_)
-                | CompoundCommand::Repeat(_)
-                | CompoundCommand::Foreach(_)
-                | CompoundCommand::ArithmeticFor(_)
-                | CompoundCommand::Arithmetic(_)
-                | CompoundCommand::Coproc(_) => false,
-            },
+            }
             Command::Function(function) => {
                 self.stmt_or_nested_sequence_contains_test_command(&function.body)
             }
@@ -130,7 +131,7 @@ impl<'source> BodyShapeAnalyzer<'source> {
     ///
     /// The analyzer owns the sibling/body traversal; the status span collector remains in
     /// `conditionals.rs` because it owns the exact payload scan and diagnostic spans.
-    pub(super) fn collect_status_test_followup_chains_with_sibling_tail(
+    pub(crate) fn collect_status_test_followup_chains_with_sibling_tail(
         &self,
         commands: &StmtSeq,
         spans: &mut Vec<Span>,
@@ -146,7 +147,7 @@ impl<'source> BodyShapeAnalyzer<'source> {
     /// The traversal owns status-availability propagation through bodies, branches, lists, and
     /// function bodies. Callers keep payload-specific span extraction local by matching on the
     /// returned site.
-    pub(super) fn visit_status_available_sites<'a>(
+    pub(crate) fn visit_status_available_sites<'a>(
         &self,
         commands: &'a StmtSeq,
         status_available: bool,
@@ -156,7 +157,7 @@ impl<'source> BodyShapeAnalyzer<'source> {
     }
 
     /// Returns whether `stmt` is a logical chain with a status-based test followed by non-test work.
-    pub(super) fn stmt_is_status_test_followup_chain(&self, stmt: &Stmt) -> bool {
+    pub(crate) fn stmt_is_status_test_followup_chain(&self, stmt: &Stmt) -> bool {
         let Command::Binary(command) = &stmt.command else {
             return false;
         };
@@ -173,7 +174,7 @@ impl<'source> BodyShapeAnalyzer<'source> {
     }
 
     /// Returns whether `commands[index]` starts a return guard using a later status accumulator.
-    pub(super) fn stmt_starts_status_accumulator_return_guard(
+    pub(crate) fn stmt_starts_status_accumulator_return_guard(
         &self,
         index: usize,
         commands: &[Stmt],
@@ -193,7 +194,7 @@ impl<'source> BodyShapeAnalyzer<'source> {
     }
 
     /// Returns whether `stmt` assigns an unquoted `$?` capture to `name`.
-    pub(super) fn stmt_contains_status_capture_assignment_to_name(
+    pub(crate) fn stmt_contains_status_capture_assignment_to_name(
         &self,
         stmt: &Stmt,
         name: &Name,
@@ -235,7 +236,7 @@ impl<'source> BodyShapeAnalyzer<'source> {
     }
 
     /// Returns whether `stmt` directly or through a transparent grouping returns `name`.
-    pub(super) fn stmt_returns_name(&self, stmt: &Stmt, name: &Name) -> bool {
+    pub(crate) fn stmt_returns_name(&self, stmt: &Stmt, name: &Name) -> bool {
         match &stmt.command {
             Command::Builtin(BuiltinCommand::Return(command)) => command
                 .code
@@ -406,11 +407,7 @@ impl<'source> BodyShapeAnalyzer<'source> {
                 }
             },
             Command::Binary(command) => {
-                self.visit_status_available_sites_in_stmt(
-                    &command.left,
-                    status_available,
-                    visitor,
-                );
+                self.visit_status_available_sites_in_stmt(&command.left, status_available, visitor);
                 self.visit_status_available_sites_in_stmt(&command.right, true, visitor);
             }
             Command::Function(command) => {

--- a/crates/shuck-linter/src/facts/braces.rs
+++ b/crates/shuck-linter/src/facts/braces.rs
@@ -1,5 +1,7 @@
+use super::*;
+
 #[cfg_attr(shuck_profiling, inline(never))]
-fn build_literal_brace_spans(
+pub(crate) fn build_literal_brace_spans(
     nodes: &[WordNode<'_>],
     occurrences: &[WordOccurrence],
     commands: CommandFacts<'_, '_>,
@@ -65,7 +67,7 @@ fn build_literal_brace_spans(
 }
 
 #[derive(Default)]
-struct LiteralBraceScratch {
+pub(crate) struct LiteralBraceScratch {
     processed_word_nodes: Vec<bool>,
     dynamic_exclusions: Vec<DynamicBraceExcludedSpan>,
     raw_escaped_exclusions: Vec<DynamicBraceExcludedSpan>,
@@ -77,7 +79,7 @@ struct LiteralBraceScratch {
     escaped_parameter_stack: Vec<usize>,
 }
 
-fn collect_literal_brace_spans_for_word(
+pub(crate) fn collect_literal_brace_spans_for_word(
     nodes: &[WordNode<'_>],
     fact: &WordOccurrence,
     fact_store: &FactStore<'_>,
@@ -168,7 +170,7 @@ fn collect_literal_brace_spans_for_word(
     );
 }
 
-fn literal_brace_word_span_is_reportable(
+pub(crate) fn literal_brace_word_span_is_reportable(
     nodes: &[WordNode<'_>],
     fact: &WordOccurrence,
     fact_store: &FactStore<'_>,
@@ -182,7 +184,7 @@ fn literal_brace_word_span_is_reportable(
         && !word_span_is_inside_command_substitution(nodes, fact, fact_store, span)
 }
 
-fn word_span_is_inside_command_substitution(
+pub(crate) fn word_span_is_inside_command_substitution(
     nodes: &[WordNode<'_>],
     fact: &WordOccurrence,
     fact_store: &FactStore<'_>,
@@ -196,7 +198,7 @@ fn word_span_is_inside_command_substitution(
         .any(|substitution| contains_span(substitution, span))
 }
 
-fn is_find_exec_placeholder_word(
+pub(crate) fn is_find_exec_placeholder_word(
     commands: CommandFacts<'_, '_>,
     nodes: &[WordNode<'_>],
     fact: &WordOccurrence,
@@ -222,7 +224,7 @@ fn is_find_exec_placeholder_word(
     }) || line_has_find_exec_placeholder_context(locator, occurrence_span(nodes, fact))
 }
 
-fn is_find_exec_command(command: CommandFactRef<'_, '_>, source: &str) -> bool {
+pub(crate) fn is_find_exec_command(command: CommandFactRef<'_, '_>, source: &str) -> bool {
     let is_find = command.static_utility_name_is("find")
         || command.body_name_word().is_some_and(|name_word| {
             name_word
@@ -250,7 +252,10 @@ fn is_find_exec_command(command: CommandFactRef<'_, '_>, source: &str) -> bool {
     has_exec_flag && has_exec_terminator
 }
 
-fn line_has_find_exec_placeholder_context(locator: Locator<'_>, brace_span: Span) -> bool {
+pub(crate) fn line_has_find_exec_placeholder_context(
+    locator: Locator<'_>,
+    brace_span: Span,
+) -> bool {
     let source = locator.source();
     let Some(line_range) = locator.line_range(brace_span.start.line) else {
         return false;
@@ -270,10 +275,9 @@ fn line_has_find_exec_placeholder_context(locator: Locator<'_>, brace_span: Span
     let prefix = &line_text[..relative_start];
     let suffix = &line_text[relative_end..];
     let first_word = shellish_words(prefix).next();
-    let has_exec_flag_before = shellish_words(prefix)
-        .any(|word| matches!(word, "-exec" | "-execdir" | "-ok" | "-okdir"));
-    let has_exec_terminator_after = shellish_words(suffix)
-        .any(|word| matches!(word, "+" | "\\;"));
+    let has_exec_flag_before =
+        shellish_words(prefix).any(|word| matches!(word, "-exec" | "-execdir" | "-ok" | "-okdir"));
+    let has_exec_terminator_after = shellish_words(suffix).any(|word| matches!(word, "+" | "\\;"));
 
     first_word
         .and_then(|word| word.rsplit('/').next())
@@ -282,7 +286,7 @@ fn line_has_find_exec_placeholder_context(locator: Locator<'_>, brace_span: Span
         && has_exec_terminator_after
 }
 
-fn is_xargs_replacement_word(
+pub(crate) fn is_xargs_replacement_word(
     commands: CommandFacts<'_, '_>,
     nodes: &[WordNode<'_>],
     fact: &WordOccurrence,
@@ -300,7 +304,7 @@ fn is_xargs_replacement_word(
     xargs_replacement_spans_contain(command.body_args(), source, occurrence_span(nodes, fact))
 }
 
-fn xargs_replacement_spans_contain(args: &[&Word], source: &str, target: Span) -> bool {
+pub(crate) fn xargs_replacement_spans_contain(args: &[&Word], source: &str, target: Span) -> bool {
     let mut index = 0usize;
 
     while let Some(word) = args.get(index) {
@@ -393,7 +397,7 @@ fn xargs_replacement_spans_contain(args: &[&Word], source: &str, target: Span) -
     false
 }
 
-struct ShellishWords<'a> {
+pub(crate) struct ShellishWords<'a> {
     text: &'a str,
     cursor: usize,
 }
@@ -428,11 +432,11 @@ impl<'a> Iterator for ShellishWords<'a> {
     }
 }
 
-fn shellish_words(text: &str) -> ShellishWords<'_> {
+pub(crate) fn shellish_words(text: &str) -> ShellishWords<'_> {
     ShellishWords { text, cursor: 0 }
 }
 
-fn collect_brace_character_spans(
+pub(crate) fn collect_brace_character_spans(
     span: Span,
     source: &str,
     out: &mut Vec<Span>,
@@ -455,7 +459,7 @@ fn collect_brace_character_spans(
     }
 }
 
-fn brace_span_has_escaped_dollar_prefix(span: Span, source: &str) -> bool {
+pub(crate) fn brace_span_has_escaped_dollar_prefix(span: Span, source: &str) -> bool {
     let span_text = span.slice(source);
     if span_text.starts_with("${") {
         return has_odd_backslash_run_before(source, span.start.offset);
@@ -464,7 +468,10 @@ fn brace_span_has_escaped_dollar_prefix(span: Span, source: &str) -> bool {
     has_escaped_dollar_before(source, span.start.offset)
 }
 
-fn brace_syntax_with_whitespace_is_literal(brace: shuck_ast::BraceSyntax, source: &str) -> bool {
+pub(crate) fn brace_syntax_with_whitespace_is_literal(
+    brace: shuck_ast::BraceSyntax,
+    source: &str,
+) -> bool {
     if !matches!(brace.kind, BraceSyntaxKind::Expansion(_)) {
         return false;
     }
@@ -549,11 +556,11 @@ fn brace_syntax_with_whitespace_is_literal(brace: shuck_ast::BraceSyntax, source
     false
 }
 
-fn word_is_empty_brace_pair_variant(word: &Word, source: &str) -> bool {
+pub(crate) fn word_is_empty_brace_pair_variant(word: &Word, source: &str) -> bool {
     matches!(word.span.slice(source), "{}" | "\\{\\}")
 }
 
-fn collect_unclassified_literal_brace_spans(
+pub(crate) fn collect_unclassified_literal_brace_spans(
     word: &Word,
     source: &str,
     excluded: &mut Vec<DynamicBraceExcludedSpan>,
@@ -639,7 +646,7 @@ fn collect_unclassified_literal_brace_spans(
     }
 }
 
-fn collect_uncovered_command_brace_spans(
+pub(crate) fn collect_uncovered_command_brace_spans(
     commands: CommandFacts<'_, '_>,
     locator: Locator<'_>,
     heredoc_ranges: &[TextRange],
@@ -738,7 +745,7 @@ fn collect_uncovered_command_brace_spans(
     }
 }
 
-fn redirect_fd_var_brace_span(redirect: &Redirect, source: &str) -> Option<Span> {
+pub(crate) fn redirect_fd_var_brace_span(redirect: &Redirect, source: &str) -> Option<Span> {
     let fd_var_span = redirect.fd_var_span?;
     let start_offset = fd_var_span.start.offset.checked_sub('{'.len_utf8())?;
     let end_offset = fd_var_span.end.offset.checked_add('}'.len_utf8())?;
@@ -764,25 +771,25 @@ fn redirect_fd_var_brace_span(redirect: &Redirect, source: &str) -> Option<Span>
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum RawLiteralBraceScanMode {
+pub(crate) enum RawLiteralBraceScanMode {
     All,
     UnmatchedOnly,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum RawLiteralBraceQuoteState {
+pub(crate) enum RawLiteralBraceQuoteState {
     Single,
     Double,
 }
 
 #[derive(Debug, Clone, Copy)]
-struct RawLiteralBraceScan<'a> {
+pub(crate) struct RawLiteralBraceScan<'a> {
     locator: Locator<'a>,
     mode: RawLiteralBraceScanMode,
     excluded_ranges: &'a [TextRange],
 }
 
-fn collect_raw_literal_brace_spans(
+pub(crate) fn collect_raw_literal_brace_spans(
     scan: RawLiteralBraceScan<'_>,
     scan_start: usize,
     scan_end: usize,
@@ -791,16 +798,14 @@ fn collect_raw_literal_brace_spans(
     unmatched_opens: &mut Vec<Span>,
 ) {
     relevant_excluded.clear();
-    relevant_excluded.extend(scan.excluded_ranges
-        .iter()
-        .filter_map(|range| {
-            let start = usize::from(range.start());
-            let end = usize::from(range.end());
-            if end <= scan_start || start >= scan_end {
-                return None;
-            }
-            Some((start.max(scan_start), end.min(scan_end)))
-        }));
+    relevant_excluded.extend(scan.excluded_ranges.iter().filter_map(|range| {
+        let start = usize::from(range.start());
+        let end = usize::from(range.end());
+        if end <= scan_start || start >= scan_end {
+            return None;
+        }
+        Some((start.max(scan_start), end.min(scan_end)))
+    }));
     relevant_excluded.sort_unstable_by_key(|&(start, end)| (start, end));
 
     unmatched_opens.clear();
@@ -833,7 +838,7 @@ fn collect_raw_literal_brace_spans(
     }
 }
 
-fn collect_raw_literal_brace_spans_without_exclusions(
+pub(crate) fn collect_raw_literal_brace_spans_without_exclusions(
     scan: RawLiteralBraceScan<'_>,
     scan_start: usize,
     scan_end: usize,
@@ -956,7 +961,7 @@ fn collect_raw_literal_brace_spans_without_exclusions(
     }
 }
 
-fn brace_at_command_start(text: &str, index: usize, ch: char) -> bool {
+pub(crate) fn brace_at_command_start(text: &str, index: usize, ch: char) -> bool {
     match ch {
         '{' => opening_brace_starts_shell_group(text, index),
         '}' => closing_brace_ends_shell_group(text, index),
@@ -964,7 +969,7 @@ fn brace_at_command_start(text: &str, index: usize, ch: char) -> bool {
     }
 }
 
-fn literal_brace_syntax_looks_like_active_expansion(
+pub(crate) fn literal_brace_syntax_looks_like_active_expansion(
     brace: shuck_ast::BraceSyntax,
     source: &str,
 ) -> bool {
@@ -976,7 +981,7 @@ fn literal_brace_syntax_looks_like_active_expansion(
     brace_text_has_unescaped_comma_or_sequence(text) && !text.chars().any(char::is_whitespace)
 }
 
-fn brace_text_has_unescaped_comma_or_sequence(text: &str) -> bool {
+pub(crate) fn brace_text_has_unescaped_comma_or_sequence(text: &str) -> bool {
     let Some(inner) = text
         .strip_prefix('{')
         .and_then(|rest| rest.strip_suffix('}'))
@@ -1006,7 +1011,7 @@ fn brace_text_has_unescaped_comma_or_sequence(text: &str) -> bool {
     false
 }
 
-fn opening_brace_starts_shell_group(text: &str, index: usize) -> bool {
+pub(crate) fn opening_brace_starts_shell_group(text: &str, index: usize) -> bool {
     let Some(next) = text[index + '{'.len_utf8()..].chars().next() else {
         return false;
     };
@@ -1030,7 +1035,7 @@ fn opening_brace_starts_shell_group(text: &str, index: usize) -> bool {
     }
 }
 
-fn closing_brace_ends_shell_group(text: &str, index: usize) -> bool {
+pub(crate) fn closing_brace_ends_shell_group(text: &str, index: usize) -> bool {
     let prefix = text[..index].trim_end_matches([' ', '\t']);
     let Some(last) = prefix.chars().next_back() else {
         return true;
@@ -1043,7 +1048,7 @@ fn closing_brace_ends_shell_group(text: &str, index: usize) -> bool {
     }
 }
 
-fn collect_unmatched_command_substitution_brace_spans(
+pub(crate) fn collect_unmatched_command_substitution_brace_spans(
     commands: CommandFacts<'_, '_>,
     locator: Locator<'_>,
     heredoc_ranges: &[TextRange],
@@ -1078,7 +1083,10 @@ fn collect_unmatched_command_substitution_brace_spans(
     }
 }
 
-fn command_substitution_body_offsets(span: Span, source: &str) -> Option<(Span, usize, usize)> {
+pub(crate) fn command_substitution_body_offsets(
+    span: Span,
+    source: &str,
+) -> Option<(Span, usize, usize)> {
     let text = span.slice(source);
     if text.starts_with("$(") && text.ends_with(')') && text.len() >= 3 {
         return Some((
@@ -1098,7 +1106,7 @@ fn command_substitution_body_offsets(span: Span, source: &str) -> Option<(Span, 
 }
 
 #[derive(Debug, Clone, Copy)]
-struct LiteralBraceCandidate {
+pub(crate) struct LiteralBraceCandidate {
     open_offset: usize,
     after_escaped_dollar: bool,
     has_excluded_content_inside: bool,
@@ -1107,25 +1115,25 @@ struct LiteralBraceCandidate {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum DynamicBraceExcludedSpanKind {
+pub(crate) enum DynamicBraceExcludedSpanKind {
     Quoted,
     RuntimeShellSyntax,
 }
 
 #[derive(Debug, Clone, Copy)]
-struct DynamicBraceExcludedSpan {
+pub(crate) struct DynamicBraceExcludedSpan {
     start_offset: usize,
     end_offset: usize,
     kind: DynamicBraceExcludedSpanKind,
 }
 
-struct EscapedParameterBraceEdgeScratch<'a> {
+pub(crate) struct EscapedParameterBraceEdgeScratch<'a> {
     literal_stack: &'a mut Vec<LiteralBraceCandidate>,
     raw_escaped_exclusions: &'a mut Vec<DynamicBraceExcludedSpan>,
     escaped_parameter_stack: &'a mut Vec<usize>,
 }
 
-fn collect_escaped_parameter_expansion_brace_edge_spans(
+pub(crate) fn collect_escaped_parameter_expansion_brace_edge_spans(
     word: &Word,
     source: &str,
     excluded: &[DynamicBraceExcludedSpan],
@@ -1275,7 +1283,7 @@ fn collect_escaped_parameter_expansion_brace_edge_spans(
     );
 }
 
-fn excluded_runtime_syntax_has_escaped_dollar_prefix(
+pub(crate) fn excluded_runtime_syntax_has_escaped_dollar_prefix(
     text: &str,
     start_offset: usize,
     end_offset: usize,
@@ -1296,7 +1304,7 @@ fn excluded_runtime_syntax_has_escaped_dollar_prefix(
     false
 }
 
-fn has_odd_backslash_run_before(text: &str, offset: usize) -> bool {
+pub(crate) fn has_odd_backslash_run_before(text: &str, offset: usize) -> bool {
     let offset = offset.min(text.len());
     text[..offset]
         .chars()
@@ -1307,7 +1315,7 @@ fn has_odd_backslash_run_before(text: &str, offset: usize) -> bool {
         == 1
 }
 
-fn has_escaped_dollar_before(text: &str, offset: usize) -> bool {
+pub(crate) fn has_escaped_dollar_before(text: &str, offset: usize) -> bool {
     let offset = offset.min(text.len());
     let prefix = &text[..offset];
     let Some((dollar_offset, '$')) = prefix.char_indices().next_back() else {
@@ -1317,7 +1325,7 @@ fn has_escaped_dollar_before(text: &str, offset: usize) -> bool {
     has_odd_backslash_run_before(text, dollar_offset)
 }
 
-fn collect_dynamic_brace_exclusions(
+pub(crate) fn collect_dynamic_brace_exclusions(
     parts: &[WordPartNode],
     word_base_offset: usize,
     source: &str,
@@ -1374,7 +1382,7 @@ fn collect_dynamic_brace_exclusions(
     }
 }
 
-fn runtime_shell_dynamic_brace_exclusion(
+pub(crate) fn runtime_shell_dynamic_brace_exclusion(
     part: &WordPartNode,
     word_base_offset: usize,
     region_index: &RegionIndex,
@@ -1398,7 +1406,10 @@ fn runtime_shell_dynamic_brace_exclusion(
     }
 }
 
-fn find_runtime_parameter_closing_brace(text: &str, start_offset: usize) -> Option<usize> {
+pub(crate) fn find_runtime_parameter_closing_brace(
+    text: &str,
+    start_offset: usize,
+) -> Option<usize> {
     if start_offset >= text.len() || !text[start_offset..].starts_with("${") {
         return None;
     }
@@ -1455,7 +1466,7 @@ fn find_runtime_parameter_closing_brace(text: &str, start_offset: usize) -> Opti
     None
 }
 
-fn collect_raw_escaped_parameter_brace_edge_spans(
+pub(crate) fn collect_raw_escaped_parameter_brace_edge_spans(
     word: &Word,
     source: &str,
     excluded: &mut Vec<DynamicBraceExcludedSpan>,
@@ -1545,7 +1556,7 @@ fn collect_raw_escaped_parameter_brace_edge_spans(
     }
 }
 
-fn brace_pair_matches_nonliteral_syntax(
+pub(crate) fn brace_pair_matches_nonliteral_syntax(
     word: &Word,
     open_offset: usize,
     close_offset: usize,
@@ -1560,7 +1571,7 @@ fn brace_pair_matches_nonliteral_syntax(
     })
 }
 
-fn collect_raw_escaped_parameter_exclusions(
+pub(crate) fn collect_raw_escaped_parameter_exclusions(
     parts: &[WordPartNode],
     word_base_offset: usize,
     source: &str,
@@ -1602,7 +1613,7 @@ fn collect_raw_escaped_parameter_exclusions(
     }
 }
 
-fn is_inline_shellcheck_directive(comment_text: &str) -> bool {
+pub(crate) fn is_inline_shellcheck_directive(comment_text: &str) -> bool {
     let body = comment_text
         .trim_start()
         .trim_start_matches('#')
@@ -1641,12 +1652,14 @@ fn is_inline_shellcheck_directive(comment_text: &str) -> bool {
     let Some(remainder) = strip_prefix_ignore_ascii_case(body, "shuck:") else {
         return false;
     };
-    let body = remainder.split_once('#').map_or(remainder, |(before, _)| before);
+    let body = remainder
+        .split_once('#')
+        .map_or(remainder, |(before, _)| before);
     strip_prefix_ignore_ascii_case(body.trim(), "disable=")
         .is_some_and(|value| !value.trim().is_empty())
 }
 
-fn strip_prefix_ignore_ascii_case<'a>(text: &'a str, prefix: &str) -> Option<&'a str> {
+pub(crate) fn strip_prefix_ignore_ascii_case<'a>(text: &'a str, prefix: &str) -> Option<&'a str> {
     let candidate = text.get(..prefix.len())?;
     candidate
         .eq_ignore_ascii_case(prefix)

--- a/crates/shuck-linter/src/facts/builder.rs
+++ b/crates/shuck-linter/src/facts/builder.rs
@@ -1,4 +1,6 @@
-struct LinterFactsBuilder<'a, 'analysis> {
+use super::*;
+
+pub(crate) struct LinterFactsBuilder<'a, 'analysis> {
     file: &'a File,
     source: &'a str,
     semantic_artifacts: &'a LinterSemanticArtifacts<'a>,
@@ -11,33 +13,33 @@ struct LinterFactsBuilder<'a, 'analysis> {
 }
 
 #[derive(Debug, Default)]
-struct FactBuildCapacity {
+pub(crate) struct FactBuildCapacity {
     commands: usize,
     functions: usize,
 }
 
 #[derive(Debug, Default)]
-struct ArithmeticFactSummary {
-    array_index_arithmetic_spans: Vec<Span>,
-    arithmetic_score_line_spans: Vec<Span>,
-    dollar_in_arithmetic_spans: Vec<Span>,
-    arithmetic_command_substitution_spans: Vec<Span>,
-    arithmetic_only_suppressed_subscript_spans: Vec<Span>,
+pub(crate) struct ArithmeticFactSummary {
+    pub(crate) array_index_arithmetic_spans: Vec<Span>,
+    pub(crate) arithmetic_score_line_spans: Vec<Span>,
+    pub(crate) dollar_in_arithmetic_spans: Vec<Span>,
+    pub(crate) arithmetic_command_substitution_spans: Vec<Span>,
+    pub(crate) arithmetic_only_suppressed_subscript_spans: Vec<Span>,
 }
 
 #[derive(Debug, Default)]
-struct HeredocFactSummary {
-    unused_heredoc_spans: Vec<Span>,
-    heredoc_missing_end_spans: Vec<Span>,
-    heredoc_closer_not_alone_spans: Vec<Span>,
-    misquoted_heredoc_close_spans: Vec<Span>,
-    heredoc_end_space_spans: Vec<Span>,
-    echo_here_doc_spans: Vec<Span>,
-    spaced_tabstrip_close_spans: Vec<Span>,
+pub(crate) struct HeredocFactSummary {
+    pub(crate) unused_heredoc_spans: Vec<Span>,
+    pub(crate) heredoc_missing_end_spans: Vec<Span>,
+    pub(crate) heredoc_closer_not_alone_spans: Vec<Span>,
+    pub(crate) misquoted_heredoc_close_spans: Vec<Span>,
+    pub(crate) heredoc_end_space_spans: Vec<Span>,
+    pub(crate) echo_here_doc_spans: Vec<Span>,
+    pub(crate) spaced_tabstrip_close_spans: Vec<Span>,
 }
 
 #[cfg_attr(shuck_profiling, inline(never))]
-fn estimate_fact_build_capacity(semantic: &SemanticModel) -> FactBuildCapacity {
+pub(crate) fn estimate_fact_build_capacity(semantic: &SemanticModel) -> FactBuildCapacity {
     let commands = semantic.command_count();
     FactBuildCapacity {
         commands,
@@ -46,7 +48,7 @@ fn estimate_fact_build_capacity(semantic: &SemanticModel) -> FactBuildCapacity {
 }
 
 impl<'a, 'analysis> LinterFactsBuilder<'a, 'analysis> {
-    fn new(
+    pub(crate) fn new(
         file: &'a File,
         source: &'a str,
         semantic: &'a LinterSemanticArtifacts<'a>,
@@ -68,7 +70,7 @@ impl<'a, 'analysis> LinterFactsBuilder<'a, 'analysis> {
         }
     }
 
-    fn build(self) -> LinterFacts<'a> {
+    pub(crate) fn build(self) -> LinterFacts<'a> {
         let source = self.source;
         let line_index = self._indexer.line_index();
         let locator = crate::Locator::new(source, line_index);
@@ -77,8 +79,7 @@ impl<'a, 'analysis> LinterFactsBuilder<'a, 'analysis> {
         let estimated_word_nodes = capacity.commands.saturating_mul(2);
         let estimated_word_occurrences = capacity.commands.saturating_mul(3);
 
-        let mut commands: Vec<CommandFact<'_>> =
-            Vec::with_capacity(self.semantic.command_count());
+        let mut commands: Vec<CommandFact<'_>> = Vec::with_capacity(self.semantic.command_count());
         let mut substitution_occurrences_by_command_id: Vec<Vec<HostedSubstitutionOccurrence<'_>>> =
             (0..self.semantic.command_count())
                 .map(|_| Vec::new())
@@ -95,10 +96,8 @@ impl<'a, 'analysis> LinterFactsBuilder<'a, 'analysis> {
             DenseCommandIdSet::with_capacity(self.semantic.command_count());
         let mut elif_condition_command_ids =
             DenseCommandIdSet::with_capacity(self.semantic.command_count());
-        let mut binding_values = FxHashMap::with_capacity_and_hasher(
-            self.semantic.bindings().len(),
-            Default::default(),
-        );
+        let mut binding_values =
+            FxHashMap::with_capacity_and_hasher(self.semantic.bindings().len(), Default::default());
         let mut broken_assoc_key_spans = Vec::new();
         let mut comma_array_assignment_spans = Vec::new();
         let mut ifs_literal_backslash_assignment_value_spans = Vec::new();
@@ -153,330 +152,318 @@ impl<'a, 'analysis> LinterFactsBuilder<'a, 'analysis> {
             else {
                 continue;
             };
-                let key = FactSpan::new(command_span(visit.command));
-                debug_assert_eq!(context.syntax_span(), command_span(visit.command));
-                debug_assert_eq!(
-                    context.kind(),
-                    shuck_semantic::CommandKind::from_command(visit.command)
-                );
-                let lookup_kind = command_lookup_kind(visit.command);
-                let entries = command_ids_by_span.entry(key).or_default();
-                // Recovery on malformed nested word commands can surface the same
-                // syntax-backed command more than once. Keep the first lookup target
-                // so stmt-to-fact resolution stays deterministic.
-                if !entries.iter().any(|entry| entry.kind == lookup_kind) {
-                    entries.push(CommandLookupEntry {
-                        kind: lookup_kind,
-                        id,
-                    });
-                }
-
-                if context.is_in_if_condition() {
-                    if_condition_command_ids.insert(id);
-                }
-                if context.is_in_elif_condition() {
-                    elif_condition_command_ids.insert(id);
-                }
-                collect_binding_values(
-                    visit.command,
-                    self.semantic,
-                    self.source,
-                    &mut binding_values,
-                );
-                collect_broken_assoc_key_spans(
-                    visit.command,
-                    self.source,
-                    &mut broken_assoc_key_spans,
-                );
-                collect_command_substitution_command_span(
-                    visit.command,
-                    self.source,
-                    &mut command_substitution_command_spans,
-                );
-                collect_comma_array_assignment_spans(
-                    visit.command,
-                    self.source,
-                    self.shell,
-                    self.semantic,
-                    &mut comma_array_assignment_spans,
-                );
-                collect_ifs_literal_backslash_assignment_value_spans(
-                    visit.command,
-                    self.source,
-                    &mut ifs_literal_backslash_assignment_value_spans,
-                );
-                let normalized = command::normalize_command(visit.command, self.source);
-                let command_start_offset = command_span(visit.command).start.offset;
-                let scope = context.scope();
-                let command_shell_behavior = effective_command_shell_behavior(
-                    self.semantic,
-                    command_start_offset,
-                    &normalized,
-                );
-                if let Some(name_word) = normalized.body_name_word() {
-                    command_ids_by_name_word_span
-                        .entry(FactSpan::new(name_word.span))
-                        .or_insert(id);
-                }
-                let nested_word_command = context.is_nested_word_command();
-                build_word_facts_for_command(
-                    visit,
-                    self.source,
-                    locator,
-                    self.semantic,
-                    WordFactCommandContext {
-                        command_id: id,
-                        nested_word_command,
-                        scope,
-                    },
-                    &normalized,
-                    command_shell_behavior.clone(),
-                    WordFactOutputs {
-                        command_visits_by_id: self.command_visits_by_id,
-                        word_nodes: &mut word_nodes,
-                        word_spans: &mut word_spans,
-                        word_span_scratch: &mut word_span_scratch,
-                        word_node_ids_by_span: &mut word_node_ids_by_span,
-                        word_occurrences: &mut word_occurrences,
-                        pending_arithmetic_word_occurrences:
-                            &mut pending_arithmetic_word_occurrences,
-                        pending_parameter_operand_word_occurrences:
-                            &mut pending_parameter_operand_word_occurrences,
-                        compound_assignment_value_word_spans:
-                            &mut compound_assignment_value_word_spans,
-                        array_assignment_split_word_ids: &mut array_assignment_split_word_ids,
-                        seen_word_occurrences: &mut seen_word_occurrences,
-                        seen_pending_arithmetic_word_occurrences:
-                            &mut seen_pending_arithmetic_word_occurrences,
-                        seen_pending_parameter_operand_word_occurrences:
-                            &mut seen_pending_parameter_operand_word_occurrences,
-                        assoc_binding_visibility_memo: &mut assoc_binding_visibility_memo,
-                        semantic_analysis: self.semantic_analysis,
-                        case_pattern_expansions: &mut case_pattern_expansions,
-                        pattern_literal_spans: &mut pattern_literal_spans,
-                        arithmetic: &mut arithmetic_summary,
-                        surface: &mut surface_fragments,
-                    },
-                );
-                collect_zsh_option_map_arithmetic_suppressed_subscripts(
-                    visit.command,
-                    self.semantic,
-                    scope,
-                    self.source,
-                    &mut arithmetic_summary.arithmetic_only_suppressed_subscript_spans,
-                );
-                collect_base_prefix_spans_in_command_parts(
-                    visit.command,
-                    self.source,
-                    &mut arithmetic_literal_spans,
-                );
-                collect_arithmetic_update_operator_spans_in_command(
-                    visit.command,
-                    self.semantic,
-                    self.semantic_artifacts,
-                    scope,
-                    self.source,
-                    &mut arithmetic_update_operator_spans,
-                );
-                for redirect in visit.redirects {
-                    if let Some(word) = redirect.word_target() {
-                        collect_base_prefix_spans_in_word(
-                            word,
-                            self.source,
-                            &mut arithmetic_literal_spans,
-                        );
-                        collect_arithmetic_update_operator_spans_in_word(
-                            word,
-                            self.semantic,
-                            self.source,
-                            &mut arithmetic_update_operator_spans,
-                        );
-                    } else if let Some(heredoc) = redirect.heredoc()
-                        && heredoc.delimiter.expands_body
-                    {
-                        collect_arithmetic_update_operator_spans_in_heredoc_body(
-                            &heredoc.body.parts,
-                            self.semantic,
-                            self.semantic_artifacts,
-                            self.source,
-                            &mut arithmetic_update_operator_spans,
-                        );
-                    }
-                }
-                let redirect_facts = build_redirect_facts(
-                    visit.redirects,
-                    Some(self.semantic_artifacts),
-                    locator,
-                    &command_shell_behavior,
-                );
-                let redirect_fact_range = redirect_fact_store.push_many(redirect_facts);
-                let options = CommandOptionFacts::build(
-                    visit.command,
-                    &normalized,
-                    self.semantic_artifacts,
-                    self.source,
-                    &command_shell_behavior,
-                )
-                .into_sparse();
-                let declaration_assignment_probes = build_declaration_assignment_probes(
-                    visit.command,
-                    &normalized,
-                    self.semantic,
-                    self.source,
-                    &command_shell_behavior,
-                );
-                let declaration_assignment_probe_range =
-                    declaration_assignment_probe_store.push_many(declaration_assignment_probes);
-                let glued_closing_bracket_operand_span =
-                    build_glued_closing_bracket_operand_span(visit.command, self.source);
-                let glued_closing_bracket_insert_offset =
-                    build_glued_closing_bracket_insert_offset(visit.command, self.source);
-                let simple_test = build_simple_test_fact(visit.command, self.source);
-                let conditional_expression_visits = self
-                    .semantic_artifacts
-                    .conditional_expression_visits(command_span(visit.command));
-                let conditional =
-                    build_conditional_fact(conditional_expression_visits, self.source);
-                let enclosing_function_scope = self.semantic.enclosing_function_scope(scope);
-                let command_fact = CommandFact {
+            let key = FactSpan::new(command_span(visit.command));
+            debug_assert_eq!(context.syntax_span(), command_span(visit.command));
+            debug_assert_eq!(
+                context.kind(),
+                shuck_semantic::CommandKind::from_command(visit.command)
+            );
+            let lookup_kind = command_lookup_kind(visit.command);
+            let entries = command_ids_by_span.entry(key).or_default();
+            // Recovery on malformed nested word commands can surface the same
+            // syntax-backed command more than once. Keep the first lookup target
+            // so stmt-to-fact resolution stays deterministic.
+            if !entries.iter().any(|entry| entry.kind == lookup_kind) {
+                entries.push(CommandLookupEntry {
+                    kind: lookup_kind,
                     id,
-                    key,
-                    visit,
+                });
+            }
+
+            if context.is_in_if_condition() {
+                if_condition_command_ids.insert(id);
+            }
+            if context.is_in_elif_condition() {
+                elif_condition_command_ids.insert(id);
+            }
+            collect_binding_values(
+                visit.command,
+                self.semantic,
+                self.source,
+                &mut binding_values,
+            );
+            collect_broken_assoc_key_spans(visit.command, self.source, &mut broken_assoc_key_spans);
+            collect_command_substitution_command_span(
+                visit.command,
+                self.source,
+                &mut command_substitution_command_spans,
+            );
+            collect_comma_array_assignment_spans(
+                visit.command,
+                self.source,
+                self.shell,
+                self.semantic,
+                &mut comma_array_assignment_spans,
+            );
+            collect_ifs_literal_backslash_assignment_value_spans(
+                visit.command,
+                self.source,
+                &mut ifs_literal_backslash_assignment_value_spans,
+            );
+            let normalized = command::normalize_command(visit.command, self.source);
+            let command_start_offset = command_span(visit.command).start.offset;
+            let scope = context.scope();
+            let command_shell_behavior =
+                effective_command_shell_behavior(self.semantic, command_start_offset, &normalized);
+            if let Some(name_word) = normalized.body_name_word() {
+                command_ids_by_name_word_span
+                    .entry(FactSpan::new(name_word.span))
+                    .or_insert(id);
+            }
+            let nested_word_command = context.is_nested_word_command();
+            build_word_facts_for_command(
+                visit,
+                self.source,
+                locator,
+                self.semantic,
+                WordFactCommandContext {
+                    command_id: id,
                     nested_word_command,
                     scope,
-                    enclosing_function_scope,
-                    normalized,
-                    shell_behavior: command_shell_behavior,
-                    redirect_facts: redirect_fact_range,
-                    substitution_facts: IdRange::empty(),
-                    options,
-                    scope_read_source_words: IdRange::empty(),
-                    scope_name_read_uses: IdRange::empty(),
-                    scope_heredoc_name_read_uses: IdRange::empty(),
-                    scope_name_write_uses: IdRange::empty(),
-                    declaration_assignment_probes: declaration_assignment_probe_range,
-                    glued_closing_bracket_operand_span,
-                    glued_closing_bracket_insert_offset,
-                    linebreak_in_test_anchor_span: None,
-                    linebreak_in_test_insert_offset: None,
-                    simple_test,
-                    conditional,
-                };
-                collect_substitution_occurrences_for_command(
-                    visit.command,
-                    visit.redirects,
-                    self.source,
-                    &mut substitution_occurrences_by_command_id[id.index()],
-                );
-                commands.push(command_fact);
-
-                if let Command::Function(function) = visit.command {
-                    functions.push(FunctionFactInput {
-                        command_id: id,
-                        function,
-                    });
-                    if let Some(span) = function_body_without_braces_span(function) {
-                        function_body_without_braces_spans.push(span);
-                    }
+                },
+                &normalized,
+                command_shell_behavior.clone(),
+                WordFactOutputs {
+                    command_visits_by_id: self.command_visits_by_id,
+                    word_nodes: &mut word_nodes,
+                    word_spans: &mut word_spans,
+                    word_span_scratch: &mut word_span_scratch,
+                    word_node_ids_by_span: &mut word_node_ids_by_span,
+                    word_occurrences: &mut word_occurrences,
+                    pending_arithmetic_word_occurrences: &mut pending_arithmetic_word_occurrences,
+                    pending_parameter_operand_word_occurrences:
+                        &mut pending_parameter_operand_word_occurrences,
+                    compound_assignment_value_word_spans: &mut compound_assignment_value_word_spans,
+                    array_assignment_split_word_ids: &mut array_assignment_split_word_ids,
+                    seen_word_occurrences: &mut seen_word_occurrences,
+                    seen_pending_arithmetic_word_occurrences:
+                        &mut seen_pending_arithmetic_word_occurrences,
+                    seen_pending_parameter_operand_word_occurrences:
+                        &mut seen_pending_parameter_operand_word_occurrences,
+                    assoc_binding_visibility_memo: &mut assoc_binding_visibility_memo,
+                    semantic_analysis: self.semantic_analysis,
+                    case_pattern_expansions: &mut case_pattern_expansions,
+                    pattern_literal_spans: &mut pattern_literal_spans,
+                    arithmetic: &mut arithmetic_summary,
+                    surface: &mut surface_fragments,
+                },
+            );
+            collect_zsh_option_map_arithmetic_suppressed_subscripts(
+                visit.command,
+                self.semantic,
+                scope,
+                self.source,
+                &mut arithmetic_summary.arithmetic_only_suppressed_subscript_spans,
+            );
+            collect_base_prefix_spans_in_command_parts(
+                visit.command,
+                self.source,
+                &mut arithmetic_literal_spans,
+            );
+            collect_arithmetic_update_operator_spans_in_command(
+                visit.command,
+                self.semantic,
+                self.semantic_artifacts,
+                scope,
+                self.source,
+                &mut arithmetic_update_operator_spans,
+            );
+            for redirect in visit.redirects {
+                if let Some(word) = redirect.word_target() {
+                    collect_base_prefix_spans_in_word(
+                        word,
+                        self.source,
+                        &mut arithmetic_literal_spans,
+                    );
+                    collect_arithmetic_update_operator_spans_in_word(
+                        word,
+                        self.semantic,
+                        self.source,
+                        &mut arithmetic_update_operator_spans,
+                    );
+                } else if let Some(heredoc) = redirect.heredoc()
+                    && heredoc.delimiter.expands_body
+                {
+                    collect_arithmetic_update_operator_spans_in_heredoc_body(
+                        &heredoc.body.parts,
+                        self.semantic,
+                        self.semantic_artifacts,
+                        self.source,
+                        &mut arithmetic_update_operator_spans,
+                    );
                 }
+            }
+            let redirect_facts = build_redirect_facts(
+                visit.redirects,
+                Some(self.semantic_artifacts),
+                locator,
+                &command_shell_behavior,
+            );
+            let redirect_fact_range = redirect_fact_store.push_many(redirect_facts);
+            let options = CommandOptionFacts::build(
+                visit.command,
+                &normalized,
+                self.semantic_artifacts,
+                self.source,
+                &command_shell_behavior,
+            )
+            .into_sparse();
+            let declaration_assignment_probes = build_declaration_assignment_probes(
+                visit.command,
+                &normalized,
+                self.semantic,
+                self.source,
+                &command_shell_behavior,
+            );
+            let declaration_assignment_probe_range =
+                declaration_assignment_probe_store.push_many(declaration_assignment_probes);
+            let glued_closing_bracket_operand_span =
+                build_glued_closing_bracket_operand_span(visit.command, self.source);
+            let glued_closing_bracket_insert_offset =
+                build_glued_closing_bracket_insert_offset(visit.command, self.source);
+            let simple_test = build_simple_test_fact(visit.command, self.source);
+            let conditional_expression_visits = self
+                .semantic_artifacts
+                .conditional_expression_visits(command_span(visit.command));
+            let conditional = build_conditional_fact(conditional_expression_visits, self.source);
+            let enclosing_function_scope = self.semantic.enclosing_function_scope(scope);
+            let command_fact = CommandFact {
+                id,
+                key,
+                visit,
+                nested_word_command,
+                scope,
+                enclosing_function_scope,
+                normalized,
+                shell_behavior: command_shell_behavior,
+                redirect_facts: redirect_fact_range,
+                substitution_facts: IdRange::empty(),
+                options,
+                scope_read_source_words: IdRange::empty(),
+                scope_name_read_uses: IdRange::empty(),
+                scope_heredoc_name_read_uses: IdRange::empty(),
+                scope_name_write_uses: IdRange::empty(),
+                declaration_assignment_probes: declaration_assignment_probe_range,
+                glued_closing_bracket_operand_span,
+                glued_closing_bracket_insert_offset,
+                linebreak_in_test_anchor_span: None,
+                linebreak_in_test_insert_offset: None,
+                simple_test,
+                conditional,
+            };
+            collect_substitution_occurrences_for_command(
+                visit.command,
+                visit.redirects,
+                self.source,
+                &mut substitution_occurrences_by_command_id[id.index()],
+            );
+            commands.push(command_fact);
 
-                if !nested_word_command {
-                    collect_condition_status_capture_from_direct_body_sequences(
-                        visit.command,
-                        self.source,
-                        &mut condition_status_capture_spans,
-                    );
-                    collect_precise_function_return_guard_suppressions_from_direct_body_sequences(
-                        visit.command,
-                        self.source,
-                        &mut precise_function_guard_suppressions,
-                        context.flow().in_function,
-                    );
-                    match visit.command {
-                        Command::Compound(CompoundCommand::If(command)) => {
-                            collect_condition_status_capture_from_body(
-                                &command.condition,
-                                &command.then_branch,
-                                self.source,
-                                &mut condition_status_capture_spans,
-                            );
+            if let Command::Function(function) = visit.command {
+                functions.push(FunctionFactInput {
+                    command_id: id,
+                    function,
+                });
+                if let Some(span) = function_body_without_braces_span(function) {
+                    function_body_without_braces_spans.push(span);
+                }
+            }
 
-                            let mut previous_condition = &command.condition;
-                            for (index, (condition, branch)) in
-                                command.elif_branches.iter().enumerate()
+            if !nested_word_command {
+                collect_condition_status_capture_from_direct_body_sequences(
+                    visit.command,
+                    self.source,
+                    &mut condition_status_capture_spans,
+                );
+                collect_precise_function_return_guard_suppressions_from_direct_body_sequences(
+                    visit.command,
+                    self.source,
+                    &mut precise_function_guard_suppressions,
+                    context.flow().in_function,
+                );
+                match visit.command {
+                    Command::Compound(CompoundCommand::If(command)) => {
+                        collect_condition_status_capture_from_body(
+                            &command.condition,
+                            &command.then_branch,
+                            self.source,
+                            &mut condition_status_capture_spans,
+                        );
+
+                        let mut previous_condition = &command.condition;
+                        for (index, (condition, branch)) in command.elif_branches.iter().enumerate()
+                        {
+                            if index > 0
+                                || !stmt_seq_contains_nested_control_flow(
+                                    &command.then_branch,
+                                    self.semantic_artifacts.command_topology(),
+                                )
                             {
-                                if index > 0
-                                    || !stmt_seq_contains_nested_control_flow(
-                                        &command.then_branch,
-                                        self.semantic_artifacts.command_topology(),
-                                    )
-                                {
-                                    collect_condition_status_capture_from_body(
-                                        previous_condition,
-                                        condition,
-                                        self.source,
-                                        &mut condition_status_capture_spans,
-                                    );
-                                }
-                                collect_condition_status_capture_from_body(
-                                    condition,
-                                    branch,
-                                    self.source,
-                                    &mut condition_status_capture_spans,
-                                );
-                                previous_condition = condition;
-                            }
-
-                            if let Some(else_branch) = &command.else_branch {
                                 collect_condition_status_capture_from_body(
                                     previous_condition,
-                                    else_branch,
+                                    condition,
                                     self.source,
                                     &mut condition_status_capture_spans,
                                 );
                             }
-                        }
-                        Command::Compound(CompoundCommand::While(command)) => {
                             collect_condition_status_capture_from_body(
-                                &command.condition,
-                                &command.body,
+                                condition,
+                                branch,
                                 self.source,
                                 &mut condition_status_capture_spans,
                             );
-                            if let Some(case) =
-                                build_getopts_case_fact_for_while(command, self.source)
-                            {
-                                getopts_cases.push(case);
-                            }
+                            previous_condition = condition;
                         }
-                        Command::Compound(CompoundCommand::Until(command)) => {
+
+                        if let Some(else_branch) = &command.else_branch {
                             collect_condition_status_capture_from_body(
-                                &command.condition,
-                                &command.body,
+                                previous_condition,
+                                else_branch,
                                 self.source,
                                 &mut condition_status_capture_spans,
                             );
                         }
-                        Command::Binary(command)
-                            if matches!(command.op, BinaryOp::And | BinaryOp::Or) =>
-                        {
-                            if stmt_terminals_are_test_commands(&command.left, self.source) {
-                                collect_status_parameter_spans_in_stmt(
-                                    &command.right,
-                                    self.source,
-                                    &mut condition_status_capture_spans,
-                                );
-                            }
-                        }
-                        Command::Simple(_)
-                        | Command::Builtin(_)
-                        | Command::Decl(_)
-                        | Command::Binary(_)
-                        | Command::Compound(_)
-                        | Command::Function(_)
-                        | Command::AnonymousFunction(_) => {}
                     }
+                    Command::Compound(CompoundCommand::While(command)) => {
+                        collect_condition_status_capture_from_body(
+                            &command.condition,
+                            &command.body,
+                            self.source,
+                            &mut condition_status_capture_spans,
+                        );
+                        if let Some(case) = build_getopts_case_fact_for_while(command, self.source)
+                        {
+                            getopts_cases.push(case);
+                        }
+                    }
+                    Command::Compound(CompoundCommand::Until(command)) => {
+                        collect_condition_status_capture_from_body(
+                            &command.condition,
+                            &command.body,
+                            self.source,
+                            &mut condition_status_capture_spans,
+                        );
+                    }
+                    Command::Binary(command)
+                        if matches!(command.op, BinaryOp::And | BinaryOp::Or) =>
+                    {
+                        if stmt_terminals_are_test_commands(&command.left, self.source) {
+                            collect_status_parameter_spans_in_stmt(
+                                &command.right,
+                                self.source,
+                                &mut condition_status_capture_spans,
+                            );
+                        }
+                    }
+                    Command::Simple(_)
+                    | Command::Builtin(_)
+                    | Command::Decl(_)
+                    | Command::Binary(_)
+                    | Command::Compound(_)
+                    | Command::Function(_)
+                    | Command::AnonymousFunction(_) => {}
                 }
+            }
         }
 
         arithmetic_update_operator_spans
@@ -491,9 +478,8 @@ impl<'a, 'analysis> LinterFactsBuilder<'a, 'analysis> {
             } else {
                 Vec::new()
             };
-        arithmetic_literal_spans.sort_unstable_by_key(|(span, kind)| {
-            (span.start.offset, span.end.offset, *kind)
-        });
+        arithmetic_literal_spans
+            .sort_unstable_by_key(|(span, kind)| (span.start.offset, span.end.offset, *kind));
         arithmetic_literal_spans.dedup();
         let arithmetic_literal_facts = arithmetic_literal_spans
             .iter()
@@ -543,11 +529,8 @@ impl<'a, 'analysis> LinterFactsBuilder<'a, 'analysis> {
             &substitution_occurrences_by_command_id,
         );
 
-        let presence_tested_names = build_presence_tested_names(
-            &commands,
-            self.source,
-            self.semantic,
-        );
+        let presence_tested_names =
+            build_presence_tested_names(&commands, self.source, self.semantic);
         let function_headers = build_function_header_facts(
             self.semantic,
             semantic_analysis,
@@ -560,7 +543,11 @@ impl<'a, 'analysis> LinterFactsBuilder<'a, 'analysis> {
         let function_cli_dispatch_facts = build_function_cli_dispatch_facts(&case_cli_dispatches);
         let function_definition_command_ids_by_scope = function_headers
             .iter()
-            .filter_map(|header| header.function_scope().map(|scope| (scope, header.command_id())))
+            .filter_map(|header| {
+                header
+                    .function_scope()
+                    .map(|scope| (scope, header.command_id()))
+            })
             .collect::<FxHashMap<_, _>>();
         let case_cli_reachable_function_scopes = semantic_analysis
             .case_cli_reachable_function_scopes(self.file, &case_cli_dispatches)
@@ -735,7 +722,10 @@ impl<'a, 'analysis> LinterFactsBuilder<'a, 'analysis> {
                 | IndexedArrayReferenceFragmentFact::OneBasedWithZeroAlias(fragment)
                 | IndexedArrayReferenceFragmentFact::Ambiguous(fragment) => fragment.span(),
             };
-            let behavior = self.semantic.shell_behavior_at(span.start.offset).subscript_indexing();
+            let behavior = self
+                .semantic
+                .shell_behavior_at(span.start.offset)
+                .subscript_indexing();
             *fragment = (*fragment).with_subscript_index_behavior(behavior);
         }
         let nonpersistent_assignment_spans = build_nonpersistent_assignment_spans(
@@ -748,11 +738,7 @@ impl<'a, 'analysis> LinterFactsBuilder<'a, 'analysis> {
             &arithmetic_only_suppressed_subscript_spans,
         );
         let heredoc_summary =
-            build_heredoc_fact_summary(
-                &commands,
-                locator,
-                self.file.span.end.offset,
-            );
+            build_heredoc_fact_summary(&commands, locator, self.file.span.end.offset);
         let plus_equals_assignment_spans = build_plus_equals_assignment_spans(&commands);
         let literal_brace_spans = build_literal_brace_spans(
             &word_nodes,
@@ -948,159 +934,169 @@ impl<'a, 'analysis> LinterFactsBuilder<'a, 'analysis> {
         LinterFacts {
             semantic: self.semantic,
             semantic_artifacts: self.semantic_artifacts,
-            source,
-            line_index: self._indexer.line_index(),
-            shell: self.shell,
-            commands,
-            command_fact_indices_by_id,
-            structural_command_ids,
-            #[cfg(test)]
-            command_ids_by_span,
-            command_ids_by_name_word_span,
-            innermost_command_ids_by_offset,
-            innermost_command_ids_by_binding_offset,
-            assignment_value_target_index,
-            command_dominance_barrier_flags,
-            if_condition_command_ids,
-            elif_condition_command_ids,
-            binding_values,
-            broken_assoc_key_spans,
-            comma_array_assignment_spans,
-            ifs_literal_backslash_assignment_value_spans,
-            env_prefix_assignment_scope_spans,
-            env_prefix_expansion_scope_spans,
-            env_prefix_expansion_fix_facts,
-            unset_command_ids_by_target_name,
-            function_unset_command_ids_by_target_name,
-            presence_tested_names: presence_tested_names.global_names,
-            nested_presence_test_spans: presence_tested_names.nested_command_spans_by_name,
-            c006_presence_tested_names: presence_tested_names.c006_global_names,
-            c006_nested_presence_test_spans: presence_tested_names
-                .c006_nested_command_spans_by_name,
-            c006_suppressing_reference_offsets_by_name,
-            presence_test_references_by_name: presence_tested_names.references_by_name,
-            presence_test_names_by_name: presence_tested_names.names_by_name,
-            possible_variable_misspelling_use_scan: OnceLock::new(),
-            possible_variable_misspelling_index: OnceLock::new(),
-            possible_variable_misspelling_scope_compat_name_uses: OnceLock::new(),
-            plain_unindexed_array_references: OnceLock::new(),
-            redundant_echo_space_facts: OnceLock::new(),
-            suppressed_subscript_reference_spans,
-            subscript_later_suppression_reference_spans,
-            compound_assignment_value_word_flags,
-            word_nodes,
-            word_occurrences,
-            word_index,
-            fact_store,
-            unquoted_command_argument_use_offsets,
-            array_assignment_split_word_ids,
-            brace_variable_before_bracket_spans,
-            completion_registered_function_command_flags,
-            completion_registered_function_scopes,
-            external_entrypoint_function_scopes,
-            function_headers,
-            function_definition_command_ids_by_scope,
-            case_cli_reachable_function_scopes,
-            function_in_alias_spans,
-            alias_definition_expansion_spans,
-            function_body_without_braces_spans,
-            function_parameter_fallback_spans,
-            redundant_return_status_spans,
-            for_headers,
-            select_headers,
-            case_items,
-            case_pattern_shadows,
-            case_pattern_impossible_spans,
-            case_pattern_expansions,
-            getopts_cases,
-            pipelines,
-            lists,
-            statement_facts,
-            background_semicolon_spans,
-            single_test_subshell_spans,
-            subshell_test_group_spans,
-            indented_shebang_span: shebang_header_facts.indented_shebang_span,
-            indented_shebang_indent_span: shebang_header_facts.indented_shebang_indent_span,
-            space_after_hash_bang_span: shebang_header_facts.space_after_hash_bang_span,
-            space_after_hash_bang_whitespace_span: shebang_header_facts
-                .space_after_hash_bang_whitespace_span,
-            shebang_not_on_first_line_span: shebang_header_facts.shebang_not_on_first_line_span,
-            shebang_not_on_first_line_fix_span: shebang_header_facts
-                .shebang_not_on_first_line_fix_span,
-            shebang_not_on_first_line_preferred_newline: shebang_header_facts
-                .shebang_not_on_first_line_preferred_newline,
-            missing_shebang_line_span: shebang_header_facts.missing_shebang_line_span,
-            duplicate_shebang_flag_span: shebang_header_facts.duplicate_shebang_flag_span,
-            non_absolute_shebang_span: shebang_header_facts.non_absolute_shebang_span,
-            errexit_enabled_anywhere,
-            commented_continuation_comment_spans,
-            comment_double_quote_nesting_spans,
-            trailing_directive_comment_spans,
-            condition_status_capture_spans,
-            command_substitution_command_spans,
-            backtick_substitution_spans,
-            backtick_escaped_parameters,
-            backtick_escaped_parameter_reference_spans,
-            backtick_double_escaped_parameter_spans,
-            backtick_command_name_spans,
-            dollar_question_after_command_spans,
-            assignment_like_command_name_spans,
-            bare_command_name_assignment_spans,
-            subshell_assignment_sites: nonpersistent_assignment_spans.subshell_assignment_sites,
-            subshell_later_use_sites: nonpersistent_assignment_spans.subshell_later_use_sites,
-            unused_heredoc_spans: heredoc_summary.unused_heredoc_spans,
-            heredoc_missing_end_spans: heredoc_summary.heredoc_missing_end_spans,
-            heredoc_closer_not_alone_spans: heredoc_summary.heredoc_closer_not_alone_spans,
-            misquoted_heredoc_close_spans: heredoc_summary.misquoted_heredoc_close_spans,
-            heredoc_end_space_spans: heredoc_summary.heredoc_end_space_spans,
-            echo_here_doc_spans: heredoc_summary.echo_here_doc_spans,
-            spaced_tabstrip_close_spans: heredoc_summary.spaced_tabstrip_close_spans,
-            plus_equals_assignment_spans,
-            array_index_arithmetic_spans: arithmetic_summary.array_index_arithmetic_spans,
-            arithmetic_score_line_spans: arithmetic_summary.arithmetic_score_line_spans,
-            dollar_in_arithmetic_spans: arithmetic_summary.dollar_in_arithmetic_spans,
-            arithmetic_command_substitution_spans: arithmetic_summary
-                .arithmetic_command_substitution_spans,
-            function_positional_parameter_facts,
-            function_cli_dispatch_facts,
-            single_quoted_fragments: single_quoted,
-            dollar_double_quoted_fragments: dollar_double_quoted,
-            open_double_quote_fragments: open_double_quotes,
-            suspect_closing_quote_fragments: suspect_closing_quotes,
-            literal_brace_spans,
-            backtick_fragments: backticks,
-            legacy_arithmetic_fragments: legacy_arithmetic,
-            positional_parameter_fragments: positional_parameters,
-            positional_parameter_operator_spans,
-            double_paren_grouping_spans,
-            arithmetic_update_operator_spans,
-            arithmetic_update_operator_fix_facts,
-            arithmetic_literal_facts,
-            escape_scan_matches,
-            echo_backslash_escape_word_spans,
-            echo_to_sed_substitution_spans,
-            unicode_smart_quote_spans,
-            pattern_exactly_one_extglob_spans,
-            pattern_literal_spans,
-            pattern_charclass_spans,
-            nested_pattern_charclass_spans,
-            nested_parameter_expansion_fragments: nested_parameter_expansions,
-            indirect_expansion_fragments: indirect_expansions,
-            indexed_array_reference_fragments: indexed_array_references,
-            plain_unindexed_reference_spans: plain_unindexed_references,
-            parameter_pattern_special_target_fragments: parameter_pattern_special_targets,
-            zsh_parameter_index_flag_fragments: zsh_parameter_index_flags,
-            substring_expansion_fragments: substring_expansions,
-            case_modification_fragments: case_modifications,
-            replacement_expansion_fragments: replacement_expansions,
-            positional_parameter_trim_fragments: positional_parameter_trims,
-            conditional_portability,
+            command: CommandFactStore {
+                commands,
+                command_fact_indices_by_id,
+                structural_command_ids,
+                #[cfg(test)]
+                command_ids_by_span,
+                command_ids_by_name_word_span,
+                innermost_command_ids_by_offset,
+                innermost_command_ids_by_binding_offset,
+                command_dominance_barrier_flags,
+                if_condition_command_ids,
+                elif_condition_command_ids,
+                fact_store,
+                redundant_echo_space_facts: OnceLock::new(),
+                completion_registered_function_command_flags,
+                completion_registered_function_scopes,
+                external_entrypoint_function_scopes,
+                function_headers,
+                function_definition_command_ids_by_scope,
+                case_cli_reachable_function_scopes,
+                function_in_alias_spans,
+                alias_definition_expansion_spans,
+                function_body_without_braces_spans,
+                function_parameter_fallback_spans,
+                redundant_return_status_spans,
+                for_headers,
+                select_headers,
+                case_items,
+                case_pattern_shadows,
+                case_pattern_impossible_spans,
+                case_pattern_expansions,
+                getopts_cases,
+                pipelines,
+                lists,
+                statement_facts,
+                background_semicolon_spans,
+                single_test_subshell_spans,
+                subshell_test_group_spans,
+                function_positional_parameter_facts,
+                function_cli_dispatch_facts,
+                condition_status_capture_spans,
+                command_substitution_command_spans,
+                backtick_command_name_spans,
+                assignment_like_command_name_spans,
+                bare_command_name_assignment_spans,
+            },
+            words: WordFactStore {
+                plain_unindexed_array_references: OnceLock::new(),
+                suppressed_subscript_reference_spans,
+                subscript_later_suppression_reference_spans,
+                compound_assignment_value_word_flags,
+                word_nodes,
+                word_occurrences,
+                word_index,
+                unquoted_command_argument_use_offsets,
+                array_assignment_split_word_ids,
+                brace_variable_before_bracket_spans,
+                array_index_arithmetic_spans: arithmetic_summary.array_index_arithmetic_spans,
+                arithmetic_score_line_spans: arithmetic_summary.arithmetic_score_line_spans,
+                dollar_in_arithmetic_spans: arithmetic_summary.dollar_in_arithmetic_spans,
+                arithmetic_command_substitution_spans: arithmetic_summary
+                    .arithmetic_command_substitution_spans,
+                single_quoted_fragments: single_quoted,
+                dollar_double_quoted_fragments: dollar_double_quoted,
+                open_double_quote_fragments: open_double_quotes,
+                suspect_closing_quote_fragments: suspect_closing_quotes,
+                literal_brace_spans,
+                backtick_fragments: backticks,
+                legacy_arithmetic_fragments: legacy_arithmetic,
+                positional_parameter_fragments: positional_parameters,
+                positional_parameter_operator_spans,
+                double_paren_grouping_spans,
+                arithmetic_update_operator_spans,
+                arithmetic_update_operator_fix_facts,
+                arithmetic_literal_facts,
+                escape_scan_matches,
+                echo_backslash_escape_word_spans,
+                echo_to_sed_substitution_spans,
+                unicode_smart_quote_spans,
+                pattern_exactly_one_extglob_spans,
+                pattern_literal_spans,
+                pattern_charclass_spans,
+                nested_pattern_charclass_spans,
+                nested_parameter_expansion_fragments: nested_parameter_expansions,
+                indirect_expansion_fragments: indirect_expansions,
+                indexed_array_reference_fragments: indexed_array_references,
+                plain_unindexed_reference_spans: plain_unindexed_references,
+                parameter_pattern_special_target_fragments: parameter_pattern_special_targets,
+                zsh_parameter_index_flag_fragments: zsh_parameter_index_flags,
+                substring_expansion_fragments: substring_expansions,
+                case_modification_fragments: case_modifications,
+                replacement_expansion_fragments: replacement_expansions,
+                positional_parameter_trim_fragments: positional_parameter_trims,
+            },
+            assignments: AssignmentFactStore {
+                assignment_value_target_index,
+                binding_values,
+                broken_assoc_key_spans,
+                comma_array_assignment_spans,
+                ifs_literal_backslash_assignment_value_spans,
+                env_prefix_assignment_scope_spans,
+                env_prefix_expansion_scope_spans,
+                env_prefix_expansion_fix_facts,
+                unset_command_ids_by_target_name,
+                function_unset_command_ids_by_target_name,
+                presence_tested_names: presence_tested_names.global_names,
+                nested_presence_test_spans: presence_tested_names.nested_command_spans_by_name,
+                c006_presence_tested_names: presence_tested_names.c006_global_names,
+                c006_nested_presence_test_spans: presence_tested_names
+                    .c006_nested_command_spans_by_name,
+                c006_suppressing_reference_offsets_by_name,
+                presence_test_references_by_name: presence_tested_names.references_by_name,
+                presence_test_names_by_name: presence_tested_names.names_by_name,
+                possible_variable_misspelling_use_scan: OnceLock::new(),
+                possible_variable_misspelling_index: OnceLock::new(),
+                subshell_assignment_sites: nonpersistent_assignment_spans.subshell_assignment_sites,
+                subshell_later_use_sites: nonpersistent_assignment_spans.subshell_later_use_sites,
+                plus_equals_assignment_spans,
+            },
+            source_facts: SourceFactStore {
+                source,
+                line_index: self._indexer.line_index(),
+                shell: self.shell,
+                indented_shebang_span: shebang_header_facts.indented_shebang_span,
+                indented_shebang_indent_span: shebang_header_facts.indented_shebang_indent_span,
+                space_after_hash_bang_span: shebang_header_facts.space_after_hash_bang_span,
+                space_after_hash_bang_whitespace_span: shebang_header_facts
+                    .space_after_hash_bang_whitespace_span,
+                shebang_not_on_first_line_span: shebang_header_facts.shebang_not_on_first_line_span,
+                shebang_not_on_first_line_fix_span: shebang_header_facts
+                    .shebang_not_on_first_line_fix_span,
+                shebang_not_on_first_line_preferred_newline: shebang_header_facts
+                    .shebang_not_on_first_line_preferred_newline,
+                missing_shebang_line_span: shebang_header_facts.missing_shebang_line_span,
+                duplicate_shebang_flag_span: shebang_header_facts.duplicate_shebang_flag_span,
+                non_absolute_shebang_span: shebang_header_facts.non_absolute_shebang_span,
+                errexit_enabled_anywhere,
+                commented_continuation_comment_spans,
+                comment_double_quote_nesting_spans,
+                trailing_directive_comment_spans,
+                backtick_substitution_spans,
+                backtick_escaped_parameters,
+                backtick_escaped_parameter_reference_spans,
+                backtick_double_escaped_parameter_spans,
+                dollar_question_after_command_spans,
+                unused_heredoc_spans: heredoc_summary.unused_heredoc_spans,
+                heredoc_missing_end_spans: heredoc_summary.heredoc_missing_end_spans,
+                heredoc_closer_not_alone_spans: heredoc_summary.heredoc_closer_not_alone_spans,
+                misquoted_heredoc_close_spans: heredoc_summary.misquoted_heredoc_close_spans,
+                heredoc_end_space_spans: heredoc_summary.heredoc_end_space_spans,
+                echo_here_doc_spans: heredoc_summary.echo_here_doc_spans,
+                spaced_tabstrip_close_spans: heredoc_summary.spaced_tabstrip_close_spans,
+            },
+            compat: CompatFactStore {
+                possible_variable_misspelling_scope_compat_name_uses: OnceLock::new(),
+                conditional_portability,
+            },
         }
     }
 }
 
 #[cfg_attr(shuck_profiling, inline(never))]
-fn build_word_occurrence_index(
+pub(crate) fn build_word_occurrence_index(
     commands: &[CommandFact<'_>],
     word_nodes: &[WordNode<'_>],
     word_occurrences: &mut Vec<WordOccurrence>,
@@ -1124,22 +1120,20 @@ fn build_word_occurrence_index(
                 array_assignment_split_scalar_expansion_spans: IdRange::empty(),
             }),
     );
-    word_occurrences.extend(
-        pending_parameter_operand_word_occurrences
-            .into_iter()
-            .map(|pending| WordOccurrence {
-                node_id: pending.node_id,
-                command_id: pending.command_id,
-                nested_word_command: pending.nested_word_command,
-                context: WordFactContext::ParameterOperand,
-                host_kind: pending.host_kind,
-                runtime_literal: RuntimeLiteralAnalysis::default(),
-                operand_class: None,
-                enclosing_expansion_context: Some(pending.enclosing_expansion_context),
-                split_sensitive_unquoted_command_substitution_spans: IdRange::empty(),
-                array_assignment_split_scalar_expansion_spans: IdRange::empty(),
-            }),
-    );
+    word_occurrences.extend(pending_parameter_operand_word_occurrences.into_iter().map(
+        |pending| WordOccurrence {
+            node_id: pending.node_id,
+            command_id: pending.command_id,
+            nested_word_command: pending.nested_word_command,
+            context: WordFactContext::ParameterOperand,
+            host_kind: pending.host_kind,
+            runtime_literal: RuntimeLiteralAnalysis::default(),
+            operand_class: None,
+            enclosing_expansion_context: Some(pending.enclosing_expansion_context),
+            split_sensitive_unquoted_command_substitution_spans: IdRange::empty(),
+            array_assignment_split_scalar_expansion_spans: IdRange::empty(),
+        },
+    ));
 
     let mut word_index = FxHashMap::<FactSpan, SmallVec<[WordOccurrenceId; 2]>>::default();
     word_index.reserve(word_occurrences.len());
@@ -1191,7 +1185,7 @@ fn build_word_occurrence_index(
     word_index
 }
 
-fn build_c006_suppressing_reference_offsets_by_name(
+pub(crate) fn build_c006_suppressing_reference_offsets_by_name(
     semantic: &SemanticModel,
     commands: &[CommandFact<'_>],
     command_fact_indices_by_id: &[Option<usize>],
@@ -1228,62 +1222,61 @@ fn build_c006_suppressing_reference_offsets_by_name(
     offsets_by_name
 }
 
-fn c006_subscript_reference_suppresses_later_references(
+pub(crate) fn c006_subscript_reference_suppresses_later_references(
     commands: &[CommandFact<'_>],
     command_fact_indices_by_id: &[Option<usize>],
     innermost_command_ids_by_offset: &CommandOffsetLookup,
     reference: &Reference,
 ) -> bool {
-    precomputed_command_id_for_offset(
-        innermost_command_ids_by_offset,
-        reference.span.start.offset,
-    )
-    .and_then(|id| {
-        command_fact_indices_by_id
-            .get(id.index())
-            .copied()
-            .flatten()
-            .and_then(|index| commands.get(index))
-    })
-    .and_then(CommandFact::static_utility_name)
-    .is_none_or(|name| !matches!(name, "unset" | "[" | "[[" | "test"))
+    precomputed_command_id_for_offset(innermost_command_ids_by_offset, reference.span.start.offset)
+        .and_then(|id| {
+            command_fact_indices_by_id
+                .get(id.index())
+                .copied()
+                .flatten()
+                .and_then(|index| commands.get(index))
+        })
+        .and_then(CommandFact::static_utility_name)
+        .is_none_or(|name| !matches!(name, "unset" | "[" | "[[" | "test"))
 }
 
-fn stmt_seq_contains_nested_control_flow(
+pub(crate) fn stmt_seq_contains_nested_control_flow(
     body: &StmtSeq,
     command_topology: CommandTopology<'_, '_>,
 ) -> bool {
     let mut contains = false;
-    command_topology.body(body).for_each_command_visit(false, |_, visit| match visit.command {
-        Command::Compound(
-            CompoundCommand::If(_)
-            | CompoundCommand::While(_)
-            | CompoundCommand::Until(_)
-            | CompoundCommand::For(_)
-            | CompoundCommand::Select(_)
-            | CompoundCommand::Case(_)
-            | CompoundCommand::Always(_),
-        ) => {
-            contains = true;
-            CommandTopologyTraversal::Break
-        }
-        Command::Binary(_)
-        | Command::Compound(
-            CompoundCommand::BraceGroup(_)
-            | CompoundCommand::Subshell(_)
-            | CompoundCommand::Time(_),
-        ) => CommandTopologyTraversal::Descend,
-        Command::Simple(_)
-        | Command::Builtin(_)
-        | Command::Decl(_)
-        | Command::Compound(_)
-        | Command::Function(_)
-        | Command::AnonymousFunction(_) => CommandTopologyTraversal::SkipChildren,
-    });
+    command_topology
+        .body(body)
+        .for_each_command_visit(false, |_, visit| match visit.command {
+            Command::Compound(
+                CompoundCommand::If(_)
+                | CompoundCommand::While(_)
+                | CompoundCommand::Until(_)
+                | CompoundCommand::For(_)
+                | CompoundCommand::Select(_)
+                | CompoundCommand::Case(_)
+                | CompoundCommand::Always(_),
+            ) => {
+                contains = true;
+                CommandTopologyTraversal::Break
+            }
+            Command::Binary(_)
+            | Command::Compound(
+                CompoundCommand::BraceGroup(_)
+                | CompoundCommand::Subshell(_)
+                | CompoundCommand::Time(_),
+            ) => CommandTopologyTraversal::Descend,
+            Command::Simple(_)
+            | Command::Builtin(_)
+            | Command::Decl(_)
+            | Command::Compound(_)
+            | Command::Function(_)
+            | Command::AnonymousFunction(_) => CommandTopologyTraversal::SkipChildren,
+        });
     contains
 }
 
-fn populate_linebreak_in_test_facts(commands: &mut [CommandFact<'_>], source: &str) {
+pub(crate) fn populate_linebreak_in_test_facts(commands: &mut [CommandFact<'_>], source: &str) {
     for index in 0..commands.len().saturating_sub(1) {
         let (current_slice, next_slice) = commands.split_at_mut(index + 1);
         let current = &mut current_slice[index];
@@ -1299,7 +1292,7 @@ fn populate_linebreak_in_test_facts(commands: &mut [CommandFact<'_>], source: &s
     }
 }
 
-fn build_linebreak_in_test_site(
+pub(crate) fn build_linebreak_in_test_site(
     current: &CommandFact<'_>,
     next: &CommandFact<'_>,
     source: &str,
@@ -1338,7 +1331,7 @@ fn build_linebreak_in_test_site(
     Some((anchor_span, insert_offset))
 }
 
-fn linebreak_in_test_insert_offset(span: Span, source: &str) -> Option<usize> {
+pub(crate) fn linebreak_in_test_insert_offset(span: Span, source: &str) -> Option<usize> {
     let text = span.slice(source);
     if text.ends_with("\r\n") {
         Some(span.end.offset - 2)
@@ -1349,21 +1342,21 @@ fn linebreak_in_test_insert_offset(span: Span, source: &str) -> Option<usize> {
     }
 }
 
-fn text_ranges_to_spans(ranges: &[TextRange], locator: Locator<'_>) -> Vec<Span> {
+pub(crate) fn text_ranges_to_spans(ranges: &[TextRange], locator: Locator<'_>) -> Vec<Span> {
     ranges
         .iter()
         .filter_map(|range| text_range_to_span(*range, locator))
         .collect()
 }
 
-fn text_range_to_span(range: TextRange, locator: Locator<'_>) -> Option<Span> {
+pub(crate) fn text_range_to_span(range: TextRange, locator: Locator<'_>) -> Option<Span> {
     Some(Span::from_positions(
         locator.position_at_offset(usize::from(range.start()))?,
         locator.position_at_offset(usize::from(range.end()))?,
     ))
 }
 
-fn build_unset_command_ids_by_target_name(
+pub(crate) fn build_unset_command_ids_by_target_name(
     commands: &[CommandFact<'_>],
     command_fact_indices_by_id: &[Option<usize>],
     structural_command_ids: &[CommandId],
@@ -1403,7 +1396,7 @@ fn build_unset_command_ids_by_target_name(
     command_ids_by_name
 }
 
-fn build_function_unset_command_ids_by_target_name(
+pub(crate) fn build_function_unset_command_ids_by_target_name(
     commands: &[CommandFact<'_>],
     command_fact_indices_by_id: &[Option<usize>],
     structural_command_ids: &[CommandId],
@@ -1439,14 +1432,19 @@ fn build_function_unset_command_ids_by_target_name(
         }
 
         for target in targets {
-            command_ids_by_name.entry(target).or_default().push(command_id);
+            command_ids_by_name
+                .entry(target)
+                .or_default()
+                .push(command_id);
         }
     }
 
     command_ids_by_name
 }
 
-fn sort_and_dedup_case_pattern_expansions(expansions: &mut Vec<CasePatternExpansionFact>) {
+pub(crate) fn sort_and_dedup_case_pattern_expansions(
+    expansions: &mut Vec<CasePatternExpansionFact>,
+) {
     let mut seen = FxHashSet::default();
     expansions.retain(|fact| seen.insert(FactSpan::new(fact.span())));
     expansions.sort_by_key(|fact| (fact.span().start.offset, fact.span().end.offset));

--- a/crates/shuck-linter/src/facts/case_patterns.rs
+++ b/crates/shuck-linter/src/facts/case_patterns.rs
@@ -1,3 +1,5 @@
+use super::*;
+
 #[derive(Debug, Clone, Copy)]
 pub struct CaseItemFact<'a> {
     item: &'a CaseItem,
@@ -135,8 +137,7 @@ impl GetoptsCaseFact {
     }
 }
 
-
-pub(super) fn build_case_item_facts<'a>(
+pub(crate) fn build_case_item_facts<'a>(
     commands: &[CommandFact<'a>],
     source: &str,
 ) -> Vec<CaseItemFact<'a>> {
@@ -158,8 +159,7 @@ pub(super) fn build_case_item_facts<'a>(
         .collect()
 }
 
-
-fn pattern_contains_word_or_group(pattern: &Pattern) -> bool {
+pub(crate) fn pattern_contains_word_or_group(pattern: &Pattern) -> bool {
     pattern.parts.iter().any(|part| match &part.kind {
         PatternPart::Word(_) => true,
         PatternPart::Group { patterns, .. } => patterns.iter().any(pattern_contains_word_or_group),
@@ -171,7 +171,7 @@ fn pattern_contains_word_or_group(pattern: &Pattern) -> bool {
 }
 
 #[derive(Debug, Clone)]
-struct StaticCasePatternMatcher {
+pub(crate) struct StaticCasePatternMatcher {
     tokens: Vec<CasePatternToken>,
     min_len: usize,
     max_len: Option<usize>,
@@ -183,7 +183,7 @@ struct StaticCasePatternMatcher {
 }
 
 #[derive(Debug, Clone)]
-struct StaticCasePatternBitNfa {
+pub(crate) struct StaticCasePatternBitNfa {
     accept: u128,
     start: u128,
     any_char: u128,
@@ -273,7 +273,7 @@ impl StaticCasePatternBitNfa {
 }
 
 #[derive(Debug, Clone)]
-struct StaticCasePatternSummary {
+pub(crate) struct StaticCasePatternSummary {
     min_len: usize,
     max_len: Option<usize>,
     literal_prefix: Box<str>,
@@ -283,22 +283,22 @@ struct StaticCasePatternSummary {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum CasePatternToken {
+pub(crate) enum CasePatternToken {
     Literal(char),
     AnyChar,
     AnyString,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum CasePatternSymbol {
+pub(crate) enum CasePatternSymbol {
     Literal(char),
     Other,
 }
 
-type CasePatternStates = SmallVec<[usize; 8]>;
+pub(crate) type CasePatternStates = SmallVec<[usize; 8]>;
 
 #[derive(Debug, Clone)]
-struct ReachableCasePattern {
+pub(crate) struct ReachableCasePattern {
     span: Span,
     matcher: StaticCasePatternMatcher,
 }
@@ -563,16 +563,12 @@ impl StaticCasePatternMatcher {
         if matches!(other.max_len, Some(max) if max < self.min_len) {
             return false;
         }
-        if !literal_prefixes_compatible(
-            self.literal_prefix.as_ref(),
-            other.literal_prefix.as_ref(),
-        ) {
+        if !literal_prefixes_compatible(self.literal_prefix.as_ref(), other.literal_prefix.as_ref())
+        {
             return false;
         }
-        if !literal_suffixes_compatible(
-            self.literal_suffix.as_ref(),
-            other.literal_suffix.as_ref(),
-        ) {
+        if !literal_suffixes_compatible(self.literal_suffix.as_ref(), other.literal_suffix.as_ref())
+        {
             return false;
         }
         true
@@ -683,7 +679,7 @@ pub mod benchmark {
     }
 }
 
-fn subsumes_fixed_length_fast_path(
+pub(crate) fn subsumes_fixed_length_fast_path(
     left: &StaticCasePatternMatcher,
     right: &StaticCasePatternMatcher,
 ) -> Option<bool> {
@@ -708,7 +704,7 @@ fn subsumes_fixed_length_fast_path(
     Some(result)
 }
 
-fn glob_simple_form(matcher: &StaticCasePatternMatcher) -> Option<bool> {
+pub(crate) fn glob_simple_form(matcher: &StaticCasePatternMatcher) -> Option<bool> {
     let mut star_count = 0u32;
     for token in &matcher.tokens {
         match token {
@@ -725,14 +721,14 @@ fn glob_simple_form(matcher: &StaticCasePatternMatcher) -> Option<bool> {
     Some(star_count == 1)
 }
 
-fn both_have_simple_glob_form(
+pub(crate) fn both_have_simple_glob_form(
     left: &StaticCasePatternMatcher,
     right: &StaticCasePatternMatcher,
 ) -> bool {
     glob_simple_form(left).is_some() && glob_simple_form(right).is_some()
 }
 
-fn intersects_simple_glob_fast_path(
+pub(crate) fn intersects_simple_glob_fast_path(
     left: &StaticCasePatternMatcher,
     right: &StaticCasePatternMatcher,
 ) -> Option<bool> {
@@ -752,7 +748,7 @@ fn intersects_simple_glob_fast_path(
     })
 }
 
-fn intersects_fixed_length_fast_path(
+pub(crate) fn intersects_fixed_length_fast_path(
     left: &StaticCasePatternMatcher,
     right: &StaticCasePatternMatcher,
 ) -> Option<bool> {
@@ -777,16 +773,18 @@ fn intersects_fixed_length_fast_path(
 }
 
 #[inline]
-fn literal_prefixes_compatible(left: &str, right: &str) -> bool {
+pub(crate) fn literal_prefixes_compatible(left: &str, right: &str) -> bool {
     left.is_empty() || right.is_empty() || left.starts_with(right) || right.starts_with(left)
 }
 
 #[inline]
-fn literal_suffixes_compatible(left: &str, right: &str) -> bool {
+pub(crate) fn literal_suffixes_compatible(left: &str, right: &str) -> bool {
     left.is_empty() || right.is_empty() || left.ends_with(right) || right.ends_with(left)
 }
 
-fn summarize_static_case_pattern_tokens(tokens: &[CasePatternToken]) -> StaticCasePatternSummary {
+pub(crate) fn summarize_static_case_pattern_tokens(
+    tokens: &[CasePatternToken],
+) -> StaticCasePatternSummary {
     let mut min_len = 0usize;
     let mut max_len = Some(0usize);
     let mut literal_prefix = String::new();
@@ -851,7 +849,7 @@ fn summarize_static_case_pattern_tokens(tokens: &[CasePatternToken]) -> StaticCa
     }
 }
 
-fn case_pattern_epsilon_closure(
+pub(crate) fn case_pattern_epsilon_closure(
     tokens: &[CasePatternToken],
     seeds: impl IntoIterator<Item = usize>,
 ) -> CasePatternStates {
@@ -874,11 +872,11 @@ fn case_pattern_epsilon_closure(
     states
 }
 
-fn case_pattern_states_from_slice(states: &[usize]) -> CasePatternStates {
+pub(crate) fn case_pattern_states_from_slice(states: &[usize]) -> CasePatternStates {
     states.iter().copied().collect()
 }
 
-fn push_case_pattern_state(
+pub(crate) fn push_case_pattern_state(
     seen: &mut [bool],
     states: &mut CasePatternStates,
     stack: &mut CasePatternStates,
@@ -893,7 +891,7 @@ fn push_case_pattern_state(
     }
 }
 
-fn merged_case_pattern_symbols(left: &[char], right: &[char]) -> Vec<CasePatternSymbol> {
+pub(crate) fn merged_case_pattern_symbols(left: &[char], right: &[char]) -> Vec<CasePatternSymbol> {
     let mut symbols = Vec::with_capacity(left.len() + right.len() + 1);
     let mut left_index = 0usize;
     let mut right_index = 0usize;
@@ -927,7 +925,7 @@ fn merged_case_pattern_symbols(left: &[char], right: &[char]) -> Vec<CasePattern
     symbols
 }
 
-fn ensure_case_pattern_is_statically_analyzable(
+pub(crate) fn ensure_case_pattern_is_statically_analyzable(
     pattern: &Pattern,
     source: &str,
     behavior: &ShellBehaviorAt<'_>,
@@ -952,14 +950,13 @@ fn ensure_case_pattern_is_statically_analyzable(
     Some(())
 }
 
-fn pattern_operator_may_be_active(behavior: shuck_semantic::PatternOperatorBehavior) -> bool {
-    !matches!(
-        behavior,
-        shuck_semantic::PatternOperatorBehavior::Disabled
-    )
+pub(crate) fn pattern_operator_may_be_active(
+    behavior: shuck_semantic::PatternOperatorBehavior,
+) -> bool {
+    !matches!(behavior, shuck_semantic::PatternOperatorBehavior::Disabled)
 }
 
-fn text_has_unquoted_zsh_extended_glob_operator(text: &str) -> bool {
+pub(crate) fn text_has_unquoted_zsh_extended_glob_operator(text: &str) -> bool {
     let bytes = text.as_bytes();
     let mut index = 0usize;
     let mut in_single_quotes = false;
@@ -988,7 +985,7 @@ fn text_has_unquoted_zsh_extended_glob_operator(text: &str) -> bool {
     false
 }
 
-fn collect_static_case_pattern_tokens(
+pub(crate) fn collect_static_case_pattern_tokens(
     pattern_syntax: &str,
     out: &mut Vec<CasePatternToken>,
 ) -> Option<()> {
@@ -1049,7 +1046,7 @@ fn collect_static_case_pattern_tokens(
     Some(())
 }
 
-fn collect_static_case_subject_tokens(
+pub(crate) fn collect_static_case_subject_tokens(
     parts: &[WordPartNode],
     source: &str,
     out: &mut Vec<CasePatternToken>,
@@ -1095,11 +1092,11 @@ fn collect_static_case_subject_tokens(
     Some(())
 }
 
-fn push_case_pattern_literal_tokens_char(ch: char, out: &mut Vec<CasePatternToken>) {
+pub(crate) fn push_case_pattern_literal_tokens_char(ch: char, out: &mut Vec<CasePatternToken>) {
     out.push(CasePatternToken::Literal(ch));
 }
 
-fn push_case_pattern_token(out: &mut Vec<CasePatternToken>, token: CasePatternToken) {
+pub(crate) fn push_case_pattern_token(out: &mut Vec<CasePatternToken>, token: CasePatternToken) {
     if matches!(token, CasePatternToken::AnyString)
         && matches!(out.last(), Some(CasePatternToken::AnyString))
     {
@@ -1109,7 +1106,7 @@ fn push_case_pattern_token(out: &mut Vec<CasePatternToken>, token: CasePatternTo
     out.push(token);
 }
 
-fn build_case_pattern_shadow_facts(
+pub(crate) fn build_case_pattern_shadow_facts(
     commands: &[CommandFact<'_>],
     source: &str,
 ) -> Vec<CasePatternShadowFact> {
@@ -1177,7 +1174,10 @@ fn build_case_pattern_shadow_facts(
     shadows
 }
 
-fn build_case_pattern_impossible_spans(commands: &[CommandFact<'_>], source: &str) -> Vec<Span> {
+pub(crate) fn build_case_pattern_impossible_spans(
+    commands: &[CommandFact<'_>],
+    source: &str,
+) -> Vec<Span> {
     let mut spans = Vec::new();
 
     for fact in commands {
@@ -1210,13 +1210,13 @@ fn build_case_pattern_impossible_spans(commands: &[CommandFact<'_>], source: &st
 }
 
 #[derive(Debug, Clone)]
-struct ParsedGetoptsCommand {
+pub(crate) struct ParsedGetoptsCommand {
     declared_options: Vec<GetoptsOptionSpec>,
     target_name: Name,
 }
 
 #[derive(Debug, Clone)]
-struct GetoptsCaseMatch {
+pub(crate) struct GetoptsCaseMatch {
     case_span: Span,
     handled_case_labels: Vec<GetoptsCaseLabelFact>,
     invalid_case_pattern_spans: Vec<Span>,
@@ -1224,7 +1224,7 @@ struct GetoptsCaseMatch {
     has_unknown_coverage: bool,
 }
 
-fn build_getopts_case_fact_for_while(
+pub(crate) fn build_getopts_case_fact_for_while(
     command: &WhileCommand,
     source: &str,
 ) -> Option<GetoptsCaseFact> {
@@ -1275,7 +1275,7 @@ fn build_getopts_case_fact_for_while(
     })
 }
 
-fn parse_getopts_command_from_condition(
+pub(crate) fn parse_getopts_command_from_condition(
     condition: &StmtSeq,
     source: &str,
 ) -> Option<ParsedGetoptsCommand> {
@@ -1299,7 +1299,7 @@ fn parse_getopts_command_from_condition(
     })
 }
 
-fn parse_getopts_option_specs(option_string: &str) -> Vec<GetoptsOptionSpec> {
+pub(crate) fn parse_getopts_option_specs(option_string: &str) -> Vec<GetoptsOptionSpec> {
     let mut specs = Vec::new();
     let mut seen = FxHashSet::default();
     let mut chars = option_string.chars().peekable();
@@ -1329,7 +1329,7 @@ fn parse_getopts_option_specs(option_string: &str) -> Vec<GetoptsOptionSpec> {
     specs
 }
 
-fn first_getopts_case_match(
+pub(crate) fn first_getopts_case_match(
     body: &StmtSeq,
     target_name: &str,
     source: &str,
@@ -1337,7 +1337,7 @@ fn first_getopts_case_match(
     first_getopts_case_match_in_commands(body, target_name, source)
 }
 
-fn first_getopts_case_match_in_commands(
+pub(crate) fn first_getopts_case_match_in_commands(
     commands: &StmtSeq,
     target_name: &str,
     source: &str,
@@ -1347,7 +1347,7 @@ fn first_getopts_case_match_in_commands(
         .find_map(|stmt| first_getopts_case_match_in_command(&stmt.command, target_name, source))
 }
 
-fn first_getopts_case_match_in_command(
+pub(crate) fn first_getopts_case_match_in_command(
     command: &Command,
     target_name: &str,
     source: &str,
@@ -1381,7 +1381,7 @@ fn first_getopts_case_match_in_command(
     }
 }
 
-fn build_getopts_case_match(command: &CaseCommand, source: &str) -> GetoptsCaseMatch {
+pub(crate) fn build_getopts_case_match(command: &CaseCommand, source: &str) -> GetoptsCaseMatch {
     let mut has_fallback_pattern = false;
     let mut has_unknown_coverage = false;
     let mut invalid_case_pattern_spans = Vec::new();
@@ -1416,7 +1416,7 @@ fn build_getopts_case_match(command: &CaseCommand, source: &str) -> GetoptsCaseM
     }
 }
 
-fn trim_trailing_case_span(span: Span, source: &str) -> Span {
+pub(crate) fn trim_trailing_case_span(span: Span, source: &str) -> Span {
     let text = span.slice(source);
     let mut line_start = 0;
     let mut last_code_end = 0;
@@ -1444,7 +1444,7 @@ fn trim_trailing_case_span(span: Span, source: &str) -> Span {
     Span::from_positions(span.start, span.start.advanced_by(&text[..last_code_end]))
 }
 
-fn trim_case_line_comment(line: &str) -> &str {
+pub(crate) fn trim_case_line_comment(line: &str) -> &str {
     for (index, ch) in line.char_indices() {
         if ch == '#'
             && line[..index]
@@ -1459,14 +1459,17 @@ fn trim_case_line_comment(line: &str) -> &str {
     line
 }
 
-enum GetoptsCasePatternKind {
+pub(crate) enum GetoptsCasePatternKind {
     Fallback,
     SingleLabel(GetoptsCaseLabelFact),
     InvalidStaticPattern(Span),
     UnknownCoverage,
 }
 
-fn classify_getopts_case_pattern(pattern: &Pattern, source: &str) -> GetoptsCasePatternKind {
+pub(crate) fn classify_getopts_case_pattern(
+    pattern: &Pattern,
+    source: &str,
+) -> GetoptsCasePatternKind {
     if getopts_case_pattern_is_fallback(pattern, source) {
         return GetoptsCasePatternKind::Fallback;
     }
@@ -1490,7 +1493,7 @@ fn classify_getopts_case_pattern(pattern: &Pattern, source: &str) -> GetoptsCase
     })
 }
 
-fn getopts_case_pattern_is_fallback(pattern: &Pattern, source: &str) -> bool {
+pub(crate) fn getopts_case_pattern_is_fallback(pattern: &Pattern, source: &str) -> bool {
     let mut tokens = Vec::new();
     if collect_static_case_pattern_tokens(pattern.span.slice(source), &mut tokens).is_none() {
         return false;
@@ -1502,7 +1505,7 @@ fn getopts_case_pattern_is_fallback(pattern: &Pattern, source: &str) -> bool {
     )
 }
 
-fn static_case_pattern_text(pattern: &Pattern, source: &str) -> Option<String> {
+pub(crate) fn static_case_pattern_text(pattern: &Pattern, source: &str) -> Option<String> {
     let behavior = ShellBehaviorAt::for_dialect(shuck_semantic::ShellDialect::Bash);
     ensure_case_pattern_is_statically_analyzable(pattern, source, &behavior)?;
 
@@ -1517,6 +1520,6 @@ fn static_case_pattern_text(pattern: &Pattern, source: &str) -> Option<String> {
         .collect()
 }
 
-fn case_subject_variable_name(word: &Word) -> Option<&str> {
+pub(crate) fn case_subject_variable_name(word: &Word) -> Option<&str> {
     standalone_variable_name_from_word_parts(&word.parts)
 }

--- a/crates/shuck-linter/src/facts/command_options/find.rs
+++ b/crates/shuck-linter/src/facts/command_options/find.rs
@@ -1,6 +1,6 @@
 use super::*;
 
-pub(super) fn parse_find_exec_shell_command(
+pub(crate) fn parse_find_exec_shell_command(
     command: &Command,
     source: &str,
 ) -> Option<FindExecShellCommandFacts> {
@@ -82,7 +82,7 @@ fn find_exec_shell_command_spans(args: &[&Word], source: &str) -> Vec<Span> {
         .collect()
 }
 
-pub(super) fn parse_find_exec_argument_word_spans(command: &Command, source: &str) -> Vec<Span> {
+pub(crate) fn parse_find_exec_argument_word_spans(command: &Command, source: &str) -> Vec<Span> {
     let Command::Simple(command) = command else {
         return Vec::new();
     };
@@ -151,7 +151,7 @@ fn is_find_exec_semicolon_terminator(word: &Word, source: &str) -> bool {
     }
 }
 
-pub(super) fn find_command_args<'a>(
+pub(crate) fn find_command_args<'a>(
     command: &'a Command,
     normalized: &'a NormalizedCommand<'a>,
     source: &'a str,
@@ -185,7 +185,7 @@ where
     }
 }
 
-pub(super) fn parse_find_command<'a>(
+pub(crate) fn parse_find_command<'a>(
     args: impl IntoIterator<Item = &'a Word>,
     source: &str,
     behavior: &ShellBehaviorAt<'_>,

--- a/crates/shuck-linter/src/facts/command_options/grep.rs
+++ b/crates/shuck-linter/src/facts/command_options/grep.rs
@@ -1,6 +1,6 @@
 use super::*;
 
-pub(super) fn parse_grep_command<'a>(
+pub(crate) fn parse_grep_command<'a>(
     args: &[&'a Word],
     source: &str,
 ) -> Option<GrepCommandFacts<'a>> {
@@ -219,7 +219,7 @@ pub(super) fn parse_grep_command<'a>(
     })
 }
 
-pub(super) fn grep_file_operand_words<'a>(args: &[&'a Word], source: &str) -> Vec<&'a Word> {
+pub(crate) fn grep_file_operand_words<'a>(args: &[&'a Word], source: &str) -> Vec<&'a Word> {
     let mut index = 0usize;
     let mut pending_dynamic_option_arg = false;
     let mut explicit_pattern_source = false;

--- a/crates/shuck-linter/src/facts/command_options/mod.rs
+++ b/crates/shuck-linter/src/facts/command_options/mod.rs
@@ -284,8 +284,8 @@ impl FindExecShellCommandFacts {
 
 #[derive(Debug, Clone)]
 pub struct MapfileCommandFacts {
-    pub(super) input_fd: Option<i32>,
-    pub(super) target_name_uses: Box<[ComparableNameUse]>,
+    pub(crate) input_fd: Option<i32>,
+    pub(crate) target_name_uses: Box<[ComparableNameUse]>,
 }
 
 impl MapfileCommandFacts {
@@ -354,7 +354,7 @@ impl XargsInlineReplaceOptionFact {
 
 #[derive(Debug, Clone)]
 pub struct WaitCommandFacts {
-    pub(super) option_spans: Box<[Span]>,
+    pub(crate) option_spans: Box<[Span]>,
 }
 
 impl WaitCommandFacts {
@@ -533,9 +533,9 @@ impl DirectoryChangeCommandFacts {
 
 #[derive(Debug, Clone, Copy, Default)]
 pub struct FunctionPositionalParameterFacts {
-    pub(super) required_arg_count: usize,
-    pub(super) uses_unprotected_positional_parameters: bool,
-    pub(super) resets_positional_parameters: bool,
+    pub(crate) required_arg_count: usize,
+    pub(crate) uses_unprotected_positional_parameters: bool,
+    pub(crate) resets_positional_parameters: bool,
 }
 
 impl FunctionPositionalParameterFacts {
@@ -567,8 +567,8 @@ pub enum ExprStringHelperKind {
 #[derive(Debug, Clone, Copy)]
 pub struct ExprCommandFacts {
     pub uses_arithmetic_operator: bool,
-    pub(super) string_helper_kind: Option<ExprStringHelperKind>,
-    pub(super) string_helper_span: Option<Span>,
+    pub(crate) string_helper_kind: Option<ExprStringHelperKind>,
+    pub(crate) string_helper_span: Option<Span>,
 }
 
 impl ExprCommandFacts {
@@ -593,8 +593,8 @@ impl ExprCommandFacts {
 pub struct ExitCommandFacts<'a> {
     pub status_word: Option<&'a Word>,
     pub is_numeric_literal: bool,
-    pub(super) status_is_static: bool,
-    pub(super) status_has_literal_content: bool,
+    pub(crate) status_is_static: bool,
+    pub(crate) status_has_literal_content: bool,
 }
 
 impl<'a> ExitCommandFacts<'a> {
@@ -648,7 +648,7 @@ pub struct CommandOptionFactsRef<'facts, 'a> {
 }
 
 impl<'facts, 'a> CommandOptionFactsRef<'facts, 'a> {
-    pub(super) fn new(inner: Option<&'facts CommandOptionFacts<'a>>) -> Self {
+    pub(crate) fn new(inner: Option<&'facts CommandOptionFacts<'a>>) -> Self {
         Self { inner }
     }
 
@@ -848,7 +848,7 @@ impl<'a> CommandOptionFacts<'a> {
         &self.file_operand_words
     }
 
-    pub(super) fn into_sparse(self) -> Option<Box<Self>> {
+    pub(crate) fn into_sparse(self) -> Option<Box<Self>> {
         (!self.is_empty()).then(|| Box::new(self))
     }
 
@@ -880,7 +880,7 @@ impl<'a> CommandOptionFacts<'a> {
     }
 
     #[cfg_attr(shuck_profiling, inline(never))]
-    pub(super) fn build(
+    pub(crate) fn build(
         command: &'a Command,
         normalized: &NormalizedCommand<'a>,
         semantic: &LinterSemanticArtifacts<'a>,

--- a/crates/shuck-linter/src/facts/command_options/read.rs
+++ b/crates/shuck-linter/src/facts/command_options/read.rs
@@ -1,6 +1,6 @@
 use super::*;
 
-pub(super) fn read_uses_raw_input(args: &[&Word], source: &str) -> bool {
+pub(crate) fn read_uses_raw_input(args: &[&Word], source: &str) -> bool {
     let mut index = 0usize;
     let mut pending_dynamic_option_arg = false;
 
@@ -56,7 +56,7 @@ pub(super) fn read_uses_raw_input(args: &[&Word], source: &str) -> bool {
     false
 }
 
-pub(super) fn read_target_name_uses(
+pub(crate) fn read_target_name_uses(
     args: &[&Word],
     semantic: &LinterSemanticArtifacts<'_>,
     source: &str,
@@ -64,7 +64,7 @@ pub(super) fn read_target_name_uses(
     read_name_uses(args, semantic, source).0
 }
 
-pub(super) fn read_array_target_name_uses(
+pub(crate) fn read_array_target_name_uses(
     args: &[&Word],
     semantic: &LinterSemanticArtifacts<'_>,
     source: &str,

--- a/crates/shuck-linter/src/facts/command_options/sed.rs
+++ b/crates/shuck-linter/src/facts/command_options/sed.rs
@@ -1,6 +1,6 @@
 use super::*;
 
-pub(super) fn parse_sed_command(args: &[&Word], source: &str) -> SedCommandFacts {
+pub(crate) fn parse_sed_command(args: &[&Word], source: &str) -> SedCommandFacts {
     SedCommandFacts {
         has_single_substitution_script: sed_has_single_substitution_script(
             args,
@@ -62,7 +62,7 @@ pub(crate) fn sed_has_single_substitution_script(
         .is_some_and(is_simple_sed_substitution_script)
 }
 
-pub(super) fn is_echo_portability_flag(text: &str) -> bool {
+pub(crate) fn is_echo_portability_flag(text: &str) -> bool {
     let Some(flags) = text.strip_prefix('-') else {
         return false;
     };
@@ -208,7 +208,7 @@ fn strip_matching_sed_script_quotes_in_source(text: &str, quote_mode: SedScriptQ
     }
 }
 
-pub(super) fn strip_shell_matching_quotes_in_source(text: &str) -> &str {
+pub(crate) fn strip_shell_matching_quotes_in_source(text: &str) -> &str {
     if text.len() >= 2
         && ((text.starts_with('"') && text.ends_with('"'))
             || (text.starts_with('\'') && text.ends_with('\'')))

--- a/crates/shuck-linter/src/facts/command_options/set.rs
+++ b/crates/shuck-linter/src/facts/command_options/set.rs
@@ -1,6 +1,6 @@
 use super::*;
 
-pub(super) fn parse_set_command(args: &[&Word], source: &str) -> SetCommandFacts {
+pub(crate) fn parse_set_command(args: &[&Word], source: &str) -> SetCommandFacts {
     let mut errexit_change = None;
     let mut errtrace_change = None;
     let mut functrace_change = None;

--- a/crates/shuck-linter/src/facts/command_options/shared.rs
+++ b/crates/shuck-linter/src/facts/command_options/shared.rs
@@ -7,7 +7,7 @@ pub(crate) fn word_starts_with_literal_dash(word: &Word, source: &str) -> bool {
     )
 }
 
-pub(super) fn word_starts_with_static_or_literal_dash(word: &Word, source: &str) -> bool {
+pub(crate) fn word_starts_with_static_or_literal_dash(word: &Word, source: &str) -> bool {
     static_word_text(word, source).is_some_and(|text| text.starts_with('-'))
         || word_starts_with_literal_dash(word, source)
 }

--- a/crates/shuck-linter/src/facts/command_options/shell_invocation.rs
+++ b/crates/shuck-linter/src/facts/command_options/shell_invocation.rs
@@ -1,6 +1,6 @@
 use super::*;
 
-pub(super) fn parse_ssh_command(args: &[&Word], source: &str) -> Option<SshCommandFacts> {
+pub(crate) fn parse_ssh_command(args: &[&Word], source: &str) -> Option<SshCommandFacts> {
     let remote_args = ssh_remote_args(args, source)?;
     let (last_remote_arg, leading_remote_args) = remote_args.split_last()?;
     if leading_remote_args
@@ -27,7 +27,7 @@ pub(super) fn parse_ssh_command(args: &[&Word], source: &str) -> Option<SshComma
     })
 }
 
-pub(super) fn parse_su_command(args: &[&Word], source: &str) -> SuCommandFacts {
+pub(crate) fn parse_su_command(args: &[&Word], source: &str) -> SuCommandFacts {
     let mut pending_option_arg = false;
     for word in args {
         let Some(text) = static_word_text(word, source) else {

--- a/crates/shuck-linter/src/facts/command_options/xargs.rs
+++ b/crates/shuck-linter/src/facts/command_options/xargs.rs
@@ -1,6 +1,6 @@
 use super::*;
 
-pub(super) fn parse_xargs_command<'a>(args: &[&'a Word], source: &str) -> XargsCommandFacts<'a> {
+pub(crate) fn parse_xargs_command<'a>(args: &[&'a Word], source: &str) -> XargsCommandFacts<'a> {
     let mut uses_null_input = false;
     let mut max_procs = None;
     let mut zero_digit_option_word = false;

--- a/crates/shuck-linter/src/facts/commands.rs
+++ b/crates/shuck-linter/src/facts/commands.rs
@@ -1,27 +1,31 @@
+use super::*;
+
+pub use super::core::CommandFactRef;
+
 #[derive(Debug, Clone)]
 pub struct CommandFact<'a> {
-    id: CommandId,
-    key: FactSpan,
-    visit: CommandVisit<'a>,
-    nested_word_command: bool,
-    scope: ScopeId,
-    enclosing_function_scope: Option<ScopeId>,
-    normalized: NormalizedCommand<'a>,
-    shell_behavior: ShellBehaviorAt<'a>,
-    redirect_facts: IdRange<RedirectFact<'a>>,
-    substitution_facts: IdRange<SubstitutionFact>,
-    options: Option<Box<CommandOptionFacts<'a>>>,
-    scope_read_source_words: IdRange<PathWordFact<'a>>,
-    scope_name_read_uses: IdRange<ComparableNameUse>,
-    scope_heredoc_name_read_uses: IdRange<ComparableNameUse>,
-    scope_name_write_uses: IdRange<ComparableNameUse>,
-    declaration_assignment_probes: IdRange<DeclarationAssignmentProbe>,
-    glued_closing_bracket_operand_span: Option<Span>,
-    glued_closing_bracket_insert_offset: Option<usize>,
-    linebreak_in_test_anchor_span: Option<Span>,
-    linebreak_in_test_insert_offset: Option<usize>,
-    simple_test: Option<SimpleTestFact<'a>>,
-    conditional: Option<ConditionalFact<'a>>,
+    pub(crate) id: CommandId,
+    pub(crate) key: FactSpan,
+    pub(crate) visit: CommandVisit<'a>,
+    pub(crate) nested_word_command: bool,
+    pub(crate) scope: ScopeId,
+    pub(crate) enclosing_function_scope: Option<ScopeId>,
+    pub(crate) normalized: NormalizedCommand<'a>,
+    pub(crate) shell_behavior: ShellBehaviorAt<'a>,
+    pub(crate) redirect_facts: IdRange<RedirectFact<'a>>,
+    pub(crate) substitution_facts: IdRange<SubstitutionFact>,
+    pub(crate) options: Option<Box<CommandOptionFacts<'a>>>,
+    pub(crate) scope_read_source_words: IdRange<PathWordFact<'a>>,
+    pub(crate) scope_name_read_uses: IdRange<ComparableNameUse>,
+    pub(crate) scope_heredoc_name_read_uses: IdRange<ComparableNameUse>,
+    pub(crate) scope_name_write_uses: IdRange<ComparableNameUse>,
+    pub(crate) declaration_assignment_probes: IdRange<DeclarationAssignmentProbe>,
+    pub(crate) glued_closing_bracket_operand_span: Option<Span>,
+    pub(crate) glued_closing_bracket_insert_offset: Option<usize>,
+    pub(crate) linebreak_in_test_anchor_span: Option<Span>,
+    pub(crate) linebreak_in_test_insert_offset: Option<usize>,
+    pub(crate) simple_test: Option<SimpleTestFact<'a>>,
+    pub(crate) conditional: Option<ConditionalFact<'a>>,
 }
 
 #[derive(Debug, Clone)]
@@ -210,7 +214,6 @@ impl<'a> CommandFact<'a> {
     pub fn file_operand_words(&self) -> &[&'a Word] {
         self.options().file_operand_words()
     }
-
 }
 
 impl<'facts, 'a> CommandFactRef<'facts, 'a> {
@@ -276,7 +279,8 @@ impl<'facts, 'a> CommandFactRef<'facts, 'a> {
     }
 
     pub(crate) fn scope_name_read_uses(self) -> &'facts [ComparableNameUse] {
-        self.store.scope_name_read_uses(self.fact.scope_name_read_uses)
+        self.store
+            .scope_name_read_uses(self.fact.scope_name_read_uses)
     }
 
     pub(crate) fn scope_heredoc_name_read_uses(self) -> &'facts [ComparableNameUse] {
@@ -426,7 +430,7 @@ impl<'facts, 'a> CommandFactRef<'facts, 'a> {
     }
 }
 
-fn pipeline_span_with_shellcheck_tail(
+pub(crate) fn pipeline_span_with_shellcheck_tail(
     commands: CommandFacts<'_, '_>,
     pipeline: &PipelineFact<'_>,
     source: &str,
@@ -448,7 +452,7 @@ fn pipeline_span_with_shellcheck_tail(
     Span::from_positions(body_name_word.span.start, end)
 }
 
-fn command_span_with_redirects_and_shellcheck_tail(
+pub(crate) fn command_span_with_redirects_and_shellcheck_tail(
     command: CommandFactRef<'_, '_>,
     source: &str,
 ) -> Option<Span> {
@@ -474,7 +478,7 @@ fn command_span_with_redirects_and_shellcheck_tail(
     ))
 }
 
-fn effective_command_shell_behavior<'a>(
+pub(crate) fn effective_command_shell_behavior<'a>(
     semantic: &'a SemanticModel,
     offset: usize,
     normalized: &NormalizedCommand<'_>,
@@ -488,14 +492,14 @@ fn effective_command_shell_behavior<'a>(
     behavior
 }
 
-fn contains_template_placeholder_text(text: &str) -> bool {
+pub(crate) fn contains_template_placeholder_text(text: &str) -> bool {
     let Some(start) = text.find("{{") else {
         return false;
     };
     text[start + 2..].contains("}}")
 }
 
-fn quoted_command_name_has_suspicious_ending(
+pub(crate) fn quoted_command_name_has_suspicious_ending(
     text: &str,
     trailing_literal_char: Option<char>,
 ) -> bool {
@@ -520,7 +524,7 @@ fn quoted_command_name_has_suspicious_ending(
     }
 }
 
-fn strip_matching_quotes(text: &str) -> Option<&str> {
+pub(crate) fn strip_matching_quotes(text: &str) -> Option<&str> {
     if text.len() < 2 {
         return None;
     }
@@ -534,24 +538,24 @@ fn strip_matching_quotes(text: &str) -> Option<&str> {
     }
 }
 
-fn is_suspicious_command_trailer(ch: char) -> bool {
+pub(crate) fn is_suspicious_command_trailer(ch: char) -> bool {
     matches!(
         ch,
         '.' | ',' | '#' | '[' | ']' | '(' | ')' | '{' | '}' | '\''
     )
 }
 
-fn inner_ends_with_parameter_expansion(inner: &str) -> bool {
+pub(crate) fn inner_ends_with_parameter_expansion(inner: &str) -> bool {
     matching_shell_delimiter_start(inner, b'{', b'}')
         .is_some_and(|index| index > 0 && inner.as_bytes()[index - 1] == b'$')
 }
 
-fn inner_ends_with_command_substitution(inner: &str) -> bool {
+pub(crate) fn inner_ends_with_command_substitution(inner: &str) -> bool {
     matching_shell_delimiter_start(inner, b'(', b')')
         .is_some_and(|index| index > 0 && inner.as_bytes()[index - 1] == b'$')
 }
 
-fn matching_shell_delimiter_start(inner: &str, open: u8, close: u8) -> Option<usize> {
+pub(crate) fn matching_shell_delimiter_start(inner: &str, open: u8, close: u8) -> Option<usize> {
     let bytes = inner.as_bytes();
     if bytes.last().copied() != Some(close) {
         return None;
@@ -604,7 +608,7 @@ fn matching_shell_delimiter_start(inner: &str, open: u8, close: u8) -> Option<us
     None
 }
 
-fn byte_is_shell_escaped(bytes: &[u8], index: usize) -> bool {
+pub(crate) fn byte_is_shell_escaped(bytes: &[u8], index: usize) -> bool {
     let mut slash_count = 0usize;
     let mut cursor = index;
 
@@ -617,13 +621,16 @@ fn byte_is_shell_escaped(bytes: &[u8], index: usize) -> bool {
 }
 
 #[derive(Clone, Copy)]
-enum QuoteState {
+pub(crate) enum QuoteState {
     Single,
     Double,
     Backtick,
 }
 
-fn extend_over_shellcheck_trailing_inline_space(end: Position, source: &str) -> Position {
+pub(crate) fn extend_over_shellcheck_trailing_inline_space(
+    end: Position,
+    source: &str,
+) -> Position {
     let tail = &source[end.offset..];
     let spaces_len = tail
         .char_indices()
@@ -649,7 +656,7 @@ fn extend_over_shellcheck_trailing_inline_space(end: Position, source: &str) -> 
     }
 }
 
-fn build_background_semicolon_spans(
+pub(crate) fn build_background_semicolon_spans(
     commands: &[CommandFact<'_>],
     case_items: &[CaseItemFact<'_>],
     locator: Locator<'_>,
@@ -667,7 +674,7 @@ fn build_background_semicolon_spans(
     spans
 }
 
-fn background_semicolon_span(
+pub(crate) fn background_semicolon_span(
     command: &CommandFact<'_>,
     case_terminator_starts: &FxHashSet<usize>,
     locator: Locator<'_>,
@@ -700,14 +707,16 @@ fn background_semicolon_span(
     Some(Span::from_positions(start, end))
 }
 
-fn build_redundant_echo_space_facts(facts: &LinterFacts<'_>) -> Vec<RedundantEchoSpaceFact> {
+pub(crate) fn build_redundant_echo_space_facts(
+    facts: &LinterFacts<'_>,
+) -> Vec<RedundantEchoSpaceFact> {
     facts
         .structural_commands()
-        .filter_map(|command| redundant_echo_space_fact(command, facts.source))
+        .filter_map(|command| redundant_echo_space_fact(command, facts.source_facts.source))
         .collect()
 }
 
-fn redundant_echo_space_fact(
+pub(crate) fn redundant_echo_space_fact(
     command: CommandFactRef<'_, '_>,
     source: &str,
 ) -> Option<RedundantEchoSpaceFact> {
@@ -732,7 +741,11 @@ fn redundant_echo_space_fact(
     })
 }
 
-fn repeated_echo_argument_space_span(left: Span, right: Span, source: &str) -> Option<Span> {
+pub(crate) fn repeated_echo_argument_space_span(
+    left: Span,
+    right: Span,
+    source: &str,
+) -> Option<Span> {
     if left.end.line != right.start.line {
         return None;
     }
@@ -757,7 +770,7 @@ fn repeated_echo_argument_space_span(left: Span, right: Span, source: &str) -> O
 }
 
 #[cfg_attr(shuck_profiling, inline(never))]
-fn populate_scope_fact_ranges<'a>(
+pub(crate) fn populate_scope_fact_ranges<'a>(
     commands: &mut [CommandFact<'a>],
     fact_store: &mut FactStore<'a>,
     command_fact_indices_by_id: &[Option<usize>],
@@ -767,12 +780,7 @@ fn populate_scope_fact_ranges<'a>(
 ) {
     let (pipeline_summaries, pipeline_summary_ids_by_writer) = {
         let command_facts = CommandFacts::new(commands, fact_store, command_fact_indices_by_id);
-        build_pipeline_scope_summaries(
-            command_facts,
-            pipelines,
-            if_condition_command_ids,
-            source,
-        )
+        build_pipeline_scope_summaries(command_facts, pipelines, if_condition_command_ids, source)
     };
     let inputs = ScopeFactInputs {
         pipeline_summaries: &pipeline_summaries,
@@ -795,7 +803,7 @@ fn populate_scope_fact_ranges<'a>(
 }
 
 #[derive(Clone, Copy)]
-struct ScopeFactInputs<'facts, 'a> {
+pub(crate) struct ScopeFactInputs<'facts, 'a> {
     pipeline_summaries: &'facts [PipelineScopeSummary<'a>],
     pipeline_summary_ids_by_writer: &'facts [SmallVec<[usize; 1]>],
     if_condition_command_ids: &'facts DenseCommandIdSet,
@@ -803,7 +811,7 @@ struct ScopeFactInputs<'facts, 'a> {
 }
 
 #[derive(Default)]
-struct ScopeFactScratch<'a> {
+pub(crate) struct ScopeFactScratch<'a> {
     source_words: Vec<PathWordFact<'a>>,
     name_reads: Vec<ComparableNameUse>,
     heredoc_name_reads: Vec<ComparableNameUse>,
@@ -811,7 +819,7 @@ struct ScopeFactScratch<'a> {
 }
 
 #[cfg_attr(shuck_profiling, inline(never))]
-fn populate_scope_fact_ranges_for_command<'a>(
+pub(crate) fn populate_scope_fact_ranges_for_command<'a>(
     index: usize,
     commands: &mut [CommandFact<'a>],
     fact_store: &mut FactStore<'a>,
@@ -871,14 +879,14 @@ fn populate_scope_fact_ranges_for_command<'a>(
         .push_many(scratch.name_writes.drain(..));
 }
 
-struct PipelineScopeSummary<'a> {
+pub(crate) struct PipelineScopeSummary<'a> {
     source_words: Vec<PathWordFact<'a>>,
     name_reads: Vec<ComparableNameUse>,
     heredoc_name_reads: Vec<ComparableNameUse>,
 }
 
 #[cfg_attr(shuck_profiling, inline(never))]
-fn build_pipeline_scope_summaries<'a>(
+pub(crate) fn build_pipeline_scope_summaries<'a>(
     commands: CommandFacts<'_, 'a>,
     pipelines: &[PipelineFact<'a>],
     if_condition_command_ids: &DenseCommandIdSet,
@@ -934,7 +942,7 @@ fn build_pipeline_scope_summaries<'a>(
 }
 
 #[cfg_attr(shuck_profiling, inline(never))]
-fn collect_scope_read_source_words_for_command<'a>(
+pub(crate) fn collect_scope_read_source_words_for_command<'a>(
     commands: CommandFacts<'_, 'a>,
     command: CommandFactRef<'_, 'a>,
     pipeline_summaries: &[PipelineScopeSummary<'a>],
@@ -953,19 +961,14 @@ fn collect_scope_read_source_words_for_command<'a>(
             words,
         );
         for summary_id in pipeline_summary_ids {
-            words.extend(
-                pipeline_summaries[*summary_id]
-                    .source_words
-                    .iter()
-                    .cloned(),
-            );
+            words.extend(pipeline_summaries[*summary_id].source_words.iter().cloned());
         }
     }
     dedup_path_words(words);
 }
 
 #[cfg_attr(shuck_profiling, inline(never))]
-fn collect_scope_name_read_uses_for_command(
+pub(crate) fn collect_scope_name_read_uses_for_command(
     commands: CommandFacts<'_, '_>,
     command: CommandFactRef<'_, '_>,
     pipeline_summaries: &[PipelineScopeSummary<'_>],
@@ -984,7 +987,7 @@ fn collect_scope_name_read_uses_for_command(
 }
 
 #[cfg_attr(shuck_profiling, inline(never))]
-fn collect_scope_heredoc_name_read_uses_for_command(
+pub(crate) fn collect_scope_heredoc_name_read_uses_for_command(
     commands: CommandFacts<'_, '_>,
     command: CommandFactRef<'_, '_>,
     pipeline_summaries: &[PipelineScopeSummary<'_>],
@@ -1010,7 +1013,7 @@ fn collect_scope_heredoc_name_read_uses_for_command(
 }
 
 #[cfg_attr(shuck_profiling, inline(never))]
-fn collect_scope_name_write_uses_for_command(
+pub(crate) fn collect_scope_name_write_uses_for_command(
     commands: CommandFacts<'_, '_>,
     command: CommandFactRef<'_, '_>,
     source: &str,
@@ -1023,25 +1026,20 @@ fn collect_scope_name_write_uses_for_command(
     dedup_name_uses(uses);
 }
 
-fn collect_own_scope_read_source_words<'a>(
+pub(crate) fn collect_own_scope_read_source_words<'a>(
     command: CommandFactRef<'_, 'a>,
     if_condition_command_ids: &DenseCommandIdSet,
     source: &str,
     words: &mut Vec<PathWordFact<'a>>,
 ) {
-    words.extend(command
-        .file_operand_words()
-        .iter()
-        .copied()
-        .map(|word| {
-            PathWordFact::new(
-                word,
-                ExpansionContext::CommandArgument,
-                source,
-                command.shell_behavior(),
-            )
-        })
-    );
+    words.extend(command.file_operand_words().iter().copied().map(|word| {
+        PathWordFact::new(
+            word,
+            ExpansionContext::CommandArgument,
+            source,
+            command.shell_behavior(),
+        )
+    }));
     collect_command_redirect_read_source_words(command, source, words);
     collect_command_simple_test_path_words(command, source, words);
     if !if_condition_command_ids.contains(command.id()) {
@@ -1049,7 +1047,7 @@ fn collect_own_scope_read_source_words<'a>(
     }
 }
 
-fn collect_own_scope_name_read_uses(
+pub(crate) fn collect_own_scope_name_read_uses(
     command: CommandFactRef<'_, '_>,
     _source: &str,
     uses: &mut Vec<ComparableNameUse>,
@@ -1072,7 +1070,7 @@ fn collect_own_scope_name_read_uses(
     }
 }
 
-fn collect_own_scope_heredoc_name_read_uses(
+pub(crate) fn collect_own_scope_heredoc_name_read_uses(
     command: CommandFactRef<'_, '_>,
     _source: &str,
     uses: &mut Vec<ComparableNameUse>,
@@ -1088,7 +1086,7 @@ fn collect_own_scope_heredoc_name_read_uses(
     }
 }
 
-fn collect_own_scope_name_write_uses(
+pub(crate) fn collect_own_scope_name_write_uses(
     command: CommandFactRef<'_, '_>,
     _source: &str,
     uses: &mut Vec<ComparableNameUse>,
@@ -1099,7 +1097,7 @@ fn collect_own_scope_name_write_uses(
 }
 
 #[cfg_attr(shuck_profiling, inline(never))]
-fn collect_nested_scope_read_source_words<'a>(
+pub(crate) fn collect_nested_scope_read_source_words<'a>(
     commands: CommandFacts<'_, 'a>,
     command: CommandFactRef<'_, 'a>,
     if_condition_command_ids: &DenseCommandIdSet,
@@ -1112,7 +1110,7 @@ fn collect_nested_scope_read_source_words<'a>(
 }
 
 #[cfg_attr(shuck_profiling, inline(never))]
-fn collect_nested_scope_name_read_uses(
+pub(crate) fn collect_nested_scope_name_read_uses(
     commands: CommandFacts<'_, '_>,
     command: CommandFactRef<'_, '_>,
     source: &str,
@@ -1124,7 +1122,7 @@ fn collect_nested_scope_name_read_uses(
 }
 
 #[cfg_attr(shuck_profiling, inline(never))]
-fn collect_nested_scope_heredoc_name_read_uses(
+pub(crate) fn collect_nested_scope_heredoc_name_read_uses(
     commands: CommandFacts<'_, '_>,
     command: CommandFactRef<'_, '_>,
     source: &str,
@@ -1136,7 +1134,7 @@ fn collect_nested_scope_heredoc_name_read_uses(
 }
 
 #[cfg_attr(shuck_profiling, inline(never))]
-fn collect_nested_scope_name_write_uses(
+pub(crate) fn collect_nested_scope_name_write_uses(
     commands: CommandFacts<'_, '_>,
     command: CommandFactRef<'_, '_>,
     source: &str,
@@ -1148,7 +1146,7 @@ fn collect_nested_scope_name_write_uses(
 }
 
 /// Visits commands nested inside `outer`'s span.
-fn for_each_nested_command<'facts, 'a>(
+pub(crate) fn for_each_nested_command<'facts, 'a>(
     commands: CommandFacts<'facts, 'a>,
     outer: CommandFactRef<'_, 'a>,
     mut visit: impl FnMut(CommandFactRef<'facts, 'a>),
@@ -1168,7 +1166,7 @@ fn for_each_nested_command<'facts, 'a>(
     }
 }
 
-fn dedup_path_words(words: &mut Vec<PathWordFact<'_>>) {
+pub(crate) fn dedup_path_words(words: &mut Vec<PathWordFact<'_>>) {
     if words.len() < 2 {
         return;
     }
@@ -1176,7 +1174,7 @@ fn dedup_path_words(words: &mut Vec<PathWordFact<'_>>) {
     words.retain(|fact| seen.insert((FactSpan::new(fact.word().span), fact.context())));
 }
 
-fn dedup_name_uses(uses: &mut Vec<ComparableNameUse>) {
+pub(crate) fn dedup_name_uses(uses: &mut Vec<ComparableNameUse>) {
     if uses.len() < 2 {
         return;
     }
@@ -1184,7 +1182,7 @@ fn dedup_name_uses(uses: &mut Vec<ComparableNameUse>) {
     uses.retain(|name_use| seen.insert((name_use.key().clone(), FactSpan::new(name_use.span()))));
 }
 
-fn command_has_file_output_redirect(command: CommandFactRef<'_, '_>) -> bool {
+pub(crate) fn command_has_file_output_redirect(command: CommandFactRef<'_, '_>) -> bool {
     command.redirect_facts().iter().any(|redirect| {
         matches!(
             redirect.redirect().kind,
@@ -1198,7 +1196,7 @@ fn command_has_file_output_redirect(command: CommandFactRef<'_, '_>) -> bool {
     })
 }
 
-fn command_has_file_input_redirect(command: CommandFactRef<'_, '_>) -> bool {
+pub(crate) fn command_has_file_input_redirect(command: CommandFactRef<'_, '_>) -> bool {
     command.redirect_facts().iter().any(|redirect| {
         matches!(
             redirect.redirect().kind,
@@ -1209,7 +1207,7 @@ fn command_has_file_input_redirect(command: CommandFactRef<'_, '_>) -> bool {
     })
 }
 
-fn collect_command_redirect_read_source_words<'a>(
+pub(crate) fn collect_command_redirect_read_source_words<'a>(
     command: CommandFactRef<'_, 'a>,
     source: &str,
     words: &mut Vec<PathWordFact<'a>>,
@@ -1238,7 +1236,7 @@ fn collect_command_redirect_read_source_words<'a>(
     }
 }
 
-fn collect_command_simple_test_path_words<'a>(
+pub(crate) fn collect_command_simple_test_path_words<'a>(
     command: CommandFactRef<'_, 'a>,
     source: &str,
     words: &mut Vec<PathWordFact<'a>>,
@@ -1247,20 +1245,22 @@ fn collect_command_simple_test_path_words<'a>(
         return;
     };
 
-    words.extend(simple_test
-        .operator_expression_operand_words(source)
-        .into_iter()
-        .map(|word| {
-            PathWordFact::new(
-                word,
-                ExpansionContext::StringTestOperand,
-                source,
-                command.shell_behavior(),
-            )
-        }));
+    words.extend(
+        simple_test
+            .operator_expression_operand_words(source)
+            .into_iter()
+            .map(|word| {
+                PathWordFact::new(
+                    word,
+                    ExpansionContext::StringTestOperand,
+                    source,
+                    command.shell_behavior(),
+                )
+            }),
+    );
 }
 
-fn collect_command_conditional_path_words<'a>(
+pub(crate) fn collect_command_conditional_path_words<'a>(
     command: CommandFactRef<'_, 'a>,
     source: &str,
     words: &mut Vec<PathWordFact<'a>>,
@@ -1296,16 +1296,16 @@ fn collect_command_conditional_path_words<'a>(
     }
 }
 
-fn contains_span(outer: Span, inner: Span) -> bool {
+pub(crate) fn contains_span(outer: Span, inner: Span) -> bool {
     outer.start.offset <= inner.start.offset && inner.end.offset <= outer.end.offset
 }
 
-fn contains_span_strictly(outer: Span, inner: Span) -> bool {
+pub(crate) fn contains_span_strictly(outer: Span, inner: Span) -> bool {
     contains_span(outer, inner)
         && (outer.start.offset < inner.start.offset || inner.end.offset < outer.end.offset)
 }
 
-fn build_backtick_command_name_spans(commands: &[CommandFact<'_>]) -> Vec<Span> {
+pub(crate) fn build_backtick_command_name_spans(commands: &[CommandFact<'_>]) -> Vec<Span> {
     let mut spans = commands
         .iter()
         .filter_map(|fact| match fact.command() {
@@ -1322,7 +1322,7 @@ fn build_backtick_command_name_spans(commands: &[CommandFact<'_>]) -> Vec<Span> 
     spans
 }
 
-fn plain_backtick_command_name_span(word: &Word) -> Option<Span> {
+pub(crate) fn plain_backtick_command_name_span(word: &Word) -> Option<Span> {
     let [part] = word.parts.as_slice() else {
         return None;
     };
@@ -1336,7 +1336,7 @@ fn plain_backtick_command_name_span(word: &Word) -> Option<Span> {
     }
 }
 
-fn command_span(command: &Command) -> Span {
+pub(crate) fn command_span(command: &Command) -> Span {
     match command {
         Command::Simple(command) => command.span,
         Command::Builtin(command) => builtin_span(command),
@@ -1348,7 +1348,7 @@ fn command_span(command: &Command) -> Span {
     }
 }
 
-fn command_lookup_kind(command: &Command) -> CommandLookupKind {
+pub(crate) fn command_lookup_kind(command: &Command) -> CommandLookupKind {
     match command {
         Command::Simple(_) => CommandLookupKind::Simple,
         Command::Builtin(command) => CommandLookupKind::Builtin(match command {
@@ -1382,7 +1382,7 @@ fn command_lookup_kind(command: &Command) -> CommandLookupKind {
     }
 }
 
-fn command_id_for_command(
+pub(crate) fn command_id_for_command(
     command: &Command,
     command_ids_by_span: &CommandLookupIndex,
 ) -> Option<CommandId> {
@@ -1397,7 +1397,7 @@ fn command_id_for_command(
         })
 }
 
-fn command_fact<'facts, 'a>(
+pub(crate) fn command_fact<'facts, 'a>(
     commands: &'facts [CommandFact<'a>],
     indices_by_id: &[Option<usize>],
     id: CommandId,
@@ -1410,7 +1410,7 @@ fn command_fact<'facts, 'a>(
         .unwrap_or_else(|| panic!("command id {} must exist", id.index()))
 }
 
-fn command_fact_for_semantic_span_matching<'facts, 'a>(
+pub(crate) fn command_fact_for_semantic_span_matching<'facts, 'a>(
     commands: &'facts [CommandFact<'a>],
     indices_by_id: &[Option<usize>],
     command_ids_by_span: &CommandLookupIndex,
@@ -1426,11 +1426,9 @@ fn command_fact_for_semantic_span_matching<'facts, 'a>(
                 .find(|command| predicate(command))
         })
         .or_else(|| {
-            commands
-                .iter()
-                .find(|command| {
-                    predicate(command) && FactSpan::new(command.stmt().span) == FactSpan::new(span)
-                })
+            commands.iter().find(|command| {
+                predicate(command) && FactSpan::new(command.stmt().span) == FactSpan::new(span)
+            })
         })
         .or_else(|| {
             commands
@@ -1448,7 +1446,7 @@ fn command_fact_for_semantic_span_matching<'facts, 'a>(
         })
 }
 
-fn command_fact_ref<'facts, 'a>(
+pub(crate) fn command_fact_ref<'facts, 'a>(
     commands: CommandFacts<'facts, 'a>,
     id: CommandId,
 ) -> CommandFactRef<'facts, 'a> {
@@ -1458,15 +1456,15 @@ fn command_fact_ref<'facts, 'a>(
 }
 
 #[derive(Clone, Copy)]
-struct CommandRelationshipContext<'facts, 'a> {
-    commands: &'facts [CommandFact<'a>],
-    command_fact_indices_by_id: &'facts [Option<usize>],
-    command_ids_by_span: &'facts CommandLookupIndex,
-    command_child_index: &'facts CommandChildIndex,
+pub(crate) struct CommandRelationshipContext<'facts, 'a> {
+    pub(crate) commands: &'facts [CommandFact<'a>],
+    pub(crate) command_fact_indices_by_id: &'facts [Option<usize>],
+    pub(crate) command_ids_by_span: &'facts CommandLookupIndex,
+    pub(crate) command_child_index: &'facts CommandChildIndex,
 }
 
 impl<'facts, 'a> CommandRelationshipContext<'facts, 'a> {
-    fn new(
+    pub(crate) fn new(
         commands: &'facts [CommandFact<'a>],
         command_fact_indices_by_id: &'facts [Option<usize>],
         command_ids_by_span: &'facts CommandLookupIndex,
@@ -1484,7 +1482,7 @@ impl<'facts, 'a> CommandRelationshipContext<'facts, 'a> {
         command_fact(self.commands, self.command_fact_indices_by_id, id)
     }
 
-    fn id_for_command(self, command: &Command) -> Option<CommandId> {
+    pub(crate) fn id_for_command(self, command: &Command) -> Option<CommandId> {
         command_id_for_command(command, self.command_ids_by_span)
     }
 
@@ -1492,11 +1490,15 @@ impl<'facts, 'a> CommandRelationshipContext<'facts, 'a> {
         self.id_for_command(command).map(|id| self.fact(id))
     }
 
-    fn fact_for_stmt(self, stmt: &Stmt) -> Option<&'facts CommandFact<'a>> {
+    pub(crate) fn fact_for_stmt(self, stmt: &Stmt) -> Option<&'facts CommandFact<'a>> {
         self.fact_for_command(&stmt.command)
     }
 
-    fn child_id_for_command(self, parent_id: CommandId, command: &Command) -> Option<CommandId> {
+    pub(crate) fn child_id_for_command(
+        self,
+        parent_id: CommandId,
+        command: &Command,
+    ) -> Option<CommandId> {
         child_command_id_for_command(
             parent_id,
             command,
@@ -1515,7 +1517,7 @@ impl<'facts, 'a> CommandRelationshipContext<'facts, 'a> {
             .map(|id| self.fact(id))
     }
 
-    fn child_or_lookup_fact(
+    pub(crate) fn child_or_lookup_fact(
         self,
         parent_id: CommandId,
         stmt: &Stmt,
@@ -1523,10 +1525,9 @@ impl<'facts, 'a> CommandRelationshipContext<'facts, 'a> {
         self.child_fact_for_stmt(parent_id, stmt)
             .or_else(|| self.fact_for_stmt(stmt))
     }
-
 }
 
-fn build_command_fact_indices_by_id(commands: &[CommandFact<'_>]) -> Vec<Option<usize>> {
+pub(crate) fn build_command_fact_indices_by_id(commands: &[CommandFact<'_>]) -> Vec<Option<usize>> {
     let len = commands
         .iter()
         .map(|command| command.id().index())
@@ -1539,14 +1540,14 @@ fn build_command_fact_indices_by_id(commands: &[CommandFact<'_>]) -> Vec<Option<
     indices
 }
 
-fn compare_command_facts_by_offset(
+pub(crate) fn compare_command_facts_by_offset(
     left: &CommandFact<'_>,
     right: &CommandFact<'_>,
 ) -> std::cmp::Ordering {
     compare_command_parent_entries((left.span(), left.id()), (right.span(), right.id()))
 }
 
-fn compare_command_parent_entries(
+pub(crate) fn compare_command_parent_entries(
     (left_span, left_id): (Span, CommandId),
     (right_span, right_id): (Span, CommandId),
 ) -> std::cmp::Ordering {
@@ -1559,7 +1560,7 @@ fn compare_command_parent_entries(
 }
 
 #[cfg_attr(shuck_profiling, inline(never))]
-fn build_command_dominance_barrier_flags(commands: &[CommandFact<'_>]) -> Vec<bool> {
+pub(crate) fn build_command_dominance_barrier_flags(commands: &[CommandFact<'_>]) -> Vec<bool> {
     let mut flags = vec![false; command_slot_count(commands)];
     for fact in commands {
         flags[fact.id().index()] = match fact.command() {
@@ -1580,7 +1581,7 @@ fn build_command_dominance_barrier_flags(commands: &[CommandFact<'_>]) -> Vec<bo
     flags
 }
 
-fn command_slot_count(commands: &[CommandFact<'_>]) -> usize {
+pub(crate) fn command_slot_count(commands: &[CommandFact<'_>]) -> usize {
     commands
         .iter()
         .map(|command| command.id().index())
@@ -1588,19 +1589,19 @@ fn command_slot_count(commands: &[CommandFact<'_>]) -> usize {
         .map_or(0, |index| index + 1)
 }
 
-fn sort_and_dedup_spans(spans: &mut Vec<Span>) {
+pub(crate) fn sort_and_dedup_spans(spans: &mut Vec<Span>) {
     let mut seen = FxHashSet::default();
     spans.retain(|span| seen.insert(FactSpan::new(*span)));
     spans.sort_by_key(|span| (span.start.offset, span.end.offset));
 }
 
-fn trim_trailing_whitespace_span(span: Span, source: &str) -> Span {
+pub(crate) fn trim_trailing_whitespace_span(span: Span, source: &str) -> Span {
     let text = span.slice(source);
     let trimmed = text.trim_end_matches(char::is_whitespace);
     Span::from_positions(span.start, span.start.advanced_by(trimmed))
 }
 
-fn command_fact_for_command<'a>(
+pub(crate) fn command_fact_for_command<'a>(
     command: &Command,
     commands: &'a [CommandFact<'a>],
     indices_by_id: &[Option<usize>],
@@ -1610,7 +1611,7 @@ fn command_fact_for_command<'a>(
         .map(|id| command_fact(commands, indices_by_id, id))
 }
 
-fn command_fact_for_stmt<'a>(
+pub(crate) fn command_fact_for_stmt<'a>(
     stmt: &Stmt,
     commands: &'a [CommandFact<'a>],
     indices_by_id: &[Option<usize>],
@@ -1619,7 +1620,7 @@ fn command_fact_for_stmt<'a>(
     command_fact_for_command(&stmt.command, commands, indices_by_id, command_ids_by_span)
 }
 
-fn child_command_id_for_command(
+pub(crate) fn child_command_id_for_command(
     parent_id: CommandId,
     command: &Command,
     commands: &[CommandFact<'_>],
@@ -1640,15 +1641,16 @@ fn child_command_id_for_command(
         })
 }
 
-fn command_fact_ref_for_stmt<'facts, 'a>(
+pub(crate) fn command_fact_ref_for_stmt<'facts, 'a>(
     stmt: &Stmt,
     commands: CommandFacts<'facts, 'a>,
     command_ids_by_span: &CommandLookupIndex,
 ) -> Option<CommandFactRef<'facts, 'a>> {
-    command_id_for_command(&stmt.command, command_ids_by_span).map(|id| command_fact_ref(commands, id))
+    command_id_for_command(&stmt.command, command_ids_by_span)
+        .map(|id| command_fact_ref(commands, id))
 }
 
-fn builtin_span(command: &BuiltinCommand) -> Span {
+pub(crate) fn builtin_span(command: &BuiltinCommand) -> Span {
     match command {
         BuiltinCommand::Break(command) => command.span,
         BuiltinCommand::Continue(command) => command.span,
@@ -1657,7 +1659,7 @@ fn builtin_span(command: &BuiltinCommand) -> Span {
     }
 }
 
-fn compound_span(command: &CompoundCommand) -> Span {
+pub(crate) fn compound_span(command: &CompoundCommand) -> Span {
     match command {
         CompoundCommand::If(command) => command.span,
         CompoundCommand::For(command) => command.span,

--- a/crates/shuck-linter/src/facts/comments.rs
+++ b/crates/shuck-linter/src/facts/comments.rs
@@ -1,20 +1,22 @@
+use super::*;
+
 #[derive(Debug, Clone, Copy, Default)]
-struct ShebangHeaderFacts {
-    indented_shebang_span: Option<Span>,
-    indented_shebang_indent_span: Option<Span>,
-    space_after_hash_bang_span: Option<Span>,
-    space_after_hash_bang_whitespace_span: Option<Span>,
-    shebang_not_on_first_line_span: Option<Span>,
-    shebang_not_on_first_line_fix_span: Option<Span>,
-    shebang_not_on_first_line_preferred_newline: Option<&'static str>,
-    missing_shebang_line_span: Option<Span>,
-    duplicate_shebang_flag_span: Option<Span>,
-    non_absolute_shebang_span: Option<Span>,
-    enables_errexit: bool,
+pub(crate) struct ShebangHeaderFacts {
+    pub(crate) indented_shebang_span: Option<Span>,
+    pub(crate) indented_shebang_indent_span: Option<Span>,
+    pub(crate) space_after_hash_bang_span: Option<Span>,
+    pub(crate) space_after_hash_bang_whitespace_span: Option<Span>,
+    pub(crate) shebang_not_on_first_line_span: Option<Span>,
+    pub(crate) shebang_not_on_first_line_fix_span: Option<Span>,
+    pub(crate) shebang_not_on_first_line_preferred_newline: Option<&'static str>,
+    pub(crate) missing_shebang_line_span: Option<Span>,
+    pub(crate) duplicate_shebang_flag_span: Option<Span>,
+    pub(crate) non_absolute_shebang_span: Option<Span>,
+    pub(crate) enables_errexit: bool,
 }
 
 #[cfg_attr(shuck_profiling, inline(never))]
-fn build_shebang_header_facts(locator: Locator<'_>) -> ShebangHeaderFacts {
+pub(crate) fn build_shebang_header_facts(locator: Locator<'_>) -> ShebangHeaderFacts {
     let source = locator.source();
     let line_index = locator.line_index();
     let Some(first_line) = source_line(source, line_index, 1) else {
@@ -143,27 +145,27 @@ fn build_shebang_header_facts(locator: Locator<'_>) -> ShebangHeaderFacts {
     }
 }
 
-fn source_line_is_header_like(line: &str) -> bool {
+pub(crate) fn source_line_is_header_like(line: &str) -> bool {
     let trimmed = line.trim_start();
     trimmed.is_empty() || trimmed.starts_with('#')
 }
 
-fn source_line_has_shebang_candidate(line: &str) -> bool {
+pub(crate) fn source_line_has_shebang_candidate(line: &str) -> bool {
     let trimmed = line.trim_start_matches(char::is_whitespace);
     trimmed.starts_with("#!") || shebang_space_after_hash_in_line(trimmed).is_some()
 }
 
-fn source_line_has_leading_whitespace_before_shebang_candidate(line: &str) -> bool {
+pub(crate) fn source_line_has_leading_whitespace_before_shebang_candidate(line: &str) -> bool {
     let trimmed = line.trim_start_matches(char::is_whitespace);
     trimmed.len() != line.len() && source_line_has_shebang_candidate(line)
 }
 
-fn source_line_leading_whitespace_len(line: &str) -> Option<usize> {
+pub(crate) fn source_line_leading_whitespace_len(line: &str) -> Option<usize> {
     let trimmed = line.trim_start_matches(char::is_whitespace);
     (trimmed.len() != line.len()).then_some(line.len() - trimmed.len())
 }
 
-fn shebang_space_after_hash_in_line(line: &str) -> Option<(usize, usize)> {
+pub(crate) fn shebang_space_after_hash_in_line(line: &str) -> Option<(usize, usize)> {
     let trimmed = line.trim_start_matches(char::is_whitespace);
     let leading_whitespace_len = line.len().saturating_sub(trimmed.len());
     let rest = trimmed.strip_prefix('#')?;
@@ -174,7 +176,7 @@ fn shebang_space_after_hash_in_line(line: &str) -> Option<(usize, usize)> {
         .then_some((leading_whitespace_len + 1, whitespace_len))
 }
 
-fn point_span(line_number: usize, column: usize, offset: usize) -> Span {
+pub(crate) fn point_span(line_number: usize, column: usize, offset: usize) -> Span {
     Span::at(Position {
         line: line_number,
         column,
@@ -182,7 +184,7 @@ fn point_span(line_number: usize, column: usize, offset: usize) -> Span {
     })
 }
 
-fn line_prefix_span(line_number: usize, offset: usize, prefix: &str) -> Span {
+pub(crate) fn line_prefix_span(line_number: usize, offset: usize, prefix: &str) -> Span {
     let start = Position {
         line: line_number,
         column: 1,
@@ -192,7 +194,7 @@ fn line_prefix_span(line_number: usize, offset: usize, prefix: &str) -> Span {
     Span::from_positions(start, end)
 }
 
-fn line_slice_span(
+pub(crate) fn line_slice_span(
     line_number: usize,
     line_offset: usize,
     line: &str,
@@ -209,7 +211,12 @@ fn line_slice_span(
     Span::from_positions(start, end)
 }
 
-fn line_with_ending_span(line_number: usize, offset: usize, line: &str, line_ending: &str) -> Span {
+pub(crate) fn line_with_ending_span(
+    line_number: usize,
+    offset: usize,
+    line: &str,
+    line_ending: &str,
+) -> Span {
     let start = Position {
         line: line_number,
         column: 1,
@@ -219,18 +226,22 @@ fn line_with_ending_span(line_number: usize, offset: usize, line: &str, line_end
     Span::from_positions(start, end)
 }
 
-fn parse_shebang_words(shebang: &str) -> Vec<&str> {
+pub(crate) fn parse_shebang_words(shebang: &str) -> Vec<&str> {
     shebang.split_whitespace().collect()
 }
 
 #[derive(Debug, Clone, Copy)]
-struct SourceLine<'a> {
+pub(crate) struct SourceLine<'a> {
     offset: usize,
     text: &'a str,
     line_ending: &'static str,
 }
 
-fn source_line<'a>(source: &'a str, line_index: &LineIndex, line: usize) -> Option<SourceLine<'a>> {
+pub(crate) fn source_line<'a>(
+    source: &'a str,
+    line_index: &LineIndex,
+    line: usize,
+) -> Option<SourceLine<'a>> {
     let range = line_index.line_range(line, source)?;
     let offset = usize::from(range.start());
     let raw_text = range.slice(source);
@@ -252,7 +263,7 @@ fn source_line<'a>(source: &'a str, line_index: &LineIndex, line: usize) -> Opti
     })
 }
 
-fn first_nonempty_source_line<'a>(
+pub(crate) fn first_nonempty_source_line<'a>(
     source: &'a str,
     line_index: &LineIndex,
 ) -> Option<(usize, &'a str)> {
@@ -262,7 +273,7 @@ fn first_nonempty_source_line<'a>(
         .map(|line| (line.offset, line.text))
 }
 
-fn shebang_duplicate_flag<'a>(shebang_words: &[&'a str]) -> Option<&'a str> {
+pub(crate) fn shebang_duplicate_flag<'a>(shebang_words: &[&'a str]) -> Option<&'a str> {
     let mut seen = FxHashSet::default();
 
     shebang_words
@@ -272,7 +283,7 @@ fn shebang_duplicate_flag<'a>(shebang_words: &[&'a str]) -> Option<&'a str> {
         .find(|word| word.starts_with('-') && !seen.insert(*word))
 }
 
-fn shebang_enables_errexit(shebang_words: &[&str]) -> bool {
+pub(crate) fn shebang_enables_errexit(shebang_words: &[&str]) -> bool {
     let mut words = shebang_words.iter().copied().peekable();
     while let Some(word) = words.next() {
         if shebang_short_option_cluster_enables_errexit(word) {
@@ -289,7 +300,7 @@ fn shebang_enables_errexit(shebang_words: &[&str]) -> bool {
     false
 }
 
-fn shebang_short_option_cluster_enables_errexit(word: &str) -> bool {
+pub(crate) fn shebang_short_option_cluster_enables_errexit(word: &str) -> bool {
     let Some(flags) = word.strip_prefix('-') else {
         return false;
     };
@@ -301,7 +312,7 @@ fn shebang_short_option_cluster_enables_errexit(word: &str) -> bool {
     flags.chars().all(|char| char.is_ascii_alphabetic()) && flags.contains('e')
 }
 
-fn line_span(line_number: usize, offset: usize, line: &str) -> Span {
+pub(crate) fn line_span(line_number: usize, offset: usize, line: &str) -> Span {
     let start = Position {
         line: line_number,
         column: 1,
@@ -312,7 +323,10 @@ fn line_span(line_number: usize, offset: usize, line: &str) -> Span {
 }
 
 #[cfg_attr(shuck_profiling, inline(never))]
-fn build_commented_continuation_comment_spans(source: &str, indexer: &Indexer) -> Vec<Span> {
+pub(crate) fn build_commented_continuation_comment_spans(
+    source: &str,
+    indexer: &Indexer,
+) -> Vec<Span> {
     let line_index = indexer.line_index();
     let comment_index = indexer.comment_index();
 
@@ -349,7 +363,10 @@ fn build_commented_continuation_comment_spans(source: &str, indexer: &Indexer) -
         .collect()
 }
 
-fn build_comment_double_quote_nesting_spans(source: &str, indexer: &Indexer) -> Vec<Span> {
+pub(crate) fn build_comment_double_quote_nesting_spans(
+    source: &str,
+    indexer: &Indexer,
+) -> Vec<Span> {
     let line_index = indexer.line_index();
 
     (1..=line_index.line_count())
@@ -385,7 +402,7 @@ fn build_comment_double_quote_nesting_spans(source: &str, indexer: &Indexer) -> 
         .collect()
 }
 
-fn build_trailing_directive_comment_spans(
+pub(crate) fn build_trailing_directive_comment_spans(
     directive_attachment_facts: &crate::suppression::DirectiveAttachmentFacts,
     case_items: &[CaseItemFact<'_>],
     source: &str,
@@ -435,7 +452,7 @@ fn build_trailing_directive_comment_spans(
         .collect()
 }
 
-fn case_item_label_comment(
+pub(crate) fn case_item_label_comment(
     case_items: &[CaseItemFact<'_>],
     line: usize,
     comment_start: usize,
@@ -457,7 +474,7 @@ fn case_item_label_comment(
     })
 }
 
-fn has_header_shellcheck_shell_directive(source: &str, line_index: &LineIndex) -> bool {
+pub(crate) fn has_header_shellcheck_shell_directive(source: &str, line_index: &LineIndex) -> bool {
     for line_number in 2..=line_index.line_count() {
         let Some(source_line) = source_line(source, line_index, line_number) else {
             continue;

--- a/crates/shuck-linter/src/facts/conditional_portability.rs
+++ b/crates/shuck-linter/src/facts/conditional_portability.rs
@@ -88,7 +88,7 @@ impl ConditionalPortabilityFacts {
     }
 }
 
-pub(super) struct ConditionalPortabilityInputs<'a> {
+pub(crate) struct ConditionalPortabilityInputs<'a> {
     pub word_nodes: &'a [WordNode<'a>],
     pub word_occurrences: &'a [WordOccurrence],
     pub pattern_exactly_one_extglob_spans: &'a [Span],
@@ -98,7 +98,7 @@ pub(super) struct ConditionalPortabilityInputs<'a> {
 }
 
 #[cfg_attr(shuck_profiling, inline(never))]
-pub(super) fn build_conditional_portability_facts<'a>(
+pub(crate) fn build_conditional_portability_facts<'a>(
     commands: &[CommandFact<'a>],
     elif_condition_command_ids: &DenseCommandIdSet,
     inputs: ConditionalPortabilityInputs<'a>,

--- a/crates/shuck-linter/src/facts/conditionals.rs
+++ b/crates/shuck-linter/src/facts/conditionals.rs
@@ -1,3 +1,5 @@
+use super::*;
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ConditionalOperatorFamily {
     StringUnary,
@@ -43,7 +45,7 @@ impl<'a> ConditionalOperandFact<'a> {
     }
 }
 
-fn word_is_optional_first_positional_parameter(word: &Word) -> bool {
+pub(crate) fn word_is_optional_first_positional_parameter(word: &Word) -> bool {
     let [part] = word.parts.as_slice() else {
         return false;
     };
@@ -51,7 +53,7 @@ fn word_is_optional_first_positional_parameter(word: &Word) -> bool {
     word_part_is_optional_first_positional_parameter(&part.kind)
 }
 
-fn word_part_is_optional_first_positional_parameter(part: &WordPart) -> bool {
+pub(crate) fn word_part_is_optional_first_positional_parameter(part: &WordPart) -> bool {
     match part {
         WordPart::Variable(name) => name.as_str() == "1",
         WordPart::DoubleQuoted { parts, .. } => {
@@ -65,8 +67,10 @@ fn word_part_is_optional_first_positional_parameter(part: &WordPart) -> bool {
             reference,
             operator,
             ..
-        } => reference_is_first_positional_parameter(reference)
-            && matches!(operator.as_ref(), ParameterOp::UseDefault),
+        } => {
+            reference_is_first_positional_parameter(reference)
+                && matches!(operator.as_ref(), ParameterOp::UseDefault)
+        }
         WordPart::Literal(_)
         | WordPart::ZshQualifiedGlob(_)
         | WordPart::SingleQuoted { .. }
@@ -85,7 +89,7 @@ fn word_part_is_optional_first_positional_parameter(part: &WordPart) -> bool {
     }
 }
 
-fn parameter_is_optional_first_positional(parameter: &ParameterExpansion) -> bool {
+pub(crate) fn parameter_is_optional_first_positional(parameter: &ParameterExpansion) -> bool {
     match &parameter.syntax {
         ParameterExpansionSyntax::Bourne(BourneParameterExpansion::Access { reference }) => {
             reference_is_first_positional_parameter(reference)
@@ -128,7 +132,7 @@ fn parameter_is_optional_first_positional(parameter: &ParameterExpansion) -> boo
     }
 }
 
-fn reference_is_first_positional_parameter(reference: &VarRef) -> bool {
+pub(crate) fn reference_is_first_positional_parameter(reference: &VarRef) -> bool {
     reference.subscript.is_none() && reference.name.as_str() == "1"
 }
 
@@ -303,10 +307,7 @@ pub(crate) struct ConditionalExpressionVisit<'a> {
 }
 
 impl<'a> ConditionalExpressionVisit<'a> {
-    pub(crate) fn new(
-        expression: &'a ConditionalExpr,
-        parent_in_same_logical_group: bool,
-    ) -> Self {
+    pub(crate) fn new(expression: &'a ConditionalExpr, parent_in_same_logical_group: bool) -> Self {
         Self {
             expression,
             parent_in_same_logical_group,
@@ -314,7 +315,7 @@ impl<'a> ConditionalExpressionVisit<'a> {
     }
 }
 
-fn collect_command_substitution_command_span(
+pub(crate) fn collect_command_substitution_command_span(
     command: &Command,
     source: &str,
     spans: &mut Vec<Span>,
@@ -327,7 +328,7 @@ fn collect_command_substitution_command_span(
     }
 }
 
-fn collect_c107_status_spans_in_simple_test(
+pub(crate) fn collect_c107_status_spans_in_simple_test(
     command: &shuck_ast::SimpleCommand,
     source: &str,
     spans: &mut Vec<Span>,
@@ -372,7 +373,7 @@ fn collect_c107_status_spans_in_simple_test(
     }
 }
 
-fn collect_c107_status_spans_in_conditional_expr(
+pub(crate) fn collect_c107_status_spans_in_conditional_expr(
     expression: &ConditionalExpr,
     source: &str,
     spans: &mut Vec<Span>,
@@ -382,7 +383,10 @@ fn collect_c107_status_spans_in_conditional_expr(
     }
 }
 
-fn c107_conditional_expr_status_span(expression: &ConditionalExpr, source: &str) -> Option<Span> {
+pub(crate) fn c107_conditional_expr_status_span(
+    expression: &ConditionalExpr,
+    source: &str,
+) -> Option<Span> {
     match expression {
         ConditionalExpr::Binary(expression) => {
             if matches!(
@@ -428,7 +432,7 @@ fn c107_conditional_expr_status_span(expression: &ConditionalExpr, source: &str)
     }
 }
 
-fn c107_conditional_operand_status_span(expression: &ConditionalExpr) -> Option<Span> {
+pub(crate) fn c107_conditional_operand_status_span(expression: &ConditionalExpr) -> Option<Span> {
     match expression {
         ConditionalExpr::Word(word) | ConditionalExpr::Regex(word) => c107_status_word_span(word),
         ConditionalExpr::Pattern(pattern) => {
@@ -454,7 +458,10 @@ fn c107_conditional_operand_status_span(expression: &ConditionalExpr) -> Option<
     }
 }
 
-fn c107_conditional_expr_is_zero_literal(expression: &ConditionalExpr, source: &str) -> bool {
+pub(crate) fn c107_conditional_expr_is_zero_literal(
+    expression: &ConditionalExpr,
+    source: &str,
+) -> bool {
     match expression {
         ConditionalExpr::Word(word) | ConditionalExpr::Regex(word) => {
             c107_word_is_zero_literal(word, source)
@@ -470,7 +477,7 @@ fn c107_conditional_expr_is_zero_literal(expression: &ConditionalExpr, source: &
     }
 }
 
-fn collect_c107_status_spans_in_arithmetic_command(
+pub(crate) fn collect_c107_status_spans_in_arithmetic_command(
     command: &shuck_ast::ArithmeticCommand,
     source: &str,
     spans: &mut Vec<Span>,
@@ -484,7 +491,7 @@ fn collect_c107_status_spans_in_arithmetic_command(
     }
 }
 
-fn c107_arithmetic_expr_status_span(
+pub(crate) fn c107_arithmetic_expr_status_span(
     expression: &shuck_ast::ArithmeticExprNode,
     source: &str,
 ) -> Option<Span> {
@@ -521,7 +528,9 @@ fn c107_arithmetic_expr_status_span(
     }
 }
 
-fn c107_arithmetic_operand_status_span(expression: &shuck_ast::ArithmeticExprNode) -> Option<Span> {
+pub(crate) fn c107_arithmetic_operand_status_span(
+    expression: &shuck_ast::ArithmeticExprNode,
+) -> Option<Span> {
     match &expression.kind {
         shuck_ast::ArithmeticExpr::ShellWord(word) => c107_status_word_span(word),
         shuck_ast::ArithmeticExpr::Parenthesized { expression } => {
@@ -532,7 +541,7 @@ fn c107_arithmetic_operand_status_span(expression: &shuck_ast::ArithmeticExprNod
     }
 }
 
-fn c107_arithmetic_expr_is_zero_literal(
+pub(crate) fn c107_arithmetic_expr_is_zero_literal(
     expression: &shuck_ast::ArithmeticExprNode,
     source: &str,
 ) -> bool {
@@ -549,15 +558,15 @@ fn c107_arithmetic_expr_is_zero_literal(
     }
 }
 
-fn c107_status_word_span(word: &Word) -> Option<Span> {
+pub(crate) fn c107_status_word_span(word: &Word) -> Option<Span> {
     word_is_standalone_status_capture(word).then_some(word.span)
 }
 
-fn c107_word_is_zero_literal(word: &Word, source: &str) -> bool {
+pub(crate) fn c107_word_is_zero_literal(word: &Word, source: &str) -> bool {
     static_word_text(word, source).as_deref() == Some("0")
 }
 
-fn c107_pattern_is_zero_literal(pattern: &Pattern, source: &str) -> bool {
+pub(crate) fn c107_pattern_is_zero_literal(pattern: &Pattern, source: &str) -> bool {
     match pattern.parts.as_slice() {
         [part] => match &part.kind {
             PatternPart::Literal(text) => text.as_str(source, part.span) == "0",
@@ -571,7 +580,7 @@ fn c107_pattern_is_zero_literal(pattern: &Pattern, source: &str) -> bool {
     }
 }
 
-fn collect_condition_status_capture_from_body(
+pub(crate) fn collect_condition_status_capture_from_body(
     condition: &StmtSeq,
     body: &StmtSeq,
     source: &str,
@@ -596,7 +605,7 @@ fn collect_condition_status_capture_from_body(
     spans.extend(stmt_spans);
 }
 
-pub(super) fn collect_condition_status_capture_from_sequence(
+pub(crate) fn collect_condition_status_capture_from_sequence(
     commands: &StmtSeq,
     source: &str,
     spans: &mut Vec<Span>,
@@ -641,7 +650,7 @@ pub(super) fn collect_condition_status_capture_from_sequence(
     }
 }
 
-pub(super) fn collect_condition_status_capture_from_direct_body_sequences(
+pub(crate) fn collect_condition_status_capture_from_direct_body_sequences(
     command: &Command,
     source: &str,
     spans: &mut Vec<Span>,
@@ -694,7 +703,7 @@ pub(super) fn collect_condition_status_capture_from_direct_body_sequences(
     }
 }
 
-fn collect_condition_status_capture_from_sequence_segment(
+pub(crate) fn collect_condition_status_capture_from_sequence_segment(
     commands: &[Stmt],
     source: &str,
     spans: &mut Vec<Span>,
@@ -708,10 +717,7 @@ fn collect_condition_status_capture_from_sequence_segment(
         if let Some(before_previous) = body_topology.previous_sibling(index) {
             recent.push(before_previous, source);
         }
-        let tail_has_test = tail_contains_test
-            .get(index + 2)
-            .copied()
-            .unwrap_or(false);
+        let tail_has_test = tail_contains_test.get(index + 2).copied().unwrap_or(false);
         let effective_tail_has_test = trailing_tail_has_test || tail_has_test;
         let in_tbegin_region = recent.seen_tbegin;
 
@@ -742,9 +748,7 @@ fn collect_condition_status_capture_from_sequence_segment(
             continue;
         }
 
-        if in_tbegin_region
-            && recent.has_prior_non_status_capture_pair
-        {
+        if in_tbegin_region && recent.has_prior_non_status_capture_pair {
             continue;
         }
 
@@ -755,7 +759,7 @@ fn collect_condition_status_capture_from_sequence_segment(
 }
 
 #[derive(Default)]
-struct RecentSequenceStatus<'a> {
+pub(crate) struct RecentSequenceStatus<'a> {
     seen_tbegin: bool,
     status_capture_count: usize,
     contains_status_based_test: bool,
@@ -792,7 +796,7 @@ impl<'a> RecentSequenceStatus<'a> {
     }
 }
 
-fn sequence_tail_test_index(commands: &[Stmt], source: &str) -> Vec<bool> {
+pub(crate) fn sequence_tail_test_index(commands: &[Stmt], source: &str) -> Vec<bool> {
     let mut suffix = vec![false; commands.len() + 1];
     for (index, stmt) in commands.iter().enumerate().rev() {
         suffix[index] = suffix[index + 1] || stmt_terminals_are_test_commands(stmt, source);
@@ -800,7 +804,7 @@ fn sequence_tail_test_index(commands: &[Stmt], source: &str) -> Vec<bool> {
     suffix
 }
 
-fn branch_body_status_capture_is_exempt(
+pub(crate) fn branch_body_status_capture_is_exempt(
     first_stmt: &Stmt,
     body: &StmtSeq,
     source: &str,
@@ -817,7 +821,7 @@ fn branch_body_status_capture_is_exempt(
     false
 }
 
-fn branch_body_preserves_status_in_plain_assignment(
+pub(crate) fn branch_body_preserves_status_in_plain_assignment(
     first_stmt: &Stmt,
     _body: &StmtSeq,
     source: &str,
@@ -833,22 +837,23 @@ fn branch_body_preserves_status_in_plain_assignment(
     true
 }
 
-fn branch_body_logs_status_then_immediately_exits(
+pub(crate) fn branch_body_logs_status_then_immediately_exits(
     first_stmt: &Stmt,
     body: &StmtSeq,
     source: &str,
     stmt_spans: &[Span],
 ) -> bool {
-    if stmt_spans.is_empty()
-        || stmt_contains_unquoted_standalone_status_capture(first_stmt, source)
+    if stmt_spans.is_empty() || stmt_contains_unquoted_standalone_status_capture(first_stmt, source)
     {
         return false;
     }
 
-    body.iter().nth(1).is_some_and(stmt_is_exit_or_return_builtin)
+    body.iter()
+        .nth(1)
+        .is_some_and(stmt_is_exit_or_return_builtin)
 }
 
-fn collect_precise_function_return_guard_suppressions_in_seq(
+pub(crate) fn collect_precise_function_return_guard_suppressions_in_seq(
     commands: &StmtSeq,
     source: &str,
     spans: &mut Vec<Span>,
@@ -875,7 +880,7 @@ fn collect_precise_function_return_guard_suppressions_in_seq(
     }
 }
 
-fn collect_precise_function_return_guard_suppressions_from_direct_body_sequences(
+pub(crate) fn collect_precise_function_return_guard_suppressions_from_direct_body_sequences(
     command: &Command,
     source: &str,
     spans: &mut Vec<Span>,
@@ -988,21 +993,21 @@ fn collect_precise_function_return_guard_suppressions_from_direct_body_sequences
     }
 }
 
-fn condition_terminals_are_test_commands(condition: &StmtSeq, source: &str) -> bool {
+pub(crate) fn condition_terminals_are_test_commands(condition: &StmtSeq, source: &str) -> bool {
     condition
         .last()
         .is_some_and(|stmt| stmt_terminals_are_test_commands(stmt, source))
 }
 
-fn stmt_is_standalone_non_status_test_command(stmt: &Stmt, source: &str) -> bool {
+pub(crate) fn stmt_is_standalone_non_status_test_command(stmt: &Stmt, source: &str) -> bool {
     stmt_terminals_are_test_commands(stmt, source) && !stmt_contains_status_capture(stmt, source)
 }
 
-fn stmt_is_status_based_test_command(stmt: &Stmt, source: &str) -> bool {
+pub(crate) fn stmt_is_status_based_test_command(stmt: &Stmt, source: &str) -> bool {
     stmt_terminals_are_test_commands(stmt, source) && stmt_contains_status_capture(stmt, source)
 }
 
-fn stmt_is_unary_test_return_status_guard(stmt: &Stmt, source: &str) -> bool {
+pub(crate) fn stmt_is_unary_test_return_status_guard(stmt: &Stmt, source: &str) -> bool {
     let Command::Binary(command) = &stmt.command else {
         return false;
     };
@@ -1011,7 +1016,7 @@ fn stmt_is_unary_test_return_status_guard(stmt: &Stmt, source: &str) -> bool {
         && stmt_is_return_status_command(&command.right, source)
 }
 
-fn stmt_is_test_return_status_guard(stmt: &Stmt, source: &str) -> bool {
+pub(crate) fn stmt_is_test_return_status_guard(stmt: &Stmt, source: &str) -> bool {
     let Command::Binary(command) = &stmt.command else {
         return false;
     };
@@ -1020,7 +1025,7 @@ fn stmt_is_test_return_status_guard(stmt: &Stmt, source: &str) -> bool {
         && stmt_is_return_status_command(&command.right, source)
 }
 
-fn stmt_is_non_test_return_status_guard(stmt: &Stmt, source: &str) -> bool {
+pub(crate) fn stmt_is_non_test_return_status_guard(stmt: &Stmt, source: &str) -> bool {
     let Command::Binary(command) = &stmt.command else {
         return false;
     };
@@ -1029,7 +1034,7 @@ fn stmt_is_non_test_return_status_guard(stmt: &Stmt, source: &str) -> bool {
         && stmt_is_return_status_command(&command.right, source)
 }
 
-fn stmt_is_return_status_command(stmt: &Stmt, source: &str) -> bool {
+pub(crate) fn stmt_is_return_status_command(stmt: &Stmt, source: &str) -> bool {
     if stmt.negated || !stmt.redirects.is_empty() {
         return false;
     }
@@ -1053,7 +1058,7 @@ fn stmt_is_return_status_command(stmt: &Stmt, source: &str) -> bool {
     }
 }
 
-fn stmt_is_simple_unary_test_command(stmt: &Stmt, source: &str) -> bool {
+pub(crate) fn stmt_is_simple_unary_test_command(stmt: &Stmt, source: &str) -> bool {
     if stmt.negated {
         return false;
     }
@@ -1091,7 +1096,7 @@ fn stmt_is_simple_unary_test_command(stmt: &Stmt, source: &str) -> bool {
     }
 }
 
-fn stmt_assignment_only_scalar_literal_name<'a>(
+pub(crate) fn stmt_assignment_only_scalar_literal_name<'a>(
     stmt: &'a Stmt,
     source: &str,
     expected: &str,
@@ -1106,7 +1111,7 @@ fn stmt_assignment_only_scalar_literal_name<'a>(
     (static_word_text(word, source).as_deref() == Some(expected)).then_some(name)
 }
 
-fn word_is_name_reference(word: &Word, name: &Name) -> bool {
+pub(crate) fn word_is_name_reference(word: &Word, name: &Name) -> bool {
     matches!(
         word.parts.as_slice(),
         [WordPartNode {
@@ -1126,19 +1131,19 @@ fn word_is_name_reference(word: &Word, name: &Name) -> bool {
     )
 }
 
-fn stmt_contains_status_capture(stmt: &Stmt, source: &str) -> bool {
+pub(crate) fn stmt_contains_status_capture(stmt: &Stmt, source: &str) -> bool {
     let mut spans = Vec::new();
     collect_status_parameter_spans_in_stmt(stmt, source, &mut spans);
     !spans.is_empty()
 }
 
-fn stmt_contains_unquoted_standalone_status_capture(stmt: &Stmt, source: &str) -> bool {
+pub(crate) fn stmt_contains_unquoted_standalone_status_capture(stmt: &Stmt, source: &str) -> bool {
     let mut spans = Vec::new();
     collect_unquoted_standalone_status_parameter_spans_in_stmt(stmt, source, &mut spans);
     !spans.is_empty()
 }
 
-fn stmt_starts_sequence_barrier(stmt: &Stmt) -> bool {
+pub(crate) fn stmt_starts_sequence_barrier(stmt: &Stmt) -> bool {
     matches!(
         &stmt.command,
         Command::Compound(
@@ -1153,7 +1158,7 @@ fn stmt_starts_sequence_barrier(stmt: &Stmt) -> bool {
     )
 }
 
-fn stmt_is_named_simple_command(stmt: &Stmt, source: &str, name: &str) -> bool {
+pub(crate) fn stmt_is_named_simple_command(stmt: &Stmt, source: &str, name: &str) -> bool {
     matches!(
         &stmt.command,
         Command::Simple(command)
@@ -1161,7 +1166,7 @@ fn stmt_is_named_simple_command(stmt: &Stmt, source: &str, name: &str) -> bool {
     )
 }
 
-fn stmt_plain_assignment_only_name(stmt: &Stmt) -> Option<&Name> {
+pub(crate) fn stmt_plain_assignment_only_name(stmt: &Stmt) -> Option<&Name> {
     if stmt.negated || !stmt.redirects.is_empty() {
         return None;
     }
@@ -1179,7 +1184,7 @@ fn stmt_plain_assignment_only_name(stmt: &Stmt) -> Option<&Name> {
     Some(&command.assignments[0].target.name)
 }
 
-fn stmt_is_assignment_only_unquoted_status_capture(stmt: &Stmt) -> bool {
+pub(crate) fn stmt_is_assignment_only_unquoted_status_capture(stmt: &Stmt) -> bool {
     if stmt.negated || !stmt.redirects.is_empty() {
         return false;
     }
@@ -1197,21 +1202,21 @@ fn stmt_is_assignment_only_unquoted_status_capture(stmt: &Stmt) -> bool {
             .all(|assignment| assignment_value_is_unquoted_status_capture(&assignment.value))
 }
 
-fn assignment_value_is_unquoted_status_capture(value: &AssignmentValue) -> bool {
+pub(crate) fn assignment_value_is_unquoted_status_capture(value: &AssignmentValue) -> bool {
     match value {
         AssignmentValue::Scalar(word) => word_is_unquoted_standalone_status_capture(word),
         AssignmentValue::Compound(_) => false,
     }
 }
 
-fn stmt_is_exit_or_return_builtin(stmt: &Stmt) -> bool {
+pub(crate) fn stmt_is_exit_or_return_builtin(stmt: &Stmt) -> bool {
     matches!(
         stmt.command,
         Command::Builtin(BuiltinCommand::Exit(_) | BuiltinCommand::Return(_))
     )
 }
 
-fn stmt_is_plain_command_with_standalone_status_argument(stmt: &Stmt) -> bool {
+pub(crate) fn stmt_is_plain_command_with_standalone_status_argument(stmt: &Stmt) -> bool {
     if stmt.negated || !stmt.redirects.is_empty() {
         return false;
     }
@@ -1234,8 +1239,7 @@ fn stmt_is_plain_command_with_standalone_status_argument(stmt: &Stmt) -> bool {
                 .code
                 .as_ref()
                 .is_some_and(word_is_unquoted_standalone_status_capture),
-            BuiltinCommand::Break(_)
-            | BuiltinCommand::Continue(_) => false,
+            BuiltinCommand::Break(_) | BuiltinCommand::Continue(_) => false,
         },
         Command::Decl(_)
         | Command::Binary(_)
@@ -1245,7 +1249,7 @@ fn stmt_is_plain_command_with_standalone_status_argument(stmt: &Stmt) -> bool {
     }
 }
 
-fn word_is_unquoted_standalone_status_capture(word: &Word) -> bool {
+pub(crate) fn word_is_unquoted_standalone_status_capture(word: &Word) -> bool {
     matches!(
         word.parts.as_slice(),
         [WordPartNode {
@@ -1265,7 +1269,7 @@ fn word_is_unquoted_standalone_status_capture(word: &Word) -> bool {
     )
 }
 
-fn stmt_terminals_are_test_commands(stmt: &Stmt, source: &str) -> bool {
+pub(crate) fn stmt_terminals_are_test_commands(stmt: &Stmt, source: &str) -> bool {
     if stmt.negated {
         return false;
     }
@@ -1273,16 +1277,14 @@ fn stmt_terminals_are_test_commands(stmt: &Stmt, source: &str) -> bool {
     command_terminals_are_test_commands(&stmt.command, source)
 }
 
-fn command_terminals_are_test_commands(command: &Command, source: &str) -> bool {
+pub(crate) fn command_terminals_are_test_commands(command: &Command, source: &str) -> bool {
     match command {
         Command::Simple(command) => matches!(
             static_word_text(&command.name, source).as_deref(),
             Some("[") | Some("test")
         ),
         Command::Compound(CompoundCommand::Conditional(_)) => true,
-        Command::Binary(command) => {
-            logical_list_segments_are_test_commands(command, source)
-        }
+        Command::Binary(command) => logical_list_segments_are_test_commands(command, source),
         Command::Builtin(_)
         | Command::Decl(_)
         | Command::Compound(_)
@@ -1291,13 +1293,20 @@ fn command_terminals_are_test_commands(command: &Command, source: &str) -> bool 
     }
 }
 
-fn logical_list_segments_are_test_commands(command: &BinaryCommand, source: &str) -> bool {
+pub(crate) fn logical_list_segments_are_test_commands(
+    command: &BinaryCommand,
+    source: &str,
+) -> bool {
     matches!(command.op, BinaryOp::And | BinaryOp::Or)
         && stmt_terminals_are_test_commands(&command.left, source)
         && stmt_terminals_are_test_commands(&command.right, source)
 }
 
-fn collect_status_parameter_spans_in_stmt(stmt: &Stmt, source: &str, spans: &mut Vec<Span>) {
+pub(crate) fn collect_status_parameter_spans_in_stmt(
+    stmt: &Stmt,
+    source: &str,
+    spans: &mut Vec<Span>,
+) {
     collect_status_parameter_spans_in_command(&stmt.command, source, spans);
     for redirect in &stmt.redirects {
         if let Some(word) = redirect.word_target() {
@@ -1306,7 +1315,7 @@ fn collect_status_parameter_spans_in_stmt(stmt: &Stmt, source: &str, spans: &mut
     }
 }
 
-fn collect_status_parameter_spans_in_return_guard_stmt(
+pub(crate) fn collect_status_parameter_spans_in_return_guard_stmt(
     stmt: &Stmt,
     source: &str,
     spans: &mut Vec<Span>,
@@ -1319,7 +1328,7 @@ fn collect_status_parameter_spans_in_return_guard_stmt(
     collect_status_parameter_spans_in_stmt(stmt, source, spans);
 }
 
-fn collect_unquoted_standalone_status_parameter_spans_in_stmt(
+pub(crate) fn collect_unquoted_standalone_status_parameter_spans_in_stmt(
     stmt: &Stmt,
     source: &str,
     spans: &mut Vec<Span>,
@@ -1332,7 +1341,7 @@ fn collect_unquoted_standalone_status_parameter_spans_in_stmt(
     }
 }
 
-fn collect_unquoted_standalone_status_parameter_spans_in_command(
+pub(crate) fn collect_unquoted_standalone_status_parameter_spans_in_command(
     command: &Command,
     source: &str,
     spans: &mut Vec<Span>,
@@ -1360,8 +1369,7 @@ fn collect_unquoted_standalone_status_parameter_spans_in_command(
                     collect_unquoted_standalone_status_parameter_spans_in_word(word, spans);
                 }
             }
-            BuiltinCommand::Break(_)
-            | BuiltinCommand::Continue(_) => {}
+            BuiltinCommand::Break(_) | BuiltinCommand::Continue(_) => {}
         },
         Command::Decl(command) => {
             collect_unquoted_standalone_status_parameter_spans_in_assignments(
@@ -1378,30 +1386,24 @@ fn collect_unquoted_standalone_status_parameter_spans_in_command(
         }
         Command::Compound(command) => match command {
             CompoundCommand::Case(command) => {
-                if let Some(first_stmt) = command
-                    .cases
-                    .iter()
-                    .find_map(|case| case.body.first())
-                {
+                if let Some(first_stmt) = command.cases.iter().find_map(|case| case.body.first()) {
                     collect_unquoted_standalone_status_parameter_spans_in_stmt(
-                        first_stmt,
-                        source,
-                        spans,
+                        first_stmt, source, spans,
                     );
                 }
             }
             CompoundCommand::BraceGroup(body) | CompoundCommand::Subshell(body) => {
                 if let Some(first_stmt) = body.first() {
                     collect_unquoted_standalone_status_parameter_spans_in_stmt(
-                        first_stmt,
-                        source,
-                        spans,
+                        first_stmt, source, spans,
                     );
                 }
             }
             CompoundCommand::Time(command) => {
                 if let Some(inner) = &command.command {
-                    collect_unquoted_standalone_status_parameter_spans_in_stmt(inner, source, spans);
+                    collect_unquoted_standalone_status_parameter_spans_in_stmt(
+                        inner, source, spans,
+                    );
                 }
             }
             CompoundCommand::If(_)
@@ -1418,14 +1420,17 @@ fn collect_unquoted_standalone_status_parameter_spans_in_command(
             | CompoundCommand::Always(_) => {}
         },
         Command::Binary(command) => {
-            collect_unquoted_standalone_status_parameter_spans_in_stmt(&command.left, source, spans);
+            collect_unquoted_standalone_status_parameter_spans_in_stmt(
+                &command.left,
+                source,
+                spans,
+            );
         }
-        Command::Function(_)
-        | Command::AnonymousFunction(_) => {}
+        Command::Function(_) | Command::AnonymousFunction(_) => {}
     }
 }
 
-fn collect_unquoted_standalone_status_parameter_spans_in_assignments(
+pub(crate) fn collect_unquoted_standalone_status_parameter_spans_in_assignments(
     assignments: &[Assignment],
     spans: &mut Vec<Span>,
 ) {
@@ -1434,7 +1439,7 @@ fn collect_unquoted_standalone_status_parameter_spans_in_assignments(
     }
 }
 
-fn collect_unquoted_standalone_status_parameter_spans_in_assignment(
+pub(crate) fn collect_unquoted_standalone_status_parameter_spans_in_assignment(
     assignment: &Assignment,
     spans: &mut Vec<Span>,
 ) {
@@ -1446,13 +1451,16 @@ fn collect_unquoted_standalone_status_parameter_spans_in_assignment(
     }
 }
 
-fn collect_unquoted_standalone_status_parameter_spans_in_word(word: &Word, spans: &mut Vec<Span>) {
+pub(crate) fn collect_unquoted_standalone_status_parameter_spans_in_word(
+    word: &Word,
+    spans: &mut Vec<Span>,
+) {
     if word_is_unquoted_standalone_status_capture(word) {
         spans.push(word.span);
     }
 }
 
-fn collect_status_parameter_spans_in_command(
+pub(crate) fn collect_status_parameter_spans_in_command(
     command: &Command,
     source: &str,
     spans: &mut Vec<Span>,
@@ -1588,7 +1596,7 @@ fn collect_status_parameter_spans_in_command(
     }
 }
 
-fn collect_status_parameter_spans_in_assignments(
+pub(crate) fn collect_status_parameter_spans_in_assignments(
     assignments: &[Assignment],
     source: &str,
     spans: &mut Vec<Span>,
@@ -1598,7 +1606,7 @@ fn collect_status_parameter_spans_in_assignments(
     }
 }
 
-fn collect_status_parameter_spans_in_assignment(
+pub(crate) fn collect_status_parameter_spans_in_assignment(
     assignment: &Assignment,
     source: &str,
     spans: &mut Vec<Span>,
@@ -1626,7 +1634,7 @@ fn collect_status_parameter_spans_in_assignment(
     }
 }
 
-fn collect_status_parameter_spans_in_var_ref(
+pub(crate) fn collect_status_parameter_spans_in_var_ref(
     reference: &VarRef,
     source: &str,
     spans: &mut Vec<Span>,
@@ -1640,13 +1648,17 @@ fn collect_status_parameter_spans_in_var_ref(
     });
 }
 
-fn collect_status_parameter_spans_in_word(word: &Word, source: &str, spans: &mut Vec<Span>) {
+pub(crate) fn collect_status_parameter_spans_in_word(
+    word: &Word,
+    source: &str,
+    spans: &mut Vec<Span>,
+) {
     for part in &word.parts {
         collect_status_parameter_spans_in_word_part(part, source, spans);
     }
 }
 
-fn collect_status_parameter_spans_in_word_part(
+pub(crate) fn collect_status_parameter_spans_in_word_part(
     part: &WordPartNode,
     source: &str,
     spans: &mut Vec<Span>,
@@ -1760,7 +1772,7 @@ fn collect_status_parameter_spans_in_word_part(
     }
 }
 
-fn collect_status_parameter_spans_in_parameter_expansion(
+pub(crate) fn collect_status_parameter_spans_in_parameter_expansion(
     parameter: &shuck_ast::ParameterExpansion,
     source: &str,
     spans: &mut Vec<Span>,
@@ -1885,7 +1897,7 @@ fn collect_status_parameter_spans_in_parameter_expansion(
     }
 }
 
-fn collect_status_parameter_spans_in_zsh_target(
+pub(crate) fn collect_status_parameter_spans_in_zsh_target(
     target: &ZshExpansionTarget,
     source: &str,
     spans: &mut Vec<Span>,
@@ -1904,7 +1916,7 @@ fn collect_status_parameter_spans_in_zsh_target(
     }
 }
 
-fn collect_status_parameter_spans_in_conditional_expr(
+pub(crate) fn collect_status_parameter_spans_in_conditional_expr(
     expression: &ConditionalExpr,
     source: &str,
     spans: &mut Vec<Span>,
@@ -1936,7 +1948,7 @@ fn collect_status_parameter_spans_in_conditional_expr(
     }
 }
 
-fn collect_status_parameter_spans_in_fragment(
+pub(crate) fn collect_status_parameter_spans_in_fragment(
     word: Option<&Word>,
     text: Option<&SourceText>,
     source: &str,
@@ -1959,7 +1971,7 @@ fn collect_status_parameter_spans_in_fragment(
     collect_status_parameter_spans_in_word(word, source, spans);
 }
 
-fn build_conditional_fact<'a>(
+pub(crate) fn build_conditional_fact<'a>(
     expression_visits: &[ConditionalExpressionVisit<'a>],
     source: &str,
 ) -> Option<ConditionalFact<'a>> {
@@ -1984,7 +1996,7 @@ fn build_conditional_fact<'a>(
     })
 }
 
-fn command_name_is_plain_command_substitution(word: &Word, source: &str) -> bool {
+pub(crate) fn command_name_is_plain_command_substitution(word: &Word, source: &str) -> bool {
     let analysis = analyze_word(word, source, None);
     analysis.substitution_shape == WordSubstitutionShape::Plain
         && analysis.quote == WordQuote::Unquoted
@@ -2000,7 +2012,7 @@ fn command_name_is_plain_command_substitution(word: &Word, source: &str) -> bool
         )
 }
 
-fn collect_mixed_logical_operator(
+pub(crate) fn collect_mixed_logical_operator(
     expression: &ConditionalExpr,
     parent_in_same_logical_group: bool,
     operators: &mut Vec<ConditionalMixedLogicalOperatorFact>,
@@ -2026,10 +2038,10 @@ fn collect_mixed_logical_operator(
     }
 }
 
-const LOGICAL_AND_MASK: u8 = 0b01;
-const LOGICAL_OR_MASK: u8 = 0b10;
+pub(crate) const LOGICAL_AND_MASK: u8 = 0b01;
+pub(crate) const LOGICAL_OR_MASK: u8 = 0b10;
 
-fn mixed_logical_grouped_subexpression_spans(
+pub(crate) fn mixed_logical_grouped_subexpression_spans(
     expression: &ConditionalExpr,
     group_op: ConditionalBinaryOp,
 ) -> Vec<Span> {
@@ -2038,7 +2050,7 @@ fn mixed_logical_grouped_subexpression_spans(
     spans
 }
 
-fn collect_mixed_logical_grouped_subexpression_spans(
+pub(crate) fn collect_mixed_logical_grouped_subexpression_spans(
     expression: &ConditionalExpr,
     group_op: ConditionalBinaryOp,
     spans: &mut Vec<Span>,
@@ -2059,7 +2071,7 @@ fn collect_mixed_logical_grouped_subexpression_spans(
     collect_mixed_logical_grouped_subexpression_spans(&binary.right, group_op, spans);
 }
 
-fn logical_operator_mask(expression: &ConditionalExpr) -> u8 {
+pub(crate) fn logical_operator_mask(expression: &ConditionalExpr) -> u8 {
     match expression {
         ConditionalExpr::Parenthesized(_) => 0,
         ConditionalExpr::Unary(unary) => logical_operator_mask(&unary.expr),
@@ -2079,11 +2091,11 @@ fn logical_operator_mask(expression: &ConditionalExpr) -> u8 {
     }
 }
 
-fn conditional_binary_op_is_logical(operator: ConditionalBinaryOp) -> bool {
+pub(crate) fn conditional_binary_op_is_logical(operator: ConditionalBinaryOp) -> bool {
     matches!(operator, ConditionalBinaryOp::And | ConditionalBinaryOp::Or)
 }
 
-fn build_conditional_node<'a>(
+pub(crate) fn build_conditional_node<'a>(
     expression: &'a ConditionalExpr,
     source: &str,
 ) -> ConditionalNodeFact<'a> {
@@ -2112,7 +2124,7 @@ fn build_conditional_node<'a>(
     }
 }
 
-fn build_conditional_operand_fact<'a>(
+pub(crate) fn build_conditional_operand_fact<'a>(
     expression: &'a ConditionalExpr,
     source: &str,
 ) -> ConditionalOperandFact<'a> {
@@ -2134,7 +2146,7 @@ fn build_conditional_operand_fact<'a>(
     }
 }
 
-fn conditional_pattern_single_word(pattern: &Pattern) -> Option<&Word> {
+pub(crate) fn conditional_pattern_single_word(pattern: &Pattern) -> Option<&Word> {
     match pattern.parts.as_slice() {
         [part] => match &part.kind {
             PatternPart::Word(word) => Some(word),
@@ -2148,7 +2160,9 @@ fn conditional_pattern_single_word(pattern: &Pattern) -> Option<&Word> {
     }
 }
 
-fn strip_parenthesized_conditionals(mut expression: &ConditionalExpr) -> &ConditionalExpr {
+pub(crate) fn strip_parenthesized_conditionals(
+    mut expression: &ConditionalExpr,
+) -> &ConditionalExpr {
     while let ConditionalExpr::Parenthesized(parenthesized) = expression {
         expression = &parenthesized.expr;
     }
@@ -2156,7 +2170,9 @@ fn strip_parenthesized_conditionals(mut expression: &ConditionalExpr) -> &Condit
     expression
 }
 
-fn conditional_unary_operator_family(operator: ConditionalUnaryOp) -> ConditionalOperatorFamily {
+pub(crate) fn conditional_unary_operator_family(
+    operator: ConditionalUnaryOp,
+) -> ConditionalOperatorFamily {
     if matches!(
         operator,
         ConditionalUnaryOp::EmptyString | ConditionalUnaryOp::NonEmptyString
@@ -2167,7 +2183,9 @@ fn conditional_unary_operator_family(operator: ConditionalUnaryOp) -> Conditiona
     }
 }
 
-fn conditional_binary_operator_family(operator: ConditionalBinaryOp) -> ConditionalOperatorFamily {
+pub(crate) fn conditional_binary_operator_family(
+    operator: ConditionalBinaryOp,
+) -> ConditionalOperatorFamily {
     match operator {
         ConditionalBinaryOp::RegexMatch => ConditionalOperatorFamily::Regex,
         ConditionalBinaryOp::And | ConditionalBinaryOp::Or => ConditionalOperatorFamily::Logical,

--- a/crates/shuck-linter/src/facts/core.rs
+++ b/crates/shuck-linter/src/facts/core.rs
@@ -1,4 +1,33 @@
+use super::{
+    assignments::DeclarationAssignmentProbe,
+    command_options::PathWordFact,
+    commands::CommandFact,
+    redirects::{ComparableNameUse, RedirectFact},
+    substitutions::SubstitutionFact,
+};
+use rustc_hash::FxHashMap;
+use shuck_ast::{Command, IdRange, ListArena, Name, Redirect, Span, Stmt};
+use shuck_semantic::SemanticModel;
+use smallvec::SmallVec;
+
 pub use shuck_semantic::CommandId;
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct CommandVisit<'a> {
+    pub(crate) stmt: &'a Stmt,
+    pub(crate) command: &'a Command,
+    pub(crate) redirects: &'a [Redirect],
+}
+
+impl<'a> CommandVisit<'a> {
+    pub(crate) fn new(stmt: &'a Stmt) -> Self {
+        Self {
+            stmt,
+            command: &stmt.command,
+            redirects: &stmt.redirects,
+        }
+    }
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct FactSpan {
@@ -25,11 +54,11 @@ impl From<Span> for FactSpan {
 pub struct WordNodeId(u32);
 
 impl WordNodeId {
-    fn new(index: usize) -> Self {
+    pub(crate) fn new(index: usize) -> Self {
         Self(fact_id_index_to_u32(index, "word node id"))
     }
 
-    fn index(self) -> usize {
+    pub(crate) fn index(self) -> usize {
         self.0 as usize
     }
 }
@@ -38,11 +67,11 @@ impl WordNodeId {
 pub struct WordOccurrenceId(u32);
 
 impl WordOccurrenceId {
-    fn new(index: usize) -> Self {
+    pub(crate) fn new(index: usize) -> Self {
         Self(fact_id_index_to_u32(index, "word occurrence id"))
     }
 
-    fn index(self) -> usize {
+    pub(crate) fn index(self) -> usize {
         self.0 as usize
     }
 }
@@ -62,7 +91,7 @@ fn fact_id_index_overflow(kind: &'static str) -> ! {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-enum CommandLookupKind {
+pub(crate) enum CommandLookupKind {
     Simple,
     Builtin(BuiltinLookupKind),
     Decl,
@@ -73,7 +102,7 @@ enum CommandLookupKind {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-enum BuiltinLookupKind {
+pub(crate) enum BuiltinLookupKind {
     Break,
     Continue,
     Return,
@@ -81,7 +110,7 @@ enum BuiltinLookupKind {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-enum CompoundLookupKind {
+pub(crate) enum CompoundLookupKind {
     If,
     For,
     Repeat,
@@ -101,28 +130,28 @@ enum CompoundLookupKind {
 }
 
 #[derive(Debug, Clone, Copy)]
-pub(super) struct CommandLookupEntry {
-    kind: CommandLookupKind,
-    id: CommandId,
+pub(crate) struct CommandLookupEntry {
+    pub(crate) kind: CommandLookupKind,
+    pub(crate) id: CommandId,
 }
 
-type CommandLookupIndex = FxHashMap<FactSpan, SmallVec<[CommandLookupEntry; 1]>>;
+pub(crate) type CommandLookupIndex = FxHashMap<FactSpan, SmallVec<[CommandLookupEntry; 1]>>;
 
 #[derive(Debug, Clone, Default)]
-pub(super) struct DenseCommandIdSet {
+pub(crate) struct DenseCommandIdSet {
     words: Vec<u64>,
 }
 
 impl DenseCommandIdSet {
     const BITS: usize = u64::BITS as usize;
 
-    pub(super) fn with_capacity(command_count: usize) -> Self {
+    pub(crate) fn with_capacity(command_count: usize) -> Self {
         Self {
             words: vec![0; command_count.div_ceil(Self::BITS)],
         }
     }
 
-    pub(super) fn insert(&mut self, id: CommandId) {
+    pub(crate) fn insert(&mut self, id: CommandId) {
         let index = id.index();
         let word = index / Self::BITS;
         let bit = index % Self::BITS;
@@ -132,7 +161,7 @@ impl DenseCommandIdSet {
         self.words[word] |= 1u64 << bit;
     }
 
-    pub(super) fn contains(&self, id: CommandId) -> bool {
+    pub(crate) fn contains(&self, id: CommandId) -> bool {
         let index = id.index();
         let word = index / Self::BITS;
         let bit = index % Self::BITS;
@@ -143,17 +172,17 @@ impl DenseCommandIdSet {
 }
 
 #[derive(Debug, Clone)]
-struct FactStore<'a> {
-    redirect_facts: ListArena<RedirectFact<'a>>,
-    substitution_facts: ListArena<SubstitutionFact>,
-    scope_read_source_words: ListArena<PathWordFact<'a>>,
-    scope_name_read_uses: ListArena<ComparableNameUse>,
-    scope_heredoc_name_read_uses: ListArena<ComparableNameUse>,
-    scope_name_write_uses: ListArena<ComparableNameUse>,
-    declaration_assignment_probes: ListArena<DeclarationAssignmentProbe>,
-    word_occurrence_ids: ListArena<WordOccurrenceId>,
-    word_occurrence_ids_by_command: Vec<IdRange<WordOccurrenceId>>,
-    word_spans: ListArena<Span>,
+pub(crate) struct FactStore<'a> {
+    pub(crate) redirect_facts: ListArena<RedirectFact<'a>>,
+    pub(crate) substitution_facts: ListArena<SubstitutionFact>,
+    pub(crate) scope_read_source_words: ListArena<PathWordFact<'a>>,
+    pub(crate) scope_name_read_uses: ListArena<ComparableNameUse>,
+    pub(crate) scope_heredoc_name_read_uses: ListArena<ComparableNameUse>,
+    pub(crate) scope_name_write_uses: ListArena<ComparableNameUse>,
+    pub(crate) declaration_assignment_probes: ListArena<DeclarationAssignmentProbe>,
+    pub(crate) word_occurrence_ids: ListArena<WordOccurrenceId>,
+    pub(crate) word_occurrence_ids_by_command: Vec<IdRange<WordOccurrenceId>>,
+    pub(crate) word_spans: ListArena<Span>,
 }
 
 #[derive(Debug, Clone)]
@@ -163,7 +192,7 @@ pub(crate) struct CommandChildIndex {
 }
 
 impl CommandChildIndex {
-    fn from_semantic_syntax_backed_children(
+    pub(crate) fn from_semantic_syntax_backed_children(
         semantic: &SemanticModel,
         command_fact_indices_by_id: &[Option<usize>],
     ) -> Self {
@@ -197,7 +226,7 @@ impl CommandChildIndex {
         Self { ids, by_parent }
     }
 
-    fn child_ids(&self, id: CommandId) -> &[CommandId] {
+    pub(crate) fn child_ids(&self, id: CommandId) -> &[CommandId] {
         self.by_parent
             .get(id.index())
             .copied()
@@ -212,7 +241,7 @@ fn command_fact_exists(command_fact_indices_by_id: &[Option<usize>], id: Command
 }
 
 impl<'a> FactStore<'a> {
-    fn empty() -> Self {
+    pub(crate) fn empty() -> Self {
         Self {
             redirect_facts: ListArena::new(),
             substitution_facts: ListArena::new(),
@@ -227,60 +256,72 @@ impl<'a> FactStore<'a> {
         }
     }
 
-    fn redirect_facts(&self, range: IdRange<RedirectFact<'a>>) -> &[RedirectFact<'a>] {
+    pub(crate) fn redirect_facts(&self, range: IdRange<RedirectFact<'a>>) -> &[RedirectFact<'a>] {
         self.redirect_facts.get(range)
     }
 
-    fn substitution_facts(&self, range: IdRange<SubstitutionFact>) -> &[SubstitutionFact] {
+    pub(crate) fn substitution_facts(
+        &self,
+        range: IdRange<SubstitutionFact>,
+    ) -> &[SubstitutionFact] {
         self.substitution_facts.get(range)
     }
 
-    fn scope_read_source_words(&self, range: IdRange<PathWordFact<'a>>) -> &[PathWordFact<'a>] {
+    pub(crate) fn scope_read_source_words(
+        &self,
+        range: IdRange<PathWordFact<'a>>,
+    ) -> &[PathWordFact<'a>] {
         self.scope_read_source_words.get(range)
     }
 
-    fn scope_name_read_uses(&self, range: IdRange<ComparableNameUse>) -> &[ComparableNameUse] {
+    pub(crate) fn scope_name_read_uses(
+        &self,
+        range: IdRange<ComparableNameUse>,
+    ) -> &[ComparableNameUse] {
         self.scope_name_read_uses.get(range)
     }
 
-    fn scope_heredoc_name_read_uses(
+    pub(crate) fn scope_heredoc_name_read_uses(
         &self,
         range: IdRange<ComparableNameUse>,
     ) -> &[ComparableNameUse] {
         self.scope_heredoc_name_read_uses.get(range)
     }
 
-    fn scope_name_write_uses(&self, range: IdRange<ComparableNameUse>) -> &[ComparableNameUse] {
+    pub(crate) fn scope_name_write_uses(
+        &self,
+        range: IdRange<ComparableNameUse>,
+    ) -> &[ComparableNameUse] {
         self.scope_name_write_uses.get(range)
     }
 
-    fn declaration_assignment_probes(
+    pub(crate) fn declaration_assignment_probes(
         &self,
         range: IdRange<DeclarationAssignmentProbe>,
     ) -> &[DeclarationAssignmentProbe] {
         self.declaration_assignment_probes.get(range)
     }
 
-    fn word_occurrence_ids_for_command(&self, id: CommandId) -> &[WordOccurrenceId] {
+    pub(crate) fn word_occurrence_ids_for_command(&self, id: CommandId) -> &[WordOccurrenceId] {
         self.word_occurrence_ids_by_command
             .get(id.index())
             .copied()
             .map_or(&[], |range| self.word_occurrence_ids.get(range))
     }
 
-    fn word_spans(&self, range: IdRange<Span>) -> &[Span] {
+    pub(crate) fn word_spans(&self, range: IdRange<Span>) -> &[Span] {
         self.word_spans.get(range)
     }
 }
 
 #[derive(Clone, Copy)]
 pub struct CommandFactRef<'facts, 'a> {
-    fact: &'facts CommandFact<'a>,
-    store: &'facts FactStore<'a>,
+    pub(crate) fact: &'facts CommandFact<'a>,
+    pub(crate) store: &'facts FactStore<'a>,
 }
 
 impl<'facts, 'a> CommandFactRef<'facts, 'a> {
-    fn new(fact: &'facts CommandFact<'a>, store: &'facts FactStore<'a>) -> Self {
+    pub(crate) fn new(fact: &'facts CommandFact<'a>, store: &'facts FactStore<'a>) -> Self {
         Self { fact, store }
     }
 }
@@ -301,13 +342,13 @@ impl<'facts, 'a> std::ops::Deref for CommandFactRef<'facts, 'a> {
 
 #[derive(Clone, Copy)]
 pub struct CommandFacts<'facts, 'a> {
-    commands: &'facts [CommandFact<'a>],
-    store: &'facts FactStore<'a>,
-    indices_by_id: &'facts [Option<usize>],
+    pub(crate) commands: &'facts [CommandFact<'a>],
+    pub(crate) store: &'facts FactStore<'a>,
+    pub(crate) indices_by_id: &'facts [Option<usize>],
 }
 
 impl<'facts, 'a> CommandFacts<'facts, 'a> {
-    fn new(
+    pub(crate) fn new(
         commands: &'facts [CommandFact<'a>],
         store: &'facts FactStore<'a>,
         indices_by_id: &'facts [Option<usize>],

--- a/crates/shuck-linter/src/facts/escape_scan.rs
+++ b/crates/shuck-linter/src/facts/escape_scan.rs
@@ -6,16 +6,16 @@ use super::{
 };
 use crate::facts::{occurrence_span, occurrence_word};
 
-pub(super) struct EscapeScanContext<'a> {
-    pub(super) source: &'a str,
+pub(crate) struct EscapeScanContext<'a> {
+    pub(crate) source: &'a str,
 }
 
-pub(super) struct EscapeScanInputs<'a> {
-    pub(super) pattern_literal_spans: &'a [Span],
-    pub(super) pattern_charclass_spans: &'a [Span],
-    pub(super) parameter_pattern_spans: &'a [Span],
-    pub(super) single_quoted_fragments: &'a [SingleQuotedFragmentFact],
-    pub(super) backtick_fragments: &'a [BacktickFragmentFact],
+pub(crate) struct EscapeScanInputs<'a> {
+    pub(crate) pattern_literal_spans: &'a [Span],
+    pub(crate) pattern_charclass_spans: &'a [Span],
+    pub(crate) parameter_pattern_spans: &'a [Span],
+    pub(crate) single_quoted_fragments: &'a [SingleQuotedFragmentFact],
+    pub(crate) backtick_fragments: &'a [BacktickFragmentFact],
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -74,7 +74,7 @@ struct EscapeScanMatchContext {
 }
 
 #[derive(Debug, Clone, Copy)]
-pub(super) struct SingleQuotedFragmentBounds {
+pub(crate) struct SingleQuotedFragmentBounds {
     start: usize,
     end: usize,
 }
@@ -97,7 +97,7 @@ fn build_sorted_single_quoted_bounds(
 }
 
 #[cfg_attr(shuck_profiling, inline(never))]
-pub(super) fn build_escape_scan_matches(
+pub(crate) fn build_escape_scan_matches(
     commands: &[CommandFact<'_>],
     command_fact_indices_by_id: &[Option<usize>],
     nodes: &[WordNode<'_>],

--- a/crates/shuck-linter/src/facts/functions.rs
+++ b/crates/shuck-linter/src/facts/functions.rs
@@ -1,3 +1,5 @@
+use super::*;
+
 #[derive(Debug, Clone)]
 pub struct FunctionHeaderFact<'a> {
     command_id: CommandId,
@@ -130,13 +132,13 @@ impl FunctionCliDispatchFacts {
 }
 
 #[derive(Debug, Clone, Copy)]
-struct FunctionFactInput<'a> {
-    command_id: CommandId,
-    function: &'a FunctionDef,
+pub(crate) struct FunctionFactInput<'a> {
+    pub(crate) command_id: CommandId,
+    pub(crate) function: &'a FunctionDef,
 }
 
 #[cfg_attr(shuck_profiling, inline(never))]
-fn build_function_header_facts<'a>(
+pub(crate) fn build_function_header_facts<'a>(
     semantic: &SemanticModel,
     semantic_analysis: &SemanticAnalysis<'_>,
     functions: &[FunctionFactInput<'a>],
@@ -158,10 +160,11 @@ fn build_function_header_facts<'a>(
         .iter()
         .copied()
         .map(|input| {
-            let binding_id = semantic
-                .function_definition_binding_for_command_span(semantic.command_span(input.command_id));
-            let scope_id =
-                binding_id.and_then(|binding_id| semantic_analysis.function_scope_for_binding(binding_id));
+            let binding_id = semantic.function_definition_binding_for_command_span(
+                semantic.command_span(input.command_id),
+            );
+            let scope_id = binding_id
+                .and_then(|binding_id| semantic_analysis.function_scope_for_binding(binding_id));
             let call_arity = binding_id
                 .and_then(|binding_id| call_arity_by_binding.get(&binding_id).cloned())
                 .unwrap_or_default();
@@ -178,7 +181,7 @@ fn build_function_header_facts<'a>(
 }
 
 #[cfg_attr(shuck_profiling, inline(never))]
-fn build_function_cli_dispatch_facts(
+pub(crate) fn build_function_cli_dispatch_facts(
     dispatches: &[CaseCliDispatch],
 ) -> FxHashMap<ScopeId, FunctionCliDispatchFacts> {
     let mut facts = FxHashMap::<ScopeId, FunctionCliDispatchFacts>::default();
@@ -191,7 +194,7 @@ fn build_function_cli_dispatch_facts(
     facts
 }
 
-fn build_function_parameter_fallback_spans(
+pub(crate) fn build_function_parameter_fallback_spans(
     commands: &[CommandFact<'_>],
     command_fact_indices_by_id: &[Option<usize>],
     structural_command_ids: &[CommandId],
@@ -220,7 +223,7 @@ fn build_function_parameter_fallback_spans(
         .collect()
 }
 
-fn build_completion_registered_function_command_flags(
+pub(crate) fn build_completion_registered_function_command_flags(
     commands: &[CommandFact<'_>],
     registered_scopes: &FxHashSet<ScopeId>,
 ) -> Vec<bool> {
@@ -233,7 +236,7 @@ fn build_completion_registered_function_command_flags(
     flags
 }
 
-fn build_completion_registered_function_scopes(
+pub(crate) fn build_completion_registered_function_scopes(
     semantic: &SemanticModel,
     semantic_analysis: &SemanticAnalysis<'_>,
     commands: &[CommandFact<'_>],
@@ -272,8 +275,11 @@ fn build_completion_registered_function_scopes(
             };
 
             if list.segments()[index + 1..].iter().any(|later_segment| {
-                let later_command =
-                    command_fact(commands, command_fact_indices_by_id, later_segment.command_id());
+                let later_command = command_fact(
+                    commands,
+                    command_fact_indices_by_id,
+                    later_segment.command_id(),
+                );
                 is_unconditional_completion_registration(semantic, later_command)
                     && command_registers_completion_function(later_command, source, &candidate.name)
             }) {
@@ -291,8 +297,11 @@ fn build_completion_registered_function_scopes(
             };
 
             if list.segments()[index + 1..].iter().any(|later_segment| {
-                let later_command =
-                    command_fact(commands, command_fact_indices_by_id, later_segment.command_id());
+                let later_command = command_fact(
+                    commands,
+                    command_fact_indices_by_id,
+                    later_segment.command_id(),
+                );
                 is_same_branch_completion_registration(semantic, later_command)
                     && command_registers_completion_function(later_command, source, &candidate.name)
             }) {
@@ -366,7 +375,7 @@ fn build_completion_registered_function_scopes(
     scopes
 }
 
-fn extend_completion_registered_function_scopes_through_helpers(
+pub(crate) fn extend_completion_registered_function_scopes_through_helpers(
     semantic: &SemanticModel,
     semantic_analysis: &SemanticAnalysis<'_>,
     commands: &[CommandFact<'_>],
@@ -388,15 +397,14 @@ fn extend_completion_registered_function_scopes_through_helpers(
                 continue;
             }
             let name = semantic.binding(*binding_id).name.clone();
-            let called_from_completion_scope =
-                semantic_analysis
-                    .function_call_arity_sites(&name)
-                    .any(|(site, resolved_binding)| {
-                        resolved_binding == *binding_id
-                            && semantic_analysis
-                                .enclosing_function_scope_at(site.name_span.start.offset)
-                                .is_some_and(|caller_scope| scopes.contains(&caller_scope))
-                    });
+            let called_from_completion_scope = semantic_analysis
+                .function_call_arity_sites(&name)
+                .any(|(site, resolved_binding)| {
+                    resolved_binding == *binding_id
+                        && semantic_analysis
+                            .enclosing_function_scope_at(site.name_span.start.offset)
+                            .is_some_and(|caller_scope| scopes.contains(&caller_scope))
+                });
             let referenced_by_completion_arguments = commands.iter().any(|command| {
                 command.normalized().effective_or_literal_name() == Some("_arguments")
                     && command
@@ -404,7 +412,10 @@ fn extend_completion_registered_function_scopes_through_helpers(
                         .is_some_and(|caller_scope| scopes.contains(&caller_scope))
                     && command.body_args().iter().any(|word| {
                         static_word_text(word, source).is_some_and(|text| {
-                            zsh_arguments_spec_invokes_function(&text, &semantic.binding(*binding_id).name)
+                            zsh_arguments_spec_invokes_function(
+                                &text,
+                                &semantic.binding(*binding_id).name,
+                            )
                         })
                     })
             });
@@ -417,7 +428,7 @@ fn extend_completion_registered_function_scopes_through_helpers(
 }
 
 #[cfg_attr(shuck_profiling, inline(never))]
-fn build_external_entrypoint_function_scopes(
+pub(crate) fn build_external_entrypoint_function_scopes(
     semantic: &SemanticModel,
     commands: &[CommandFact<'_>],
     command_fact_indices_by_id: &[Option<usize>],
@@ -518,7 +529,7 @@ fn build_external_entrypoint_function_scopes(
     scopes
 }
 
-fn is_top_level_zsh_entrypoint_registration(
+pub(crate) fn is_top_level_zsh_entrypoint_registration(
     semantic: &SemanticModel,
     command: &CommandFact<'_>,
 ) -> bool {
@@ -527,11 +538,14 @@ fn is_top_level_zsh_entrypoint_registration(
         && !has_structural_parent_command(semantic, command.id())
 }
 
-fn has_structural_parent_command(semantic: &SemanticModel, id: CommandId) -> bool {
+pub(crate) fn has_structural_parent_command(semantic: &SemanticModel, id: CommandId) -> bool {
     nearest_structural_parent_command(semantic, id).is_some()
 }
 
-fn nearest_structural_parent_command(semantic: &SemanticModel, id: CommandId) -> Option<CommandId> {
+pub(crate) fn nearest_structural_parent_command(
+    semantic: &SemanticModel,
+    id: CommandId,
+) -> Option<CommandId> {
     let mut current = semantic.syntax_backed_command_parent_id(id);
     while let Some(parent) = current {
         if matches!(
@@ -547,14 +561,14 @@ fn nearest_structural_parent_command(semantic: &SemanticModel, id: CommandId) ->
     None
 }
 
-fn same_structural_branch_between(source: &str, start: usize, end: usize) -> bool {
+pub(crate) fn same_structural_branch_between(source: &str, start: usize, end: usize) -> bool {
     let Some(between) = source.get(start..end) else {
         return false;
     };
     !contains_zsh_structural_branch_boundary(between)
 }
 
-fn contains_zsh_structural_branch_boundary(text: &str) -> bool {
+pub(crate) fn contains_zsh_structural_branch_boundary(text: &str) -> bool {
     #[derive(Clone, Copy, PartialEq, Eq)]
     enum Quote {
         None,
@@ -664,15 +678,15 @@ fn contains_zsh_structural_branch_boundary(text: &str) -> bool {
     structural_boundary_word(&word)
 }
 
-fn structural_boundary_word(word: &str) -> bool {
+pub(crate) fn structural_boundary_word(word: &str) -> bool {
     matches!(word, "else" | "elif")
 }
 
-fn is_shell_identifier_char(ch: char) -> bool {
+pub(crate) fn is_shell_identifier_char(ch: char) -> bool {
     ch == '_' || ch.is_ascii_alphanumeric()
 }
 
-fn is_unconditional_completion_registration(
+pub(crate) fn is_unconditional_completion_registration(
     semantic: &SemanticModel,
     command: &CommandFact<'_>,
 ) -> bool {
@@ -683,7 +697,7 @@ fn is_unconditional_completion_registration(
         || !has_binary_parent_command(semantic, command.id())
 }
 
-fn is_same_branch_completion_registration(
+pub(crate) fn is_same_branch_completion_registration(
     semantic: &SemanticModel,
     command: &CommandFact<'_>,
 ) -> bool {
@@ -693,10 +707,13 @@ fn is_same_branch_completion_registration(
     ) && !has_binary_parent_command(semantic, command.id())
 }
 
-fn has_binary_parent_command(semantic: &SemanticModel, id: CommandId) -> bool {
+pub(crate) fn has_binary_parent_command(semantic: &SemanticModel, id: CommandId) -> bool {
     let mut current = semantic.syntax_backed_command_parent_id(id);
     while let Some(parent) = current {
-        if matches!(semantic.command_kind(parent), shuck_semantic::CommandKind::Binary) {
+        if matches!(
+            semantic.command_kind(parent),
+            shuck_semantic::CommandKind::Binary
+        ) {
             return true;
         }
         current = semantic.syntax_backed_command_parent_id(parent);
@@ -704,7 +721,7 @@ fn has_binary_parent_command(semantic: &SemanticModel, id: CommandId) -> bool {
     false
 }
 
-fn function_command_slot_count(commands: &[CommandFact<'_>]) -> usize {
+pub(crate) fn function_command_slot_count(commands: &[CommandFact<'_>]) -> usize {
     commands
         .iter()
         .map(|command| command.id().index())
@@ -712,7 +729,7 @@ fn function_command_slot_count(commands: &[CommandFact<'_>]) -> usize {
         .map_or(0, |index| index + 1)
 }
 
-fn completion_registered_function_candidate(
+pub(crate) fn completion_registered_function_candidate(
     semantic: &SemanticModel,
     command: &CommandFact<'_>,
 ) -> Option<CompletionRegisteredFunctionCandidate> {
@@ -731,11 +748,12 @@ fn completion_registered_function_candidate(
     })
 }
 
-fn file_level_completion_function_candidate(
+pub(crate) fn file_level_completion_function_candidate(
     semantic: &SemanticModel,
     command: &CommandFact<'_>,
 ) -> Option<CompletionRegisteredFunctionCandidate> {
-    if command.is_nested_word_command() || semantic.enclosing_function_scope(command.scope()).is_some()
+    if command.is_nested_word_command()
+        || semantic.enclosing_function_scope(command.scope()).is_some()
     {
         return None;
     }
@@ -751,7 +769,7 @@ fn file_level_completion_function_candidate(
     })
 }
 
-fn external_entrypoint_function_candidate(
+pub(crate) fn external_entrypoint_function_candidate(
     semantic: &SemanticModel,
     command: &CommandFact<'_>,
 ) -> Option<CompletionRegisteredFunctionCandidate> {
@@ -768,7 +786,7 @@ fn external_entrypoint_function_candidate(
     })
 }
 
-fn command_registers_completion_function(
+pub(crate) fn command_registers_completion_function(
     command: &CommandFact<'_>,
     source: &str,
     expected_name: &str,
@@ -854,26 +872,49 @@ fn command_registers_completion_function(
     false
 }
 
-fn zsh_arguments_spec_invokes_function(spec: &str, expected_name: &Name) -> bool {
+pub(crate) fn zsh_arguments_spec_invokes_function(spec: &str, expected_name: &Name) -> bool {
     spec.split(':')
         .skip(1)
         .map(str::trim)
         .any(|segment| segment == expected_name.as_str())
 }
 
-enum ZshExternalEntrypointAction {
-    RegisterWidget { widget: Box<str>, function: Box<str> },
-    UnregisterWidgets { widgets: Vec<Box<str>> },
-    RegisterHookFunction { hook: Box<str>, function: Box<str> },
-    RegisterHookWidget { hook: Box<str>, widget: Box<str> },
-    UnregisterHookFunction { hook: Box<str>, function: Box<str> },
-    UnregisterHookWidget { hook: Box<str>, widget: Box<str> },
-    UnregisterHookFunctionPattern { hook: Box<str>, pattern: Box<str> },
-    UnregisterHookWidgetPattern { hook: Box<str>, pattern: Box<str> },
+pub(crate) enum ZshExternalEntrypointAction {
+    RegisterWidget {
+        widget: Box<str>,
+        function: Box<str>,
+    },
+    UnregisterWidgets {
+        widgets: Vec<Box<str>>,
+    },
+    RegisterHookFunction {
+        hook: Box<str>,
+        function: Box<str>,
+    },
+    RegisterHookWidget {
+        hook: Box<str>,
+        widget: Box<str>,
+    },
+    UnregisterHookFunction {
+        hook: Box<str>,
+        function: Box<str>,
+    },
+    UnregisterHookWidget {
+        hook: Box<str>,
+        widget: Box<str>,
+    },
+    UnregisterHookFunctionPattern {
+        hook: Box<str>,
+        pattern: Box<str>,
+    },
+    UnregisterHookWidgetPattern {
+        hook: Box<str>,
+        pattern: Box<str>,
+    },
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
-enum ZshHookTarget {
+pub(crate) enum ZshHookTarget {
     Function(Box<str>),
     Widget(Box<str>),
 }
@@ -910,27 +951,23 @@ impl ZshHookTarget {
     }
 }
 
-fn command_zsh_external_entrypoint_action(
+pub(crate) fn command_zsh_external_entrypoint_action(
     command: &CommandFact<'_>,
     source: &str,
 ) -> Option<ZshExternalEntrypointAction> {
     match command.effective_or_literal_name()? {
         "zle" => zle_external_entrypoint_action(command, source),
-        "add-zsh-hook" => add_zsh_hook_external_entrypoint_action(
-            command,
-            source,
-            AddZshHookTargetKind::Function,
-        ),
-        "add-zle-hook-widget" => add_zsh_hook_external_entrypoint_action(
-            command,
-            source,
-            AddZshHookTargetKind::Widget,
-        ),
+        "add-zsh-hook" => {
+            add_zsh_hook_external_entrypoint_action(command, source, AddZshHookTargetKind::Function)
+        }
+        "add-zle-hook-widget" => {
+            add_zsh_hook_external_entrypoint_action(command, source, AddZshHookTargetKind::Widget)
+        }
         _ => None,
     }
 }
 
-fn zle_external_entrypoint_action(
+pub(crate) fn zle_external_entrypoint_action(
     command: &CommandFact<'_>,
     source: &str,
 ) -> Option<ZshExternalEntrypointAction> {
@@ -968,7 +1005,7 @@ fn zle_external_entrypoint_action(
     None
 }
 
-fn add_zsh_hook_external_entrypoint_action(
+pub(crate) fn add_zsh_hook_external_entrypoint_action(
     command: &CommandFact<'_>,
     source: &str,
     target_kind: AddZshHookTargetKind,
@@ -980,38 +1017,45 @@ fn add_zsh_hook_external_entrypoint_action(
         .filter(|arg| !arg.starts_with('-'))
         .collect::<Vec<_>>();
     match operands.as_slice() {
-        [hook, function, ..] if removal_mode == Some(AddZshHookRemovalMode::Exact) => match target_kind
-        {
-            AddZshHookTargetKind::Function => Some(ZshExternalEntrypointAction::UnregisterHookFunction {
-                hook: hook.as_str().into(),
-                function: function.as_str().into(),
-            }),
-            AddZshHookTargetKind::Widget => Some(ZshExternalEntrypointAction::UnregisterHookWidget {
-                hook: hook.as_str().into(),
-                widget: function.as_str().into(),
-            }),
-        },
+        [hook, function, ..] if removal_mode == Some(AddZshHookRemovalMode::Exact) => {
+            match target_kind {
+                AddZshHookTargetKind::Function => {
+                    Some(ZshExternalEntrypointAction::UnregisterHookFunction {
+                        hook: hook.as_str().into(),
+                        function: function.as_str().into(),
+                    })
+                }
+                AddZshHookTargetKind::Widget => {
+                    Some(ZshExternalEntrypointAction::UnregisterHookWidget {
+                        hook: hook.as_str().into(),
+                        widget: function.as_str().into(),
+                    })
+                }
+            }
+        }
         [hook, pattern, ..] if removal_mode == Some(AddZshHookRemovalMode::Pattern) => {
             match target_kind {
-                AddZshHookTargetKind::Function => Some(
-                    ZshExternalEntrypointAction::UnregisterHookFunctionPattern {
+                AddZshHookTargetKind::Function => {
+                    Some(ZshExternalEntrypointAction::UnregisterHookFunctionPattern {
                         hook: hook.as_str().into(),
                         pattern: pattern.as_str().into(),
-                    },
-                ),
-                AddZshHookTargetKind::Widget => Some(
-                    ZshExternalEntrypointAction::UnregisterHookWidgetPattern {
+                    })
+                }
+                AddZshHookTargetKind::Widget => {
+                    Some(ZshExternalEntrypointAction::UnregisterHookWidgetPattern {
                         hook: hook.as_str().into(),
                         pattern: pattern.as_str().into(),
-                    },
-                ),
+                    })
+                }
             }
         }
         [hook, function, ..] if removal_mode.is_none() => match target_kind {
-            AddZshHookTargetKind::Function => Some(ZshExternalEntrypointAction::RegisterHookFunction {
-                hook: hook.as_str().into(),
-                function: function.as_str().into(),
-            }),
+            AddZshHookTargetKind::Function => {
+                Some(ZshExternalEntrypointAction::RegisterHookFunction {
+                    hook: hook.as_str().into(),
+                    function: function.as_str().into(),
+                })
+            }
             AddZshHookTargetKind::Widget => Some(ZshExternalEntrypointAction::RegisterHookWidget {
                 hook: hook.as_str().into(),
                 widget: function.as_str().into(),
@@ -1022,19 +1066,22 @@ fn add_zsh_hook_external_entrypoint_action(
 }
 
 #[derive(Debug, Clone, Copy)]
-enum AddZshHookTargetKind {
+pub(crate) enum AddZshHookTargetKind {
     Function,
     Widget,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum AddZshHookRemovalMode {
+pub(crate) enum AddZshHookRemovalMode {
     Exact,
     Pattern,
 }
 
-fn add_zsh_hook_removal_mode(args: &[String]) -> Option<AddZshHookRemovalMode> {
-    if args.iter().any(|arg| add_zsh_hook_option_contains(arg, 'D')) {
+pub(crate) fn add_zsh_hook_removal_mode(args: &[String]) -> Option<AddZshHookRemovalMode> {
+    if args
+        .iter()
+        .any(|arg| add_zsh_hook_option_contains(arg, 'D'))
+    {
         return Some(AddZshHookRemovalMode::Pattern);
     }
     args.iter()
@@ -1042,18 +1089,18 @@ fn add_zsh_hook_removal_mode(args: &[String]) -> Option<AddZshHookRemovalMode> {
         .then_some(AddZshHookRemovalMode::Exact)
 }
 
-fn add_zsh_hook_option_contains(arg: &str, flag: char) -> bool {
+pub(crate) fn add_zsh_hook_option_contains(arg: &str, flag: char) -> bool {
     arg.starts_with('-') && arg != "--" && arg.chars().skip(1).any(|c| c == flag)
 }
 
-fn zsh_hook_function_pattern_matches(pattern: &str, function: &str) -> bool {
+pub(crate) fn zsh_hook_function_pattern_matches(pattern: &str, function: &str) -> bool {
     if pattern_contains_unsupported_zsh_metachar(pattern) {
         return true;
     }
     zsh_simple_glob_pattern_matches(pattern.as_bytes(), function.as_bytes())
 }
 
-fn zsh_simple_glob_pattern_matches(pattern: &[u8], text: &[u8]) -> bool {
+pub(crate) fn zsh_simple_glob_pattern_matches(pattern: &[u8], text: &[u8]) -> bool {
     if pattern.is_empty() {
         return text.is_empty();
     }
@@ -1073,7 +1120,7 @@ fn zsh_simple_glob_pattern_matches(pattern: &[u8], text: &[u8]) -> bool {
     }
 }
 
-fn pattern_contains_unsupported_zsh_metachar(pattern: &str) -> bool {
+pub(crate) fn pattern_contains_unsupported_zsh_metachar(pattern: &str) -> bool {
     let mut in_bracket_class = false;
     for byte in pattern.bytes() {
         match byte {
@@ -1086,17 +1133,13 @@ fn pattern_contains_unsupported_zsh_metachar(pattern: &str) -> bool {
     false
 }
 
-fn zsh_numeric_pattern_matches(pattern_after_numeric: &[u8], text: &[u8]) -> bool {
-    let digit_count = text
-        .iter()
-        .take_while(|byte| byte.is_ascii_digit())
-        .count();
-    (1..=digit_count).any(|consumed| {
-        zsh_simple_glob_pattern_matches(pattern_after_numeric, &text[consumed..])
-    })
+pub(crate) fn zsh_numeric_pattern_matches(pattern_after_numeric: &[u8], text: &[u8]) -> bool {
+    let digit_count = text.iter().take_while(|byte| byte.is_ascii_digit()).count();
+    (1..=digit_count)
+        .any(|consumed| zsh_simple_glob_pattern_matches(pattern_after_numeric, &text[consumed..]))
 }
 
-fn zsh_bracket_pattern_matches(pattern: &[u8], text: &[u8]) -> bool {
+pub(crate) fn zsh_bracket_pattern_matches(pattern: &[u8], text: &[u8]) -> bool {
     let Some(&candidate) = text.first() else {
         return false;
     };
@@ -1120,7 +1163,7 @@ fn zsh_bracket_pattern_matches(pattern: &[u8], text: &[u8]) -> bool {
     }
 }
 
-fn zsh_bracket_class_contains(class: &[u8], candidate: u8) -> bool {
+pub(crate) fn zsh_bracket_class_contains(class: &[u8], candidate: u8) -> bool {
     let mut index = 0;
     while index < class.len() {
         if index + 2 < class.len() && class[index + 1] == b'-' {
@@ -1138,7 +1181,7 @@ fn zsh_bracket_class_contains(class: &[u8], candidate: u8) -> bool {
     false
 }
 
-fn static_command_args(command: &CommandFact<'_>, source: &str) -> Option<Vec<String>> {
+pub(crate) fn static_command_args(command: &CommandFact<'_>, source: &str) -> Option<Vec<String>> {
     command
         .body_args()
         .iter()
@@ -1146,7 +1189,7 @@ fn static_command_args(command: &CommandFact<'_>, source: &str) -> Option<Vec<St
         .collect()
 }
 
-fn is_zsh_special_hook_name(name: &str) -> bool {
+pub(crate) fn is_zsh_special_hook_name(name: &str) -> bool {
     matches!(
         name,
         "precmd"
@@ -1160,12 +1203,15 @@ fn is_zsh_special_hook_name(name: &str) -> bool {
 }
 
 #[derive(Debug, Clone)]
-struct CompletionRegisteredFunctionCandidate {
+pub(crate) struct CompletionRegisteredFunctionCandidate {
     scope: ScopeId,
     name: Box<str>,
 }
 
-fn function_parameter_fallback_span(pair: &[&CommandFact<'_>], source: &str) -> Option<Span> {
+pub(crate) fn function_parameter_fallback_span(
+    pair: &[&CommandFact<'_>],
+    source: &str,
+) -> Option<Span> {
     let [first, second] = pair else {
         return None;
     };
@@ -1195,7 +1241,7 @@ fn function_parameter_fallback_span(pair: &[&CommandFact<'_>], source: &str) -> 
     Some(Span::from_positions(start, start.advanced_by("(")))
 }
 
-fn named_coproc_subshell_fallback_span(command: &CommandFact<'_>) -> Option<Span> {
+pub(crate) fn named_coproc_subshell_fallback_span(command: &CommandFact<'_>) -> Option<Span> {
     let Command::Compound(CompoundCommand::Coproc(coproc)) = command.command() else {
         return None;
     };
@@ -1212,7 +1258,7 @@ fn named_coproc_subshell_fallback_span(command: &CommandFact<'_>) -> Option<Span
     }
     Some(Span::from_positions(body_start, body_start))
 }
-fn build_function_call_arity_facts<'a>(
+pub(crate) fn build_function_call_arity_facts<'a>(
     semantic_analysis: &SemanticAnalysis<'_>,
     functions: &[&FunctionDef],
     commands: &[CommandFact<'a>],
@@ -1248,9 +1294,10 @@ fn build_function_call_arity_facts<'a>(
 
     for name in unique_function_names {
         for (site, binding_id) in semantic_analysis.function_call_arity_sites(name) {
-            let Some(command_id) =
-                precomputed_command_id_for_offset(&command_ids_by_offset, site.name_span.start.offset)
-            else {
+            let Some(command_id) = precomputed_command_id_for_offset(
+                &command_ids_by_offset,
+                site.name_span.start.offset,
+            ) else {
                 continue;
             };
             let command = command_fact(commands, command_fact_indices_by_id, command_id);
@@ -1262,21 +1309,18 @@ fn build_function_call_arity_facts<'a>(
             let Some(name_word) = command.body_name_word() else {
                 continue;
             };
-            facts
-                .entry(binding_id)
-                .or_default()
-                .record_call(
-                    site.arg_count,
-                    name_word.span,
-                    function_call_diagnostic_span(command, name_word.span, source),
-                );
+            facts.entry(binding_id).or_default().record_call(
+                site.arg_count,
+                name_word.span,
+                function_call_diagnostic_span(command, name_word.span, source),
+            );
         }
     }
 
     facts
 }
 
-fn function_call_diagnostic_span(
+pub(crate) fn function_call_diagnostic_span(
     command: &CommandFact<'_>,
     name_span: Span,
     source: &str,
@@ -1288,7 +1332,7 @@ fn function_call_diagnostic_span(
     trim_trailing_whitespace_span(command.stmt().span, source)
 }
 
-fn function_body_without_braces_span(function: &FunctionDef) -> Option<Span> {
+pub(crate) fn function_body_without_braces_span(function: &FunctionDef) -> Option<Span> {
     match &function.body.command {
         Command::Compound(
             CompoundCommand::BraceGroup(_)
@@ -1305,7 +1349,7 @@ fn function_body_without_braces_span(function: &FunctionDef) -> Option<Span> {
     }
 }
 
-fn next_function_body_delimiter(text: &str) -> Option<char> {
+pub(crate) fn next_function_body_delimiter(text: &str) -> Option<char> {
     let mut tail = text;
 
     loop {
@@ -1320,7 +1364,7 @@ fn next_function_body_delimiter(text: &str) -> Option<char> {
     }
 }
 
-fn trim_shell_layout_prefix(text: &str) -> &str {
+pub(crate) fn trim_shell_layout_prefix(text: &str) -> &str {
     let mut tail = text;
 
     loop {
@@ -1338,7 +1382,7 @@ fn trim_shell_layout_prefix(text: &str) -> &str {
     }
 }
 
-fn is_plausible_shell_function_name(name: &str) -> bool {
+pub(crate) fn is_plausible_shell_function_name(name: &str) -> bool {
     let Some(first) = name.chars().next() else {
         return false;
     };
@@ -1377,7 +1421,7 @@ fn is_plausible_shell_function_name(name: &str) -> bool {
     )
 }
 
-fn build_function_positional_parameter_facts(
+pub(crate) fn build_function_positional_parameter_facts(
     semantic: &SemanticModel,
     commands: &[CommandFact<'_>],
     positional_parameter_fragments: &[PositionalParameterFragmentFact],
@@ -1445,7 +1489,8 @@ fn build_function_positional_parameter_facts(
     }
 
     for command in commands {
-        let Some(scope) = semantic.enclosing_function_scope_without_transient_boundary(command.scope())
+        let Some(scope) =
+            semantic.enclosing_function_scope_without_transient_boundary(command.scope())
         else {
             continue;
         };
@@ -1462,7 +1507,7 @@ fn build_function_positional_parameter_facts(
     facts
 }
 
-fn reference_has_local_positional_reset(
+pub(crate) fn reference_has_local_positional_reset(
     semantic: &SemanticModel,
     scope: ScopeId,
     offset: usize,

--- a/crates/shuck-linter/src/facts/heredocs.rs
+++ b/crates/shuck-linter/src/facts/heredocs.rs
@@ -1,5 +1,7 @@
+use super::*;
+
 #[cfg_attr(shuck_profiling, inline(never))]
-fn build_heredoc_fact_summary(
+pub(crate) fn build_heredoc_fact_summary(
     commands: &[CommandFact<'_>],
     locator: Locator<'_>,
     file_end: usize,
@@ -90,11 +92,11 @@ fn build_heredoc_fact_summary(
     summary
 }
 
-fn is_heredoc_redirect_kind(kind: RedirectKind) -> bool {
+pub(crate) fn is_heredoc_redirect_kind(kind: RedirectKind) -> bool {
     matches!(kind, RedirectKind::HereDoc | RedirectKind::HereDocStrip)
 }
 
-fn heredoc_closer_not_alone_span(
+pub(crate) fn heredoc_closer_not_alone_span(
     body_span: Span,
     delimiter: &str,
     strip_tabs: bool,
@@ -127,7 +129,7 @@ fn heredoc_closer_not_alone_span(
     None
 }
 
-fn has_misquoted_heredoc_close(
+pub(crate) fn has_misquoted_heredoc_close(
     body_span: Span,
     delimiter: &str,
     strip_tabs: bool,
@@ -141,7 +143,7 @@ fn has_misquoted_heredoc_close(
         .any(|candidate_line| is_quoted_delimiter_variant(candidate_line, delimiter))
 }
 
-fn heredoc_end_space_span(
+pub(crate) fn heredoc_end_space_span(
     body_span: Span,
     delimiter: &str,
     strip_tabs: bool,
@@ -162,7 +164,7 @@ fn heredoc_end_space_span(
     Some(Span::from_positions(start, start))
 }
 
-fn spaced_tabstrip_close_spans(
+pub(crate) fn spaced_tabstrip_close_spans(
     body_span: Span,
     delimiter: &str,
     locator: Locator<'_>,
@@ -183,7 +185,7 @@ fn spaced_tabstrip_close_spans(
     spans
 }
 
-fn normalized_heredoc_line(raw_line: &str, strip_tabs: bool) -> (&str, usize) {
+pub(crate) fn normalized_heredoc_line(raw_line: &str, strip_tabs: bool) -> (&str, usize) {
     let line_without_newline = raw_line.trim_end_matches('\n').trim_end_matches('\r');
     if strip_tabs {
         let trimmed = line_without_newline.trim_start_matches('\t');
@@ -193,15 +195,15 @@ fn normalized_heredoc_line(raw_line: &str, strip_tabs: bool) -> (&str, usize) {
     }
 }
 
-fn is_quoted_delimiter_variant(candidate_line: &str, delimiter: &str) -> bool {
+pub(crate) fn is_quoted_delimiter_variant(candidate_line: &str, delimiter: &str) -> bool {
     candidate_line != delimiter && trim_quote_like_wrappers(candidate_line) == delimiter
 }
 
-fn trim_quote_like_wrappers(text: &str) -> &str {
+pub(crate) fn trim_quote_like_wrappers(text: &str) -> &str {
     text.trim_matches(|ch| matches!(ch, '\'' | '"' | '\\'))
 }
 
-fn is_spaced_tabstrip_close_line(line: &str, delimiter: &str) -> bool {
+pub(crate) fn is_spaced_tabstrip_close_line(line: &str, delimiter: &str) -> bool {
     if line.trim_start_matches('\t') == delimiter {
         return false;
     }
@@ -219,4 +221,3 @@ fn is_spaced_tabstrip_close_line(line: &str, delimiter: &str) -> bool {
     let rest = &line_without_trailing_ws[leading_len..];
     leading.contains(' ') && rest == delimiter
 }
-

--- a/crates/shuck-linter/src/facts/lists.rs
+++ b/crates/shuck-linter/src/facts/lists.rs
@@ -1,7 +1,9 @@
+use super::*;
+
 #[derive(Debug, Clone, Copy)]
 pub struct ListOperatorFact {
-    op: BinaryOp,
-    span: Span,
+    pub(crate) op: BinaryOp,
+    pub(crate) span: Span,
 }
 
 impl ListOperatorFact {
@@ -64,7 +66,6 @@ pub enum MixedShortCircuitKind {
     Fallthrough,
 }
 
-
 #[derive(Debug, Clone)]
 pub struct ListFact<'a> {
     key: FactSpan,
@@ -106,7 +107,7 @@ impl<'a> ListFact<'a> {
 }
 
 #[cfg_attr(shuck_profiling, inline(never))]
-pub(super) fn build_list_facts<'a>(
+pub(crate) fn build_list_facts<'a>(
     commands: &[CommandFact<'a>],
     command_fact_indices_by_id: &[Option<usize>],
     command_ids_by_span: &CommandLookupIndex,
@@ -157,12 +158,8 @@ pub(super) fn build_list_facts<'a>(
 
             let mut operators = Vec::new();
             collect_short_circuit_operators(command, &mut operators);
-            let segments = build_list_segment_facts(
-                command,
-                command_relationships,
-                fact.id(),
-                source,
-            )?;
+            let segments =
+                build_list_segment_facts(command, command_relationships, fact.id(), source)?;
             let mixed_short_circuit_span = mixed_short_circuit_operator_span(&operators);
             let mixed_short_circuit_kind = mixed_short_circuit_span
                 .map(|_| classify_mixed_short_circuit_kind(&segments, &operators));
@@ -179,7 +176,7 @@ pub(super) fn build_list_facts<'a>(
         .collect()
 }
 
-fn record_nested_list_command(
+pub(crate) fn record_nested_list_command(
     stmt: &Stmt,
     parent_id: CommandId,
     command_relationships: CommandRelationshipContext<'_, '_>,
@@ -195,7 +192,7 @@ fn record_nested_list_command(
     }
 }
 
-fn build_list_segment_facts<'a>(
+pub(crate) fn build_list_segment_facts<'a>(
     command: &BinaryCommand,
     command_relationships: CommandRelationshipContext<'_, 'a>,
     parent_id: CommandId,
@@ -212,7 +209,7 @@ fn build_list_segment_facts<'a>(
     Some(segments.into_boxed_slice())
 }
 
-fn collect_list_segment_facts<'a>(
+pub(crate) fn collect_list_segment_facts<'a>(
     command: &BinaryCommand,
     command_relationships: CommandRelationshipContext<'_, 'a>,
     parent_id: CommandId,
@@ -236,7 +233,7 @@ fn collect_list_segment_facts<'a>(
     ok.then_some(())
 }
 
-fn push_list_stmt_segment_fact<'a>(
+pub(crate) fn push_list_stmt_segment_fact<'a>(
     stmt: &Stmt,
     command_relationships: CommandRelationshipContext<'_, 'a>,
     parent_id: CommandId,
@@ -262,7 +259,7 @@ fn push_list_stmt_segment_fact<'a>(
     Some(())
 }
 
-fn list_segment_kind(fact: &CommandFact<'_>) -> ListSegmentKind {
+pub(crate) fn list_segment_kind(fact: &CommandFact<'_>) -> ListSegmentKind {
     if list_segment_is_condition(fact) {
         ListSegmentKind::Condition
     } else if list_segment_assignment_target(fact).is_some() {
@@ -272,24 +269,24 @@ fn list_segment_kind(fact: &CommandFact<'_>) -> ListSegmentKind {
     }
 }
 
-fn list_segment_is_condition(fact: &CommandFact<'_>) -> bool {
+pub(crate) fn list_segment_is_condition(fact: &CommandFact<'_>) -> bool {
     fact.simple_test().is_some()
         || fact.conditional().is_some()
         || matches!(fact.effective_or_literal_name(), Some("true" | "false"))
 }
 
-fn list_segment_assignment_target<'a>(fact: &CommandFact<'a>) -> Option<&'a str> {
+pub(crate) fn list_segment_assignment_target<'a>(fact: &CommandFact<'a>) -> Option<&'a str> {
     list_segment_assignment_info(fact).map(|info| info.target)
 }
 
 #[derive(Clone, Copy)]
-struct ListSegmentAssignmentInfo<'a> {
+pub(crate) struct ListSegmentAssignmentInfo<'a> {
     target: &'a str,
     span: Span,
     is_declaration: bool,
 }
 
-fn list_segment_assignment_info<'a>(
+pub(crate) fn list_segment_assignment_info<'a>(
     fact: &CommandFact<'a>,
 ) -> Option<ListSegmentAssignmentInfo<'a>> {
     match fact.command() {
@@ -305,7 +302,7 @@ fn list_segment_assignment_info<'a>(
     }
 }
 
-fn single_assignment_info<'a>(
+pub(crate) fn single_assignment_info<'a>(
     assignments: &'a [Assignment],
 ) -> Option<ListSegmentAssignmentInfo<'a>> {
     (assignments.len() == 1).then(|| ListSegmentAssignmentInfo {
@@ -315,7 +312,7 @@ fn single_assignment_info<'a>(
     })
 }
 
-fn declaration_assignment_info<'a>(
+pub(crate) fn declaration_assignment_info<'a>(
     command: &'a DeclClause,
 ) -> Option<ListSegmentAssignmentInfo<'a>> {
     if !command.assignments.is_empty() {
@@ -343,7 +340,7 @@ fn declaration_assignment_info<'a>(
     })
 }
 
-fn classify_mixed_short_circuit_kind(
+pub(crate) fn classify_mixed_short_circuit_kind(
     segments: &[ListSegmentFact<'_>],
     operators: &[ListOperatorFact],
 ) -> MixedShortCircuitKind {
@@ -359,7 +356,7 @@ fn classify_mixed_short_circuit_kind(
     }
 }
 
-fn matches_assignment_ternary(
+pub(crate) fn matches_assignment_ternary(
     segments: &[ListSegmentFact<'_>],
     operators: &[ListOperatorFact],
 ) -> bool {

--- a/crates/shuck-linter/src/facts/loop_headers.rs
+++ b/crates/shuck-linter/src/facts/loop_headers.rs
@@ -1,3 +1,5 @@
+use super::*;
+
 #[derive(Debug, Clone, Copy)]
 pub struct LoopHeaderWordFact<'a> {
     word: &'a Word,
@@ -131,7 +133,7 @@ impl<'a> SelectHeaderFact<'a> {
     }
 }
 
-pub(super) fn build_for_header_facts<'a>(
+pub(crate) fn build_for_header_facts<'a>(
     commands: &[CommandFact<'a>],
     command_fact_indices_by_id: &[Option<usize>],
     command_ids_by_span: &CommandLookupIndex,
@@ -161,7 +163,7 @@ pub(super) fn build_for_header_facts<'a>(
         .collect()
 }
 
-pub(super) fn build_select_header_facts<'a>(
+pub(crate) fn build_select_header_facts<'a>(
     commands: &[CommandFact<'a>],
     command_fact_indices_by_id: &[Option<usize>],
     command_ids_by_span: &CommandLookupIndex,
@@ -191,8 +193,7 @@ pub(super) fn build_select_header_facts<'a>(
         .collect()
 }
 
-
-fn build_loop_header_word_facts<'a>(
+pub(crate) fn build_loop_header_word_facts<'a>(
     words: impl IntoIterator<Item = &'a Word>,
     commands: &[CommandFact<'a>],
     command_fact_indices_by_id: &[Option<usize>],
@@ -213,13 +214,12 @@ fn build_loop_header_word_facts<'a>(
                         word,
                         source,
                         shell_dialect,
+                    ) || !word_spans::all_elements_array_expansion_part_spans(
+                        word,
+                        locator,
+                        shell_dialect,
                     )
-                        || !word_spans::all_elements_array_expansion_part_spans(
-                            word,
-                            locator,
-                            shell_dialect,
-                        )
-                        .is_empty(),
+                    .is_empty(),
                 has_unquoted_command_substitution: classification.has_command_substitution()
                     && !word_spans::unquoted_command_substitution_part_spans(word).is_empty(),
                 contains_line_oriented_substitution: word_contains_line_oriented_substitution(

--- a/crates/shuck-linter/src/facts/misspelling.rs
+++ b/crates/shuck-linter/src/facts/misspelling.rs
@@ -332,7 +332,7 @@ enum CandidateTieBreak {
     PresenceTest,
 }
 
-pub(super) fn build_possible_variable_misspelling_index(
+pub(crate) fn build_possible_variable_misspelling_index(
     semantic: &SemanticModel,
     presence_test_references_by_name: &FxHashMap<Name, Vec<PresenceTestReferenceFact>>,
     presence_test_names_by_name: &FxHashMap<Name, Vec<PresenceTestNameFact>>,
@@ -359,7 +359,7 @@ pub(super) fn build_possible_variable_misspelling_index(
     }
 }
 
-pub(super) fn should_scan_possible_variable_misspelling_candidates(
+pub(crate) fn should_scan_possible_variable_misspelling_candidates(
     semantic: &SemanticModel,
     presence_test_references_by_name: &FxHashMap<Name, Vec<PresenceTestReferenceFact>>,
     presence_test_names_by_name: &FxHashMap<Name, Vec<PresenceTestNameFact>>,
@@ -386,7 +386,7 @@ pub(super) fn should_scan_possible_variable_misspelling_candidates(
         < INDEX_BUILD_THRESHOLD
 }
 
-pub(super) fn scan_possible_variable_misspelling_candidate(
+pub(crate) fn scan_possible_variable_misspelling_candidate(
     semantic: &SemanticModel,
     presence_test_references_by_name: &FxHashMap<Name, Vec<PresenceTestReferenceFact>>,
     presence_test_names_by_name: &FxHashMap<Name, Vec<PresenceTestNameFact>>,

--- a/crates/shuck-linter/src/facts/mod.rs
+++ b/crates/shuck-linter/src/facts/mod.rs
@@ -7,16 +7,39 @@
 //! declaration summaries, option-shape summaries, and later word/expansion
 //! facts.
 
+mod arithmetic;
+mod arrays;
+mod assignments;
+mod body_shape;
+mod braces;
+mod builder;
+mod case_patterns;
 pub(crate) mod command_options;
+pub(crate) mod commands;
+mod comments;
 mod conditional_portability;
+pub(crate) mod conditionals;
+pub(crate) mod core;
 mod escape_scan;
+pub(crate) mod functions;
+mod heredocs;
+pub(crate) mod lists;
+pub(crate) mod loop_headers;
 mod misspelling;
+mod model;
 mod normalized_commands;
+pub(crate) mod pipelines;
 mod presence;
+pub(crate) mod redirects;
+pub(crate) mod simple_tests;
+pub(crate) mod statements;
+pub(crate) mod substitutions;
 pub(crate) mod surface;
 #[cfg(test)]
 mod tests;
+mod traversal;
 pub(crate) mod word_spans;
+pub(crate) mod words;
 
 use self::word_spans::{expansion_part_spans, word_unbraced_variable_before_bracket_spans};
 use self::{
@@ -105,89 +128,40 @@ pub use self::surface::{
     PositionalParameterFragmentFact, SelectorRequiredArrayReference, SingleQuotedFragmentFact,
 };
 
-include!("traversal.rs");
-include!("body_shape.rs");
-include!("core.rs");
-include!("simple_tests.rs");
-include!("conditionals.rs");
-include!("redirects.rs");
-include!("substitutions.rs");
-include!("loop_headers.rs");
-include!("case_patterns.rs");
-include!("functions.rs");
-include!("pipelines.rs");
-include!("lists.rs");
-include!("statements.rs");
-include!("commands.rs");
-include!("model.rs");
-include!("builder.rs");
-include!("assignments.rs");
-include!("arrays.rs");
-include!("comments.rs");
-include!("heredocs.rs");
-include!("braces.rs");
-include!("arithmetic.rs");
-pub(crate) mod words;
-use self::words::*;
-
 #[allow(unused_imports)]
-pub(crate) mod core {
-    pub use super::{
-        CommandFactRef, CommandFacts, CommandId, FactSpan, SudoFamilyInvoker, WordNodeId,
-        WordOccurrenceId,
-    };
-}
+pub(crate) use self::{
+    arithmetic::*, arrays::*, assignments::*, body_shape::*, braces::*, builder::*,
+    case_patterns::*, commands::*, comments::*, conditionals::*, core::*, functions::*,
+    heredocs::*, lists::*, loop_headers::*, model::*, pipelines::*, redirects::*, simple_tests::*,
+    statements::*, substitutions::*, traversal::*, words::*,
+};
 
-#[allow(unused_imports)]
-pub(crate) mod simple_tests {
-    pub use super::{SimpleTestFact, SimpleTestOperatorFamily, SimpleTestShape, SimpleTestSyntax};
-}
-
-#[allow(unused_imports)]
-pub(crate) mod conditionals {
-    pub use super::{
+pub use self::{
+    arithmetic::ArithmeticUpdateOperatorFixFact,
+    assignments::EnvPrefixExpansionFixFact,
+    case_patterns::CaseItemFact,
+    commands::{CommandFact, RedundantEchoSpaceFact},
+    conditionals::{
         ConditionalBareWordFact, ConditionalBinaryFact, ConditionalFact,
         ConditionalMixedLogicalOperatorFact, ConditionalNodeFact, ConditionalOperandFact,
         ConditionalOperatorFamily, ConditionalUnaryFact,
-    };
-}
+    },
+    core::{CommandFactRef, CommandFacts, CommandId, FactSpan, SudoFamilyInvoker},
+    functions::{FunctionCallArityFacts, FunctionHeaderFact},
+    lists::{ListFact, ListOperatorFact, ListSegmentKind, MixedShortCircuitKind},
+    loop_headers::{ForHeaderFact, LoopHeaderWordFact, SelectHeaderFact},
+    model::LinterFacts,
+    pipelines::{PipelineFact, PipelineOperatorFact, PipelineSegmentFact},
+    redirects::{RedirectDevNullStatus, RedirectFact, RedirectTargetAnalysis, RedirectTargetKind},
+    simple_tests::{SimpleTestFact, SimpleTestOperatorFamily, SimpleTestShape, SimpleTestSyntax},
+    statements::StatementFact,
+    substitutions::{
+        CommandSubstitutionKind, SubstitutionFact, SubstitutionHostKind, SubstitutionOutputIntent,
+    },
+};
 
-#[allow(unused_imports)]
-pub(crate) mod redirects {
-    pub use super::RedirectFact;
-}
-
-#[allow(unused_imports)]
-pub(crate) mod substitutions {
-    pub use super::{CommandSubstitutionKind, SubstitutionFact, SubstitutionHostKind};
-}
-
-#[allow(unused_imports)]
-pub(crate) mod loop_headers {
-    pub use super::{ForHeaderFact, LoopHeaderWordFact, SelectHeaderFact};
-}
-
-#[allow(unused_imports)]
-pub(crate) mod functions {
-    pub use super::{FunctionCallArityFacts, FunctionHeaderFact};
-}
-
-#[allow(unused_imports)]
-pub(crate) mod pipelines {
-    pub use super::{PipelineFact, PipelineOperatorFact, PipelineSegmentFact};
-}
-
-#[allow(unused_imports)]
-pub(crate) mod lists {
-    pub use super::{ListFact, ListOperatorFact, ListSegmentKind, MixedShortCircuitKind};
-}
-
-#[allow(unused_imports)]
-pub(crate) mod statements {
-    pub use super::StatementFact;
-}
-
-#[allow(unused_imports)]
-pub(crate) mod commands {
-    pub use super::{CommandFact, CommandFactRef};
-}
+pub(crate) use self::conditionals::ConditionalExpressionVisit;
+pub(crate) use self::core::CommandVisit;
+pub(crate) use self::redirects::{
+    ComparableNameKey, ComparableNameUseKind, ComparablePathKey, ComparablePathMatchKey,
+};

--- a/crates/shuck-linter/src/facts/model.rs
+++ b/crates/shuck-linter/src/facts/model.rs
@@ -1,148 +1,178 @@
-pub struct LinterFacts<'a> {
-    semantic: &'a SemanticModel,
-    semantic_artifacts: &'a LinterSemanticArtifacts<'a>,
-    source: &'a str,
-    line_index: &'a LineIndex,
-    shell: ShellDialect,
-    commands: Vec<CommandFact<'a>>,
-    command_fact_indices_by_id: Vec<Option<usize>>,
-    structural_command_ids: Vec<CommandId>,
+use super::*;
+
+pub(crate) struct CommandFactStore<'a> {
+    pub(in crate::facts) commands: Vec<CommandFact<'a>>,
+    pub(in crate::facts) command_fact_indices_by_id: Vec<Option<usize>>,
+    pub(in crate::facts) structural_command_ids: Vec<CommandId>,
     #[cfg(test)]
-    command_ids_by_span: CommandLookupIndex,
-    command_ids_by_name_word_span: FxHashMap<FactSpan, CommandId>,
-    innermost_command_ids_by_offset: CommandOffsetLookup,
-    innermost_command_ids_by_binding_offset: CommandOffsetLookup,
-    assignment_value_target_index: AssignmentValueTargetIndex,
-    command_dominance_barrier_flags: Vec<bool>,
-    if_condition_command_ids: DenseCommandIdSet,
-    elif_condition_command_ids: DenseCommandIdSet,
-    binding_values: FxHashMap<BindingId, BindingValueFact<'a>>,
-    broken_assoc_key_spans: Vec<Span>,
-    comma_array_assignment_spans: Vec<Span>,
-    ifs_literal_backslash_assignment_value_spans: Vec<Span>,
-    env_prefix_assignment_scope_spans: Vec<Span>,
-    env_prefix_expansion_scope_spans: Vec<Span>,
-    env_prefix_expansion_fix_facts: Vec<EnvPrefixExpansionFixFact>,
-    unset_command_ids_by_target_name: FxHashMap<Name, Vec<CommandId>>,
-    function_unset_command_ids_by_target_name: FxHashMap<Name, Vec<CommandId>>,
-    presence_tested_names: FxHashSet<Name>,
-    nested_presence_test_spans: FxHashMap<Name, Vec<Span>>,
-    c006_presence_tested_names: FxHashSet<Name>,
-    c006_nested_presence_test_spans: FxHashMap<Name, Vec<Span>>,
-    c006_suppressing_reference_offsets_by_name: FxHashMap<Name, Vec<usize>>,
-    presence_test_references_by_name: FxHashMap<Name, Vec<PresenceTestReferenceFact>>,
-    presence_test_names_by_name: FxHashMap<Name, Vec<PresenceTestNameFact>>,
-    possible_variable_misspelling_use_scan: OnceLock<bool>,
-    possible_variable_misspelling_index: OnceLock<PossibleVariableMisspellingIndex>,
-    possible_variable_misspelling_scope_compat_name_uses: OnceLock<Vec<ComparableNameUse>>,
-    plain_unindexed_array_references: OnceLock<Vec<PlainUnindexedArrayReferenceFact>>,
-    redundant_echo_space_facts: OnceLock<Vec<RedundantEchoSpaceFact>>,
-    suppressed_subscript_reference_spans: FxHashSet<FactSpan>,
-    subscript_later_suppression_reference_spans: FxHashSet<FactSpan>,
-    compound_assignment_value_word_flags: Box<[bool]>,
-    word_nodes: Vec<WordNode<'a>>,
-    word_occurrences: Vec<WordOccurrence>,
-    word_index: FxHashMap<FactSpan, SmallVec<[WordOccurrenceId; 2]>>,
-    fact_store: FactStore<'a>,
-    unquoted_command_argument_use_offsets: FxHashMap<Name, Vec<usize>>,
-    array_assignment_split_word_ids: Vec<WordOccurrenceId>,
-    brace_variable_before_bracket_spans: Vec<Span>,
-    completion_registered_function_command_flags: Vec<bool>,
-    completion_registered_function_scopes: FxHashSet<ScopeId>,
-    external_entrypoint_function_scopes: FxHashSet<ScopeId>,
-    function_headers: Vec<FunctionHeaderFact<'a>>,
-    function_definition_command_ids_by_scope: FxHashMap<ScopeId, CommandId>,
-    case_cli_reachable_function_scopes: FxHashSet<ScopeId>,
-    function_in_alias_spans: Vec<Span>,
-    alias_definition_expansion_spans: Vec<Span>,
-    function_body_without_braces_spans: Vec<Span>,
-    function_parameter_fallback_spans: Vec<Span>,
-    redundant_return_status_spans: Vec<Span>,
-    for_headers: Vec<ForHeaderFact<'a>>,
-    select_headers: Vec<SelectHeaderFact<'a>>,
-    case_items: Vec<CaseItemFact<'a>>,
-    case_pattern_shadows: Vec<CasePatternShadowFact>,
-    case_pattern_impossible_spans: Vec<Span>,
-    case_pattern_expansions: Vec<CasePatternExpansionFact>,
-    getopts_cases: Vec<GetoptsCaseFact>,
-    pipelines: Vec<PipelineFact<'a>>,
-    lists: Vec<ListFact<'a>>,
-    statement_facts: Vec<StatementFact>,
-    background_semicolon_spans: Vec<Span>,
-    single_test_subshell_spans: Vec<Span>,
-    subshell_test_group_spans: Vec<Span>,
-    indented_shebang_span: Option<Span>,
-    indented_shebang_indent_span: Option<Span>,
-    space_after_hash_bang_span: Option<Span>,
-    space_after_hash_bang_whitespace_span: Option<Span>,
-    shebang_not_on_first_line_span: Option<Span>,
-    shebang_not_on_first_line_fix_span: Option<Span>,
-    shebang_not_on_first_line_preferred_newline: Option<&'static str>,
-    missing_shebang_line_span: Option<Span>,
-    duplicate_shebang_flag_span: Option<Span>,
-    non_absolute_shebang_span: Option<Span>,
-    errexit_enabled_anywhere: bool,
-    commented_continuation_comment_spans: Vec<Span>,
-    comment_double_quote_nesting_spans: Vec<Span>,
-    trailing_directive_comment_spans: Vec<Span>,
-    condition_status_capture_spans: Vec<Span>,
-    command_substitution_command_spans: Vec<Span>,
-    backtick_substitution_spans: Vec<Span>,
-    backtick_escaped_parameters: Vec<BacktickEscapedParameter>,
-    backtick_escaped_parameter_reference_spans: Vec<Span>,
-    backtick_double_escaped_parameter_spans: Vec<Span>,
-    backtick_command_name_spans: Vec<Span>,
-    dollar_question_after_command_spans: Vec<Span>,
-    assignment_like_command_name_spans: Vec<Span>,
-    bare_command_name_assignment_spans: Vec<Span>,
-    subshell_assignment_sites: Vec<NamedSpan>,
-    subshell_later_use_sites: Vec<NamedSpan>,
-    unused_heredoc_spans: Vec<Span>,
-    heredoc_missing_end_spans: Vec<Span>,
-    heredoc_closer_not_alone_spans: Vec<Span>,
-    misquoted_heredoc_close_spans: Vec<Span>,
-    heredoc_end_space_spans: Vec<Span>,
-    echo_here_doc_spans: Vec<Span>,
-    spaced_tabstrip_close_spans: Vec<Span>,
-    plus_equals_assignment_spans: Vec<Span>,
-    array_index_arithmetic_spans: Vec<Span>,
-    arithmetic_score_line_spans: Vec<Span>,
-    dollar_in_arithmetic_spans: Vec<Span>,
-    arithmetic_command_substitution_spans: Vec<Span>,
-    function_positional_parameter_facts: FxHashMap<ScopeId, FunctionPositionalParameterFacts>,
-    function_cli_dispatch_facts: FxHashMap<ScopeId, FunctionCliDispatchFacts>,
-    single_quoted_fragments: Vec<SingleQuotedFragmentFact>,
-    dollar_double_quoted_fragments: Vec<DollarDoubleQuotedFragmentFact>,
-    open_double_quote_fragments: Vec<OpenDoubleQuoteFragmentFact>,
-    suspect_closing_quote_fragments: Vec<SuspectClosingQuoteFragmentFact>,
-    literal_brace_spans: Vec<Span>,
-    backtick_fragments: Vec<BacktickFragmentFact>,
-    legacy_arithmetic_fragments: Vec<LegacyArithmeticFragmentFact>,
-    positional_parameter_fragments: Vec<PositionalParameterFragmentFact>,
-    positional_parameter_operator_spans: Vec<Span>,
-    double_paren_grouping_spans: Vec<Span>,
-    arithmetic_update_operator_spans: Vec<Span>,
-    arithmetic_update_operator_fix_facts: Vec<ArithmeticUpdateOperatorFixFact>,
-    arithmetic_literal_facts: Vec<ArithmeticLiteralFact>,
-    escape_scan_matches: Vec<EscapeScanMatch>,
-    echo_backslash_escape_word_spans: Vec<Span>,
-    echo_to_sed_substitution_spans: Vec<Span>,
-    unicode_smart_quote_spans: Vec<Span>,
-    pattern_exactly_one_extglob_spans: Vec<Span>,
-    pattern_literal_spans: Vec<Span>,
-    pattern_charclass_spans: Vec<Span>,
-    nested_pattern_charclass_spans: FxHashSet<FactSpan>,
-    nested_parameter_expansion_fragments: Vec<NestedParameterExpansionFragmentFact>,
-    indirect_expansion_fragments: Vec<IndirectExpansionFragmentFact>,
-    indexed_array_reference_fragments: Vec<IndexedArrayReferenceFragmentFact>,
-    plain_unindexed_reference_spans: Vec<Span>,
-    parameter_pattern_special_target_fragments: Vec<ParameterPatternSpecialTargetFragmentFact>,
-    zsh_parameter_index_flag_fragments: Vec<ZshParameterIndexFlagFragmentFact>,
-    substring_expansion_fragments: Vec<SubstringExpansionFragmentFact>,
-    case_modification_fragments: Vec<CaseModificationFragmentFact>,
-    replacement_expansion_fragments: Vec<ReplacementExpansionFragmentFact>,
-    positional_parameter_trim_fragments: Vec<PositionalParameterTrimFragmentFact>,
-    conditional_portability: ConditionalPortabilityFacts,
+    pub(in crate::facts) command_ids_by_span: CommandLookupIndex,
+    pub(in crate::facts) command_ids_by_name_word_span: FxHashMap<FactSpan, CommandId>,
+    pub(in crate::facts) innermost_command_ids_by_offset: CommandOffsetLookup,
+    pub(in crate::facts) innermost_command_ids_by_binding_offset: CommandOffsetLookup,
+    pub(in crate::facts) command_dominance_barrier_flags: Vec<bool>,
+    pub(in crate::facts) if_condition_command_ids: DenseCommandIdSet,
+    pub(in crate::facts) elif_condition_command_ids: DenseCommandIdSet,
+    pub(in crate::facts) fact_store: FactStore<'a>,
+    pub(in crate::facts) redundant_echo_space_facts: OnceLock<Vec<RedundantEchoSpaceFact>>,
+    pub(in crate::facts) completion_registered_function_command_flags: Vec<bool>,
+    pub(in crate::facts) completion_registered_function_scopes: FxHashSet<ScopeId>,
+    pub(in crate::facts) external_entrypoint_function_scopes: FxHashSet<ScopeId>,
+    pub(in crate::facts) function_headers: Vec<FunctionHeaderFact<'a>>,
+    pub(in crate::facts) function_definition_command_ids_by_scope: FxHashMap<ScopeId, CommandId>,
+    pub(in crate::facts) case_cli_reachable_function_scopes: FxHashSet<ScopeId>,
+    pub(in crate::facts) function_in_alias_spans: Vec<Span>,
+    pub(in crate::facts) alias_definition_expansion_spans: Vec<Span>,
+    pub(in crate::facts) function_body_without_braces_spans: Vec<Span>,
+    pub(in crate::facts) function_parameter_fallback_spans: Vec<Span>,
+    pub(in crate::facts) redundant_return_status_spans: Vec<Span>,
+    pub(in crate::facts) for_headers: Vec<ForHeaderFact<'a>>,
+    pub(in crate::facts) select_headers: Vec<SelectHeaderFact<'a>>,
+    pub(in crate::facts) case_items: Vec<CaseItemFact<'a>>,
+    pub(in crate::facts) case_pattern_shadows: Vec<CasePatternShadowFact>,
+    pub(in crate::facts) case_pattern_impossible_spans: Vec<Span>,
+    pub(in crate::facts) case_pattern_expansions: Vec<CasePatternExpansionFact>,
+    pub(in crate::facts) getopts_cases: Vec<GetoptsCaseFact>,
+    pub(in crate::facts) pipelines: Vec<PipelineFact<'a>>,
+    pub(in crate::facts) lists: Vec<ListFact<'a>>,
+    pub(in crate::facts) statement_facts: Vec<StatementFact>,
+    pub(in crate::facts) background_semicolon_spans: Vec<Span>,
+    pub(in crate::facts) single_test_subshell_spans: Vec<Span>,
+    pub(in crate::facts) subshell_test_group_spans: Vec<Span>,
+    pub(in crate::facts) function_positional_parameter_facts:
+        FxHashMap<ScopeId, FunctionPositionalParameterFacts>,
+    pub(in crate::facts) function_cli_dispatch_facts: FxHashMap<ScopeId, FunctionCliDispatchFacts>,
+    pub(in crate::facts) condition_status_capture_spans: Vec<Span>,
+    pub(in crate::facts) command_substitution_command_spans: Vec<Span>,
+    pub(in crate::facts) backtick_command_name_spans: Vec<Span>,
+    pub(in crate::facts) assignment_like_command_name_spans: Vec<Span>,
+    pub(in crate::facts) bare_command_name_assignment_spans: Vec<Span>,
+}
+
+pub(crate) struct WordFactStore<'a> {
+    pub(in crate::facts) plain_unindexed_array_references:
+        OnceLock<Vec<PlainUnindexedArrayReferenceFact>>,
+    pub(in crate::facts) suppressed_subscript_reference_spans: FxHashSet<FactSpan>,
+    pub(in crate::facts) subscript_later_suppression_reference_spans: FxHashSet<FactSpan>,
+    pub(in crate::facts) compound_assignment_value_word_flags: Box<[bool]>,
+    pub(in crate::facts) word_nodes: Vec<WordNode<'a>>,
+    pub(in crate::facts) word_occurrences: Vec<WordOccurrence>,
+    pub(in crate::facts) word_index: FxHashMap<FactSpan, SmallVec<[WordOccurrenceId; 2]>>,
+    pub(in crate::facts) unquoted_command_argument_use_offsets: FxHashMap<Name, Vec<usize>>,
+    pub(in crate::facts) array_assignment_split_word_ids: Vec<WordOccurrenceId>,
+    pub(in crate::facts) brace_variable_before_bracket_spans: Vec<Span>,
+    pub(in crate::facts) array_index_arithmetic_spans: Vec<Span>,
+    pub(in crate::facts) arithmetic_score_line_spans: Vec<Span>,
+    pub(in crate::facts) dollar_in_arithmetic_spans: Vec<Span>,
+    pub(in crate::facts) arithmetic_command_substitution_spans: Vec<Span>,
+    pub(in crate::facts) single_quoted_fragments: Vec<SingleQuotedFragmentFact>,
+    pub(in crate::facts) dollar_double_quoted_fragments: Vec<DollarDoubleQuotedFragmentFact>,
+    pub(in crate::facts) open_double_quote_fragments: Vec<OpenDoubleQuoteFragmentFact>,
+    pub(in crate::facts) suspect_closing_quote_fragments: Vec<SuspectClosingQuoteFragmentFact>,
+    pub(in crate::facts) literal_brace_spans: Vec<Span>,
+    pub(in crate::facts) backtick_fragments: Vec<BacktickFragmentFact>,
+    pub(in crate::facts) legacy_arithmetic_fragments: Vec<LegacyArithmeticFragmentFact>,
+    pub(in crate::facts) positional_parameter_fragments: Vec<PositionalParameterFragmentFact>,
+    pub(in crate::facts) positional_parameter_operator_spans: Vec<Span>,
+    pub(in crate::facts) double_paren_grouping_spans: Vec<Span>,
+    pub(in crate::facts) arithmetic_update_operator_spans: Vec<Span>,
+    pub(in crate::facts) arithmetic_update_operator_fix_facts: Vec<ArithmeticUpdateOperatorFixFact>,
+    pub(in crate::facts) arithmetic_literal_facts: Vec<ArithmeticLiteralFact>,
+    pub(in crate::facts) escape_scan_matches: Vec<EscapeScanMatch>,
+    pub(in crate::facts) echo_backslash_escape_word_spans: Vec<Span>,
+    pub(in crate::facts) echo_to_sed_substitution_spans: Vec<Span>,
+    pub(in crate::facts) unicode_smart_quote_spans: Vec<Span>,
+    pub(in crate::facts) pattern_exactly_one_extglob_spans: Vec<Span>,
+    pub(in crate::facts) pattern_literal_spans: Vec<Span>,
+    pub(in crate::facts) pattern_charclass_spans: Vec<Span>,
+    pub(in crate::facts) nested_pattern_charclass_spans: FxHashSet<FactSpan>,
+    pub(in crate::facts) nested_parameter_expansion_fragments:
+        Vec<NestedParameterExpansionFragmentFact>,
+    pub(in crate::facts) indirect_expansion_fragments: Vec<IndirectExpansionFragmentFact>,
+    pub(in crate::facts) indexed_array_reference_fragments: Vec<IndexedArrayReferenceFragmentFact>,
+    pub(in crate::facts) plain_unindexed_reference_spans: Vec<Span>,
+    pub(in crate::facts) parameter_pattern_special_target_fragments:
+        Vec<ParameterPatternSpecialTargetFragmentFact>,
+    pub(in crate::facts) zsh_parameter_index_flag_fragments: Vec<ZshParameterIndexFlagFragmentFact>,
+    pub(in crate::facts) substring_expansion_fragments: Vec<SubstringExpansionFragmentFact>,
+    pub(in crate::facts) case_modification_fragments: Vec<CaseModificationFragmentFact>,
+    pub(in crate::facts) replacement_expansion_fragments: Vec<ReplacementExpansionFragmentFact>,
+    pub(in crate::facts) positional_parameter_trim_fragments:
+        Vec<PositionalParameterTrimFragmentFact>,
+}
+
+pub(crate) struct AssignmentFactStore<'a> {
+    pub(in crate::facts) assignment_value_target_index: AssignmentValueTargetIndex,
+    pub(in crate::facts) binding_values: FxHashMap<BindingId, BindingValueFact<'a>>,
+    pub(in crate::facts) broken_assoc_key_spans: Vec<Span>,
+    pub(in crate::facts) comma_array_assignment_spans: Vec<Span>,
+    pub(in crate::facts) ifs_literal_backslash_assignment_value_spans: Vec<Span>,
+    pub(in crate::facts) env_prefix_assignment_scope_spans: Vec<Span>,
+    pub(in crate::facts) env_prefix_expansion_scope_spans: Vec<Span>,
+    pub(in crate::facts) env_prefix_expansion_fix_facts: Vec<EnvPrefixExpansionFixFact>,
+    pub(in crate::facts) unset_command_ids_by_target_name: FxHashMap<Name, Vec<CommandId>>,
+    pub(in crate::facts) function_unset_command_ids_by_target_name: FxHashMap<Name, Vec<CommandId>>,
+    pub(in crate::facts) presence_tested_names: FxHashSet<Name>,
+    pub(in crate::facts) nested_presence_test_spans: FxHashMap<Name, Vec<Span>>,
+    pub(in crate::facts) c006_presence_tested_names: FxHashSet<Name>,
+    pub(in crate::facts) c006_nested_presence_test_spans: FxHashMap<Name, Vec<Span>>,
+    pub(in crate::facts) c006_suppressing_reference_offsets_by_name: FxHashMap<Name, Vec<usize>>,
+    pub(in crate::facts) presence_test_references_by_name:
+        FxHashMap<Name, Vec<PresenceTestReferenceFact>>,
+    pub(in crate::facts) presence_test_names_by_name: FxHashMap<Name, Vec<PresenceTestNameFact>>,
+    pub(in crate::facts) possible_variable_misspelling_use_scan: OnceLock<bool>,
+    pub(in crate::facts) possible_variable_misspelling_index:
+        OnceLock<PossibleVariableMisspellingIndex>,
+    pub(in crate::facts) subshell_assignment_sites: Vec<NamedSpan>,
+    pub(in crate::facts) subshell_later_use_sites: Vec<NamedSpan>,
+    pub(in crate::facts) plus_equals_assignment_spans: Vec<Span>,
+}
+
+pub(crate) struct SourceFactStore<'a> {
+    pub(in crate::facts) source: &'a str,
+    pub(in crate::facts) line_index: &'a LineIndex,
+    pub(in crate::facts) shell: ShellDialect,
+    pub(in crate::facts) indented_shebang_span: Option<Span>,
+    pub(in crate::facts) indented_shebang_indent_span: Option<Span>,
+    pub(in crate::facts) space_after_hash_bang_span: Option<Span>,
+    pub(in crate::facts) space_after_hash_bang_whitespace_span: Option<Span>,
+    pub(in crate::facts) shebang_not_on_first_line_span: Option<Span>,
+    pub(in crate::facts) shebang_not_on_first_line_fix_span: Option<Span>,
+    pub(in crate::facts) shebang_not_on_first_line_preferred_newline: Option<&'static str>,
+    pub(in crate::facts) missing_shebang_line_span: Option<Span>,
+    pub(in crate::facts) duplicate_shebang_flag_span: Option<Span>,
+    pub(in crate::facts) non_absolute_shebang_span: Option<Span>,
+    pub(in crate::facts) errexit_enabled_anywhere: bool,
+    pub(in crate::facts) commented_continuation_comment_spans: Vec<Span>,
+    pub(in crate::facts) comment_double_quote_nesting_spans: Vec<Span>,
+    pub(in crate::facts) trailing_directive_comment_spans: Vec<Span>,
+    pub(in crate::facts) backtick_substitution_spans: Vec<Span>,
+    pub(in crate::facts) backtick_escaped_parameters: Vec<BacktickEscapedParameter>,
+    pub(in crate::facts) backtick_escaped_parameter_reference_spans: Vec<Span>,
+    pub(in crate::facts) backtick_double_escaped_parameter_spans: Vec<Span>,
+    pub(in crate::facts) dollar_question_after_command_spans: Vec<Span>,
+    pub(in crate::facts) unused_heredoc_spans: Vec<Span>,
+    pub(in crate::facts) heredoc_missing_end_spans: Vec<Span>,
+    pub(in crate::facts) heredoc_closer_not_alone_spans: Vec<Span>,
+    pub(in crate::facts) misquoted_heredoc_close_spans: Vec<Span>,
+    pub(in crate::facts) heredoc_end_space_spans: Vec<Span>,
+    pub(in crate::facts) echo_here_doc_spans: Vec<Span>,
+    pub(in crate::facts) spaced_tabstrip_close_spans: Vec<Span>,
+}
+
+pub(crate) struct CompatFactStore {
+    pub(in crate::facts) possible_variable_misspelling_scope_compat_name_uses:
+        OnceLock<Vec<ComparableNameUse>>,
+    pub(in crate::facts) conditional_portability: ConditionalPortabilityFacts,
+}
+
+pub struct LinterFacts<'a> {
+    pub(in crate::facts) semantic: &'a SemanticModel,
+    pub(in crate::facts) semantic_artifacts: &'a LinterSemanticArtifacts<'a>,
+    pub(in crate::facts) command: CommandFactStore<'a>,
+    pub(in crate::facts) words: WordFactStore<'a>,
+    pub(in crate::facts) assignments: AssignmentFactStore<'a>,
+    pub(in crate::facts) source_facts: SourceFactStore<'a>,
+    pub(in crate::facts) compat: CompatFactStore,
 }
 
 impl<'a> LinterFacts<'a> {
@@ -220,11 +250,32 @@ impl<'a> LinterFacts<'a> {
     }
 
     pub fn commands(&self) -> CommandFacts<'_, 'a> {
-        CommandFacts::new(&self.commands, &self.fact_store, &self.command_fact_indices_by_id)
+        CommandFacts::new(
+            &self.command.commands,
+            &self.command.fact_store,
+            &self.command.command_fact_indices_by_id,
+        )
+    }
+
+    pub(crate) fn words(&self) -> &WordFactStore<'a> {
+        &self.words
+    }
+
+    pub(crate) fn assignments(&self) -> &AssignmentFactStore<'a> {
+        &self.assignments
+    }
+
+    pub(crate) fn source_facts(&self) -> &SourceFactStore<'a> {
+        &self.source_facts
+    }
+
+    pub(crate) fn compat(&self) -> &CompatFactStore {
+        &self.compat
     }
 
     pub fn malformed_bracket_test_spans(&self, source: &str) -> Vec<Span> {
-        self.commands
+        self.command
+            .commands
             .iter()
             .filter(|fact| fact.static_utility_name_is("["))
             .filter(|fact| {
@@ -239,7 +290,8 @@ impl<'a> LinterFacts<'a> {
     }
 
     pub fn abort_like_bracket_test_spans(&self, source: &str) -> Vec<Span> {
-        self.commands
+        self.command
+            .commands
             .iter()
             .filter_map(|fact| {
                 let simple_test = fact.simple_test()?;
@@ -259,24 +311,24 @@ impl<'a> LinterFacts<'a> {
         &self,
         scope: ScopeId,
     ) -> FunctionPositionalParameterFacts {
-        self.function_positional_parameter_facts
+        self.command
+            .function_positional_parameter_facts
             .get(&scope)
             .copied()
             .unwrap_or_default()
     }
 
-    pub(crate) fn function_cli_dispatch_facts(
-        &self,
-        scope: ScopeId,
-    ) -> FunctionCliDispatchFacts {
-        self.function_cli_dispatch_facts
+    pub(crate) fn function_cli_dispatch_facts(&self, scope: ScopeId) -> FunctionCliDispatchFacts {
+        self.command
+            .function_cli_dispatch_facts
             .get(&scope)
             .copied()
             .unwrap_or_default()
     }
 
     pub fn structural_commands(&self) -> impl Iterator<Item = CommandFactRef<'_, 'a>> + '_ {
-        self.structural_command_ids
+        self.command
+            .structural_command_ids
             .iter()
             .copied()
             .map(|id| self.command(id))
@@ -286,7 +338,8 @@ impl<'a> LinterFacts<'a> {
         &self,
         name: &Name,
     ) -> impl Iterator<Item = CommandFactRef<'_, 'a>> + '_ {
-        self.unset_command_ids_by_target_name
+        self.assignments
+            .unset_command_ids_by_target_name
             .get(name)
             .into_iter()
             .flatten()
@@ -298,7 +351,8 @@ impl<'a> LinterFacts<'a> {
         &self,
         name: &Name,
     ) -> impl Iterator<Item = CommandFactRef<'_, 'a>> + '_ {
-        self.function_unset_command_ids_by_target_name
+        self.assignments
+            .function_unset_command_ids_by_target_name
             .get(name)
             .into_iter()
             .flatten()
@@ -308,16 +362,18 @@ impl<'a> LinterFacts<'a> {
 
     pub fn command(&self, id: CommandId) -> CommandFactRef<'_, 'a> {
         let index = self
+            .command
             .command_fact_indices_by_id
             .get(id.index())
             .and_then(|index| *index)
             .unwrap_or_else(|| panic!("command id {} must exist", id.index()));
 
-        CommandFactRef::new(&self.commands[index], &self.fact_store)
+        CommandFactRef::new(&self.command.commands[index], &self.command.fact_store)
     }
 
     pub fn command_for_name_word_span(&self, span: Span) -> Option<CommandFactRef<'_, 'a>> {
-        self.command_ids_by_name_word_span
+        self.command
+            .command_ids_by_name_word_span
             .get(&FactSpan::new(span))
             .copied()
             .or_else(|| self.command_id_for_exact_span(span))
@@ -337,14 +393,18 @@ impl<'a> LinterFacts<'a> {
     }
 
     pub fn innermost_command_id_at(&self, offset: usize) -> Option<CommandId> {
-        precomputed_command_id_for_offset(&self.innermost_command_ids_by_offset, offset)
+        precomputed_command_id_for_offset(&self.command.innermost_command_ids_by_offset, offset)
     }
 
-    pub(crate) fn innermost_command_id_containing_offset(&self, offset: usize) -> Option<CommandId> {
+    pub(crate) fn innermost_command_id_containing_offset(
+        &self,
+        offset: usize,
+    ) -> Option<CommandId> {
         self.semantic
             .innermost_command_id_containing_offset(offset)
             .filter(|id| {
-                self.command_fact_indices_by_id
+                self.command
+                    .command_fact_indices_by_id
                     .get(id.index())
                     .is_some_and(Option::is_some)
             })
@@ -354,16 +414,22 @@ impl<'a> LinterFacts<'a> {
         &self,
         offset: usize,
     ) -> Option<CommandFactRef<'_, 'a>> {
-        precomputed_command_id_for_offset(&self.innermost_command_ids_by_binding_offset, offset)
-            .map(|id| self.command(id))
+        precomputed_command_id_for_offset(
+            &self.command.innermost_command_ids_by_binding_offset,
+            offset,
+        )
+        .map(|id| self.command(id))
     }
 
     pub fn command_parent_id(&self, id: CommandId) -> Option<CommandId> {
-        self.semantic.syntax_backed_command_parent_id(id).filter(|parent_id| {
-            self.command_fact_indices_by_id
-                .get(parent_id.index())
-                .is_some_and(Option::is_some)
-        })
+        self.semantic
+            .syntax_backed_command_parent_id(id)
+            .filter(|parent_id| {
+                self.command
+                    .command_fact_indices_by_id
+                    .get(parent_id.index())
+                    .is_some_and(Option::is_some)
+            })
     }
 
     pub fn command_parent(&self, id: CommandId) -> Option<CommandFactRef<'_, 'a>> {
@@ -372,36 +438,41 @@ impl<'a> LinterFacts<'a> {
     }
 
     pub fn redundant_echo_space_facts(&self) -> &[RedundantEchoSpaceFact] {
-        self.redundant_echo_space_facts
+        self.command
+            .redundant_echo_space_facts
             .get_or_init(|| build_redundant_echo_space_facts(self))
     }
 
     pub fn function_definition_command(&self, scope: ScopeId) -> Option<CommandFactRef<'_, 'a>> {
-        self.function_definition_command_ids_by_scope
+        self.command
+            .function_definition_command_ids_by_scope
             .get(&scope)
             .copied()
             .map(|id| self.command(id))
     }
 
     pub fn is_case_cli_reachable_function_scope(&self, scope: ScopeId) -> bool {
-        self.case_cli_reachable_function_scopes.contains(&scope)
+        self.command
+            .case_cli_reachable_function_scopes
+            .contains(&scope)
     }
 
     pub fn command_is_dominance_barrier(&self, id: CommandId) -> bool {
-        self.command_dominance_barrier_flags
+        self.command
+            .command_dominance_barrier_flags
             .get(id.index())
             .copied()
             .unwrap_or(false)
     }
 
     #[cfg(test)]
-    fn command_id_for_stmt(&self, stmt: &Stmt) -> Option<CommandId> {
+    pub(crate) fn command_id_for_stmt(&self, stmt: &Stmt) -> Option<CommandId> {
         self.command_id_for_command(&stmt.command)
     }
 
     #[cfg(test)]
-    fn command_id_for_command(&self, command: &Command) -> Option<CommandId> {
-        command_id_for_command(command, &self.command_ids_by_span)
+    pub(crate) fn command_id_for_command(&self, command: &Command) -> Option<CommandId> {
+        command_id_for_command(command, &self.command.command_ids_by_span)
     }
 
     fn command_id_for_exact_span(&self, span: Span) -> Option<CommandId> {
@@ -415,43 +486,45 @@ impl<'a> LinterFacts<'a> {
     }
 
     pub fn binding_value(&self, binding_id: BindingId) -> Option<&BindingValueFact<'a>> {
-        self.binding_values.get(&binding_id)
+        self.assignments().binding_values.get(&binding_id)
     }
 
     pub fn broken_assoc_key_spans(&self) -> &[Span] {
-        &self.broken_assoc_key_spans
+        &self.assignments.broken_assoc_key_spans
     }
 
     pub fn comma_array_assignment_spans(&self) -> &[Span] {
-        &self.comma_array_assignment_spans
+        &self.assignments.comma_array_assignment_spans
     }
 
     pub fn ifs_literal_backslash_assignment_value_spans(&self) -> &[Span] {
-        &self.ifs_literal_backslash_assignment_value_spans
+        &self
+            .assignments
+            .ifs_literal_backslash_assignment_value_spans
     }
 
     pub fn env_prefix_assignment_scope_spans(&self) -> &[Span] {
-        &self.env_prefix_assignment_scope_spans
+        &self.assignments.env_prefix_assignment_scope_spans
     }
 
     pub fn env_prefix_expansion_scope_spans(&self) -> &[Span] {
-        &self.env_prefix_expansion_scope_spans
+        &self.assignments.env_prefix_expansion_scope_spans
     }
 
     pub fn env_prefix_expansion_fix_facts(&self) -> &[EnvPrefixExpansionFixFact] {
-        &self.env_prefix_expansion_fix_facts
+        &self.assignments.env_prefix_expansion_fix_facts
     }
 
     pub fn is_if_condition_command(&self, id: CommandId) -> bool {
-        self.if_condition_command_ids.contains(id)
+        self.command.if_condition_command_ids.contains(id)
     }
 
     pub fn is_elif_condition_command(&self, id: CommandId) -> bool {
-        self.elif_condition_command_ids.contains(id)
+        self.command.elif_condition_command_ids.contains(id)
     }
 
     pub fn presence_tested_names(&self) -> &FxHashSet<Name> {
-        &self.presence_tested_names
+        &self.assignments.presence_tested_names
     }
 
     pub(crate) fn possible_variable_misspelling_candidate(
@@ -459,27 +532,32 @@ impl<'a> LinterFacts<'a> {
         semantic: &SemanticModel,
         target_name: &str,
     ) -> Option<String> {
-        if *self.possible_variable_misspelling_use_scan.get_or_init(|| {
-            should_scan_possible_variable_misspelling_candidates(
-                semantic,
-                &self.presence_test_references_by_name,
-                &self.presence_test_names_by_name,
-            )
-        }) {
+        if *self
+            .assignments
+            .possible_variable_misspelling_use_scan
+            .get_or_init(|| {
+                should_scan_possible_variable_misspelling_candidates(
+                    semantic,
+                    &self.assignments.presence_test_references_by_name,
+                    &self.assignments.presence_test_names_by_name,
+                )
+            })
+        {
             return scan_possible_variable_misspelling_candidate(
                 semantic,
-                &self.presence_test_references_by_name,
-                &self.presence_test_names_by_name,
+                &self.assignments.presence_test_references_by_name,
+                &self.assignments.presence_test_names_by_name,
                 target_name,
             );
         }
 
-        self.possible_variable_misspelling_index
+        self.assignments
+            .possible_variable_misspelling_index
             .get_or_init(|| {
                 build_possible_variable_misspelling_index(
                     semantic,
-                    &self.presence_test_references_by_name,
-                    &self.presence_test_names_by_name,
+                    &self.assignments.presence_test_references_by_name,
+                    &self.assignments.presence_test_names_by_name,
                 )
             })
             .candidate_name(target_name)
@@ -487,8 +565,9 @@ impl<'a> LinterFacts<'a> {
     }
 
     pub fn is_presence_tested_name(&self, name: &Name, span: Span) -> bool {
-        self.presence_tested_names.contains(name)
+        self.assignments.presence_tested_names.contains(name)
             || self
+                .assignments
                 .nested_presence_test_spans
                 .get(name)
                 .is_some_and(|spans| {
@@ -500,12 +579,16 @@ impl<'a> LinterFacts<'a> {
     }
 
     pub fn is_c006_presence_tested_name(&self, name: &Name, _span: Span) -> bool {
-        self.c006_presence_tested_names.contains(name)
-            || self.c006_nested_presence_test_spans.contains_key(name)
+        self.assignments.c006_presence_tested_names.contains(name)
+            || self
+                .assignments
+                .c006_nested_presence_test_spans
+                .contains_key(name)
     }
 
     pub fn has_prior_c006_suppressing_reference(&self, name: &Name, span: Span) -> bool {
-        self.c006_suppressing_reference_offsets_by_name
+        self.assignments
+            .c006_suppressing_reference_offsets_by_name
             .get(name)
             .is_some_and(|offsets| {
                 offsets.partition_point(|offset| *offset < span.start.offset) > 0
@@ -516,27 +599,27 @@ impl<'a> LinterFacts<'a> {
         let query_start = span.start.offset;
         let query_end = span.end.offset;
         let upper = self
+            .assignments
             .assignment_value_target_index
             .partition_point(|entry| entry.value_start <= query_start);
-        self.assignment_value_target_index[..upper]
+        self.assignments.assignment_value_target_index[..upper]
             .iter()
             .rev()
             .find(|entry| entry.value_end >= query_end)
             .map(|entry| &entry.target_name)
     }
 
-    pub(crate) fn presence_test_references(
-        &self,
-        name: &Name,
-    ) -> &[PresenceTestReferenceFact] {
-        self.presence_test_references_by_name
+    pub(crate) fn presence_test_references(&self, name: &Name) -> &[PresenceTestReferenceFact] {
+        self.assignments
+            .presence_test_references_by_name
             .get(name)
             .map(Vec::as_slice)
             .unwrap_or(&[])
     }
 
     pub(crate) fn presence_test_names(&self, name: &Name) -> &[PresenceTestNameFact] {
-        self.presence_test_names_by_name
+        self.assignments
+            .presence_test_names_by_name
             .get(name)
             .map(Vec::as_slice)
             .unwrap_or(&[])
@@ -547,8 +630,13 @@ impl<'a> LinterFacts<'a> {
         semantic: &SemanticModel,
     ) -> Vec<(Name, Span)> {
         let mut names = FxHashSet::<Name>::default();
-        names.extend(self.presence_test_references_by_name.keys().cloned());
-        names.extend(self.presence_test_names_by_name.keys().cloned());
+        names.extend(
+            self.assignments
+                .presence_test_references_by_name
+                .keys()
+                .cloned(),
+        );
+        names.extend(self.assignments.presence_test_names_by_name.keys().cloned());
 
         names
             .into_iter()
@@ -564,13 +652,15 @@ impl<'a> LinterFacts<'a> {
         semantic: &SemanticModel,
         candidate_name: &Name,
     ) -> Option<Span> {
-        self.presence_test_references_by_name
+        self.assignments
+            .presence_test_references_by_name
             .get(candidate_name)
             .into_iter()
             .flatten()
             .map(|presence| semantic.reference(presence.reference_id()).span)
             .chain(
-                self.presence_test_names_by_name
+                self.assignments
+                    .presence_test_names_by_name
                     .get(candidate_name)
                     .into_iter()
                     .flatten()
@@ -580,12 +670,14 @@ impl<'a> LinterFacts<'a> {
     }
 
     pub fn is_suppressed_subscript_reference(&self, span: Span) -> bool {
-        self.suppressed_subscript_reference_spans
+        self.words()
+            .suppressed_subscript_reference_spans
             .contains(&FactSpan::new(span))
     }
 
     pub fn is_subscript_later_suppression_reference(&self, span: Span) -> bool {
-        self.subscript_later_suppression_reference_spans
+        self.words
+            .subscript_later_suppression_reference_spans
             .contains(&FactSpan::new(span))
     }
 
@@ -602,7 +694,8 @@ impl<'a> LinterFacts<'a> {
     }
 
     pub fn is_compound_assignment_value_word(&self, fact: WordOccurrenceRef<'_, '_>) -> bool {
-        self.compound_assignment_value_word_flags
+        self.words
+            .compound_assignment_value_word_flags
             .get(fact.occurrence_id().index())
             .copied()
             .unwrap_or(false)
@@ -621,7 +714,8 @@ impl<'a> LinterFacts<'a> {
         span: Span,
         context: WordFactContext,
     ) -> Option<WordOccurrenceRef<'_, 'a>> {
-        self.word_index
+        self.words
+            .word_index
             .get(&FactSpan::new(span))
             .into_iter()
             .flat_map(|indices| indices.iter())
@@ -631,7 +725,8 @@ impl<'a> LinterFacts<'a> {
     }
 
     pub fn any_word_fact(&self, span: Span) -> Option<WordOccurrenceRef<'_, 'a>> {
-        self.word_index
+        self.words
+            .word_index
             .get(&FactSpan::new(span))
             .and_then(|indices| indices.first().copied())
             .map(|id| self.word_occurrence_ref(id))
@@ -642,7 +737,8 @@ impl<'a> LinterFacts<'a> {
         name: &Name,
         after_offset: usize,
     ) -> bool {
-        self.unquoted_command_argument_use_offsets
+        self.words
+            .unquoted_command_argument_use_offsets
             .get(name)
             .is_some_and(|offsets| {
                 offsets.partition_point(|offset| *offset <= after_offset) < offsets.len()
@@ -652,375 +748,384 @@ impl<'a> LinterFacts<'a> {
     pub fn array_assignment_split_word_facts(&self) -> WordOccurrenceIter<'_, 'a> {
         WordOccurrenceIter::ids(
             self,
-            &self.array_assignment_split_word_ids,
+            &self.words.array_assignment_split_word_ids,
             WordOccurrenceFilter::Any,
         )
     }
 
-    fn word_occurrence_ref(&self, id: WordOccurrenceId) -> WordOccurrenceRef<'_, 'a> {
+    pub(crate) fn word_occurrence_ref(&self, id: WordOccurrenceId) -> WordOccurrenceRef<'_, 'a> {
         WordOccurrenceRef { facts: self, id }
     }
 
-    fn word_occurrence(&self, id: WordOccurrenceId) -> &WordOccurrence {
-        &self.word_occurrences[id.index()]
+    pub(crate) fn word_occurrence(&self, id: WordOccurrenceId) -> &WordOccurrence {
+        &self.words.word_occurrences[id.index()]
     }
 
-    fn word_node(&self, id: WordNodeId) -> &WordNode<'a> {
-        &self.word_nodes[id.index()]
+    pub(crate) fn word_node(&self, id: WordNodeId) -> &WordNode<'a> {
+        &self.words.word_nodes[id.index()]
     }
 
-    fn word_node_derived(&self, id: WordNodeId) -> &WordNodeDerived<'a> {
+    pub(crate) fn word_node_derived(&self, id: WordNodeId) -> &WordNodeDerived<'a> {
         word_node_derived(self.word_node(id))
     }
 
     pub fn brace_variable_before_bracket_spans(&self) -> &[Span] {
-        &self.brace_variable_before_bracket_spans
+        &self.words.brace_variable_before_bracket_spans
     }
 
     pub fn command_is_in_completion_registered_function(&self, id: CommandId) -> bool {
-        self.completion_registered_function_command_flags
+        self.command
+            .completion_registered_function_command_flags
             .get(id.index())
             .copied()
             .unwrap_or(false)
     }
 
     pub fn function_is_completion_registered(&self, scope: ScopeId) -> bool {
-        self.completion_registered_function_scopes.contains(&scope)
+        self.command
+            .completion_registered_function_scopes
+            .contains(&scope)
     }
 
     pub fn function_is_external_entrypoint(&self, scope: ScopeId) -> bool {
-        self.external_entrypoint_function_scopes.contains(&scope)
+        self.command
+            .external_entrypoint_function_scopes
+            .contains(&scope)
     }
 
     pub fn function_headers(&self) -> &[FunctionHeaderFact<'a>] {
-        &self.function_headers
+        &self.command.function_headers
     }
 
     pub fn function_in_alias_spans(&self) -> &[Span] {
-        &self.function_in_alias_spans
+        &self.command.function_in_alias_spans
     }
 
     pub fn alias_definition_expansion_spans(&self) -> &[Span] {
-        &self.alias_definition_expansion_spans
+        &self.command.alias_definition_expansion_spans
     }
 
     pub fn function_body_without_braces_spans(&self) -> &[Span] {
-        &self.function_body_without_braces_spans
+        &self.command.function_body_without_braces_spans
     }
 
     pub fn function_parameter_fallback_spans(&self) -> &[Span] {
-        &self.function_parameter_fallback_spans
+        &self.command.function_parameter_fallback_spans
     }
 
     pub fn redundant_return_status_spans(&self) -> &[Span] {
-        &self.redundant_return_status_spans
+        &self.command.redundant_return_status_spans
     }
 
     pub fn for_headers(&self) -> &[ForHeaderFact<'a>] {
-        &self.for_headers
+        &self.command.for_headers
     }
 
     pub fn select_headers(&self) -> &[SelectHeaderFact<'a>] {
-        &self.select_headers
+        &self.command.select_headers
     }
 
     pub fn case_items(&self) -> &[CaseItemFact<'a>] {
-        &self.case_items
+        &self.command.case_items
     }
 
     pub fn case_pattern_shadows(&self) -> &[CasePatternShadowFact] {
-        &self.case_pattern_shadows
+        &self.command.case_pattern_shadows
     }
 
     pub fn case_pattern_impossible_spans(&self) -> &[Span] {
-        &self.case_pattern_impossible_spans
+        &self.command.case_pattern_impossible_spans
     }
 
     pub fn case_pattern_expansions(&self) -> &[CasePatternExpansionFact] {
-        &self.case_pattern_expansions
+        &self.command.case_pattern_expansions
     }
 
     pub fn getopts_cases(&self) -> &[GetoptsCaseFact] {
-        &self.getopts_cases
+        &self.command.getopts_cases
     }
 
     pub fn pipelines(&self) -> &[PipelineFact<'a>] {
-        &self.pipelines
+        &self.command.pipelines
     }
 
     pub fn lists(&self) -> &[ListFact<'a>] {
-        &self.lists
+        &self.command.lists
     }
 
     pub fn statement_facts(&self) -> &[StatementFact] {
-        &self.statement_facts
+        &self.command.statement_facts
     }
 
     pub fn background_semicolon_spans(&self) -> &[Span] {
-        &self.background_semicolon_spans
+        &self.command.background_semicolon_spans
     }
 
     pub fn single_test_subshell_spans(&self) -> &[Span] {
-        &self.single_test_subshell_spans
+        &self.command.single_test_subshell_spans
     }
 
     pub fn subshell_test_group_spans(&self) -> &[Span] {
-        &self.subshell_test_group_spans
+        &self.command.subshell_test_group_spans
     }
 
     pub fn indented_shebang_span(&self) -> Option<Span> {
-        self.indented_shebang_span
+        self.source_facts.indented_shebang_span
     }
 
     pub fn indented_shebang_indent_span(&self) -> Option<Span> {
-        self.indented_shebang_indent_span
+        self.source_facts.indented_shebang_indent_span
     }
 
     pub fn space_after_hash_bang_span(&self) -> Option<Span> {
-        self.space_after_hash_bang_span
+        self.source_facts.space_after_hash_bang_span
     }
 
     pub fn space_after_hash_bang_whitespace_span(&self) -> Option<Span> {
-        self.space_after_hash_bang_whitespace_span
+        self.source_facts.space_after_hash_bang_whitespace_span
     }
 
     pub fn shebang_not_on_first_line_span(&self) -> Option<Span> {
-        self.shebang_not_on_first_line_span
+        self.source_facts.shebang_not_on_first_line_span
     }
 
     pub fn shebang_not_on_first_line_fix_span(&self) -> Option<Span> {
-        self.shebang_not_on_first_line_fix_span
+        self.source_facts.shebang_not_on_first_line_fix_span
     }
 
     pub fn shebang_not_on_first_line_preferred_newline(&self) -> Option<&'static str> {
-        self.shebang_not_on_first_line_preferred_newline
+        self.source_facts
+            .shebang_not_on_first_line_preferred_newline
     }
 
     pub fn missing_shebang_line_span(&self) -> Option<Span> {
-        self.missing_shebang_line_span
+        self.source_facts.missing_shebang_line_span
     }
 
     pub fn duplicate_shebang_flag_span(&self) -> Option<Span> {
-        self.duplicate_shebang_flag_span
+        self.source_facts.duplicate_shebang_flag_span
     }
 
     pub fn non_absolute_shebang_span(&self) -> Option<Span> {
-        self.non_absolute_shebang_span
+        self.source_facts.non_absolute_shebang_span
     }
 
     pub fn errexit_enabled_anywhere(&self) -> bool {
-        self.errexit_enabled_anywhere
+        self.source_facts.errexit_enabled_anywhere
     }
 
     pub fn commented_continuation_comment_spans(&self) -> &[Span] {
-        &self.commented_continuation_comment_spans
+        &self.source_facts.commented_continuation_comment_spans
     }
 
     pub fn comment_double_quote_nesting_spans(&self) -> &[Span] {
-        &self.comment_double_quote_nesting_spans
+        &self.source_facts.comment_double_quote_nesting_spans
     }
 
     pub fn trailing_directive_comment_spans(&self) -> &[Span] {
-        &self.trailing_directive_comment_spans
+        &self.source_facts.trailing_directive_comment_spans
     }
 
     pub fn condition_status_capture_spans(&self) -> &[Span] {
-        &self.condition_status_capture_spans
+        &self.command.condition_status_capture_spans
     }
 
     pub fn command_substitution_command_spans(&self) -> &[Span] {
-        &self.command_substitution_command_spans
+        &self.command.command_substitution_command_spans
     }
 
     pub fn backtick_substitution_spans(&self) -> &[Span] {
-        &self.backtick_substitution_spans
+        &self.source_facts.backtick_substitution_spans
     }
 
     pub fn backtick_escaped_parameters(&self) -> &[BacktickEscapedParameter] {
-        &self.backtick_escaped_parameters
+        &self.source_facts.backtick_escaped_parameters
     }
 
     pub fn backtick_escaped_parameter_reference_spans(&self) -> &[Span] {
-        &self.backtick_escaped_parameter_reference_spans
+        &self.source_facts.backtick_escaped_parameter_reference_spans
     }
 
     pub fn is_backtick_double_escaped_parameter_reference(&self, span: Span) -> bool {
-        self.backtick_double_escaped_parameter_spans
+        self.source_facts
+            .backtick_double_escaped_parameter_spans
             .contains(&span)
     }
 
     pub fn backtick_command_name_spans(&self) -> &[Span] {
-        &self.backtick_command_name_spans
+        &self.command.backtick_command_name_spans
     }
 
     pub fn dollar_question_after_command_spans(&self) -> &[Span] {
-        &self.dollar_question_after_command_spans
+        &self.source_facts.dollar_question_after_command_spans
     }
 
     pub fn assignment_like_command_name_spans(&self) -> &[Span] {
-        &self.assignment_like_command_name_spans
+        &self.command.assignment_like_command_name_spans
     }
 
     pub fn bare_command_name_assignment_spans(&self) -> &[Span] {
-        &self.bare_command_name_assignment_spans
+        &self.command.bare_command_name_assignment_spans
     }
 
     pub fn subshell_assignment_sites(&self) -> &[NamedSpan] {
-        &self.subshell_assignment_sites
+        &self.assignments.subshell_assignment_sites
     }
 
     pub fn subshell_later_use_sites(&self) -> &[NamedSpan] {
-        &self.subshell_later_use_sites
+        &self.assignments.subshell_later_use_sites
     }
 
     pub fn unused_heredoc_spans(&self) -> &[Span] {
-        &self.unused_heredoc_spans
+        &self.source_facts.unused_heredoc_spans
     }
 
     pub fn heredoc_missing_end_spans(&self) -> &[Span] {
-        &self.heredoc_missing_end_spans
+        &self.source_facts.heredoc_missing_end_spans
     }
 
     pub fn heredoc_closer_not_alone_spans(&self) -> &[Span] {
-        &self.heredoc_closer_not_alone_spans
+        &self.source_facts.heredoc_closer_not_alone_spans
     }
 
     pub fn misquoted_heredoc_close_spans(&self) -> &[Span] {
-        &self.misquoted_heredoc_close_spans
+        &self.source_facts.misquoted_heredoc_close_spans
     }
 
     pub fn heredoc_end_space_spans(&self) -> &[Span] {
-        &self.heredoc_end_space_spans
+        &self.source_facts.heredoc_end_space_spans
     }
 
     pub fn echo_here_doc_spans(&self) -> &[Span] {
-        &self.echo_here_doc_spans
+        &self.source_facts.echo_here_doc_spans
     }
 
     pub fn spaced_tabstrip_close_spans(&self) -> &[Span] {
-        &self.spaced_tabstrip_close_spans
+        &self.source_facts.spaced_tabstrip_close_spans
     }
 
     pub fn plus_equals_assignment_spans(&self) -> &[Span] {
-        &self.plus_equals_assignment_spans
+        &self.assignments.plus_equals_assignment_spans
     }
 
     pub fn array_index_arithmetic_spans(&self) -> &[Span] {
-        &self.array_index_arithmetic_spans
+        &self.words.array_index_arithmetic_spans
     }
 
     pub fn arithmetic_score_line_spans(&self) -> &[Span] {
-        &self.arithmetic_score_line_spans
+        &self.words.arithmetic_score_line_spans
     }
 
     pub fn dollar_in_arithmetic_spans(&self) -> &[Span] {
-        &self.dollar_in_arithmetic_spans
+        &self.words.dollar_in_arithmetic_spans
     }
 
     pub fn single_quoted_fragments(&self) -> &[SingleQuotedFragmentFact] {
-        &self.single_quoted_fragments
+        &self.words.single_quoted_fragments
     }
 
     pub fn dollar_double_quoted_fragments(&self) -> &[DollarDoubleQuotedFragmentFact] {
-        &self.dollar_double_quoted_fragments
+        &self.words.dollar_double_quoted_fragments
     }
 
     pub fn open_double_quote_fragments(&self) -> &[OpenDoubleQuoteFragmentFact] {
-        &self.open_double_quote_fragments
+        &self.words.open_double_quote_fragments
     }
 
     pub fn suspect_closing_quote_fragments(&self) -> &[SuspectClosingQuoteFragmentFact] {
-        &self.suspect_closing_quote_fragments
+        &self.words.suspect_closing_quote_fragments
     }
 
     pub fn literal_brace_spans(&self) -> &[Span] {
-        &self.literal_brace_spans
+        &self.words.literal_brace_spans
     }
 
     pub fn backtick_fragments(&self) -> &[BacktickFragmentFact] {
-        &self.backtick_fragments
+        &self.words.backtick_fragments
     }
 
     pub fn legacy_arithmetic_fragments(&self) -> &[LegacyArithmeticFragmentFact] {
-        &self.legacy_arithmetic_fragments
+        &self.words.legacy_arithmetic_fragments
     }
 
     pub fn positional_parameter_fragments(&self) -> &[PositionalParameterFragmentFact] {
-        &self.positional_parameter_fragments
+        &self.words.positional_parameter_fragments
     }
 
     pub fn positional_parameter_operator_spans(&self) -> &[Span] {
-        &self.positional_parameter_operator_spans
+        &self.words.positional_parameter_operator_spans
     }
 
     pub fn double_paren_grouping_spans(&self) -> &[Span] {
-        &self.double_paren_grouping_spans
+        &self.words.double_paren_grouping_spans
     }
 
     pub fn arithmetic_update_operator_spans(&self) -> &[Span] {
-        &self.arithmetic_update_operator_spans
+        &self.words.arithmetic_update_operator_spans
     }
 
     pub fn arithmetic_update_operator_fix_facts(&self) -> &[ArithmeticUpdateOperatorFixFact] {
-        &self.arithmetic_update_operator_fix_facts
+        &self.words.arithmetic_update_operator_fix_facts
     }
 
     pub fn arithmetic_literal_facts(&self) -> &[ArithmeticLiteralFact] {
-        &self.arithmetic_literal_facts
+        &self.words.arithmetic_literal_facts
     }
 
     pub(crate) fn escape_scan_matches(&self) -> &[EscapeScanMatch] {
-        &self.escape_scan_matches
+        &self.words.escape_scan_matches
     }
 
     pub fn echo_backslash_escape_word_spans(&self) -> &[Span] {
-        &self.echo_backslash_escape_word_spans
+        &self.words.echo_backslash_escape_word_spans
     }
 
     pub fn echo_to_sed_substitution_spans(&self) -> &[Span] {
-        &self.echo_to_sed_substitution_spans
+        &self.words.echo_to_sed_substitution_spans
     }
 
     pub fn arithmetic_command_substitution_spans(&self) -> &[Span] {
-        &self.arithmetic_command_substitution_spans
+        &self.words.arithmetic_command_substitution_spans
     }
     pub fn unicode_smart_quote_spans(&self) -> &[Span] {
-        &self.unicode_smart_quote_spans
+        &self.words.unicode_smart_quote_spans
     }
 
     pub fn pattern_exactly_one_extglob_spans(&self) -> &[Span] {
-        &self.pattern_exactly_one_extglob_spans
+        &self.words.pattern_exactly_one_extglob_spans
     }
 
     pub fn pattern_literal_spans(&self) -> &[Span] {
-        &self.pattern_literal_spans
+        &self.words.pattern_literal_spans
     }
 
     pub fn pattern_charclass_spans(&self) -> &[Span] {
-        &self.pattern_charclass_spans
+        &self.words.pattern_charclass_spans
     }
 
     pub fn is_nested_pattern_charclass_span(&self, span: Span) -> bool {
-        self.nested_pattern_charclass_spans
+        self.words
+            .nested_pattern_charclass_spans
             .contains(&FactSpan::new(span))
     }
 
     pub fn nested_parameter_expansion_fragments(&self) -> &[NestedParameterExpansionFragmentFact] {
-        &self.nested_parameter_expansion_fragments
+        &self.words.nested_parameter_expansion_fragments
     }
 
     pub fn indirect_expansion_fragments(&self) -> &[IndirectExpansionFragmentFact] {
-        &self.indirect_expansion_fragments
+        &self.words.indirect_expansion_fragments
     }
 
     pub fn indexed_array_reference_fragments(&self) -> &[IndexedArrayReferenceFragmentFact] {
-        &self.indexed_array_reference_fragments
+        &self.words.indexed_array_reference_fragments
     }
 
     pub fn plain_unindexed_array_references(
         &self,
     ) -> impl Iterator<Item = PlainUnindexedArrayReferenceFact> + '_ {
-        self.plain_unindexed_array_references
+        self.words
+            .plain_unindexed_array_references
             .get_or_init(|| build_plain_unindexed_array_reference_facts(self))
             .iter()
             .copied()
@@ -1029,45 +1134,47 @@ impl<'a> LinterFacts<'a> {
     pub fn parameter_pattern_special_target_fragments(
         &self,
     ) -> &[ParameterPatternSpecialTargetFragmentFact] {
-        &self.parameter_pattern_special_target_fragments
+        &self.words.parameter_pattern_special_target_fragments
     }
 
     pub fn zsh_parameter_index_flag_fragments(&self) -> &[ZshParameterIndexFlagFragmentFact] {
-        &self.zsh_parameter_index_flag_fragments
+        &self.words.zsh_parameter_index_flag_fragments
     }
 
     pub fn substring_expansion_fragments(&self) -> &[SubstringExpansionFragmentFact] {
-        &self.substring_expansion_fragments
+        &self.words.substring_expansion_fragments
     }
 
     pub fn case_modification_fragments(&self) -> &[CaseModificationFragmentFact] {
-        &self.case_modification_fragments
+        &self.words.case_modification_fragments
     }
 
     pub fn replacement_expansion_fragments(&self) -> &[ReplacementExpansionFragmentFact] {
-        &self.replacement_expansion_fragments
+        &self.words.replacement_expansion_fragments
     }
 
     pub fn positional_parameter_trim_fragments(&self) -> &[PositionalParameterTrimFragmentFact] {
-        &self.positional_parameter_trim_fragments
+        &self.words.positional_parameter_trim_fragments
     }
 
     pub fn conditional_portability(&self) -> &ConditionalPortabilityFacts {
-        &self.conditional_portability
+        &self.compat().conditional_portability
     }
 
     pub(crate) fn possible_variable_misspelling_scope_compat_name_uses(
         &self,
     ) -> &[ComparableNameUse] {
-        self.possible_variable_misspelling_scope_compat_name_uses
+        self.compat
+            .possible_variable_misspelling_scope_compat_name_uses
             .get_or_init(|| build_possible_variable_misspelling_scope_compat_name_uses(self))
     }
 }
 
-fn build_possible_variable_misspelling_scope_compat_name_uses(
+pub(crate) fn build_possible_variable_misspelling_scope_compat_name_uses(
     facts: &LinterFacts<'_>,
 ) -> Vec<ComparableNameUse> {
-    if !source_may_have_scope_compat_misspelling(facts.source) {
+    let source_facts = facts.source_facts();
+    if !source_may_have_scope_compat_misspelling(source_facts.source) {
         return Vec::new();
     }
 
@@ -1085,12 +1192,12 @@ fn build_possible_variable_misspelling_scope_compat_name_uses(
         visit_command_words_for_substitutions(
             command.command(),
             command.redirects(),
-            facts.source,
+            source_facts.source,
             &mut |word| {
                 collect_scope_compat_derived_name_uses(
                     word,
                     facts.semantic_artifacts,
-                    facts.source,
+                    source_facts.source,
                     &mut uses,
                 );
             },
@@ -1100,12 +1207,17 @@ fn build_possible_variable_misspelling_scope_compat_name_uses(
         .for_headers()
         .iter()
         .flat_map(|header| header.words())
-        .chain(facts.select_headers().iter().flat_map(|header| header.words()))
+        .chain(
+            facts
+                .select_headers()
+                .iter()
+                .flat_map(|header| header.words()),
+        )
     {
         if let Some(mut name_use) = scope_compat_standalone_parameter_name_use(word.word()) {
             name_use.mark_derived();
             if is_interesting_scope_compat_name_use(
-                facts.source,
+                source_facts.source,
                 name_use.key().as_str(),
                 name_use.kind(),
                 name_use.span(),
@@ -1114,26 +1226,33 @@ fn build_possible_variable_misspelling_scope_compat_name_uses(
             }
         }
     }
-    uses.extend(build_flag_for_loop_source_name_uses(Locator::new(facts.source, facts.line_index)).into_iter().filter(|name_use| {
-        is_interesting_scope_compat_name_use(
-            facts.source,
-            name_use.key().as_str(),
-            name_use.kind(),
-            name_use.span(),
-        )
-    }));
+    uses.extend(
+        build_flag_for_loop_source_name_uses(Locator::new(
+            source_facts.source,
+            source_facts.line_index,
+        ))
+        .into_iter()
+        .filter(|name_use| {
+            is_interesting_scope_compat_name_use(
+                source_facts.source,
+                name_use.key().as_str(),
+                name_use.kind(),
+                name_use.span(),
+            )
+        }),
+    );
     dedup_comparable_name_uses(&mut uses);
     uses
 }
 
-fn source_may_have_scope_compat_misspelling(source: &str) -> bool {
+pub(crate) fn source_may_have_scope_compat_misspelling(source: &str) -> bool {
     source.contains("SHELLSPEC_EXECDIR")
         || source.contains("CFLAGS")
         || source.contains("CPPFLAGS")
         || source.contains("CXXFLAGS")
 }
 
-fn scope_compat_standalone_parameter_name_use(word: &Word) -> Option<ComparableNameUse> {
+pub(crate) fn scope_compat_standalone_parameter_name_use(word: &Word) -> Option<ComparableNameUse> {
     let name = standalone_comparable_parameter_name(&word.parts)?;
     Some(ComparableNameUse {
         span: word.span,
@@ -1142,7 +1261,7 @@ fn scope_compat_standalone_parameter_name_use(word: &Word) -> Option<ComparableN
     })
 }
 
-fn collect_scope_compat_derived_name_uses(
+pub(crate) fn collect_scope_compat_derived_name_uses(
     word: &Word,
     semantic: &LinterSemanticArtifacts<'_>,
     source: &str,
@@ -1159,7 +1278,7 @@ fn collect_scope_compat_derived_name_uses(
     );
 }
 
-fn collect_scope_compat_command_substitution_name_uses_in_parts(
+pub(crate) fn collect_scope_compat_command_substitution_name_uses_in_parts(
     parts: &[WordPartNode],
     semantic: &LinterSemanticArtifacts<'_>,
     source: &str,
@@ -1239,7 +1358,7 @@ fn collect_scope_compat_command_substitution_name_uses_in_parts(
     }
 }
 
-fn collect_scope_compat_command_substitution_name_uses(
+pub(crate) fn collect_scope_compat_command_substitution_name_uses(
     body: &StmtSeq,
     semantic: &LinterSemanticArtifacts<'_>,
     source: &str,
@@ -1256,13 +1375,14 @@ fn collect_scope_compat_command_substitution_name_uses(
     });
 }
 
-fn push_scope_compat_command_substitution_word_use(
+pub(crate) fn push_scope_compat_command_substitution_word_use(
     word: &Word,
     source: &str,
     allow_quoted_derived_words: bool,
     uses: &mut Vec<ComparableNameUse>,
 ) {
-    if !allow_quoted_derived_words && analyze_word(word, source, None).quote == WordQuote::FullyQuoted
+    if !allow_quoted_derived_words
+        && analyze_word(word, source, None).quote == WordQuote::FullyQuoted
     {
         return;
     }
@@ -1271,7 +1391,7 @@ fn push_scope_compat_command_substitution_word_use(
     }
 }
 
-fn collect_scope_compat_arithmetic_name_use(
+pub(crate) fn collect_scope_compat_arithmetic_name_use(
     word: &Word,
     source: &str,
     uses: &mut Vec<ComparableNameUse>,
@@ -1281,7 +1401,7 @@ fn collect_scope_compat_arithmetic_name_use(
     }
 }
 
-fn scope_compat_standalone_derived_name_use(
+pub(crate) fn scope_compat_standalone_derived_name_use(
     word: &Word,
     source: &str,
 ) -> Option<ComparableNameUse> {
@@ -1296,7 +1416,7 @@ fn scope_compat_standalone_derived_name_use(
     .then_some(name_use)
 }
 
-fn is_interesting_scope_compat_name_use(
+pub(crate) fn is_interesting_scope_compat_name_use(
     _source: &str,
     name: &str,
     kind: ComparableNameUseKind,
@@ -1307,14 +1427,16 @@ fn is_interesting_scope_compat_name_use(
         || kind == ComparableNameUseKind::Derived && is_reportable_build_flag_family_name(name)
 }
 
-fn is_reportable_build_flag_family_name(name: &str) -> bool {
+pub(crate) fn is_reportable_build_flag_family_name(name: &str) -> bool {
     let Some((_, suffix)) = split_scope_compat_build_flag_family_name(name) else {
         return false;
     };
     matches!(suffix, "CFLAGS" | "CPPFLAGS" | "CXXFLAGS")
 }
 
-fn split_scope_compat_build_flag_family_name(name: &str) -> Option<(&str, &'static str)> {
+pub(crate) fn split_scope_compat_build_flag_family_name(
+    name: &str,
+) -> Option<(&str, &'static str)> {
     ["CXXFLAGS", "CPPFLAGS", "CFLAGS"]
         .into_iter()
         .find_map(|suffix| {
@@ -1329,7 +1451,7 @@ fn split_scope_compat_build_flag_family_name(name: &str) -> Option<(&str, &'stat
 }
 
 #[cfg_attr(shuck_profiling, inline(never))]
-fn populate_array_assignment_split_scalar_expansion_spans(
+pub(crate) fn populate_array_assignment_split_scalar_expansion_spans(
     shell: ShellDialect,
     commands: &[CommandFact<'_>],
     word_nodes: &[WordNode<'_>],
@@ -1356,13 +1478,14 @@ fn populate_array_assignment_split_scalar_expansion_spans(
             &mut use_replacement_spans,
             &mut brace_expansion_spans,
         );
-        word_occurrences[id.index()].array_assignment_split_scalar_expansion_spans =
-            fact_store.word_spans.push_many(split_sensitive_spans.drain(..));
+        word_occurrences[id.index()].array_assignment_split_scalar_expansion_spans = fact_store
+            .word_spans
+            .push_many(split_sensitive_spans.drain(..));
     }
 }
 
 #[allow(clippy::too_many_arguments)]
-fn collect_array_assignment_split_scalar_expansion_spans(
+pub(crate) fn collect_array_assignment_split_scalar_expansion_spans(
     id: WordOccurrenceId,
     commands: &[CommandFact<'_>],
     word_nodes: &[WordNode<'_>],
@@ -1396,8 +1519,7 @@ fn collect_array_assignment_split_scalar_expansion_spans(
     if !unquoted_command_substitution_spans.is_empty() {
         // commands is sorted by start offset (compare_command_facts_by_offset),
         // so binary-search the subrange whose start lies inside fact_span.
-        let start =
-            commands.partition_point(|c| c.span().start.offset < fact_span.start.offset);
+        let start = commands.partition_point(|c| c.span().start.offset < fact_span.start.offset);
         for command in &commands[start..] {
             let command_span = command.span();
             if command_span.start.offset > fact_span.end.offset {
@@ -1453,14 +1575,14 @@ fn collect_array_assignment_split_scalar_expansion_spans(
     sort_and_dedup_spans(split_sensitive_spans);
 }
 
-fn shell_has_brace_expansion(shell: ShellDialect) -> bool {
+pub(crate) fn shell_has_brace_expansion(shell: ShellDialect) -> bool {
     matches!(
         shell,
         ShellDialect::Bash | ShellDialect::Ksh | ShellDialect::Mksh | ShellDialect::Zsh
     )
 }
 
-fn build_flag_for_loop_source_name_uses(locator: Locator<'_>) -> Vec<ComparableNameUse> {
+pub(crate) fn build_flag_for_loop_source_name_uses(locator: Locator<'_>) -> Vec<ComparableNameUse> {
     let source = locator.source();
     let mut uses = Vec::new();
     for line_number in 1..=locator.line_index().line_count() {
@@ -1511,7 +1633,7 @@ fn build_flag_for_loop_source_name_uses(locator: Locator<'_>) -> Vec<ComparableN
     uses
 }
 
-fn is_build_flag_source_name(name: &str) -> bool {
+pub(crate) fn is_build_flag_source_name(name: &str) -> bool {
     matches!(
         name,
         "CFLAGS" | "CXXFLAGS" | "CPPFLAGS" | "LDFLAGS" | "GOFLAGS"
@@ -1521,14 +1643,14 @@ fn is_build_flag_source_name(name: &str) -> bool {
         || name.ends_with("_LDFLAGS")
 }
 
-fn assignment_value_span(value: &AssignmentValue) -> Option<Span> {
+pub(crate) fn assignment_value_span(value: &AssignmentValue) -> Option<Span> {
     match value {
         AssignmentValue::Scalar(word) => Some(word.span),
         AssignmentValue::Compound(_) => None,
     }
 }
 
-struct AssignmentValueTargetEntry {
+pub(crate) struct AssignmentValueTargetEntry {
     value_start: usize,
     value_end: usize,
     target_name: Name,
@@ -1536,9 +1658,9 @@ struct AssignmentValueTargetEntry {
 
 // Sorted ascending by `value_start`. Scalar assignment value spans are word-level
 // and do not overlap, so a query span is contained by at most one entry.
-type AssignmentValueTargetIndex = Vec<AssignmentValueTargetEntry>;
+pub(crate) type AssignmentValueTargetIndex = Vec<AssignmentValueTargetEntry>;
 
-fn build_assignment_value_target_index(
+pub(crate) fn build_assignment_value_target_index(
     commands: &[CommandFact<'_>],
 ) -> AssignmentValueTargetIndex {
     let mut entries = Vec::<AssignmentValueTargetEntry>::new();
@@ -1562,7 +1684,7 @@ fn build_assignment_value_target_index(
     entries
 }
 
-fn push_assignment_value_target_entry(
+pub(crate) fn push_assignment_value_target_entry(
     entries: &mut Vec<AssignmentValueTargetEntry>,
     assignment: &Assignment,
 ) {

--- a/crates/shuck-linter/src/facts/pipelines.rs
+++ b/crates/shuck-linter/src/facts/pipelines.rs
@@ -1,3 +1,5 @@
+use super::*;
+
 #[derive(Debug, Clone)]
 pub struct PipelineSegmentFact<'a> {
     stmt: &'a Stmt,
@@ -98,9 +100,8 @@ impl<'a> PipelineFact<'a> {
     }
 }
 
-
 #[cfg_attr(shuck_profiling, inline(never))]
-pub(super) fn build_pipeline_facts<'a>(
+pub(crate) fn build_pipeline_facts<'a>(
     commands: &[CommandFact<'a>],
     command_fact_indices_by_id: &[Option<usize>],
     semantic: &SemanticModel,
@@ -164,7 +165,7 @@ pub(super) fn build_pipeline_facts<'a>(
         .collect()
 }
 
-fn build_pipeline_segment_fact<'a>(
+pub(crate) fn build_pipeline_segment_fact<'a>(
     command_span: Span,
     command_relationships: CommandRelationshipContext<'_, 'a>,
 ) -> PipelineSegmentFact<'a> {

--- a/crates/shuck-linter/src/facts/presence.rs
+++ b/crates/shuck-linter/src/facts/presence.rs
@@ -33,17 +33,17 @@ impl PresenceTestNameFact {
 }
 
 #[derive(Debug, Default)]
-pub(super) struct PresenceTestedNames {
-    pub(super) global_names: FxHashSet<Name>,
-    pub(super) nested_command_spans_by_name: FxHashMap<Name, Vec<Span>>,
-    pub(super) c006_global_names: FxHashSet<Name>,
-    pub(super) c006_nested_command_spans_by_name: FxHashMap<Name, Vec<Span>>,
-    pub(super) references_by_name: FxHashMap<Name, Vec<PresenceTestReferenceFact>>,
-    pub(super) names_by_name: FxHashMap<Name, Vec<PresenceTestNameFact>>,
+pub(crate) struct PresenceTestedNames {
+    pub(crate) global_names: FxHashSet<Name>,
+    pub(crate) nested_command_spans_by_name: FxHashMap<Name, Vec<Span>>,
+    pub(crate) c006_global_names: FxHashSet<Name>,
+    pub(crate) c006_nested_command_spans_by_name: FxHashMap<Name, Vec<Span>>,
+    pub(crate) references_by_name: FxHashMap<Name, Vec<PresenceTestReferenceFact>>,
+    pub(crate) names_by_name: FxHashMap<Name, Vec<PresenceTestNameFact>>,
 }
 
 #[cfg_attr(shuck_profiling, inline(never))]
-pub(super) fn build_presence_tested_names(
+pub(crate) fn build_presence_tested_names(
     commands: &[CommandFact<'_>],
     source: &str,
     semantic: &SemanticModel,

--- a/crates/shuck-linter/src/facts/redirects.rs
+++ b/crates/shuck-linter/src/facts/redirects.rs
@@ -1,3 +1,5 @@
+use super::*;
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum RedirectTargetKind {
     File,
@@ -102,7 +104,7 @@ impl ComparablePath {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub(crate) struct ComparableNameKey(Box<str>);
+pub(crate) struct ComparableNameKey(pub(crate) Box<str>);
 
 impl ComparableNameKey {
     pub(crate) fn as_str(&self) -> &str {
@@ -119,9 +121,9 @@ pub(crate) enum ComparableNameUseKind {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct ComparableNameUse {
-    span: Span,
-    key: ComparableNameKey,
-    kind: ComparableNameUseKind,
+    pub(crate) span: Span,
+    pub(crate) key: ComparableNameKey,
+    pub(crate) kind: ComparableNameUseKind,
 }
 
 impl ComparableNameUse {
@@ -137,7 +139,7 @@ impl ComparableNameUse {
         self.kind
     }
 
-    fn mark_derived(&mut self) {
+    pub(crate) fn mark_derived(&mut self) {
         self.kind = ComparableNameUseKind::Derived;
     }
 }
@@ -256,7 +258,7 @@ pub(crate) fn comparable_heredoc_name_uses(
     uses.into_boxed_slice()
 }
 
-fn collect_command_substitution_comparable_name_uses_in_parts(
+pub(crate) fn collect_command_substitution_comparable_name_uses_in_parts(
     parts: &[WordPartNode],
     semantic: Option<&LinterSemanticArtifacts<'_>>,
     source: &str,
@@ -343,7 +345,7 @@ fn collect_command_substitution_comparable_name_uses_in_parts(
     }
 }
 
-fn collect_command_substitution_comparable_name_uses(
+pub(crate) fn collect_command_substitution_comparable_name_uses(
     body: &StmtSeq,
     semantic: Option<&LinterSemanticArtifacts<'_>>,
     source: &str,
@@ -354,7 +356,8 @@ fn collect_command_substitution_comparable_name_uses(
         return;
     };
     visit_command_substitution_candidate_words(body, semantic, source, &mut |word| {
-        if !allow_quoted_derived_words && analyze_word(word, source, None).quote == WordQuote::FullyQuoted
+        if !allow_quoted_derived_words
+            && analyze_word(word, source, None).quote == WordQuote::FullyQuoted
         {
             return;
         }
@@ -365,7 +368,10 @@ fn collect_command_substitution_comparable_name_uses(
     });
 }
 
-fn standalone_comparable_name_use(word: &Word, source: &str) -> Option<ComparableNameUse> {
+pub(crate) fn standalone_comparable_name_use(
+    word: &Word,
+    source: &str,
+) -> Option<ComparableNameUse> {
     if let Some(text) = static_word_text(word, source)
         && comparable_name_text(text.as_ref())
         && analyze_word(word, source, None).quote == WordQuote::Unquoted
@@ -380,7 +386,7 @@ fn standalone_comparable_name_use(word: &Word, source: &str) -> Option<Comparabl
     })
 }
 
-fn literal_comparable_name_use(span: Span, text: &str) -> ComparableNameUse {
+pub(crate) fn literal_comparable_name_use(span: Span, text: &str) -> ComparableNameUse {
     ComparableNameUse {
         span,
         key: ComparableNameKey(text.into()),
@@ -388,7 +394,7 @@ fn literal_comparable_name_use(span: Span, text: &str) -> ComparableNameUse {
     }
 }
 
-fn comparable_name_uses_with_quoted_literals(
+pub(crate) fn comparable_name_uses_with_quoted_literals(
     word: &Word,
     semantic: Option<&LinterSemanticArtifacts<'_>>,
     source: &str,
@@ -403,14 +409,14 @@ fn comparable_name_uses_with_quoted_literals(
     uses.into_boxed_slice()
 }
 
-fn standalone_comparable_parameter_name(parts: &[WordPartNode]) -> Option<&str> {
+pub(crate) fn standalone_comparable_parameter_name(parts: &[WordPartNode]) -> Option<&str> {
     match parts {
         [part] => comparable_name_from_word_part(part),
         _ => None,
     }
 }
 
-fn comparable_name_from_word_part(part: &WordPartNode) -> Option<&str> {
+pub(crate) fn comparable_name_from_word_part(part: &WordPartNode) -> Option<&str> {
     match &part.kind {
         WordPart::Variable(name) if comparable_name_text(name.as_str()) => Some(name.as_str()),
         WordPart::Parameter(parameter) => comparable_name_from_parameter(parameter),
@@ -419,7 +425,7 @@ fn comparable_name_from_word_part(part: &WordPartNode) -> Option<&str> {
     }
 }
 
-fn comparable_name_from_parameter(parameter: &ParameterExpansion) -> Option<&str> {
+pub(crate) fn comparable_name_from_parameter(parameter: &ParameterExpansion) -> Option<&str> {
     match parameter.bourne()? {
         BourneParameterExpansion::Access { reference }
             if reference.subscript.is_none() && comparable_name_text(reference.name.as_str()) =>
@@ -430,16 +436,16 @@ fn comparable_name_from_parameter(parameter: &ParameterExpansion) -> Option<&str
     }
 }
 
-fn comparable_name_text(text: &str) -> bool {
+pub(crate) fn comparable_name_text(text: &str) -> bool {
     is_shell_variable_name(text)
 }
 
-fn dedup_comparable_name_uses(uses: &mut Vec<ComparableNameUse>) {
+pub(crate) fn dedup_comparable_name_uses(uses: &mut Vec<ComparableNameUse>) {
     let mut seen = FxHashSet::<(ComparableNameKey, FactSpan)>::default();
     uses.retain(|name_use| seen.insert((name_use.key.clone(), FactSpan::new(name_use.span))));
 }
 
-fn heredoc_variable_name_span(span: Span, locator: Locator<'_>) -> Span {
+pub(crate) fn heredoc_variable_name_span(span: Span, locator: Locator<'_>) -> Span {
     let source = locator.source();
     let Some(text) = source.get(span.start.offset..span.end.offset) else {
         return span;
@@ -454,7 +460,7 @@ fn heredoc_variable_name_span(span: Span, locator: Locator<'_>) -> Span {
     Span::from_positions(start, span.end)
 }
 
-fn comparable_path_key_is_special_device(key: &ComparablePathKey) -> bool {
+pub(crate) fn comparable_path_key_is_special_device(key: &ComparablePathKey) -> bool {
     let ComparablePathKey::Literal(path) = key else {
         return false;
     };
@@ -470,7 +476,7 @@ fn comparable_path_key_is_special_device(key: &ComparablePathKey) -> bool {
             .is_some_and(|suffix| suffix.bytes().all(|byte| byte.is_ascii_digit()))
 }
 
-fn comparable_path_key_from_parts(
+pub(crate) fn comparable_path_key_from_parts(
     parts: &[WordPartNode],
     source: &str,
 ) -> Option<ComparablePathKey> {
@@ -487,7 +493,7 @@ fn comparable_path_key_from_parts(
     }
 }
 
-fn push_comparable_path_parts(
+pub(crate) fn push_comparable_path_parts(
     part: &WordPartNode,
     source: &str,
     components: &mut Vec<ComparablePathPart>,
@@ -541,7 +547,7 @@ fn push_comparable_path_parts(
     }
 }
 
-fn push_comparable_literal(text: &str, components: &mut Vec<ComparablePathPart>) {
+pub(crate) fn push_comparable_literal(text: &str, components: &mut Vec<ComparablePathPart>) {
     if text.is_empty() {
         return;
     }
@@ -556,7 +562,7 @@ fn push_comparable_literal(text: &str, components: &mut Vec<ComparablePathPart>)
     }
 }
 
-fn is_comparable_parameter_name(name: &str) -> bool {
+pub(crate) fn is_comparable_parameter_name(name: &str) -> bool {
     let mut chars = name.chars();
     match chars.next() {
         Some(first) if first == '_' || first.is_ascii_alphabetic() => {}
@@ -663,7 +669,7 @@ pub(crate) fn analyze_redirect_target(
 }
 
 #[cfg_attr(shuck_profiling, inline(never))]
-fn build_redirect_facts<'a>(
+pub(crate) fn build_redirect_facts<'a>(
     redirects: &'a [Redirect],
     semantic: Option<&LinterSemanticArtifacts<'a>>,
     locator: Locator<'_>,
@@ -690,23 +696,19 @@ fn build_redirect_facts<'a>(
                         );
                     }
                     spans
-            })
-            .into_boxed_slice(),
+                })
+                .into_boxed_slice(),
             analysis: analyze_redirect_target(redirect, source, Some(behavior)),
             comparable_path: redirect.word_target().and_then(|word| {
                 ExpansionContext::from_redirect_kind(redirect.kind)
                     .and_then(|context| comparable_path(word, source, context, Some(behavior)))
             }),
-            comparable_name_uses: comparable_redirect_name_uses(
-                redirect,
-                semantic,
-                locator,
-            ),
+            comparable_name_uses: comparable_redirect_name_uses(redirect, semantic, locator),
         })
         .collect()
 }
 
-fn comparable_redirect_name_uses(
+pub(crate) fn comparable_redirect_name_uses(
     redirect: &Redirect,
     semantic: Option<&LinterSemanticArtifacts<'_>>,
     locator: Locator<'_>,
@@ -739,14 +741,14 @@ fn comparable_redirect_name_uses(
     comparable_heredoc_name_uses(&heredoc.body, semantic, locator)
 }
 
-fn brace_fd_redirection_span(redirect: &Redirect, source: &str) -> Option<Span> {
+pub(crate) fn brace_fd_redirection_span(redirect: &Redirect, source: &str) -> Option<Span> {
     let brace_span = redirect_fd_var_brace_span(redirect, source)?;
     let gap = source.get(brace_span.end.offset..redirect.span.start.offset)?;
     brace_fd_gap_allows_attachment(gap)
         .then(|| Span::from_positions(brace_span.start, redirect.span.end))
 }
 
-fn brace_fd_gap_allows_attachment(gap: &str) -> bool {
+pub(crate) fn brace_fd_gap_allows_attachment(gap: &str) -> bool {
     if gap.is_empty() {
         return true;
     }
@@ -767,7 +769,7 @@ fn brace_fd_gap_allows_attachment(gap: &str) -> bool {
     true
 }
 
-fn redirect_operator_span(redirect: &Redirect) -> Span {
+pub(crate) fn redirect_operator_span(redirect: &Redirect) -> Span {
     let operator_start = redirect
         .fd_var_span
         .map(|span| span.end)
@@ -783,7 +785,7 @@ fn redirect_operator_span(redirect: &Redirect) -> Span {
     Span::from_positions(operator_start, operator_end)
 }
 
-fn redirect_operator_text(kind: RedirectKind) -> &'static str {
+pub(crate) fn redirect_operator_text(kind: RedirectKind) -> &'static str {
     match kind {
         RedirectKind::Output => ">",
         RedirectKind::Clobber => ">|",

--- a/crates/shuck-linter/src/facts/simple_tests.rs
+++ b/crates/shuck-linter/src/facts/simple_tests.rs
@@ -1,3 +1,5 @@
+use super::*;
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SimpleTestSyntax {
     Test,
@@ -111,16 +113,16 @@ impl<'a> SimpleTestFact<'a> {
         }
 
         escaped_negation_is_operator(self, source).then(|| {
-            let diagnostic_span =
-                if self.syntax == SimpleTestSyntax::Bracket && self.shape == SimpleTestShape::Binary
-                {
-                    self.operands
-                        .get(1)
-                        .copied()
-                        .map_or(leading.span, |word| word.span)
-                } else {
-                    leading.span
-                };
+            let diagnostic_span = if self.syntax == SimpleTestSyntax::Bracket
+                && self.shape == SimpleTestShape::Binary
+            {
+                self.operands
+                    .get(1)
+                    .copied()
+                    .map_or(leading.span, |word| word.span)
+            } else {
+                leading.span
+            };
             let fix_start = leading.span.start;
             let fix_end = fix_start.advanced_by("\\");
             (diagnostic_span, Span::from_positions(fix_start, fix_end))
@@ -214,7 +216,7 @@ impl<'a> SimpleTestFact<'a> {
     }
 }
 
-fn escaped_negation_is_operator(simple_test: &SimpleTestFact<'_>, source: &str) -> bool {
+pub(crate) fn escaped_negation_is_operator(simple_test: &SimpleTestFact<'_>, source: &str) -> bool {
     match simple_test.shape() {
         SimpleTestShape::Unary => true,
         SimpleTestShape::Binary => simple_test
@@ -233,7 +235,7 @@ fn escaped_negation_is_operator(simple_test: &SimpleTestFact<'_>, source: &str) 
     }
 }
 
-enum SimpleTestExpression<'a> {
+pub(crate) enum SimpleTestExpression<'a> {
     Truthy(&'a Word),
     StringUnary {
         operator: &'a Word,
@@ -246,7 +248,10 @@ enum SimpleTestExpression<'a> {
     },
 }
 
-fn simple_test_operands<'a>(command: &'a SimpleCommand, source: &str) -> Option<&'a [Word]> {
+pub(crate) fn simple_test_operands<'a>(
+    command: &'a SimpleCommand,
+    source: &str,
+) -> Option<&'a [Word]> {
     match static_word_text(&command.name, source).as_deref()? {
         "[" => {
             let (closing_bracket, operands) = command.args.split_last()?;
@@ -257,7 +262,10 @@ fn simple_test_operands<'a>(command: &'a SimpleCommand, source: &str) -> Option<
     }
 }
 
-fn build_simple_test_fact<'a>(command: &'a Command, source: &str) -> Option<SimpleTestFact<'a>> {
+pub(crate) fn build_simple_test_fact<'a>(
+    command: &'a Command,
+    source: &str,
+) -> Option<SimpleTestFact<'a>> {
     let Command::Simple(command) = command else {
         return None;
     };
@@ -305,16 +313,23 @@ fn build_simple_test_fact<'a>(command: &'a Command, source: &str) -> Option<Simp
     })
 }
 
-fn build_glued_closing_bracket_operand_span(command: &Command, source: &str) -> Option<Span> {
+pub(crate) fn build_glued_closing_bracket_operand_span(
+    command: &Command,
+    source: &str,
+) -> Option<Span> {
     build_glued_closing_bracket_operand_word(command, source)
         .map(|operand| Span::from_positions(operand.span.start, operand.span.start))
 }
 
-fn build_glued_closing_bracket_insert_offset(command: &Command, source: &str) -> Option<usize> {
-    build_glued_closing_bracket_operand_word(command, source).map(|operand| operand.span.end.offset - 1)
+pub(crate) fn build_glued_closing_bracket_insert_offset(
+    command: &Command,
+    source: &str,
+) -> Option<usize> {
+    build_glued_closing_bracket_operand_word(command, source)
+        .map(|operand| operand.span.end.offset - 1)
 }
 
-fn build_glued_closing_bracket_operand_word<'a>(
+pub(crate) fn build_glued_closing_bracket_operand_word<'a>(
     command: &'a Command,
     source: &str,
 ) -> Option<&'a Word> {
@@ -335,7 +350,10 @@ fn build_glued_closing_bracket_operand_word<'a>(
     glued_closing_bracket_unary_operand(&args, source)
 }
 
-fn glued_closing_bracket_unary_operand<'a>(args: &[&'a Word], source: &str) -> Option<&'a Word> {
+pub(crate) fn glued_closing_bracket_unary_operand<'a>(
+    args: &[&'a Word],
+    source: &str,
+) -> Option<&'a Word> {
     let [first, second] = args else {
         let [bang, operator, operand] = args else {
             return None;
@@ -359,7 +377,7 @@ fn glued_closing_bracket_unary_operand<'a>(args: &[&'a Word], source: &str) -> O
     .then_some(*second)
 }
 
-fn simple_test_shape(operand_count: usize) -> SimpleTestShape {
+pub(crate) fn simple_test_shape(operand_count: usize) -> SimpleTestShape {
     match operand_count {
         0 => SimpleTestShape::Empty,
         1 => SimpleTestShape::Truthy,
@@ -369,7 +387,7 @@ fn simple_test_shape(operand_count: usize) -> SimpleTestShape {
     }
 }
 
-fn simple_test_effective_operand_offset(operands: &[&Word], source: &str) -> usize {
+pub(crate) fn simple_test_effective_operand_offset(operands: &[&Word], source: &str) -> usize {
     if operands
         .first()
         .and_then(|word| static_word_text(word, source))
@@ -393,7 +411,7 @@ fn simple_test_effective_operand_offset(operands: &[&Word], source: &str) -> usi
     }
 }
 
-fn simple_test_is_binary_operator(operator: &str) -> bool {
+pub(crate) fn simple_test_is_binary_operator(operator: &str) -> bool {
     matches!(
         operator,
         "=" | "=="
@@ -414,7 +432,7 @@ fn simple_test_is_binary_operator(operator: &str) -> bool {
     )
 }
 
-fn simple_test_is_unary_operator(operator: &str) -> bool {
+pub(crate) fn simple_test_is_unary_operator(operator: &str) -> bool {
     matches!(
         operator,
         "-e" | "-a"
@@ -445,7 +463,7 @@ fn simple_test_is_unary_operator(operator: &str) -> bool {
     )
 }
 
-fn simple_test_operator_family(
+pub(crate) fn simple_test_operator_family(
     operands: &[&Word],
     shape: SimpleTestShape,
     source: &str,
@@ -471,7 +489,7 @@ fn simple_test_operator_family(
     }
 }
 
-fn simple_test_unary_operator_family(operator: &str) -> SimpleTestOperatorFamily {
+pub(crate) fn simple_test_unary_operator_family(operator: &str) -> SimpleTestOperatorFamily {
     if matches!(operator, "-n" | "-z") {
         SimpleTestOperatorFamily::StringUnary
     } else {
@@ -479,7 +497,7 @@ fn simple_test_unary_operator_family(operator: &str) -> SimpleTestOperatorFamily
     }
 }
 
-fn simple_test_binary_operator_family(operator: &str) -> SimpleTestOperatorFamily {
+pub(crate) fn simple_test_binary_operator_family(operator: &str) -> SimpleTestOperatorFamily {
     if matches!(operator, "=" | "==" | "!=" | "<" | ">") {
         SimpleTestOperatorFamily::StringBinary
     } else {
@@ -487,7 +505,7 @@ fn simple_test_binary_operator_family(operator: &str) -> SimpleTestOperatorFamil
     }
 }
 
-fn simple_test_expressions<'a>(
+pub(crate) fn simple_test_expressions<'a>(
     simple_test: &'a SimpleTestFact<'a>,
     source: &str,
 ) -> Vec<SimpleTestExpression<'a>> {
@@ -518,7 +536,7 @@ fn simple_test_expressions<'a>(
     expressions
 }
 
-fn simple_test_operator_expression_operand_words<'a>(
+pub(crate) fn simple_test_operator_expression_operand_words<'a>(
     simple_test: &SimpleTestFact<'a>,
     source: &str,
 ) -> Vec<&'a Word> {
@@ -551,7 +569,7 @@ fn simple_test_operator_expression_operand_words<'a>(
     expression_operands
 }
 
-fn simple_test_numeric_binary_expression_operand_words<'a>(
+pub(crate) fn simple_test_numeric_binary_expression_operand_words<'a>(
     simple_test: &SimpleTestFact<'a>,
     source: &str,
 ) -> Vec<&'a Word> {
@@ -584,7 +602,7 @@ fn simple_test_numeric_binary_expression_operand_words<'a>(
     expression_operands
 }
 
-fn collect_simple_test_operator_expression_operand_words<'a>(
+pub(crate) fn collect_simple_test_operator_expression_operand_words<'a>(
     simple_test: &SimpleTestFact<'a>,
     start: usize,
     end: usize,
@@ -634,7 +652,7 @@ fn collect_simple_test_operator_expression_operand_words<'a>(
     }
 }
 
-fn collect_simple_test_numeric_binary_expression_operand_words<'a>(
+pub(crate) fn collect_simple_test_numeric_binary_expression_operand_words<'a>(
     simple_test: &SimpleTestFact<'a>,
     start: usize,
     end: usize,
@@ -673,7 +691,7 @@ fn collect_simple_test_numeric_binary_expression_operand_words<'a>(
     }
 }
 
-fn simple_test_segment_is_expression(
+pub(crate) fn simple_test_segment_is_expression(
     simple_test: &SimpleTestFact<'_>,
     start: usize,
     end: usize,
@@ -712,7 +730,7 @@ fn simple_test_segment_is_expression(
     }
 }
 
-fn parse_simple_test_expression_segment<'a>(
+pub(crate) fn parse_simple_test_expression_segment<'a>(
     simple_test: &'a SimpleTestFact<'a>,
     start: usize,
     end: usize,
@@ -765,7 +783,7 @@ fn parse_simple_test_expression_segment<'a>(
     }
 }
 
-fn simple_test_effective_operand_text(
+pub(crate) fn simple_test_effective_operand_text(
     simple_test: &SimpleTestFact<'_>,
     index: usize,
     source: &str,
@@ -789,7 +807,7 @@ fn simple_test_effective_operand_text(
     Some(text.into_owned())
 }
 
-fn simple_test_effective_unquoted_operand_text(
+pub(crate) fn simple_test_effective_unquoted_operand_text(
     simple_test: &SimpleTestFact<'_>,
     index: usize,
     source: &str,
@@ -800,11 +818,11 @@ fn simple_test_effective_unquoted_operand_text(
         .flatten()
 }
 
-fn simple_test_is_logical_connector(text: &str) -> bool {
+pub(crate) fn simple_test_is_logical_connector(text: &str) -> bool {
     matches!(text, "-a" | "-o")
 }
 
-fn simple_test_is_logical_negation(
+pub(crate) fn simple_test_is_logical_negation(
     simple_test: &SimpleTestFact<'_>,
     index: usize,
     source: &str,
@@ -820,15 +838,15 @@ fn simple_test_is_logical_negation(
             != Some("(")
 }
 
-fn simple_test_is_string_unary_operator(text: &str) -> bool {
+pub(crate) fn simple_test_is_string_unary_operator(text: &str) -> bool {
     matches!(text, "-n" | "-z")
 }
 
-fn simple_test_is_string_binary_operator(text: &str) -> bool {
+pub(crate) fn simple_test_is_string_binary_operator(text: &str) -> bool {
     matches!(text, "=" | "==" | "!=" | "<" | ">")
 }
 
-fn simple_test_parse_logical_expression(
+pub(crate) fn simple_test_parse_logical_expression(
     simple_test: &SimpleTestFact<'_>,
     start: usize,
     source: &str,
@@ -850,7 +868,7 @@ fn simple_test_parse_logical_expression(
     Some((index, spans))
 }
 
-fn simple_test_parse_logical_term(
+pub(crate) fn simple_test_parse_logical_term(
     simple_test: &SimpleTestFact<'_>,
     start: usize,
     source: &str,
@@ -866,7 +884,7 @@ fn simple_test_parse_logical_term(
     simple_test_parse_logical_primary(simple_test, index, source)
 }
 
-fn simple_test_parse_logical_primary(
+pub(crate) fn simple_test_parse_logical_primary(
     simple_test: &SimpleTestFact<'_>,
     index: usize,
     source: &str,
@@ -901,7 +919,7 @@ fn simple_test_parse_logical_primary(
         .map(|_| (index + 1, Vec::new()))
 }
 
-fn simple_test_logical_connector_span(
+pub(crate) fn simple_test_logical_connector_span(
     simple_test: &SimpleTestFact<'_>,
     index: usize,
     source: &str,
@@ -913,15 +931,15 @@ fn simple_test_logical_connector_span(
         .then_some(word.span)
 }
 
-fn simple_test_is_nonlogical_binary_operator(text: &str) -> bool {
+pub(crate) fn simple_test_is_nonlogical_binary_operator(text: &str) -> bool {
     simple_test_is_binary_operator(text) && !simple_test_is_logical_connector(text)
 }
 
-fn simple_test_is_numeric_binary_operator(text: &str) -> bool {
+pub(crate) fn simple_test_is_numeric_binary_operator(text: &str) -> bool {
     matches!(text, "-eq" | "-ne" | "-gt" | "-ge" | "-lt" | "-le")
 }
 
-pub(super) fn build_single_test_subshell_spans<'a>(
+pub(crate) fn build_single_test_subshell_spans<'a>(
     commands: &[CommandFact<'a>],
     command_fact_indices_by_id: &[Option<usize>],
     command_ids_by_span: &CommandLookupIndex,
@@ -940,7 +958,7 @@ pub(super) fn build_single_test_subshell_spans<'a>(
         .collect()
 }
 
-pub(super) fn build_subshell_test_group_spans<'a>(
+pub(crate) fn build_subshell_test_group_spans<'a>(
     commands: &[CommandFact<'a>],
     command_fact_indices_by_id: &[Option<usize>],
     command_ids_by_span: &CommandLookupIndex,
@@ -959,7 +977,7 @@ pub(super) fn build_subshell_test_group_spans<'a>(
         .collect()
 }
 
-fn single_test_subshell_span<'a>(
+pub(crate) fn single_test_subshell_span<'a>(
     fact: &CommandFact<'a>,
     command_relationships: CommandRelationshipContext<'_, 'a>,
     locator: Locator<'_>,
@@ -1000,7 +1018,7 @@ fn single_test_subshell_span<'a>(
     ))
 }
 
-fn is_test_like_command(fact: &CommandFact<'_>) -> bool {
+pub(crate) fn is_test_like_command(fact: &CommandFact<'_>) -> bool {
     fact.wrappers()
         .iter()
         .all(|wrapper| matches!(wrapper, WrapperKind::Command | WrapperKind::Builtin))
@@ -1012,7 +1030,7 @@ fn is_test_like_command(fact: &CommandFact<'_>) -> bool {
             ))
 }
 
-fn is_test_condition_fact<'a>(
+pub(crate) fn is_test_condition_fact<'a>(
     fact: &CommandFact<'a>,
     command_relationships: CommandRelationshipContext<'_, 'a>,
 ) -> bool {
@@ -1033,7 +1051,7 @@ fn is_test_condition_fact<'a>(
     }
 }
 
-fn subshell_test_group_span<'a>(
+pub(crate) fn subshell_test_group_span<'a>(
     fact: &CommandFact<'a>,
     command_relationships: CommandRelationshipContext<'_, 'a>,
     locator: Locator<'_>,
@@ -1049,7 +1067,7 @@ fn subshell_test_group_span<'a>(
     Some(subshell_anchor_span(fact.span(), locator))
 }
 
-fn subshell_body_contains_grouped_tests<'a>(
+pub(crate) fn subshell_body_contains_grouped_tests<'a>(
     body: &StmtSeq,
     parent_id: CommandId,
     command_relationships: CommandRelationshipContext<'_, 'a>,
@@ -1059,12 +1077,12 @@ fn subshell_body_contains_grouped_tests<'a>(
 }
 
 #[derive(Debug, Default, Clone, Copy)]
-struct GroupedTestAnalysis {
+pub(crate) struct GroupedTestAnalysis {
     test_count: usize,
     has_grouping: bool,
 }
 
-fn subshell_stmt_analysis<'a>(
+pub(crate) fn subshell_stmt_analysis<'a>(
     stmt: &Stmt,
     parent_id: CommandId,
     command_relationships: CommandRelationshipContext<'_, 'a>,
@@ -1073,7 +1091,7 @@ fn subshell_stmt_analysis<'a>(
     subshell_command_analysis(fact, command_relationships)
 }
 
-fn subshell_command_analysis<'a>(
+pub(crate) fn subshell_command_analysis<'a>(
     fact: &CommandFact<'a>,
     command_relationships: CommandRelationshipContext<'_, 'a>,
 ) -> Option<GroupedTestAnalysis> {
@@ -1126,7 +1144,7 @@ fn subshell_command_analysis<'a>(
     }
 }
 
-fn subshell_body_analysis<'a>(
+pub(crate) fn subshell_body_analysis<'a>(
     body: &StmtSeq,
     parent_id: CommandId,
     command_relationships: CommandRelationshipContext<'_, 'a>,
@@ -1146,7 +1164,7 @@ fn subshell_body_analysis<'a>(
     Some(analysis)
 }
 
-fn subshell_anchor_span(span: Span, locator: Locator<'_>) -> Span {
+pub(crate) fn subshell_anchor_span(span: Span, locator: Locator<'_>) -> Span {
     let source = locator.source();
     let Some(open_paren_offset) = leading_open_paren_offset(source, span.start.offset) else {
         return span;
@@ -1159,7 +1177,7 @@ fn subshell_anchor_span(span: Span, locator: Locator<'_>) -> Span {
     )
 }
 
-fn leading_open_paren_offset(source: &str, start_offset: usize) -> Option<usize> {
+pub(crate) fn leading_open_paren_offset(source: &str, start_offset: usize) -> Option<usize> {
     for (offset, ch) in source[..start_offset].char_indices().rev() {
         if ch.is_whitespace() {
             continue;
@@ -1175,7 +1193,7 @@ fn leading_open_paren_offset(source: &str, start_offset: usize) -> Option<usize>
     None
 }
 
-fn trim_trailing_whitespace_offset(source: &str, end_offset: usize) -> usize {
+pub(crate) fn trim_trailing_whitespace_offset(source: &str, end_offset: usize) -> usize {
     for (offset, ch) in source[..end_offset].char_indices().rev() {
         if ch.is_whitespace() {
             continue;
@@ -1187,7 +1205,10 @@ fn trim_trailing_whitespace_offset(source: &str, end_offset: usize) -> usize {
     end_offset
 }
 
-fn collect_short_circuit_operators(command: &BinaryCommand, operators: &mut Vec<ListOperatorFact>) {
+pub(crate) fn collect_short_circuit_operators(
+    command: &BinaryCommand,
+    operators: &mut Vec<ListOperatorFact>,
+) {
     let Some(chain) = BinaryCommandChain::logical_list(command) else {
         return;
     };
@@ -1199,7 +1220,7 @@ fn collect_short_circuit_operators(command: &BinaryCommand, operators: &mut Vec<
     });
 }
 
-fn mixed_short_circuit_operator_span(operators: &[ListOperatorFact]) -> Option<Span> {
+pub(crate) fn mixed_short_circuit_operator_span(operators: &[ListOperatorFact]) -> Option<Span> {
     let mut previous = operators.first()?;
 
     for operator in operators.iter().skip(1) {
@@ -1213,7 +1234,7 @@ fn mixed_short_circuit_operator_span(operators: &[ListOperatorFact]) -> Option<S
     None
 }
 
-fn word_contains_find_substitution<'a>(
+pub(crate) fn word_contains_find_substitution<'a>(
     word: &'a Word,
     commands: &[CommandFact<'a>],
     command_fact_indices_by_id: &[Option<usize>],
@@ -1229,7 +1250,7 @@ fn word_contains_find_substitution<'a>(
     })
 }
 
-fn word_contains_line_oriented_substitution<'a>(
+pub(crate) fn word_contains_line_oriented_substitution<'a>(
     word: &'a Word,
     commands: &[CommandFact<'a>],
     command_fact_indices_by_id: &[Option<usize>],
@@ -1245,7 +1266,7 @@ fn word_contains_line_oriented_substitution<'a>(
     })
 }
 
-fn word_contains_command_substitution_named<'a>(
+pub(crate) fn word_contains_command_substitution_named<'a>(
     word: &'a Word,
     name: &str,
     commands: &[CommandFact<'a>],
@@ -1263,7 +1284,7 @@ fn word_contains_command_substitution_named<'a>(
     })
 }
 
-fn part_contains_command_substitution_named<'a>(
+pub(crate) fn part_contains_command_substitution_named<'a>(
     part: &WordPart,
     name: &str,
     commands: &[CommandFact<'a>],
@@ -1293,7 +1314,7 @@ fn part_contains_command_substitution_named<'a>(
     }
 }
 
-fn part_contains_line_oriented_substitution<'a>(
+pub(crate) fn part_contains_line_oriented_substitution<'a>(
     part: &WordPart,
     commands: &[CommandFact<'a>],
     command_fact_indices_by_id: &[Option<usize>],
@@ -1318,7 +1339,7 @@ fn part_contains_line_oriented_substitution<'a>(
     }
 }
 
-fn part_contains_find_substitution<'a>(
+pub(crate) fn part_contains_find_substitution<'a>(
     part: &WordPart,
     commands: &[CommandFact<'a>],
     command_fact_indices_by_id: &[Option<usize>],
@@ -1345,7 +1366,7 @@ fn part_contains_find_substitution<'a>(
     }
 }
 
-fn substitution_body_is_find<'a>(
+pub(crate) fn substitution_body_is_find<'a>(
     body: &'a StmtSeq,
     commands: &[CommandFact<'a>],
     command_fact_indices_by_id: &[Option<usize>],
@@ -1357,7 +1378,7 @@ fn substitution_body_is_find<'a>(
     )
 }
 
-fn substitution_body_is_line_oriented<'a>(
+pub(crate) fn substitution_body_is_line_oriented<'a>(
     body: &'a StmtSeq,
     commands: &[CommandFact<'a>],
     command_fact_indices_by_id: &[Option<usize>],
@@ -1374,7 +1395,7 @@ fn substitution_body_is_line_oriented<'a>(
     )
 }
 
-fn substitution_body_is_pgrep_lookup<'a>(
+pub(crate) fn substitution_body_is_pgrep_lookup<'a>(
     body: &'a StmtSeq,
     commands: CommandFacts<'_, 'a>,
     command_ids_by_span: &CommandLookupIndex,
@@ -1386,7 +1407,7 @@ fn substitution_body_is_pgrep_lookup<'a>(
     )
 }
 
-fn substitution_body_is_seq_utility<'a>(
+pub(crate) fn substitution_body_is_seq_utility<'a>(
     body: &'a StmtSeq,
     commands: CommandFacts<'_, 'a>,
     command_ids_by_span: &CommandLookupIndex,
@@ -1397,7 +1418,7 @@ fn substitution_body_is_seq_utility<'a>(
     )
 }
 
-fn substitution_body_is_simple_command_named<'a>(
+pub(crate) fn substitution_body_is_simple_command_named<'a>(
     body: &'a StmtSeq,
     name: &str,
     commands: &[CommandFact<'a>],
@@ -1410,7 +1431,7 @@ fn substitution_body_is_simple_command_named<'a>(
     )
 }
 
-fn command_is_line_oriented_substitution_body<'a>(
+pub(crate) fn command_is_line_oriented_substitution_body<'a>(
     command: &'a Command,
     commands: &[CommandFact<'a>],
     command_fact_indices_by_id: &[Option<usize>],
@@ -1440,17 +1461,16 @@ fn command_is_line_oriented_substitution_body<'a>(
             }
             BinaryOp::And | BinaryOp::Or => false,
         },
-        Command::Compound(CompoundCommand::Time(command)) => command
-            .command
-            .as_deref()
-            .is_some_and(|stmt| {
+        Command::Compound(CompoundCommand::Time(command)) => {
+            command.command.as_deref().is_some_and(|stmt| {
                 command_is_line_oriented_substitution_body(
                     &stmt.command,
                     commands,
                     command_fact_indices_by_id,
                     command_ids_by_span,
                 )
-            }),
+            })
+        }
         Command::Compound(
             CompoundCommand::If(_)
             | CompoundCommand::For(_)
@@ -1472,7 +1492,7 @@ fn command_is_line_oriented_substitution_body<'a>(
     }
 }
 
-fn command_fact_is_line_oriented_utility(fact: &CommandFact<'_>) -> bool {
+pub(crate) fn command_fact_is_line_oriented_utility(fact: &CommandFact<'_>) -> bool {
     if command_fact_invokes_find(fact) {
         return false;
     }
@@ -1485,40 +1505,50 @@ fn command_fact_is_line_oriented_utility(fact: &CommandFact<'_>) -> bool {
     })
 }
 
-fn stmt_invokes_find<'a>(
+pub(crate) fn stmt_invokes_find<'a>(
     stmt: &'a Stmt,
     commands: &[CommandFact<'a>],
     command_fact_indices_by_id: &[Option<usize>],
     command_ids_by_span: &CommandLookupIndex,
 ) -> bool {
-    command_fact_for_stmt(stmt, commands, command_fact_indices_by_id, command_ids_by_span)
-        .is_some_and(command_fact_invokes_find)
+    command_fact_for_stmt(
+        stmt,
+        commands,
+        command_fact_indices_by_id,
+        command_ids_by_span,
+    )
+    .is_some_and(command_fact_invokes_find)
 }
 
-fn command_fact_invokes_find(fact: &CommandFact<'_>) -> bool {
+pub(crate) fn command_fact_invokes_find(fact: &CommandFact<'_>) -> bool {
     command_name_matches_basename(fact.literal_name(), "find")
         || command_name_matches_basename(fact.effective_name(), "find")
         || fact.has_wrapper(WrapperKind::FindExec)
         || fact.has_wrapper(WrapperKind::FindExecDir)
 }
 
-fn command_name_matches_basename(name: Option<&str>, expected: &str) -> bool {
+pub(crate) fn command_name_matches_basename(name: Option<&str>, expected: &str) -> bool {
     name.is_some_and(|name| name == expected || name.rsplit('/').next() == Some(expected))
 }
 
-fn stmt_literal_name_is<'a>(
+pub(crate) fn stmt_literal_name_is<'a>(
     stmt: &'a Stmt,
     name: &str,
     commands: &[CommandFact<'a>],
     command_fact_indices_by_id: &[Option<usize>],
     command_ids_by_span: &CommandLookupIndex,
 ) -> bool {
-    command_fact_for_stmt(stmt, commands, command_fact_indices_by_id, command_ids_by_span)
-        .and_then(CommandFact::literal_name)
+    command_fact_for_stmt(
+        stmt,
+        commands,
+        command_fact_indices_by_id,
+        command_ids_by_span,
+    )
+    .and_then(CommandFact::literal_name)
         == Some(name)
 }
 
-fn stmt_effective_or_literal_basename_is_ref<'a>(
+pub(crate) fn stmt_effective_or_literal_basename_is_ref<'a>(
     stmt: &'a Stmt,
     name: &str,
     commands: CommandFacts<'_, 'a>,

--- a/crates/shuck-linter/src/facts/statements.rs
+++ b/crates/shuck-linter/src/facts/statements.rs
@@ -1,3 +1,5 @@
+use super::*;
+
 #[derive(Debug, Clone, Copy)]
 pub struct StatementFact {
     body_span: Span,
@@ -20,7 +22,7 @@ impl StatementFact {
 }
 
 #[cfg_attr(shuck_profiling, inline(never))]
-pub(super) fn build_statement_facts<'a>(
+pub(crate) fn build_statement_facts<'a>(
     commands: &[CommandFact<'a>],
     semantic: &SemanticModel,
 ) -> Vec<StatementFact> {
@@ -30,8 +32,7 @@ pub(super) fn build_statement_facts<'a>(
         .statement_sequence_commands()
         .iter()
         .filter_map(|statement| {
-            let command_id =
-                command_ids_by_stmt_span.get(&FactSpan::new(statement.stmt_span()))?;
+            let command_id = command_ids_by_stmt_span.get(&FactSpan::new(statement.stmt_span()))?;
             Some(StatementFact {
                 body_span: statement.body_span(),
                 stmt_span: statement.stmt_span(),
@@ -41,7 +42,9 @@ pub(super) fn build_statement_facts<'a>(
         .collect()
 }
 
-fn build_command_ids_by_stmt_span(commands: &[CommandFact<'_>]) -> FxHashMap<FactSpan, CommandId> {
+pub(crate) fn build_command_ids_by_stmt_span(
+    commands: &[CommandFact<'_>],
+) -> FxHashMap<FactSpan, CommandId> {
     let mut command_ids_by_stmt_span =
         FxHashMap::with_capacity_and_hasher(commands.len(), Default::default());
 

--- a/crates/shuck-linter/src/facts/substitutions.rs
+++ b/crates/shuck-linter/src/facts/substitutions.rs
@@ -1,3 +1,5 @@
+use super::*;
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum CommandSubstitutionKind {
     Command,
@@ -149,13 +151,13 @@ impl SubstitutionFact {
 }
 
 #[derive(Debug, Clone, Copy)]
-struct HostedSubstitutionOccurrence<'a> {
+pub(crate) struct HostedSubstitutionOccurrence<'a> {
     occurrence: SubstitutionOccurrence<'a>,
     host_word_span: Span,
     host_kind: SubstitutionHostKind,
 }
 
-fn collect_substitution_occurrences_for_command<'a>(
+pub(crate) fn collect_substitution_occurrences_for_command<'a>(
     command: &'a Command,
     redirects: &'a [Redirect],
     source: &'a str,
@@ -192,7 +194,7 @@ fn collect_substitution_occurrences_for_command<'a>(
 
 #[cfg_attr(shuck_profiling, inline(never))]
 #[allow(clippy::too_many_arguments)]
-fn populate_substitution_fact_ranges<'a>(
+pub(crate) fn populate_substitution_fact_ranges<'a>(
     commands: &mut [CommandFact<'a>],
     fact_store: &mut FactStore<'a>,
     command_fact_indices_by_id: &[Option<usize>],
@@ -209,8 +211,7 @@ fn populate_substitution_fact_ranges<'a>(
             .get(command_id_index)
             .unwrap_or(&empty);
         let substitutions = {
-            let command_facts =
-                CommandFacts::new(commands, fact_store, command_fact_indices_by_id);
+            let command_facts = CommandFacts::new(commands, fact_store, command_fact_indices_by_id);
             let fact = command_facts
                 .get(index)
                 .expect("command index should resolve while populating substitution facts");
@@ -228,7 +229,7 @@ fn populate_substitution_fact_ranges<'a>(
     }
 }
 
-fn build_command_substitution_facts<'a>(
+pub(crate) fn build_command_substitution_facts<'a>(
     fact: CommandFactRef<'_, 'a>,
     commands: CommandFacts<'_, 'a>,
     command_ids_by_span: &CommandLookupIndex,
@@ -303,7 +304,7 @@ fn build_command_substitution_facts<'a>(
 }
 
 #[derive(Clone, Copy)]
-struct SubstitutionFactBuildContext<'a, 'b> {
+pub(crate) struct SubstitutionFactBuildContext<'a, 'b> {
     commands: CommandFacts<'b, 'a>,
     command_relationships: CommandRelationshipContext<'b, 'a>,
     host_command_id: CommandId,
@@ -312,7 +313,7 @@ struct SubstitutionFactBuildContext<'a, 'b> {
 }
 
 #[derive(Debug, Clone, Copy)]
-struct SubstitutionOccurrence<'a> {
+pub(crate) struct SubstitutionOccurrence<'a> {
     body: &'a StmtSeq,
     span: Span,
     kind: CommandSubstitutionKind,
@@ -320,7 +321,7 @@ struct SubstitutionOccurrence<'a> {
     unquoted_in_host: bool,
 }
 
-fn collect_word_substitution_occurrences<'a>(
+pub(crate) fn collect_word_substitution_occurrences<'a>(
     parts: &'a [WordPartNode],
     quoted: bool,
     occurrences: &mut Vec<SubstitutionOccurrence<'a>>,
@@ -331,7 +332,11 @@ fn collect_word_substitution_occurrences<'a>(
                 collect_word_substitution_occurrences(parts, true, occurrences);
             }
             WordPart::ArithmeticExpansion { expression_ast, .. } => {
-                visit_arithmetic_words_in_expression(expression_ast.as_deref(), quoted, occurrences);
+                visit_arithmetic_words_in_expression(
+                    expression_ast.as_deref(),
+                    quoted,
+                    occurrences,
+                );
             }
             WordPart::CommandSubstitution { body, syntax } => {
                 occurrences.push(SubstitutionOccurrence {
@@ -374,7 +379,7 @@ fn collect_word_substitution_occurrences<'a>(
     }
 }
 
-fn collect_heredoc_body_substitution_occurrences<'a>(
+pub(crate) fn collect_heredoc_body_substitution_occurrences<'a>(
     parts: &'a [shuck_ast::HeredocBodyPartNode],
     occurrences: &mut Vec<SubstitutionOccurrence<'a>>,
 ) {
@@ -399,7 +404,7 @@ fn collect_heredoc_body_substitution_occurrences<'a>(
     }
 }
 
-fn visit_arithmetic_words_in_expression<'a>(
+pub(crate) fn visit_arithmetic_words_in_expression<'a>(
     expression: Option<&'a ArithmeticExprNode>,
     quoted: bool,
     occurrences: &mut Vec<SubstitutionOccurrence<'a>>,
@@ -411,7 +416,7 @@ fn visit_arithmetic_words_in_expression<'a>(
     collect_arithmetic_word_substitution_occurrences(expression, quoted, occurrences);
 }
 
-fn collect_arithmetic_word_substitution_occurrences<'a>(
+pub(crate) fn collect_arithmetic_word_substitution_occurrences<'a>(
     expression: &'a ArithmeticExprNode,
     quoted: bool,
     occurrences: &mut Vec<SubstitutionOccurrence<'a>>,
@@ -450,7 +455,7 @@ fn collect_arithmetic_word_substitution_occurrences<'a>(
     }
 }
 
-fn collect_arithmetic_lvalue_substitution_occurrences<'a>(
+pub(crate) fn collect_arithmetic_lvalue_substitution_occurrences<'a>(
     target: &'a ArithmeticLvalue,
     quoted: bool,
     occurrences: &mut Vec<SubstitutionOccurrence<'a>>,
@@ -464,7 +469,7 @@ fn collect_arithmetic_lvalue_substitution_occurrences<'a>(
 }
 
 #[derive(Debug, Clone)]
-struct SubstitutionBodyFacts {
+pub(crate) struct SubstitutionBodyFacts {
     stdout_intent: SubstitutionOutputIntent,
     terminal_stdout_intent: SubstitutionOutputIntent,
     has_stdout_redirect: bool,
@@ -483,7 +488,7 @@ struct SubstitutionBodyFacts {
 }
 
 #[derive(Debug, Clone)]
-struct RedirectSummary {
+pub(crate) struct RedirectSummary {
     stdout_intent: SubstitutionOutputIntent,
     terminal_stdout_intent: SubstitutionOutputIntent,
     has_stdout_redirect: bool,
@@ -491,7 +496,7 @@ struct RedirectSummary {
     stdout_dev_null_redirect_spans: Vec<Span>,
 }
 
-fn classify_substitution_body<'a>(
+pub(crate) fn classify_substitution_body<'a>(
     body: &'a StmtSeq,
     commands: CommandFacts<'_, 'a>,
     command_relationships: CommandRelationshipContext<'_, 'a>,
@@ -511,7 +516,8 @@ fn classify_substitution_body<'a>(
             body_has_commands = true;
             body_command_count += 1;
             if body_command_count == 1 {
-                bash_file_slurp = is_bash_file_slurp_command(visit.command, visit.redirects, source);
+                bash_file_slurp =
+                    is_bash_file_slurp_command(visit.command, visit.redirects, source);
             } else {
                 bash_file_slurp = false;
             }
@@ -566,7 +572,7 @@ fn classify_substitution_body<'a>(
     }
 }
 
-fn summarize_stmt_seq_redirects<'a>(
+pub(crate) fn summarize_stmt_seq_redirects<'a>(
     body: &'a StmtSeq,
     parent_id: CommandId,
     commands: CommandFacts<'_, 'a>,
@@ -583,13 +589,8 @@ fn summarize_stmt_seq_redirects<'a>(
     let mut saw_stmt = false;
 
     for stmt in &body.stmts {
-        let stmt_summary = summarize_stmt_redirects(
-            stmt,
-            parent_id,
-            commands,
-            command_relationships,
-            locator,
-        );
+        let stmt_summary =
+            summarize_stmt_redirects(stmt, parent_id, commands, command_relationships, locator);
         summary = merge_redirect_summaries(summary, stmt_summary, saw_stmt);
         saw_stmt = true;
     }
@@ -597,7 +598,7 @@ fn summarize_stmt_seq_redirects<'a>(
     summary
 }
 
-fn summarize_stmt_redirects<'a>(
+pub(crate) fn summarize_stmt_redirects<'a>(
     stmt: &'a Stmt,
     parent_id: CommandId,
     commands: CommandFacts<'_, 'a>,
@@ -661,17 +662,11 @@ fn summarize_stmt_redirects<'a>(
             | CompoundCommand::Time(_)
             | CompoundCommand::Coproc(_)
             | CompoundCommand::Always(_),
-        ) => summarize_command_redirects(
-            stmt,
-            parent_id,
-            commands,
-            command_relationships,
-            locator,
-        ),
+        ) => summarize_command_redirects(stmt, parent_id, commands, command_relationships, locator),
     }
 }
 
-fn summarize_command_redirects<'a>(
+pub(crate) fn summarize_command_redirects<'a>(
     stmt: &Stmt,
     parent_id: CommandId,
     commands: CommandFacts<'_, 'a>,
@@ -691,7 +686,10 @@ fn summarize_command_redirects<'a>(
     }
 }
 
-fn summarize_redirect_facts(redirects: &[RedirectFact<'_>], source: &str) -> RedirectSummary {
+pub(crate) fn summarize_redirect_facts(
+    redirects: &[RedirectFact<'_>],
+    source: &str,
+) -> RedirectSummary {
     let state = classify_redirect_facts(redirects);
     RedirectSummary {
         stdout_intent: state.stdout_intent,
@@ -702,13 +700,15 @@ fn summarize_redirect_facts(redirects: &[RedirectFact<'_>], source: &str) -> Red
     }
 }
 
-fn merge_redirect_summaries(
+pub(crate) fn merge_redirect_summaries(
     mut current: RedirectSummary,
     next: RedirectSummary,
     saw_existing: bool,
 ) -> RedirectSummary {
     current.has_stdout_redirect |= next.has_stdout_redirect;
-    current.stdout_redirect_spans.extend(next.stdout_redirect_spans);
+    current
+        .stdout_redirect_spans
+        .extend(next.stdout_redirect_spans);
     current
         .stdout_dev_null_redirect_spans
         .extend(next.stdout_dev_null_redirect_spans);
@@ -726,19 +726,19 @@ fn merge_redirect_summaries(
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum OutputSink {
+pub(crate) enum OutputSink {
     Captured,
     DevNull,
     Other,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-struct RedirectState {
+pub(crate) struct RedirectState {
     stdout_intent: SubstitutionOutputIntent,
     has_stdout_redirect: bool,
 }
 
-fn classify_redirect_facts(redirects: &[RedirectFact<'_>]) -> RedirectState {
+pub(crate) fn classify_redirect_facts(redirects: &[RedirectFact<'_>]) -> RedirectState {
     let mut fds = FxHashMap::from_iter([(1, OutputSink::Captured), (2, OutputSink::Other)]);
     let mut has_stdout_redirect = false;
 
@@ -789,7 +789,10 @@ fn classify_redirect_facts(redirects: &[RedirectFact<'_>]) -> RedirectState {
     }
 }
 
-fn stdout_redirect_spans_for_fix(redirects: &[RedirectFact<'_>], source: &str) -> Vec<Span> {
+pub(crate) fn stdout_redirect_spans_for_fix(
+    redirects: &[RedirectFact<'_>],
+    source: &str,
+) -> Vec<Span> {
     redirects
         .iter()
         .filter(|redirect| redirect_matches_substitution_warning(redirect, source))
@@ -797,7 +800,7 @@ fn stdout_redirect_spans_for_fix(redirects: &[RedirectFact<'_>], source: &str) -
         .collect()
 }
 
-fn stdout_dev_null_redirect_spans_for_fix(
+pub(crate) fn stdout_dev_null_redirect_spans_for_fix(
     redirects: &[RedirectFact<'_>],
     source: &str,
 ) -> Vec<Span> {
@@ -810,7 +813,7 @@ fn stdout_dev_null_redirect_spans_for_fix(
         .collect()
 }
 
-fn redirect_affects_stdout(redirect: &RedirectFact<'_>) -> bool {
+pub(crate) fn redirect_affects_stdout(redirect: &RedirectFact<'_>) -> bool {
     match redirect.redirect().kind {
         RedirectKind::Output
         | RedirectKind::Clobber
@@ -826,11 +829,11 @@ fn redirect_affects_stdout(redirect: &RedirectFact<'_>) -> bool {
     }
 }
 
-fn redirect_targets_stdout_dev_null(redirect: &RedirectFact<'_>) -> bool {
+pub(crate) fn redirect_targets_stdout_dev_null(redirect: &RedirectFact<'_>) -> bool {
     redirect_affects_stdout(redirect) && redirect_file_sink(redirect) == OutputSink::DevNull
 }
 
-fn redirect_targets_stdout_dev_null_for_substitution_warning(
+pub(crate) fn redirect_targets_stdout_dev_null_for_substitution_warning(
     redirect: &RedirectFact<'_>,
     source: &str,
 ) -> bool {
@@ -838,14 +841,22 @@ fn redirect_targets_stdout_dev_null_for_substitution_warning(
         && redirect_targets_stdout_dev_null(redirect)
 }
 
-fn redirect_matches_substitution_warning(redirect: &RedirectFact<'_>, source: &str) -> bool {
+pub(crate) fn redirect_matches_substitution_warning(
+    redirect: &RedirectFact<'_>,
+    source: &str,
+) -> bool {
     match redirect.redirect().kind {
         RedirectKind::Output | RedirectKind::Clobber | RedirectKind::Append => {
             redirect.redirect().fd.unwrap_or(1) == 1
         }
         RedirectKind::DupOutput => {
             redirect.redirect().fd.unwrap_or(1) == 1
-                && redirect.redirect().span.slice(source).trim_start().starts_with(">&")
+                && redirect
+                    .redirect()
+                    .span
+                    .slice(source)
+                    .trim_start()
+                    .starts_with(">&")
                 && dup_stdout_target_redirects_capture_away(redirect, source)
         }
         RedirectKind::Input
@@ -858,7 +869,10 @@ fn redirect_matches_substitution_warning(redirect: &RedirectFact<'_>, source: &s
     }
 }
 
-fn dup_stdout_target_redirects_capture_away(redirect: &RedirectFact<'_>, source: &str) -> bool {
+pub(crate) fn dup_stdout_target_redirects_capture_away(
+    redirect: &RedirectFact<'_>,
+    source: &str,
+) -> bool {
     let Some(target) = redirect.target_span().map(|span| span.slice(source).trim()) else {
         return false;
     };
@@ -866,7 +880,7 @@ fn dup_stdout_target_redirects_capture_away(redirect: &RedirectFact<'_>, source:
     target == "-" || (target.chars().all(|ch| ch.is_ascii_digit()) && target != "1")
 }
 
-fn substitution_body_contains_echo(body: &StmtSeq, source: &str) -> bool {
+pub(crate) fn substitution_body_contains_echo(body: &StmtSeq, source: &str) -> bool {
     let [stmt] = body.stmts.as_slice() else {
         return false;
     };
@@ -913,12 +927,12 @@ fn substitution_body_contains_echo(body: &StmtSeq, source: &str) -> bool {
         .all(|word| !word_contains_unquoted_glob_or_brace(word, source))
 }
 
-fn command_name_word_matches_source(word: &Word, source: &str, name: &str) -> bool {
+pub(crate) fn command_name_word_matches_source(word: &Word, source: &str, name: &str) -> bool {
     static_command_name_text(word, source).is_some_and(|decoded| decoded == name)
         && source_span_static_command_name(word.span, source).as_deref() == Some(name)
 }
 
-fn source_span_static_command_name(span: Span, source: &str) -> Option<String> {
+pub(crate) fn source_span_static_command_name(span: Span, source: &str) -> Option<String> {
     let mut chars = span.slice(source).trim().chars().peekable();
     let mut decoded = String::new();
     let mut quote = None;
@@ -954,10 +968,13 @@ fn source_span_static_command_name(span: Span, source: &str) -> Option<String> {
         }
     }
 
-    quote.is_none().then_some(decoded).filter(|text| !text.is_empty())
+    quote
+        .is_none()
+        .then_some(decoded)
+        .filter(|text| !text.is_empty())
 }
 
-fn append_backslash_escaped_char(
+pub(crate) fn append_backslash_escaped_char(
     chars: &mut std::iter::Peekable<std::str::Chars<'_>>,
     decoded: &mut String,
 ) -> Option<()> {
@@ -969,7 +986,7 @@ fn append_backslash_escaped_char(
     Some(())
 }
 
-fn word_is_command_substitution_only(word: &Word) -> bool {
+pub(crate) fn word_is_command_substitution_only(word: &Word) -> bool {
     match word.parts.as_slice() {
         [
             WordPartNode {
@@ -993,12 +1010,12 @@ fn word_is_command_substitution_only(word: &Word) -> bool {
     }
 }
 
-fn word_has_leading_dynamic_dash_literal(word: &Word, source: &str) -> bool {
+pub(crate) fn word_has_leading_dynamic_dash_literal(word: &Word, source: &str) -> bool {
     let mut saw_dynamic = false;
     leading_dynamic_dash_literal_in_parts(&word.parts, source, &mut saw_dynamic).unwrap_or(false)
 }
 
-fn leading_dynamic_dash_literal_in_parts(
+pub(crate) fn leading_dynamic_dash_literal_in_parts(
     parts: &[WordPartNode],
     source: &str,
     saw_dynamic: &mut bool,
@@ -1048,7 +1065,7 @@ fn leading_dynamic_dash_literal_in_parts(
     None
 }
 
-fn substitution_body_processed_ls_pipeline_spans<'a>(
+pub(crate) fn substitution_body_processed_ls_pipeline_spans<'a>(
     body: &'a StmtSeq,
     parent_id: CommandId,
     commands: CommandFacts<'_, 'a>,
@@ -1074,7 +1091,7 @@ fn substitution_body_processed_ls_pipeline_spans<'a>(
     spans
 }
 
-fn collect_processed_ls_pipeline_spans_in_stmt<'a>(
+pub(crate) fn collect_processed_ls_pipeline_spans_in_stmt<'a>(
     stmt: &'a Stmt,
     parent_id: CommandId,
     commands: CommandFacts<'_, 'a>,
@@ -1097,24 +1114,27 @@ fn collect_processed_ls_pipeline_spans_in_stmt<'a>(
         let pipeline_id = command_relationships
             .child_or_lookup_fact(parent_id, stmt)
             .map_or(parent_id, CommandFact::id);
-        if stmt_is_raw_ls(pair[0], pipeline_id, commands, command_relationships, source)
-            && !stmt_static_utility_name_is(
-                pair[1],
-                pipeline_id,
-                commands,
-                command_relationships,
-                source,
-                "grep",
-            )
-            && !stmt_static_utility_name_is(
-                pair[1],
-                pipeline_id,
-                commands,
-                command_relationships,
-                source,
-                "xargs",
-            )
-        {
+        if stmt_is_raw_ls(
+            pair[0],
+            pipeline_id,
+            commands,
+            command_relationships,
+            source,
+        ) && !stmt_static_utility_name_is(
+            pair[1],
+            pipeline_id,
+            commands,
+            command_relationships,
+            source,
+            "grep",
+        ) && !stmt_static_utility_name_is(
+            pair[1],
+            pipeline_id,
+            commands,
+            command_relationships,
+            source,
+            "xargs",
+        ) {
             spans.push(ls_command_span_before_pipe(
                 pair[0],
                 operators[index],
@@ -1127,7 +1147,7 @@ fn collect_processed_ls_pipeline_spans_in_stmt<'a>(
     }
 }
 
-fn collect_pipeline_parts<'a>(
+pub(crate) fn collect_pipeline_parts<'a>(
     command: &'a BinaryCommand,
     segments: &mut Vec<&'a Stmt>,
     operators: &mut Vec<Span>,
@@ -1135,10 +1155,13 @@ fn collect_pipeline_parts<'a>(
     let Some(chain) = BinaryCommandChain::pipeline(command) else {
         return;
     };
-    chain.visit_parts(|stmt| segments.push(stmt), |command| operators.push(command.op_span));
+    chain.visit_parts(
+        |stmt| segments.push(stmt),
+        |command| operators.push(command.op_span),
+    );
 }
 
-fn stmt_is_raw_ls<'a>(
+pub(crate) fn stmt_is_raw_ls<'a>(
     stmt: &'a Stmt,
     parent_id: CommandId,
     commands: CommandFacts<'_, 'a>,
@@ -1157,7 +1180,7 @@ fn stmt_is_raw_ls<'a>(
     normalized.literal_name.as_deref() == Some("ls") && normalized.wrappers.is_empty()
 }
 
-fn stmt_static_utility_name_is<'a>(
+pub(crate) fn stmt_static_utility_name_is<'a>(
     stmt: &'a Stmt,
     parent_id: CommandId,
     commands: CommandFacts<'_, 'a>,
@@ -1176,7 +1199,7 @@ fn stmt_static_utility_name_is<'a>(
     command::normalize_command(&stmt.command, source).effective_or_literal_name() == Some(name)
 }
 
-fn ls_command_span_before_pipe<'a>(
+pub(crate) fn ls_command_span_before_pipe<'a>(
     stmt: &'a Stmt,
     operator_span: Span,
     parent_id: CommandId,
@@ -1202,7 +1225,7 @@ fn ls_command_span_before_pipe<'a>(
     }
 }
 
-fn substitution_body_contains_grep<'a>(
+pub(crate) fn substitution_body_contains_grep<'a>(
     body: &'a StmtSeq,
     commands: CommandFacts<'_, 'a>,
     command_relationships: CommandRelationshipContext<'_, 'a>,
@@ -1213,7 +1236,7 @@ fn substitution_body_contains_grep<'a>(
         .is_some_and(|fact| command_fact_is_grep_family(fact, source))
 }
 
-fn substitution_body_terminal_command_fact<'facts, 'a>(
+pub(crate) fn substitution_body_terminal_command_fact<'facts, 'a>(
     body: &'a StmtSeq,
     commands: CommandFacts<'facts, 'a>,
     command_relationships: CommandRelationshipContext<'facts, 'a>,
@@ -1274,7 +1297,7 @@ fn substitution_body_terminal_command_fact<'facts, 'a>(
     }
 }
 
-fn command_fact_is_grep_family(fact: CommandFactRef<'_, '_>, source: &str) -> bool {
+pub(crate) fn command_fact_is_grep_family(fact: CommandFactRef<'_, '_>, source: &str) -> bool {
     if fact
         .effective_or_literal_name()
         .is_some_and(command_name_is_grep_family)
@@ -1289,15 +1312,15 @@ fn command_fact_is_grep_family(fact: CommandFactRef<'_, '_>, source: &str) -> bo
     })
 }
 
-fn command_name_is_grep_family(name: &str) -> bool {
+pub(crate) fn command_name_is_grep_family(name: &str) -> bool {
     matches!(name, "grep" | "egrep" | "fgrep")
 }
 
-fn word_contains_unquoted_glob_or_brace(word: &Word, source: &str) -> bool {
+pub(crate) fn word_contains_unquoted_glob_or_brace(word: &Word, source: &str) -> bool {
     word_parts_contain_unquoted_glob_or_brace(&word.parts, source, false)
 }
 
-fn word_parts_contain_unquoted_glob_or_brace(
+pub(crate) fn word_parts_contain_unquoted_glob_or_brace(
     parts: &[WordPartNode],
     source: &str,
     in_double_quotes: bool,
@@ -1342,7 +1365,7 @@ fn word_parts_contain_unquoted_glob_or_brace(
     false
 }
 
-fn redirect_file_sink(redirect: &RedirectFact<'_>) -> OutputSink {
+pub(crate) fn redirect_file_sink(redirect: &RedirectFact<'_>) -> OutputSink {
     match redirect.analysis() {
         Some(analysis) if analysis.is_definitely_dev_null() => OutputSink::DevNull,
         Some(_) => OutputSink::Other,
@@ -1350,7 +1373,7 @@ fn redirect_file_sink(redirect: &RedirectFact<'_>) -> OutputSink {
     }
 }
 
-fn redirect_dup_output_sink(
+pub(crate) fn redirect_dup_output_sink(
     redirect: &RedirectFact<'_>,
     fds: &FxHashMap<i32, OutputSink>,
 ) -> OutputSink {
@@ -1364,7 +1387,7 @@ fn redirect_dup_output_sink(
     *fds.get(&fd).unwrap_or(&OutputSink::Other)
 }
 
-fn visit_command_words_for_substitutions(
+pub(crate) fn visit_command_words_for_substitutions(
     command: &Command,
     redirects: &[Redirect],
     source: &str,
@@ -1436,7 +1459,11 @@ fn visit_command_words_for_substitutions(
     }
 }
 
-fn is_bash_file_slurp_command(command: &Command, redirects: &[Redirect], source: &str) -> bool {
+pub(crate) fn is_bash_file_slurp_command(
+    command: &Command,
+    redirects: &[Redirect],
+    source: &str,
+) -> bool {
     let Command::Simple(command) = command else {
         return false;
     };
@@ -1457,7 +1484,7 @@ fn is_bash_file_slurp_command(command: &Command, redirects: &[Redirect], source:
     )
 }
 
-fn visit_command_argument_words_for_substitutions<'a>(
+pub(crate) fn visit_command_argument_words_for_substitutions<'a>(
     command: &'a Command,
     source: &str,
     visitor: &mut impl FnMut(&'a Word),
@@ -1514,7 +1541,7 @@ fn visit_command_argument_words_for_substitutions<'a>(
     }
 }
 
-fn visit_heredoc_bodies_for_substitutions<'a>(
+pub(crate) fn visit_heredoc_bodies_for_substitutions<'a>(
     redirects: &'a [Redirect],
     visitor: &mut impl FnMut(&'a shuck_ast::HeredocBody),
 ) {
@@ -1528,7 +1555,7 @@ fn visit_heredoc_bodies_for_substitutions<'a>(
     }
 }
 
-fn emit_assignment_substitution_words<'a>(
+pub(crate) fn emit_assignment_substitution_words<'a>(
     assignment: &'a Assignment,
     scalar_kind: SubstitutionHostKind,
     source: &'a str,
@@ -1548,8 +1575,7 @@ fn emit_assignment_substitution_words<'a>(
             for element in &array.elements {
                 match element {
                     ArrayElem::Sequential(word) => visitor(SubstitutionHostKind::Other, word),
-                    ArrayElem::Keyed { key, value }
-                    | ArrayElem::KeyedAppend { key, value } => {
+                    ArrayElem::Keyed { key, value } | ArrayElem::KeyedAppend { key, value } => {
                         visit_subscript_words(Some(key), source, &mut |word| {
                             visitor(SubstitutionHostKind::ArrayKeySubscript, word);
                         });
@@ -1561,7 +1587,7 @@ fn emit_assignment_substitution_words<'a>(
     }
 }
 
-fn visit_command_substitution_inputs<'a>(
+pub(crate) fn visit_command_substitution_inputs<'a>(
     command: &'a Command,
     redirects: &'a [Redirect],
     source: &'a str,
@@ -1741,7 +1767,7 @@ fn visit_command_substitution_inputs<'a>(
     }
 }
 
-fn visit_assignments_for_substitutions(
+pub(crate) fn visit_assignments_for_substitutions(
     assignments: &[shuck_ast::Assignment],
     source: &str,
     visitor: &mut impl FnMut(&Word),
@@ -1767,7 +1793,7 @@ fn visit_assignments_for_substitutions(
     }
 }
 
-fn visit_builtin_words_for_substitutions(
+pub(crate) fn visit_builtin_words_for_substitutions(
     command: &BuiltinCommand,
     source: &str,
     visitor: &mut impl FnMut(&Word),
@@ -1804,7 +1830,7 @@ fn visit_builtin_words_for_substitutions(
     }
 }
 
-fn visit_decl_operand_words_for_substitutions(
+pub(crate) fn visit_decl_operand_words_for_substitutions(
     operand: &DeclOperand,
     source: &str,
     visitor: &mut impl FnMut(&Word),
@@ -1820,13 +1846,16 @@ fn visit_decl_operand_words_for_substitutions(
     }
 }
 
-fn visit_words_for_substitutions<'a>(words: &'a [Word], visitor: &mut impl FnMut(&'a Word)) {
+pub(crate) fn visit_words_for_substitutions<'a>(
+    words: &'a [Word],
+    visitor: &mut impl FnMut(&'a Word),
+) {
     for word in words {
         visitor(word);
     }
 }
 
-fn visit_patterns_for_substitutions<'a>(
+pub(crate) fn visit_patterns_for_substitutions<'a>(
     patterns: &'a [Pattern],
     visitor: &mut impl FnMut(&'a Word),
 ) {
@@ -1835,7 +1864,7 @@ fn visit_patterns_for_substitutions<'a>(
     }
 }
 
-fn visit_pattern_for_substitutions<'a>(
+pub(crate) fn visit_pattern_for_substitutions<'a>(
     pattern: &'a Pattern,
     visitor: &mut impl FnMut(&'a Word),
 ) {
@@ -1853,7 +1882,7 @@ fn visit_pattern_for_substitutions<'a>(
     }
 }
 
-fn visit_conditional_words_for_substitutions<'a>(
+pub(crate) fn visit_conditional_words_for_substitutions<'a>(
     expression: &'a ConditionalExpr,
     source: &'a str,
     visitor: &mut impl FnMut(&'a Word),

--- a/crates/shuck-linter/src/facts/surface.rs
+++ b/crates/shuck-linter/src/facts/surface.rs
@@ -96,7 +96,7 @@ pub struct CasePatternExpansionFact {
 }
 
 impl CasePatternExpansionFact {
-    pub(super) fn new(span: Span, replacement: Box<str>) -> Self {
+    pub(crate) fn new(span: Span, replacement: Box<str>) -> Self {
         Self { span, replacement }
     }
 
@@ -161,7 +161,7 @@ pub struct ArithmeticLiteralFact {
 }
 
 impl ArithmeticLiteralFact {
-    pub(super) fn new(
+    pub(crate) fn new(
         span: Span,
         kind: ArithmeticLiteralKind,
         behavior: ArithmeticLiteralBehavior,
@@ -253,11 +253,11 @@ pub enum IndexedArrayReferenceFragmentFact {
 }
 
 impl IndexedArrayReferenceFragmentFact {
-    pub(super) fn new(span: Span, plain: bool) -> Self {
+    pub(crate) fn new(span: Span, plain: bool) -> Self {
         Self::Ambiguous(IndexedArrayReferenceFragment { span, plain })
     }
 
-    pub(super) fn with_plain(mut self, plain: bool) -> Self {
+    pub(crate) fn with_plain(mut self, plain: bool) -> Self {
         match &mut self {
             Self::OneBased(fragment)
             | Self::ZeroBased(fragment)
@@ -267,7 +267,7 @@ impl IndexedArrayReferenceFragmentFact {
         self
     }
 
-    pub(super) fn with_subscript_index_behavior(self, behavior: SubscriptIndexBehavior) -> Self {
+    pub(crate) fn with_subscript_index_behavior(self, behavior: SubscriptIndexBehavior) -> Self {
         let fragment = match self {
             Self::OneBased(fragment)
             | Self::ZeroBased(fragment)
@@ -443,37 +443,37 @@ impl PositionalParameterTrimFragmentFact {
 }
 
 #[derive(Debug, Default)]
-pub(super) struct SurfaceFragmentFacts {
-    pub(super) single_quoted: Vec<SingleQuotedFragmentFact>,
-    pub(super) dollar_double_quoted: Vec<DollarDoubleQuotedFragmentFact>,
-    pub(super) open_double_quotes: Vec<OpenDoubleQuoteFragmentFact>,
-    pub(super) suspect_closing_quotes: Vec<SuspectClosingQuoteFragmentFact>,
-    pub(super) backticks: Vec<BacktickFragmentFact>,
-    pub(super) legacy_arithmetic: Vec<LegacyArithmeticFragmentFact>,
-    pub(super) positional_parameters: Vec<PositionalParameterFragmentFact>,
-    pub(super) positional_parameter_operator_spans: Vec<Span>,
-    pub(super) unicode_smart_quote_spans: Vec<Span>,
-    pub(super) pattern_exactly_one_extglob_spans: Vec<Span>,
-    pub(super) pattern_charclass_spans: Vec<Span>,
-    pub(super) parameter_pattern_spans: Vec<Span>,
-    pub(super) nested_pattern_charclass_spans: Vec<Span>,
-    pub(super) nested_parameter_expansions: Vec<NestedParameterExpansionFragmentFact>,
-    pub(super) indirect_expansions: Vec<IndirectExpansionFragmentFact>,
-    pub(super) indexed_array_references: Vec<IndexedArrayReferenceFragmentFact>,
-    pub(super) plain_unindexed_references: Vec<Span>,
-    pub(super) parameter_pattern_special_targets: Vec<ParameterPatternSpecialTargetFragmentFact>,
-    pub(super) zsh_parameter_index_flags: Vec<ZshParameterIndexFlagFragmentFact>,
-    pub(super) substring_expansions: Vec<SubstringExpansionFragmentFact>,
-    pub(super) case_modifications: Vec<CaseModificationFragmentFact>,
-    pub(super) replacement_expansions: Vec<ReplacementExpansionFragmentFact>,
-    pub(super) positional_parameter_trims: Vec<PositionalParameterTrimFragmentFact>,
-    pub(super) suppressed_subscript_spans: Vec<Span>,
-    pub(super) subscript_later_suppression_spans: Vec<Span>,
-    pub(super) arithmetic_only_suppressed_subscript_spans: Vec<Span>,
+pub(crate) struct SurfaceFragmentFacts {
+    pub(crate) single_quoted: Vec<SingleQuotedFragmentFact>,
+    pub(crate) dollar_double_quoted: Vec<DollarDoubleQuotedFragmentFact>,
+    pub(crate) open_double_quotes: Vec<OpenDoubleQuoteFragmentFact>,
+    pub(crate) suspect_closing_quotes: Vec<SuspectClosingQuoteFragmentFact>,
+    pub(crate) backticks: Vec<BacktickFragmentFact>,
+    pub(crate) legacy_arithmetic: Vec<LegacyArithmeticFragmentFact>,
+    pub(crate) positional_parameters: Vec<PositionalParameterFragmentFact>,
+    pub(crate) positional_parameter_operator_spans: Vec<Span>,
+    pub(crate) unicode_smart_quote_spans: Vec<Span>,
+    pub(crate) pattern_exactly_one_extglob_spans: Vec<Span>,
+    pub(crate) pattern_charclass_spans: Vec<Span>,
+    pub(crate) parameter_pattern_spans: Vec<Span>,
+    pub(crate) nested_pattern_charclass_spans: Vec<Span>,
+    pub(crate) nested_parameter_expansions: Vec<NestedParameterExpansionFragmentFact>,
+    pub(crate) indirect_expansions: Vec<IndirectExpansionFragmentFact>,
+    pub(crate) indexed_array_references: Vec<IndexedArrayReferenceFragmentFact>,
+    pub(crate) plain_unindexed_references: Vec<Span>,
+    pub(crate) parameter_pattern_special_targets: Vec<ParameterPatternSpecialTargetFragmentFact>,
+    pub(crate) zsh_parameter_index_flags: Vec<ZshParameterIndexFlagFragmentFact>,
+    pub(crate) substring_expansions: Vec<SubstringExpansionFragmentFact>,
+    pub(crate) case_modifications: Vec<CaseModificationFragmentFact>,
+    pub(crate) replacement_expansions: Vec<ReplacementExpansionFragmentFact>,
+    pub(crate) positional_parameter_trims: Vec<PositionalParameterTrimFragmentFact>,
+    pub(crate) suppressed_subscript_spans: Vec<Span>,
+    pub(crate) subscript_later_suppression_spans: Vec<Span>,
+    pub(crate) arithmetic_only_suppressed_subscript_spans: Vec<Span>,
 }
 
 #[derive(Debug, Clone, Copy, Default)]
-pub(super) struct SurfaceScanContext<'a> {
+pub(crate) struct SurfaceScanContext<'a> {
     command_name: Option<&'a str>,
     assignment_target: Option<&'a str>,
     shell_dialect: shuck_parser::ShellDialect,
@@ -487,7 +487,7 @@ pub(super) struct SurfaceScanContext<'a> {
 }
 
 impl<'a> SurfaceScanContext<'a> {
-    pub(super) fn new(
+    pub(crate) fn new(
         command_name: Option<&'a str>,
         nested_word_command: bool,
         shell_dialect: shuck_parser::ShellDialect,
@@ -503,53 +503,53 @@ impl<'a> SurfaceScanContext<'a> {
         }
     }
 
-    pub(super) fn command_name(&self) -> Option<&'a str> {
+    pub(crate) fn command_name(&self) -> Option<&'a str> {
         self.command_name
     }
 
-    pub(super) fn with_assignment_target(self, assignment_target: &'a str) -> Self {
+    pub(crate) fn with_assignment_target(self, assignment_target: &'a str) -> Self {
         Self {
             assignment_target: Some(assignment_target),
             ..self
         }
     }
 
-    pub(super) fn variable_set_operand(self) -> Self {
+    pub(crate) fn variable_set_operand(self) -> Self {
         Self {
             variable_set_operand: true,
             ..self
         }
     }
 
-    pub(super) fn literal_expansion_exempt(self) -> Self {
+    pub(crate) fn literal_expansion_exempt(self) -> Self {
         Self {
             literal_expansion_exempt: true,
             ..self
         }
     }
 
-    pub(super) fn guarded_parameter_operand(self) -> Self {
+    pub(crate) fn guarded_parameter_operand(self) -> Self {
         Self {
             guarded_parameter_operand: true,
             ..self
         }
     }
 
-    pub(super) fn without_open_double_quote_scan(self) -> Self {
+    pub(crate) fn without_open_double_quote_scan(self) -> Self {
         Self {
             collect_open_double_quotes: false,
             ..self
         }
     }
 
-    pub(super) fn without_command_name(self) -> Self {
+    pub(crate) fn without_command_name(self) -> Self {
         Self {
             command_name: None,
             ..self
         }
     }
 
-    pub(super) fn with_pattern_charclass_scan(self) -> Self {
+    pub(crate) fn with_pattern_charclass_scan(self) -> Self {
         Self {
             collect_pattern_charclasses: true,
             ..self
@@ -557,7 +557,7 @@ impl<'a> SurfaceScanContext<'a> {
     }
 }
 
-pub(super) struct SurfaceFragmentSink<'a> {
+pub(crate) struct SurfaceFragmentSink<'a> {
     source: &'a str,
     facts: SurfaceFragmentFacts,
     zsh_parameter_index_flag_scratch: Vec<Span>,
@@ -567,7 +567,7 @@ pub(super) struct SurfaceFragmentSink<'a> {
 }
 
 impl<'a> SurfaceFragmentSink<'a> {
-    pub(super) fn new(source: &'a str) -> Self {
+    pub(crate) fn new(source: &'a str) -> Self {
         Self {
             source,
             facts: SurfaceFragmentFacts::default(),
@@ -579,7 +579,7 @@ impl<'a> SurfaceFragmentSink<'a> {
     }
 
     #[cfg_attr(shuck_profiling, inline(never))]
-    pub(super) fn finish(mut self) -> SurfaceFragmentFacts {
+    pub(crate) fn finish(mut self) -> SurfaceFragmentFacts {
         self.facts
             .plain_unindexed_references
             .sort_by_key(|span| (span.start.offset, span.end.offset));
@@ -739,7 +739,7 @@ impl<'a> SurfaceFragmentSink<'a> {
             .push(PositionalParameterTrimFragmentFact { span });
     }
 
-    pub(super) fn collect_word(&mut self, word: &Word, context: SurfaceScanContext<'_>) -> bool {
+    pub(crate) fn collect_word(&mut self, word: &Word, context: SurfaceScanContext<'_>) -> bool {
         let open_double_quote_count = self.facts.open_double_quotes.len();
         let context = if zsh_delayed_eval_word_is_exempt(word, self.source, context) {
             context.literal_expansion_exempt()
@@ -779,7 +779,7 @@ impl<'a> SurfaceFragmentSink<'a> {
         self.facts.open_double_quotes.len() > open_double_quote_count
     }
 
-    pub(super) fn collect_heredoc_body(
+    pub(crate) fn collect_heredoc_body(
         &mut self,
         body: &HeredocBody,
         context: SurfaceScanContext<'_>,
@@ -787,7 +787,7 @@ impl<'a> SurfaceFragmentSink<'a> {
         self.collect_heredoc_body_parts(&body.parts, context);
     }
 
-    pub(super) fn record_unset_array_target_word(&mut self, word: &Word) {
+    pub(crate) fn record_unset_array_target_word(&mut self, word: &Word) {
         if word_looks_like_unset_array_target(word, self.source) {
             self.facts.suppressed_subscript_spans.push(word.span);
         }
@@ -828,7 +828,7 @@ impl<'a> SurfaceFragmentSink<'a> {
         }
     }
 
-    pub(super) fn collect_split_suspect_closing_quote_fragment_in_words(&mut self, words: &[Word]) {
+    pub(crate) fn collect_split_suspect_closing_quote_fragment_in_words(&mut self, words: &[Word]) {
         for (index, word) in words.iter().enumerate() {
             let has_later_words = index + 1 < words.len();
             self.split_suspect_closing_quote_scratch.clear();
@@ -1278,11 +1278,11 @@ impl<'a> SurfaceFragmentSink<'a> {
         }
     }
 
-    pub(super) fn collect_pattern(&mut self, pattern: &Pattern, context: SurfaceScanContext<'_>) {
+    pub(crate) fn collect_pattern(&mut self, pattern: &Pattern, context: SurfaceScanContext<'_>) {
         self.collect_pattern_impl(pattern, context, true);
     }
 
-    pub(super) fn collect_pattern_structure(
+    pub(crate) fn collect_pattern_structure(
         &mut self,
         pattern: &Pattern,
         context: SurfaceScanContext<'_>,
@@ -1545,7 +1545,7 @@ impl<'a> SurfaceFragmentSink<'a> {
         }
     }
 
-    pub(super) fn record_var_ref_subscript(
+    pub(crate) fn record_var_ref_subscript(
         &mut self,
         reference: &VarRef,
         suppresses_later_references: bool,
@@ -1563,7 +1563,7 @@ impl<'a> SurfaceFragmentSink<'a> {
         }
     }
 
-    pub(super) fn record_arithmetic_only_suppressed_subscript(
+    pub(crate) fn record_arithmetic_only_suppressed_subscript(
         &mut self,
         subscript: Option<&Subscript>,
     ) {
@@ -2610,7 +2610,7 @@ fn is_right_operand_neighbor(ch: char) -> bool {
     ch.is_ascii_alphanumeric() || matches!(ch, '_' | '$' | '(' | '[' | '{' | '"' | '\'')
 }
 
-pub(super) fn build_suppressed_subscript_reference_spans(
+pub(crate) fn build_suppressed_subscript_reference_spans(
     semantic: &SemanticModel,
     suppressed_subscript_spans: &[Span],
     arithmetic_only_suppressed_subscript_spans: &[Span],
@@ -2631,7 +2631,7 @@ pub(super) fn build_suppressed_subscript_reference_spans(
     spans
 }
 
-pub(super) fn build_subscript_later_suppression_reference_spans(
+pub(crate) fn build_subscript_later_suppression_reference_spans(
     semantic: &SemanticModel,
     subscript_later_suppression_spans: &[Span],
 ) -> FxHashSet<FactSpan> {
@@ -2710,7 +2710,7 @@ pub(crate) fn rewrite_word_as_single_double_quoted_string(
     rendered.into_boxed_str()
 }
 
-pub(super) fn rewrite_pattern_as_single_double_quoted_string(
+pub(crate) fn rewrite_pattern_as_single_double_quoted_string(
     pattern: &Pattern,
     source: &str,
 ) -> Box<str> {
@@ -2825,7 +2825,7 @@ fn word_part_syntax(part: &WordPartNode, source: &str) -> String {
     .render_syntax(source)
 }
 
-pub(super) fn word_has_reopened_double_quote_window(
+pub(crate) fn word_has_reopened_double_quote_window(
     word: &Word,
     source: &str,
     command_name: Option<&str>,
@@ -3127,7 +3127,7 @@ fn contains_nested_parameter_marker(text: &str) -> bool {
 fn is_bourne_nested_parameter_start(char: char) -> bool {
     matches!(char, '_' | '@' | '*' | '#' | '?' | '$' | '!' | '-') || char.is_ascii_alphanumeric()
 }
-pub(super) fn simple_command_variable_set_operand<'a>(
+pub(crate) fn simple_command_variable_set_operand<'a>(
     command: &'a SimpleCommand,
     source: &str,
 ) -> Option<&'a Word> {

--- a/crates/shuck-linter/src/facts/tests/support.rs
+++ b/crates/shuck-linter/src/facts/tests/support.rs
@@ -5,7 +5,7 @@ use shuck_parser::parser::{Parser, ShellDialect as ParseShellDialect};
 
 use crate::{AmbientShellOptions, LinterFacts, LinterSemanticArtifacts, ShellDialect};
 
-pub(super) fn with_facts_dialect(
+pub(crate) fn with_facts_dialect(
     source: &str,
     _path: Option<&Path>,
     parse_dialect: ParseShellDialect,
@@ -26,7 +26,7 @@ pub(super) fn with_facts_dialect(
     visit(&output, &facts);
 }
 
-pub(super) fn with_facts(
+pub(crate) fn with_facts(
     source: &str,
     path: Option<&Path>,
     visit: impl FnOnce(&shuck_parser::parser::ParseResult, &LinterFacts<'_>),

--- a/crates/shuck-linter/src/facts/traversal.rs
+++ b/crates/shuck-linter/src/facts/traversal.rs
@@ -1,27 +1,12 @@
+use super::*;
+
 // Shared command/word traversal helpers. Normal fact construction consumes semantic
 // command visits rather than maintaining a separate recursive command walker.
-
-#[derive(Debug, Clone, Copy)]
-pub(super) struct CommandVisit<'a> {
-    pub(super) stmt: &'a Stmt,
-    pub(super) command: &'a Command,
-    pub(super) redirects: &'a [Redirect],
-}
-
-impl<'a> CommandVisit<'a> {
-    pub(super) fn new(stmt: &'a Stmt) -> Self {
-        Self {
-            stmt,
-            command: &stmt.command,
-            redirects: &stmt.redirects,
-        }
-    }
-}
 
 /// Controls traversal when walking nested statement-sequence bodies.
 #[allow(dead_code)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(super) enum BodyTraversal {
+pub(crate) enum BodyTraversal {
     /// Visit nested bodies below the current body.
     Descend,
     /// Visit the current body but do not visit its nested bodies.
@@ -35,14 +20,14 @@ pub(super) enum BodyTraversal {
 /// Use this for direct statement order, sibling windows, and nested body traversal when semantic
 /// command ids are not needed. Use `CommandTopology::body` instead when command identity or
 /// syntax-backed parent/child relationships are part of the fact.
-pub(super) struct BodyTopology<'a> {
+pub(crate) struct BodyTopology<'a> {
     body: Option<&'a StmtSeq>,
     statements: &'a [Stmt],
 }
 
 impl<'a> BodyTopology<'a> {
     /// Creates a topology view over `body`.
-    pub(super) fn new(body: &'a StmtSeq) -> Self {
+    pub(crate) fn new(body: &'a StmtSeq) -> Self {
         Self {
             body: Some(body),
             statements: body.as_slice(),
@@ -50,7 +35,7 @@ impl<'a> BodyTopology<'a> {
     }
 
     /// Creates a topology view over an already sliced body segment.
-    pub(super) fn from_statements(statements: &'a [Stmt]) -> Self {
+    pub(crate) fn from_statements(statements: &'a [Stmt]) -> Self {
         Self {
             body: None,
             statements,
@@ -58,18 +43,18 @@ impl<'a> BodyTopology<'a> {
     }
 
     /// Returns direct statements in this body.
-    pub(super) fn statements(&self) -> &'a [Stmt] {
+    pub(crate) fn statements(&self) -> &'a [Stmt] {
         self.statements
     }
 
     /// Iterates adjacent direct statement pairs in source order.
-    pub(super) fn sibling_pairs(&self) -> impl Iterator<Item = (&'a Stmt, &'a Stmt)> + '_ {
+    pub(crate) fn sibling_pairs(&self) -> impl Iterator<Item = (&'a Stmt, &'a Stmt)> + '_ {
         self.indexed_sibling_pairs()
             .map(|(_, previous, current)| (previous, current))
     }
 
     /// Iterates adjacent direct statement pairs with the first statement's index.
-    pub(super) fn indexed_sibling_pairs(
+    pub(crate) fn indexed_sibling_pairs(
         &self,
     ) -> impl Iterator<Item = (usize, &'a Stmt, &'a Stmt)> + '_ {
         self.statements()
@@ -80,7 +65,7 @@ impl<'a> BodyTopology<'a> {
 
     /// Returns the direct statement before `index`, if one exists.
     #[allow(dead_code)]
-    pub(super) fn previous_sibling(&self, index: usize) -> Option<&'a Stmt> {
+    pub(crate) fn previous_sibling(&self, index: usize) -> Option<&'a Stmt> {
         index
             .checked_sub(1)
             .and_then(|previous| self.statements().get(previous))
@@ -88,7 +73,7 @@ impl<'a> BodyTopology<'a> {
 
     /// Returns the direct statement after `index`, if one exists.
     #[allow(dead_code)]
-    pub(super) fn next_sibling(&self, index: usize) -> Option<&'a Stmt> {
+    pub(crate) fn next_sibling(&self, index: usize) -> Option<&'a Stmt> {
         self.statements().get(index + 1)
     }
 
@@ -97,10 +82,7 @@ impl<'a> BodyTopology<'a> {
     /// The visitor controls whether nested bodies below each visited body should be traversed.
     /// This keeps skip behavior explicit at the call site instead of baking policy into another
     /// recursive helper.
-    pub(super) fn for_each_body(
-        &self,
-        mut visitor: impl FnMut(&'a StmtSeq) -> BodyTraversal,
-    ) {
+    pub(crate) fn for_each_body(&self, mut visitor: impl FnMut(&'a StmtSeq) -> BodyTraversal) {
         let Some(body) = self.body else {
             debug_assert!(
                 false,
@@ -179,7 +161,7 @@ impl<'a> BodyTopology<'a> {
 
 /// Kind of adjacent binary command chain to flatten.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(super) enum BinaryCommandChainKind {
+pub(crate) enum BinaryCommandChainKind {
     /// A chain formed from `&&` and `||` operators.
     LogicalList,
     /// A chain formed from `|` and `|&` operators.
@@ -201,19 +183,19 @@ impl BinaryCommandChainKind {
 /// inspect words, or recurse into unrelated command forms; callers keep that payload-specific
 /// policy local to the owning fact.
 #[derive(Debug, Clone, Copy)]
-pub(super) struct BinaryCommandChain<'a> {
+pub(crate) struct BinaryCommandChain<'a> {
     root: &'a BinaryCommand,
     kind: BinaryCommandChainKind,
 }
 
 impl<'a> BinaryCommandChain<'a> {
     /// Returns a logical-list chain when `root` is joined by `&&` or `||`.
-    pub(super) fn logical_list(root: &'a BinaryCommand) -> Option<Self> {
+    pub(crate) fn logical_list(root: &'a BinaryCommand) -> Option<Self> {
         Self::new(root, BinaryCommandChainKind::LogicalList)
     }
 
     /// Returns a pipeline chain when `root` is joined by `|` or `|&`.
-    pub(super) fn pipeline(root: &'a BinaryCommand) -> Option<Self> {
+    pub(crate) fn pipeline(root: &'a BinaryCommand) -> Option<Self> {
         Self::new(root, BinaryCommandChainKind::Pipeline)
     }
 
@@ -222,7 +204,7 @@ impl<'a> BinaryCommandChain<'a> {
     }
 
     /// Visits leaf segments and chain operator nodes in source order.
-    pub(super) fn visit_parts(
+    pub(crate) fn visit_parts(
         &self,
         mut visit_segment: impl FnMut(&'a Stmt),
         mut visit_operator: impl FnMut(&'a BinaryCommand),
@@ -252,23 +234,23 @@ impl<'a> BinaryCommandChain<'a> {
     }
 
     /// Visits only leaf command segments in source order.
-    pub(super) fn visit_segments(&self, visitor: impl FnMut(&'a Stmt)) {
+    pub(crate) fn visit_segments(&self, visitor: impl FnMut(&'a Stmt)) {
         self.visit_parts(visitor, |_| {});
     }
 
     /// Visits only binary operator nodes in source order.
-    pub(super) fn visit_nodes(&self, visitor: impl FnMut(&'a BinaryCommand)) {
+    pub(crate) fn visit_nodes(&self, visitor: impl FnMut(&'a BinaryCommand)) {
         self.visit_parts(|_| {}, visitor);
     }
 }
 
-enum BinaryChainStackItem<'a> {
+pub(crate) enum BinaryChainStackItem<'a> {
     Command(&'a BinaryCommand),
     Operator(&'a BinaryCommand),
     Segment(&'a Stmt),
 }
 
-fn visit_command_substitution_candidate_words<'a>(
+pub(crate) fn visit_command_substitution_candidate_words<'a>(
     body: &'a StmtSeq,
     semantic: &LinterSemanticArtifacts<'a>,
     source: &str,
@@ -284,7 +266,7 @@ fn visit_command_substitution_candidate_words<'a>(
         });
 }
 
-fn visit_command_substitution_loop_header_words<'a>(
+pub(crate) fn visit_command_substitution_loop_header_words<'a>(
     command: &'a Command,
     visitor: &mut impl FnMut(&'a Word),
 ) {
@@ -305,7 +287,7 @@ fn visit_command_substitution_loop_header_words<'a>(
     }
 }
 
-fn command_assignments(command: &Command) -> &[Assignment] {
+pub(crate) fn command_assignments(command: &Command) -> &[Assignment] {
     match command {
         Command::Simple(command) => &command.assignments,
         Command::Builtin(command) => builtin_assignments(command),
@@ -317,7 +299,7 @@ fn command_assignments(command: &Command) -> &[Assignment] {
     }
 }
 
-fn declaration_operands(command: &Command) -> &[DeclOperand] {
+pub(crate) fn declaration_operands(command: &Command) -> &[DeclOperand] {
     match command {
         Command::Decl(command) => &command.operands,
         Command::Simple(_)
@@ -329,14 +311,14 @@ fn declaration_operands(command: &Command) -> &[DeclOperand] {
     }
 }
 
-fn visit_arithmetic_words<'a>(
+pub(super) fn visit_arithmetic_words<'a>(
     expression: &'a ArithmeticExprNode,
     visitor: &mut impl FnMut(&'a Word),
 ) {
     visit_arithmetic_words_in_expr(expression, visitor);
 }
 
-fn visit_var_ref_subscript_words_with_source<'a>(
+pub(super) fn visit_var_ref_subscript_words_with_source<'a>(
     reference: &'a VarRef,
     _source: &'a str,
     visitor: &mut impl FnMut(&'a Word),
@@ -344,7 +326,7 @@ fn visit_var_ref_subscript_words_with_source<'a>(
     visit_subscript_words(reference.subscript.as_deref(), _source, visitor);
 }
 
-fn visit_subscript_words<'a>(
+pub(super) fn visit_subscript_words<'a>(
     subscript: Option<&'a Subscript>,
     _source: &'a str,
     visitor: &mut impl FnMut(&'a Word),
@@ -371,7 +353,7 @@ fn visit_subscript_words<'a>(
     );
 }
 
-fn visit_arithmetic_words_in_expr<'a>(
+pub(super) fn visit_arithmetic_words_in_expr<'a>(
     expression: &'a ArithmeticExprNode,
     visitor: &mut impl FnMut(&'a Word),
 ) {
@@ -405,7 +387,7 @@ fn visit_arithmetic_words_in_expr<'a>(
     }
 }
 
-fn visit_arithmetic_lvalue_words<'a>(
+pub(crate) fn visit_arithmetic_lvalue_words<'a>(
     target: &'a ArithmeticLvalue,
     visitor: &mut impl FnMut(&'a Word),
 ) {
@@ -415,7 +397,7 @@ fn visit_arithmetic_lvalue_words<'a>(
     }
 }
 
-fn builtin_assignments(command: &BuiltinCommand) -> &[Assignment] {
+pub(crate) fn builtin_assignments(command: &BuiltinCommand) -> &[Assignment] {
     match command {
         BuiltinCommand::Break(command) => &command.assignments,
         BuiltinCommand::Continue(command) => &command.assignments,

--- a/crates/shuck-linter/src/facts/words/arithmetic.rs
+++ b/crates/shuck-linter/src/facts/words/arithmetic.rs
@@ -1,10 +1,10 @@
-pub(super) fn is_scannable_simple_arithmetic_subscript_text(text: &str) -> bool {
+pub(crate) fn is_scannable_simple_arithmetic_subscript_text(text: &str) -> bool {
     let trimmed = text.trim();
     !trimmed.is_empty()
         && (is_shell_variable_name(trimmed) || trimmed.bytes().all(|byte| byte.is_ascii_digit()))
 }
 
-pub(super) fn is_simple_arithmetic_reference_subscript(subscript: &Subscript, source: &str) -> bool {
+pub(crate) fn is_simple_arithmetic_reference_subscript(subscript: &Subscript, source: &str) -> bool {
     subscript.selector().is_none()
         && !subscript.syntax_text(source).contains('$')
         && matches!(
@@ -13,7 +13,7 @@ pub(super) fn is_simple_arithmetic_reference_subscript(subscript: &Subscript, so
         )
 }
 
-pub(super) fn is_arithmetic_variable_reference_word(word: &Word, source: &str) -> bool {
+pub(crate) fn is_arithmetic_variable_reference_word(word: &Word, source: &str) -> bool {
     matches!(word.parts.as_slice(), [part] if match &part.kind {
         WordPart::Variable(name) => is_shell_variable_name(name.as_str()),
         WordPart::Parameter(parameter) => matches!(
@@ -31,7 +31,7 @@ pub(super) fn is_arithmetic_variable_reference_word(word: &Word, source: &str) -
     })
 }
 
-pub(super) fn collect_arithmetic_command_spans(
+pub(crate) fn collect_arithmetic_command_spans(
     expression: &ArithmeticExprNode,
     source: &str,
     dollar_spans: &mut Vec<Span>,
@@ -48,7 +48,7 @@ pub(super) fn collect_arithmetic_command_spans(
     });
 }
 
-pub(super) fn collect_slice_arithmetic_expression_spans(
+pub(crate) fn collect_slice_arithmetic_expression_spans(
     expression: &ArithmeticExprNode,
     source: &str,
     dollar_spans: &mut Vec<Span>,
@@ -70,7 +70,7 @@ pub(super) fn collect_slice_arithmetic_expression_spans(
     });
 }
 
-pub(super) fn collect_arithmetic_spans_in_fragment(
+pub(crate) fn collect_arithmetic_spans_in_fragment(
     word: Option<&Word>,
     text: Option<&SourceText>,
     source: &str,
@@ -101,7 +101,7 @@ pub(super) fn collect_arithmetic_spans_in_fragment(
     );
 }
 
-pub(super) fn collect_dollar_prefixed_arithmetic_variable_spans(
+pub(crate) fn collect_dollar_prefixed_arithmetic_variable_spans(
     span: Span,
     source: &str,
     spans: &mut Vec<Span>,
@@ -187,7 +187,7 @@ pub(super) fn collect_dollar_prefixed_arithmetic_variable_spans(
     }
 }
 
-pub(super) fn collect_dollar_prefixed_indexed_subscript_word_spans(
+pub(crate) fn collect_dollar_prefixed_indexed_subscript_word_spans(
     word: &Word,
     source: &str,
     spans: &mut Vec<Span>,
@@ -234,7 +234,7 @@ pub(super) fn collect_dollar_prefixed_indexed_subscript_word_spans(
     }
 }
 
-pub(super) fn collect_wrapped_arithmetic_spans_in_word(
+pub(crate) fn collect_wrapped_arithmetic_spans_in_word(
     word: &Word,
     source: &str,
     dollar_spans: &mut Vec<Span>,
@@ -310,7 +310,7 @@ pub(super) fn collect_wrapped_arithmetic_spans_in_word(
     }
 }
 
-pub(super) fn collect_wrapped_arithmetic_command_substitution_spans(
+pub(crate) fn collect_wrapped_arithmetic_command_substitution_spans(
     span: Span,
     source: &str,
     spans: &mut Vec<Span>,
@@ -339,7 +339,7 @@ pub(super) fn collect_wrapped_arithmetic_command_substitution_spans(
     }
 }
 
-pub(super) fn is_unescaped_dollar(bytes: &[u8], index: usize) -> bool {
+pub(crate) fn is_unescaped_dollar(bytes: &[u8], index: usize) -> bool {
     if bytes.get(index) != Some(&b'$') {
         return false;
     }
@@ -354,7 +354,7 @@ pub(super) fn is_unescaped_dollar(bytes: &[u8], index: usize) -> bool {
     backslash_count.is_multiple_of(2)
 }
 
-pub(super) fn find_command_substitution_end(text: &str, start: usize) -> Option<usize> {
+pub(crate) fn find_command_substitution_end(text: &str, start: usize) -> Option<usize> {
     let bytes = text.as_bytes();
     let mut paren_depth = 0usize;
     let mut cursor = start + 2;
@@ -418,7 +418,7 @@ pub(super) fn find_command_substitution_end(text: &str, start: usize) -> Option<
     None
 }
 
-pub(super) fn find_wrapped_arithmetic_end(text: &str, start: usize) -> Option<usize> {
+pub(crate) fn find_wrapped_arithmetic_end(text: &str, start: usize) -> Option<usize> {
     let bytes = text.as_bytes();
     let mut paren_depth = 0usize;
     let mut cursor = start + 3;
@@ -484,7 +484,7 @@ pub(super) fn find_wrapped_arithmetic_end(text: &str, start: usize) -> Option<us
     None
 }
 
-pub(super) fn find_process_substitution_end(text: &str, start: usize) -> Option<usize> {
+pub(crate) fn find_process_substitution_end(text: &str, start: usize) -> Option<usize> {
     let bytes = text.as_bytes();
     let mut paren_depth = 0usize;
     let mut cursor = start + 2;
@@ -548,7 +548,7 @@ pub(super) fn find_process_substitution_end(text: &str, start: usize) -> Option<
     None
 }
 
-pub(super) fn skip_single_quoted(bytes: &[u8], start: usize) -> Option<usize> {
+pub(crate) fn skip_single_quoted(bytes: &[u8], start: usize) -> Option<usize> {
     let mut cursor = start;
     while cursor < bytes.len() {
         if bytes[cursor] == b'\'' {
@@ -559,7 +559,7 @@ pub(super) fn skip_single_quoted(bytes: &[u8], start: usize) -> Option<usize> {
     None
 }
 
-pub(super) fn skip_double_quoted(text: &str, start: usize) -> Option<usize> {
+pub(crate) fn skip_double_quoted(text: &str, start: usize) -> Option<usize> {
     let bytes = text.as_bytes();
     let mut cursor = start;
 
@@ -596,7 +596,7 @@ pub(super) fn skip_double_quoted(text: &str, start: usize) -> Option<usize> {
     None
 }
 
-pub(super) fn skip_backticks(bytes: &[u8], start: usize) -> Option<usize> {
+pub(crate) fn skip_backticks(bytes: &[u8], start: usize) -> Option<usize> {
     let mut cursor = start;
     while cursor < bytes.len() {
         if bytes[cursor] == b'\\' {
@@ -611,11 +611,11 @@ pub(super) fn skip_backticks(bytes: &[u8], start: usize) -> Option<usize> {
     None
 }
 
-pub(super) fn word_needs_wrapped_arithmetic_fallback(word: &Word, source: &str) -> bool {
+pub(crate) fn word_needs_wrapped_arithmetic_fallback(word: &Word, source: &str) -> bool {
     parts_need_wrapped_arithmetic_fallback(&word.parts, source)
 }
 
-pub(super) fn parts_need_wrapped_arithmetic_fallback(parts: &[WordPartNode], source: &str) -> bool {
+pub(crate) fn parts_need_wrapped_arithmetic_fallback(parts: &[WordPartNode], source: &str) -> bool {
     parts.iter().any(|part| match &part.kind {
         WordPart::DoubleQuoted { parts, .. } => {
             parts_need_wrapped_arithmetic_fallback(parts, source)
@@ -637,7 +637,7 @@ pub(super) fn parts_need_wrapped_arithmetic_fallback(parts: &[WordPartNode], sou
     })
 }
 
-pub(super) fn parameter_needs_wrapped_arithmetic_fallback(
+pub(crate) fn parameter_needs_wrapped_arithmetic_fallback(
     parameter: &ParameterExpansion,
     source: &str,
 ) -> bool {
@@ -658,7 +658,7 @@ pub(super) fn parameter_needs_wrapped_arithmetic_fallback(
     }
 }
 
-pub(super) fn collect_dollar_spans_in_nested_arithmetic_expansions_from_parts(
+pub(crate) fn collect_dollar_spans_in_nested_arithmetic_expansions_from_parts(
     parts: &[WordPartNode],
     source: &str,
     dollar_spans: &mut Vec<Span>,
@@ -719,7 +719,7 @@ pub(super) fn collect_dollar_spans_in_nested_arithmetic_expansions_from_parts(
     }
 }
 
-pub(super) fn collect_arithmetic_context_spans_in_word(
+pub(crate) fn collect_arithmetic_context_spans_in_word(
     word: &Word,
     source: &str,
     collect_dollar_spans: bool,
@@ -745,7 +745,7 @@ pub(super) fn collect_arithmetic_context_spans_in_word(
     );
 }
 
-pub(super) fn collect_arithmetic_spans_in_parameter_operator(
+pub(crate) fn collect_arithmetic_spans_in_parameter_operator(
     operator: &ParameterOp,
     source: &str,
     collect_dollar_spans: bool,
@@ -782,7 +782,7 @@ pub(super) fn collect_arithmetic_spans_in_parameter_operator(
     }
 }
 
-pub(super) fn collect_arithmetic_summary_spans_in_word(
+pub(crate) fn collect_arithmetic_summary_spans_in_word(
     word: &Word,
     source: &str,
     collect_dollar_spans: bool,
@@ -962,7 +962,7 @@ impl<'word> WordSubtreeVisitor<'word> for ArithmeticSummarySpanVisitor<'_, '_> {
     }
 }
 
-pub(super) fn collect_arithmetic_expansion_spans_from_parts(
+pub(crate) fn collect_arithmetic_expansion_spans_from_parts(
     parts: &[WordPartNode],
     source: &str,
     collect_dollar_spans: bool,
@@ -1119,7 +1119,7 @@ pub(super) fn collect_arithmetic_expansion_spans_from_parts(
     }
 }
 
-pub(super) fn collect_arithmetic_update_operator_spans_from_parts(
+pub(crate) fn collect_arithmetic_update_operator_spans_from_parts(
     parts: &[WordPartNode],
     semantic: &SemanticModel,
     source: &str,
@@ -1130,7 +1130,7 @@ pub(super) fn collect_arithmetic_update_operator_spans_from_parts(
     );
 }
 
-pub(super) fn collect_arithmetic_update_operator_spans_from_parts_with_nested_commands(
+pub(crate) fn collect_arithmetic_update_operator_spans_from_parts_with_nested_commands(
     parts: &[WordPartNode],
     semantic: &SemanticModel,
     semantic_artifacts: &LinterSemanticArtifacts<'_>,
@@ -1147,7 +1147,7 @@ pub(super) fn collect_arithmetic_update_operator_spans_from_parts_with_nested_co
     );
 }
 
-pub(super) fn collect_arithmetic_update_operator_spans_from_parts_impl(
+pub(crate) fn collect_arithmetic_update_operator_spans_from_parts_impl(
     parts: &[WordPartNode],
     semantic: &SemanticModel,
     semantic_artifacts: Option<&LinterSemanticArtifacts<'_>>,
@@ -1304,7 +1304,7 @@ pub(super) fn collect_arithmetic_update_operator_spans_from_parts_impl(
     }
 }
 
-pub(super) fn collect_arithmetic_update_operator_spans_in_var_ref(
+pub(crate) fn collect_arithmetic_update_operator_spans_in_var_ref(
     reference: &VarRef,
     semantic: &SemanticModel,
     source: &str,
@@ -1315,7 +1315,7 @@ pub(super) fn collect_arithmetic_update_operator_spans_in_var_ref(
     );
 }
 
-pub(super) fn collect_arithmetic_update_operator_spans_in_var_ref_impl(
+pub(crate) fn collect_arithmetic_update_operator_spans_in_var_ref_impl(
     reference: &VarRef,
     semantic: &SemanticModel,
     semantic_artifacts: Option<&LinterSemanticArtifacts<'_>>,
@@ -1342,7 +1342,7 @@ pub(super) fn collect_arithmetic_update_operator_spans_in_var_ref_impl(
     });
 }
 
-pub(super) fn collect_arithmetic_update_operator_spans_in_parameter_expansion_with_nested_commands(
+pub(crate) fn collect_arithmetic_update_operator_spans_in_parameter_expansion_with_nested_commands(
     parameter: &ParameterExpansion,
     semantic: &SemanticModel,
     semantic_artifacts: &LinterSemanticArtifacts<'_>,
@@ -1359,7 +1359,7 @@ pub(super) fn collect_arithmetic_update_operator_spans_in_parameter_expansion_wi
     );
 }
 
-pub(super) fn collect_arithmetic_update_operator_spans_in_parameter_expansion_impl(
+pub(crate) fn collect_arithmetic_update_operator_spans_in_parameter_expansion_impl(
     parameter: &ParameterExpansion,
     semantic: &SemanticModel,
     semantic_artifacts: Option<&LinterSemanticArtifacts<'_>>,
@@ -1529,7 +1529,7 @@ pub(super) fn collect_arithmetic_update_operator_spans_in_parameter_expansion_im
     }
 }
 
-pub(super) fn collect_arithmetic_update_operator_spans_in_parameter_operator_impl(
+pub(crate) fn collect_arithmetic_update_operator_spans_in_parameter_operator_impl(
     operator: &ParameterOp,
     semantic: &SemanticModel,
     semantic_artifacts: Option<&LinterSemanticArtifacts<'_>>,
@@ -1568,7 +1568,7 @@ pub(super) fn collect_arithmetic_update_operator_spans_in_parameter_operator_imp
     }
 }
 
-pub(super) fn collect_arithmetic_spans_in_var_ref(
+pub(crate) fn collect_arithmetic_spans_in_var_ref(
     reference: &VarRef,
     source: &str,
     _collect_dollar_spans: bool,
@@ -1591,7 +1591,7 @@ pub(super) fn collect_arithmetic_spans_in_var_ref(
     });
 }
 
-pub(super) fn collect_arithmetic_spans_in_parameter_expansion(
+pub(crate) fn collect_arithmetic_spans_in_parameter_expansion(
     parameter: &ParameterExpansion,
     source: &str,
     collect_dollar_spans: bool,

--- a/crates/shuck-linter/src/facts/words/command_facts.rs
+++ b/crates/shuck-linter/src/facts/words/command_facts.rs
@@ -1,4 +1,4 @@
-pub(super) fn build_function_in_alias_spans(commands: &[CommandFact<'_>], source: &str) -> Vec<Span> {
+pub(crate) fn build_function_in_alias_spans(commands: &[CommandFact<'_>], source: &str) -> Vec<Span> {
     let mut spans = commands
         .iter()
         .filter(|fact| fact.effective_name_is("alias"))
@@ -10,7 +10,7 @@ pub(super) fn build_function_in_alias_spans(commands: &[CommandFact<'_>], source
 }
 
 #[cfg_attr(shuck_profiling, inline(never))]
-pub(super) fn build_alias_definition_expansion_spans(
+pub(crate) fn build_alias_definition_expansion_spans(
     commands: &[CommandFact<'_>],
     fact_store: &FactStore<'_>,
     nodes: &[WordNode<'_>],
@@ -51,7 +51,7 @@ pub(super) fn build_alias_definition_expansion_spans(
     spans
 }
 
-pub(super) fn alias_definition_word_groups_for_command<'a>(
+pub(crate) fn alias_definition_word_groups_for_command<'a>(
     command: &'a CommandFact<'a>,
     source: &str,
 ) -> Vec<&'a [&'a Word]> {
@@ -82,17 +82,17 @@ pub(super) fn alias_definition_word_groups_for_command<'a>(
     definition_words
 }
 
-pub(super) fn word_contains_literal_equals(word: &Word, source: &str) -> bool {
+pub(crate) fn word_contains_literal_equals(word: &Word, source: &str) -> bool {
     word_chars_outside_expansions(word, source).any(|(_, ch)| ch == '=')
 }
 
-pub(super) fn word_ends_with_literal_equals(word: &Word, source: &str) -> bool {
+pub(crate) fn word_ends_with_literal_equals(word: &Word, source: &str) -> bool {
     word_chars_outside_expansions(word, source)
         .last()
         .is_some_and(|(_, ch)| ch == '=')
 }
 
-pub(super) fn word_chars_outside_expansions<'a>(
+pub(crate) fn word_chars_outside_expansions<'a>(
     word: &'a Word,
     source: &'a str,
 ) -> impl Iterator<Item = (usize, char)> + 'a {
@@ -117,7 +117,7 @@ pub(super) fn word_chars_outside_expansions<'a>(
     })
 }
 
-pub(super) fn function_in_alias_definition_span(words: &[&Word], source: &str) -> Option<Span> {
+pub(crate) fn function_in_alias_definition_span(words: &[&Word], source: &str) -> Option<Span> {
     let definition = static_alias_definition_text(words, source)?;
     let (_, value) = definition.split_once('=').unwrap_or(("", &definition));
     let end = words.last()?.span.end;
@@ -125,7 +125,7 @@ pub(super) fn function_in_alias_definition_span(words: &[&Word], source: &str) -
         .then(|| Span::from_positions(words[0].span.start, end))
 }
 
-pub(super) fn static_alias_definition_text(words: &[&Word], source: &str) -> Option<String> {
+pub(crate) fn static_alias_definition_text(words: &[&Word], source: &str) -> Option<String> {
     let mut text = String::new();
     for word in words {
         text.push_str(&static_word_text(word, source)?);
@@ -133,7 +133,7 @@ pub(super) fn static_alias_definition_text(words: &[&Word], source: &str) -> Opt
     Some(text)
 }
 
-pub(super) fn contains_positional_parameter_reference(value: &str) -> bool {
+pub(crate) fn contains_positional_parameter_reference(value: &str) -> bool {
     let bytes = value.as_bytes();
     let mut index = 0usize;
     let mut in_single_quotes = false;
@@ -192,7 +192,7 @@ pub(super) fn contains_positional_parameter_reference(value: &str) -> bool {
     false
 }
 
-pub(super) fn starts_comment(value: &str, hash: usize) -> bool {
+pub(crate) fn starts_comment(value: &str, hash: usize) -> bool {
     hash == 0
         || value.as_bytes()[hash - 1].is_ascii_whitespace()
         || matches!(
@@ -201,7 +201,7 @@ pub(super) fn starts_comment(value: &str, hash: usize) -> bool {
         )
 }
 
-pub(super) fn is_escaped_dollar(value: &str, dollar: usize) -> bool {
+pub(crate) fn is_escaped_dollar(value: &str, dollar: usize) -> bool {
     let bytes = value.as_bytes();
     let mut cursor = dollar;
     let mut backslashes = 0usize;
@@ -214,7 +214,7 @@ pub(super) fn is_escaped_dollar(value: &str, dollar: usize) -> bool {
     backslashes % 2 == 1
 }
 
-pub(super) fn braced_parameter_starts_with_positional(value: &str, index: usize) -> bool {
+pub(crate) fn braced_parameter_starts_with_positional(value: &str, index: usize) -> bool {
     let bytes = value.as_bytes();
     let Some(first) = bytes.get(index).copied() else {
         return false;
@@ -231,11 +231,11 @@ pub(super) fn braced_parameter_starts_with_positional(value: &str, index: usize)
             .is_some_and(is_positional_parameter_start)
 }
 
-pub(super) fn is_positional_parameter_start(byte: u8) -> bool {
+pub(crate) fn is_positional_parameter_start(byte: u8) -> bool {
     byte.is_ascii_digit() || matches!(byte, b'@' | b'*')
 }
 
-pub(super) fn build_echo_backslash_escape_word_spans(commands: &[CommandFact<'_>], source: &str) -> Vec<Span> {
+pub(crate) fn build_echo_backslash_escape_word_spans(commands: &[CommandFact<'_>], source: &str) -> Vec<Span> {
     let mut spans = commands
         .iter()
         .filter(|fact| fact.effective_name_is("echo") && fact.wrappers().is_empty())
@@ -250,18 +250,18 @@ pub(super) fn build_echo_backslash_escape_word_spans(commands: &[CommandFact<'_>
     spans
 }
 
-pub(super) fn echo_uses_escape_interpreting_flag(command: &CommandFact<'_>) -> bool {
+pub(crate) fn echo_uses_escape_interpreting_flag(command: &CommandFact<'_>) -> bool {
     command
         .options()
         .echo()
         .is_some_and(|echo| echo.uses_escape_interpreting_flag())
 }
 
-pub(super) fn word_contains_echo_backslash_escape(word: &Word, source: &str) -> bool {
+pub(crate) fn word_contains_echo_backslash_escape(word: &Word, source: &str) -> bool {
     word_parts_contain_echo_backslash_escape(&word.parts, source, false)
 }
 
-pub(super) fn word_parts_contain_echo_backslash_escape(
+pub(crate) fn word_parts_contain_echo_backslash_escape(
     parts: &[WordPartNode],
     source: &str,
     in_double_quotes: bool,
@@ -300,18 +300,18 @@ pub(super) fn word_parts_contain_echo_backslash_escape(
         })
 }
 
-pub(super) fn echo_escape_is_core_family(byte: u8) -> bool {
+pub(crate) fn echo_escape_is_core_family(byte: u8) -> bool {
     matches!(
         byte,
         b'a' | b'b' | b'e' | b'f' | b'n' | b'r' | b't' | b'v' | b'x' | b'0'..=b'9'
     )
 }
 
-pub(super) fn echo_escape_is_quote_like(byte: u8) -> bool {
+pub(crate) fn echo_escape_is_quote_like(byte: u8) -> bool {
     matches!(byte, b'`' | b'\'')
 }
 
-pub(super) fn literal_double_backslash_touches_double_quoted_fragment(
+pub(crate) fn literal_double_backslash_touches_double_quoted_fragment(
     parts: &[WordPartNode],
     index: usize,
     rendered_text: &str,
@@ -327,14 +327,14 @@ pub(super) fn literal_double_backslash_touches_double_quoted_fragment(
                 .is_some_and(|part| matches!(part.kind, WordPart::DoubleQuoted { .. })))
 }
 
-pub(super) fn leading_backslash_count(text: &str) -> usize {
+pub(crate) fn leading_backslash_count(text: &str) -> usize {
     text.as_bytes()
         .iter()
         .take_while(|byte| **byte == b'\\')
         .count()
 }
 
-pub(super) fn trailing_backslash_count(text: &str) -> usize {
+pub(crate) fn trailing_backslash_count(text: &str) -> usize {
     text.as_bytes()
         .iter()
         .rev()
@@ -342,7 +342,7 @@ pub(super) fn trailing_backslash_count(text: &str) -> usize {
         .count()
 }
 
-pub(super) fn text_contains_echo_double_backslash(text: &str) -> bool {
+pub(crate) fn text_contains_echo_double_backslash(text: &str) -> bool {
     let bytes = text.as_bytes();
     let mut index = 0usize;
 
@@ -367,7 +367,7 @@ pub(super) fn text_contains_echo_double_backslash(text: &str) -> bool {
     false
 }
 
-pub(super) fn text_contains_echo_backslash_escape(text: &str, is_sensitive: fn(u8) -> bool) -> bool {
+pub(crate) fn text_contains_echo_backslash_escape(text: &str, is_sensitive: fn(u8) -> bool) -> bool {
     let bytes = text.as_bytes();
     let mut index = 0usize;
 
@@ -395,17 +395,17 @@ pub(super) fn text_contains_echo_backslash_escape(text: &str, is_sensitive: fn(u
 }
 
 #[derive(Clone, Copy)]
-pub(super) struct WordFactLookup<'facts, 'a> {
-    pub(super) nodes: &'facts [WordNode<'a>],
-    pub(super) occurrences: &'facts [WordOccurrence],
-    pub(super) word_index: &'facts FxHashMap<FactSpan, SmallVec<[WordOccurrenceId; 2]>>,
-    pub(super) fact_store: &'facts FactStore<'a>,
-    pub(super) source: &'a str,
-    pub(super) line_index: &'facts LineIndex,
+pub(crate) struct WordFactLookup<'facts, 'a> {
+    pub(crate) nodes: &'facts [WordNode<'a>],
+    pub(crate) occurrences: &'facts [WordOccurrence],
+    pub(crate) word_index: &'facts FxHashMap<FactSpan, SmallVec<[WordOccurrenceId; 2]>>,
+    pub(crate) fact_store: &'facts FactStore<'a>,
+    pub(crate) source: &'a str,
+    pub(crate) line_index: &'facts LineIndex,
 }
 
 #[cfg_attr(shuck_profiling, inline(never))]
-pub(super) fn build_echo_to_sed_substitution_spans<'a>(
+pub(crate) fn build_echo_to_sed_substitution_spans<'a>(
     commands: CommandFacts<'_, 'a>,
     pipelines: &[PipelineFact<'a>],
     backticks: &[BacktickFragmentFact],
@@ -442,7 +442,7 @@ pub(super) fn build_echo_to_sed_substitution_spans<'a>(
     spans
 }
 
-pub(super) fn sc2001_like_pipeline_span<'a>(
+pub(crate) fn sc2001_like_pipeline_span<'a>(
     commands: CommandFacts<'_, 'a>,
     pipeline: &PipelineFact<'a>,
     backtick_commands: &BacktickCommandIndex,
@@ -540,7 +540,7 @@ pub(super) fn sc2001_like_pipeline_span<'a>(
     ))
 }
 
-pub(super) fn sc2001_like_here_string_span(
+pub(crate) fn sc2001_like_here_string_span(
     command: CommandFactRef<'_, '_>,
     backtick_commands: &BacktickCommandIndex,
     source: &str,
@@ -570,11 +570,11 @@ pub(super) fn sc2001_like_here_string_span(
     command_span_with_redirects_and_shellcheck_tail(command, source)
 }
 
-pub(super) fn command_is_plain_named(command: CommandFactRef<'_, '_>, name: &str) -> bool {
+pub(crate) fn command_is_plain_named(command: CommandFactRef<'_, '_>, name: &str) -> bool {
     command.effective_name_is(name) && command.wrappers().is_empty()
 }
 
-pub(super) fn sc2001_like_backtick_pipeline_span(
+pub(crate) fn sc2001_like_backtick_pipeline_span(
     commands: CommandFacts<'_, '_>,
     pipeline: &PipelineFact<'_>,
     sed_command: CommandFactRef<'_, '_>,
@@ -588,7 +588,7 @@ pub(super) fn sc2001_like_backtick_pipeline_span(
     Some(Span::from_positions(start, end))
 }
 
-pub(super) fn sc2001_like_backtick_command_span(
+pub(crate) fn sc2001_like_backtick_command_span(
     command: CommandFactRef<'_, '_>,
     source: &str,
     line_index: &LineIndex,
@@ -598,7 +598,7 @@ pub(super) fn sc2001_like_backtick_command_span(
     Some(Span::from_positions(start, end))
 }
 
-pub(super) fn sc2001_like_backtick_sed_script_end(
+pub(crate) fn sc2001_like_backtick_sed_script_end(
     args: &[&Word],
     source: &str,
     line_index: &LineIndex,
@@ -627,7 +627,7 @@ pub(super) fn sc2001_like_backtick_sed_script_end(
     Locator::new(source, line_index).position_at_offset(end_offset)
 }
 
-pub(super) fn backtick_sed_script_content_end_offset(text: &str, end_offset: usize) -> Option<usize> {
+pub(crate) fn backtick_sed_script_content_end_offset(text: &str, end_offset: usize) -> Option<usize> {
     if text.len() >= 4 && text.starts_with("\\\"") && text.ends_with("\\\"") {
         end_offset.checked_sub(2)
     } else if text.len() >= 2
@@ -640,7 +640,7 @@ pub(super) fn backtick_sed_script_content_end_offset(text: &str, end_offset: usi
     }
 }
 
-pub(super) fn sc2001_like_backtick_sed_script_trim_chars(
+pub(crate) fn sc2001_like_backtick_sed_script_trim_chars(
     script_words: &[&Word],
     source: &str,
 ) -> Option<usize> {
@@ -687,7 +687,7 @@ pub(super) fn sc2001_like_backtick_sed_script_trim_chars(
     Some(trim_chars)
 }
 
-pub(super) fn backtick_sed_script_uses_escaped_double_quotes(script_words: &[&Word], source: &str) -> bool {
+pub(crate) fn backtick_sed_script_uses_escaped_double_quotes(script_words: &[&Word], source: &str) -> bool {
     match script_words {
         [script] => {
             let text = script.span.slice(source);
@@ -701,7 +701,7 @@ pub(super) fn backtick_sed_script_uses_escaped_double_quotes(script_words: &[&Wo
     }
 }
 
-pub(super) fn rewind_offset_by_chars(source: &str, mut offset: usize, count: usize) -> Option<usize> {
+pub(crate) fn rewind_offset_by_chars(source: &str, mut offset: usize, count: usize) -> Option<usize> {
     if offset > source.len() || !source.is_char_boundary(offset) {
         return None;
     }
@@ -715,7 +715,7 @@ pub(super) fn rewind_offset_by_chars(source: &str, mut offset: usize, count: usi
     Some(offset)
 }
 
-pub(super) fn command_has_sc2001_like_sed_script(
+pub(crate) fn command_has_sc2001_like_sed_script(
     command: CommandFactRef<'_, '_>,
     backtick_commands: &BacktickCommandIndex,
     source: &str,
@@ -732,7 +732,7 @@ pub(super) fn command_has_sc2001_like_sed_script(
             ))
 }
 
-pub(super) struct BacktickCommandIndex {
+pub(crate) struct BacktickCommandIndex {
     command_ids: DenseCommandIdSet,
 }
 
@@ -753,7 +753,7 @@ impl BacktickCommandIndex {
 }
 
 
-pub(super) fn parse_wait_command(args: &[&Word], source: &str) -> WaitCommandFacts {
+pub(crate) fn parse_wait_command(args: &[&Word], source: &str) -> WaitCommandFacts {
     let mut option_spans = Vec::new();
     let mut index = 0;
 
@@ -783,7 +783,7 @@ pub(super) fn parse_wait_command(args: &[&Word], source: &str) -> WaitCommandFac
     }
 }
 
-pub(super) fn wait_option_consumes_argument(text: &str) -> bool {
+pub(crate) fn wait_option_consumes_argument(text: &str) -> bool {
     let Some(flags) = text.strip_prefix('-') else {
         return false;
     };
@@ -794,7 +794,7 @@ pub(super) fn wait_option_consumes_argument(text: &str) -> bool {
     p_index + 1 == flags.len()
 }
 
-pub(super) fn parse_mapfile_command(
+pub(crate) fn parse_mapfile_command(
     args: &[&Word],
     semantic: &LinterSemanticArtifacts<'_>,
     source: &str,
@@ -868,11 +868,11 @@ pub(super) fn parse_mapfile_command(
     }
 }
 
-pub(super) fn mapfile_option_takes_argument(flag: char) -> bool {
+pub(crate) fn mapfile_option_takes_argument(flag: char) -> bool {
     matches!(flag, 'u' | 'C' | 'c' | 'd' | 'n' | 'O' | 's')
 }
 
-pub(super) fn parse_expr_command(args: &[&Word], source: &str) -> Option<ExprCommandFacts> {
+pub(crate) fn parse_expr_command(args: &[&Word], source: &str) -> Option<ExprCommandFacts> {
     let (string_helper_kind, string_helper_span) = expr_string_helper(args, source)
         .map_or((None, None), |(kind, span)| (Some(kind), Some(span)));
 
@@ -883,7 +883,7 @@ pub(super) fn parse_expr_command(args: &[&Word], source: &str) -> Option<ExprCom
     })
 }
 
-pub(super) fn expr_uses_string_form(args: &[&Word], source: &str) -> bool {
+pub(crate) fn expr_uses_string_form(args: &[&Word], source: &str) -> bool {
     matches!(
         args.first()
             .and_then(|word| static_word_text(word, source))
@@ -896,7 +896,7 @@ pub(super) fn expr_uses_string_form(args: &[&Word], source: &str) -> bool {
         .is_some_and(|text| matches!(text, ":" | "=" | "!=" | "<" | ">" | "<=" | ">=" | "=="))
 }
 
-pub(super) fn expr_string_helper(args: &[&Word], source: &str) -> Option<(ExprStringHelperKind, Span)> {
+pub(crate) fn expr_string_helper(args: &[&Word], source: &str) -> Option<(ExprStringHelperKind, Span)> {
     let word = args.first()?;
     let kind = match static_word_text(word, source).as_deref() {
         Some("length") => ExprStringHelperKind::Length,
@@ -909,7 +909,7 @@ pub(super) fn expr_string_helper(args: &[&Word], source: &str) -> Option<(ExprSt
     Some((kind, word.span))
 }
 
-pub(super) fn parse_exit_command<'a>(command: &'a Command, source: &str) -> Option<ExitCommandFacts<'a>> {
+pub(crate) fn parse_exit_command<'a>(command: &'a Command, source: &str) -> Option<ExitCommandFacts<'a>> {
     let Command::Builtin(BuiltinCommand::Exit(exit)) = command else {
         return None;
     };
@@ -933,11 +933,11 @@ pub(super) fn parse_exit_command<'a>(command: &'a Command, source: &str) -> Opti
     })
 }
 
-pub(super) fn word_contains_literal_content(word: &Word, source: &str) -> bool {
+pub(crate) fn word_contains_literal_content(word: &Word, source: &str) -> bool {
     word_parts_contain_literal_content(&word.parts, source)
 }
 
-pub(super) fn word_parts_contain_literal_content(parts: &[WordPartNode], source: &str) -> bool {
+pub(crate) fn word_parts_contain_literal_content(parts: &[WordPartNode], source: &str) -> bool {
     parts.iter().any(|part| match &part.kind {
         WordPart::Literal(text) => !text.as_str(source, part.span).is_empty(),
         WordPart::SingleQuoted { value, .. } => !value.slice(source).is_empty(),
@@ -961,7 +961,7 @@ pub(super) fn word_parts_contain_literal_content(parts: &[WordPartNode], source:
     })
 }
 
-pub(super) fn detect_sudo_family_invoker(
+pub(crate) fn detect_sudo_family_invoker(
     command: &Command,
     normalized: &NormalizedCommand<'_>,
     source: &str,
@@ -988,7 +988,7 @@ pub(super) fn detect_sudo_family_invoker(
         .last()
 }
 
-pub(super) fn single_quoted_literal_exempt_argument(
+pub(crate) fn single_quoted_literal_exempt_argument(
     command_name: Option<&str>,
     shell_dialect: shuck_parser::ShellDialect,
     args: &[Word],
@@ -1207,11 +1207,11 @@ fn p10k_prompt_segment_expansion_argument(relative_arg_index: usize) -> bool {
     matches!(relative_arg_index, 5 | 6)
 }
 
-pub(super) fn single_quoted_literal_exempt_here_string(command_name: Option<&str>) -> bool {
+pub(crate) fn single_quoted_literal_exempt_here_string(command_name: Option<&str>) -> bool {
     matches!(command_name, Some("sh" | "bash" | "dash" | "ksh" | "zsh"))
 }
 
-pub(super) fn single_quoted_literal_instructional_output_argument(
+pub(crate) fn single_quoted_literal_instructional_output_argument(
     command_name: Option<&str>,
     redirects: &[Redirect],
     inherited_output_sinks: &FxHashMap<i32, CommandOutputSink>,
@@ -1260,16 +1260,16 @@ fn command_redirects_stdout_to_file(
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(super) enum CommandOutputSink {
+pub(crate) enum CommandOutputSink {
     File,
     Other,
 }
 
-pub(super) fn output_sink_state_defaults() -> FxHashMap<i32, CommandOutputSink> {
+pub(crate) fn output_sink_state_defaults() -> FxHashMap<i32, CommandOutputSink> {
     FxHashMap::from_iter([(1, CommandOutputSink::Other), (2, CommandOutputSink::Other)])
 }
 
-pub(super) fn apply_output_redirects(
+pub(crate) fn apply_output_redirects(
     redirects: &[Redirect],
     source: &str,
     shell_behavior: &ShellBehaviorAt<'_>,
@@ -1345,7 +1345,7 @@ fn redirected_output_fd(redirect: &Redirect) -> Option<i32> {
     }
 }
 
-pub(super) fn printf_assigns_to_variable(args: &[Word], arg_index: usize, source: &str) -> bool {
+pub(crate) fn printf_assigns_to_variable(args: &[Word], arg_index: usize, source: &str) -> bool {
     match args.first().and_then(|word| static_word_text(word, source)) {
         Some(text) if text == "-v" => arg_index >= 2,
         Some(text) if text.starts_with("-v") && text.len() > 2 => arg_index >= 1,
@@ -1465,14 +1465,14 @@ fn byte_is_escaped(bytes: &[u8], index: usize) -> bool {
     backslashes % 2 == 1
 }
 
-pub(super) fn shell_command_argument_index(args: &[Word], source: &str) -> Option<usize> {
+pub(crate) fn shell_command_argument_index(args: &[Word], source: &str) -> Option<usize> {
     args.windows(2).enumerate().find_map(|(index, pair)| {
         let flag = static_word_text(&pair[0], source)?;
         shell_flag_contains_command_string(flag.as_ref()).then_some(index + 1)
     })
 }
 
-pub(super) fn awk_literal_argument_index(args: &[Word], source: &str) -> Vec<usize> {
+pub(crate) fn awk_literal_argument_index(args: &[Word], source: &str) -> Vec<usize> {
     let mut result = Vec::new();
     let mut index = 0usize;
     while index < args.len() {
@@ -1529,7 +1529,7 @@ pub(super) fn awk_literal_argument_index(args: &[Word], source: &str) -> Vec<usi
     result
 }
 
-pub(super) fn jq_literal_argument_index(args: &[Word], source: &str) -> Vec<usize> {
+pub(crate) fn jq_literal_argument_index(args: &[Word], source: &str) -> Vec<usize> {
     let mut result = Vec::new();
     let mut index = 0usize;
     while index < args.len() {
@@ -1564,7 +1564,7 @@ pub(super) fn jq_literal_argument_index(args: &[Word], source: &str) -> Vec<usiz
     result
 }
 
-pub(super) fn perl_program_argument_index(args: &[Word], source: &str) -> Vec<usize> {
+pub(crate) fn perl_program_argument_index(args: &[Word], source: &str) -> Vec<usize> {
     args.windows(2)
         .enumerate()
         .filter_map(|(index, pair)| {
@@ -1574,19 +1574,19 @@ pub(super) fn perl_program_argument_index(args: &[Word], source: &str) -> Vec<us
         .collect()
 }
 
-pub(super) fn perl_option_takes_program_argument(option: &str) -> bool {
+pub(crate) fn perl_option_takes_program_argument(option: &str) -> bool {
     matches!(option, "-e" | "-E")
         || (option.starts_with('-')
             && !option.starts_with("--")
             && option.chars().any(|character| matches!(character, 'e' | 'E')))
 }
 
-pub(super) fn rename_program_argument_index(args: &[Word], source: &str) -> Option<usize> {
+pub(crate) fn rename_program_argument_index(args: &[Word], source: &str) -> Option<usize> {
     args.iter()
         .position(|word| static_word_text(word, source).is_none_or(|text| !text.starts_with('-')))
 }
 
-pub(super) fn ssh_remote_command_argument_index(args: &[Word], source: &str) -> Option<usize> {
+pub(crate) fn ssh_remote_command_argument_index(args: &[Word], source: &str) -> Option<usize> {
     let mut index = 0usize;
     while let Some(word) = args.get(index) {
         let Some(text) = static_word_text(word, source) else {
@@ -1613,7 +1613,7 @@ pub(super) fn ssh_remote_command_argument_index(args: &[Word], source: &str) -> 
     args.get(index + 1).map(|_| index + 1)
 }
 
-pub(super) fn rg_pattern_argument_index(args: &[Word], source: &str) -> Option<usize> {
+pub(crate) fn rg_pattern_argument_index(args: &[Word], source: &str) -> Option<usize> {
     let mut index = 0usize;
     while index < args.len() {
         let text = static_word_text(&args[index], source)?;
@@ -1636,7 +1636,7 @@ pub(super) fn rg_pattern_argument_index(args: &[Word], source: &str) -> Option<u
     None
 }
 
-pub(super) fn rg_option_consumes_next_argument(option: &str) -> bool {
+pub(crate) fn rg_option_consumes_next_argument(option: &str) -> bool {
     matches!(
         option,
         "-A" | "--after-context"
@@ -1659,7 +1659,7 @@ pub(super) fn rg_option_consumes_next_argument(option: &str) -> bool {
     )
 }
 
-pub(super) fn container_shell_command_argument_index(args: &[Word], source: &str) -> Option<usize> {
+pub(crate) fn container_shell_command_argument_index(args: &[Word], source: &str) -> Option<usize> {
     let run_index = args
         .iter()
         .position(|word| static_word_text(word, source).as_deref() == Some("run"))?;
@@ -1713,11 +1713,11 @@ pub(super) fn container_shell_command_argument_index(args: &[Word], source: &str
         .map(|relative| shell_index + 1 + relative)
 }
 
-pub(super) fn shell_command_name(name: &str) -> bool {
+pub(crate) fn shell_command_name(name: &str) -> bool {
     matches!(name, "sh" | "bash" | "dash" | "ksh" | "zsh")
 }
 
-pub(super) fn container_run_option_consumes_next_argument(option: &str) -> bool {
+pub(crate) fn container_run_option_consumes_next_argument(option: &str) -> bool {
     matches!(
         option,
         "-a" | "--attach"
@@ -1770,14 +1770,14 @@ pub(super) fn container_run_option_consumes_next_argument(option: &str) -> bool 
     )
 }
 
-pub(super) fn format_option_argument_index(args: &[Word], source: &str) -> Option<usize> {
+pub(crate) fn format_option_argument_index(args: &[Word], source: &str) -> Option<usize> {
     args.windows(2).enumerate().find_map(|(index, pair)| {
         let flag = static_word_text(&pair[0], source)?;
         matches!(flag.as_ref(), "-f" | "--format" | "--template").then_some(index + 1)
     })
 }
 
-pub(super) fn format_option_value_word(args: &[Word], arg_index: usize, source: &str) -> bool {
+pub(crate) fn format_option_value_word(args: &[Word], arg_index: usize, source: &str) -> bool {
     static_word_text(&args[arg_index], source).is_some_and(|text| {
         matches!(
             text.as_ref(),
@@ -1786,14 +1786,14 @@ pub(super) fn format_option_value_word(args: &[Word], arg_index: usize, source: 
     })
 }
 
-pub(super) fn dpkg_query_format_argument_index(args: &[Word], source: &str) -> Option<usize> {
+pub(crate) fn dpkg_query_format_argument_index(args: &[Word], source: &str) -> Option<usize> {
     args.windows(2).enumerate().find_map(|(index, pair)| {
         let flag = static_word_text(&pair[0], source)?;
         matches!(flag.as_ref(), "-f" | "--showformat").then_some(index + 1)
     })
 }
 
-pub(super) fn dpkg_query_format_option_value_word(args: &[Word], arg_index: usize, source: &str) -> bool {
+pub(crate) fn dpkg_query_format_option_value_word(args: &[Word], arg_index: usize, source: &str) -> bool {
     static_word_text(&args[arg_index], source).is_some_and(|text| {
         text.starts_with("-f=")
             || text.starts_with("--showformat=")
@@ -1801,14 +1801,14 @@ pub(super) fn dpkg_query_format_option_value_word(args: &[Word], arg_index: usiz
     })
 }
 
-pub(super) fn xprop_value_argument_index(args: &[Word], source: &str) -> Option<usize> {
+pub(crate) fn xprop_value_argument_index(args: &[Word], source: &str) -> Option<usize> {
     args.windows(3).enumerate().find_map(|(index, triple)| {
         let flag = static_word_text(&triple[0], source)?;
         (flag.as_ref() == "-set").then_some(index + 2)
     })
 }
 
-pub(super) fn trap_action_word<'a>(command: &'a Command, source: &str) -> Option<&'a Word> {
+pub(crate) fn trap_action_word<'a>(command: &'a Command, source: &str) -> Option<&'a Word> {
     let Command::Simple(command) = command else {
         return None;
     };
@@ -1816,7 +1816,7 @@ pub(super) fn trap_action_word<'a>(command: &'a Command, source: &str) -> Option
     trap_action_word_from_simple_command(command, source)
 }
 
-pub(super) fn trap_action_word_from_simple_command<'a>(
+pub(crate) fn trap_action_word_from_simple_command<'a>(
     command: &'a SimpleCommand,
     source: &str,
 ) -> Option<&'a Word> {

--- a/crates/shuck-linter/src/facts/words/expansion.rs
+++ b/crates/shuck-linter/src/facts/words/expansion.rs
@@ -230,11 +230,11 @@ impl TestOperandClass {
     }
 }
 
-pub(super) fn classify_word(word: &Word, source: &str) -> WordClassification {
+pub(crate) fn classify_word(word: &Word, source: &str) -> WordClassification {
     word_classification_from_analysis(analyze_word(word, source, None))
 }
 
-pub(super) fn classify_contextual_operand(
+pub(crate) fn classify_contextual_operand(
     word: &Word,
     source: &str,
     context: ExpansionContext,
@@ -251,7 +251,7 @@ pub(super) fn classify_contextual_operand(
     }
 }
 
-pub(super) fn classify_conditional_operand(
+pub(crate) fn classify_conditional_operand(
     expression: &ConditionalExpr,
     source: &str,
 ) -> TestOperandClass {
@@ -275,7 +275,7 @@ pub(super) fn classify_conditional_operand(
     }
 }
 
-pub(super) fn classify_pattern_operand(pattern: &Pattern, source: &str) -> TestOperandClass {
+pub(crate) fn classify_pattern_operand(pattern: &Pattern, source: &str) -> TestOperandClass {
     for (part, _) in pattern.parts_with_spans() {
         match part {
             PatternPart::Group { patterns, .. } => {
@@ -351,14 +351,14 @@ fn merge_pathname_expansion_behavior(
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(super) enum PartValueShape {
+pub(crate) enum PartValueShape {
     Scalar,
     Array,
     Unknown,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(super) struct PartAnalysis {
+pub(crate) struct PartAnalysis {
     value_shape: PartValueShape,
     array_valued: bool,
     can_expand_to_multiple_fields: bool,
@@ -370,7 +370,7 @@ pub(super) struct PartAnalysis {
 }
 
 #[derive(Default)]
-pub(super) struct AnalysisSummary {
+pub(crate) struct AnalysisSummary {
     has_non_literal: bool,
     has_scalar_value: bool,
     has_array_value: bool,
@@ -383,7 +383,7 @@ pub(super) struct AnalysisSummary {
     has_process_substitution: bool,
 }
 
-pub(super) fn analyze_word(
+pub(crate) fn analyze_word(
     word: &Word,
     source: &str,
     behavior: Option<&ShellBehaviorAt<'_>>,
@@ -478,13 +478,13 @@ pub(crate) fn analyze_literal_runtime(
 }
 
 #[derive(Debug, Default)]
-pub(super) struct RuntimeLiteralState {
+pub(crate) struct RuntimeLiteralState {
     seen_text: bool,
     last_unquoted_char: Option<char>,
     deferred_tilde: bool,
 }
 
-pub(super) fn analyze_literal_runtime_parts(
+pub(crate) fn analyze_literal_runtime_parts(
     parts: &[WordPartNode],
     source: &str,
     context: ExpansionContext,
@@ -524,7 +524,7 @@ pub(super) fn analyze_literal_runtime_parts(
     flush_deferred_tilde(state, analysis);
 }
 
-pub(super) fn scan_literal_runtime_text(
+pub(crate) fn scan_literal_runtime_text(
     text: &str,
     context: ExpansionContext,
     behavior: &ShellBehaviorAt<'_>,
@@ -608,15 +608,15 @@ fn cancel_deferred_tilde(state: &mut RuntimeLiteralState) {
     state.deferred_tilde = false;
 }
 
-pub(super) fn tilde_is_runtime_sensitive(state: &RuntimeLiteralState) -> bool {
+pub(crate) fn tilde_is_runtime_sensitive(state: &RuntimeLiteralState) -> bool {
     !state.seen_text || matches!(state.last_unquoted_char, Some('=') | Some(':'))
 }
 
-pub(super) fn brace_fanout_is_runtime_sensitive(content: &str) -> bool {
+pub(crate) fn brace_fanout_is_runtime_sensitive(content: &str) -> bool {
     content.contains(',') || content.contains("..")
 }
 
-pub(super) fn context_allows_tilde(context: ExpansionContext) -> bool {
+pub(crate) fn context_allows_tilde(context: ExpansionContext) -> bool {
     matches!(
         context,
         ExpansionContext::CommandName
@@ -631,7 +631,7 @@ pub(super) fn context_allows_tilde(context: ExpansionContext) -> bool {
     )
 }
 
-pub(super) fn context_allows_pathname_matching(context: ExpansionContext) -> bool {
+pub(crate) fn context_allows_pathname_matching(context: ExpansionContext) -> bool {
     matches!(
         context,
         ExpansionContext::CommandName
@@ -643,7 +643,7 @@ pub(super) fn context_allows_pathname_matching(context: ExpansionContext) -> boo
     )
 }
 
-pub(super) fn context_allows_brace_fanout(context: ExpansionContext) -> bool {
+pub(crate) fn context_allows_brace_fanout(context: ExpansionContext) -> bool {
     matches!(
         context,
         ExpansionContext::CommandName
@@ -656,7 +656,7 @@ pub(super) fn context_allows_brace_fanout(context: ExpansionContext) -> bool {
     )
 }
 
-pub(super) fn analyze_parts(
+pub(crate) fn analyze_parts(
     parts: &[WordPartNode],
     source: &str,
     in_double_quotes: bool,
@@ -699,7 +699,7 @@ pub(super) fn analyze_parts(
     }
 }
 
-pub(super) fn analyze_part(
+pub(crate) fn analyze_part(
     part: &WordPart,
     source: &str,
     in_double_quotes: bool,
@@ -919,7 +919,7 @@ pub(super) fn analyze_part(
     }
 }
 
-pub(super) fn analyze_parameter_part(
+pub(crate) fn analyze_parameter_part(
     parameter: &ParameterExpansion,
     in_double_quotes: bool,
     behavior: &ShellBehaviorAt<'_>,
@@ -1143,7 +1143,7 @@ pub(super) fn analyze_parameter_part(
     }
 }
 
-pub(super) fn substitution_can_expand_to_multiple_fields(
+pub(crate) fn substitution_can_expand_to_multiple_fields(
     in_double_quotes: bool,
     behavior: &ShellBehaviorAt<'_>,
 ) -> bool {
@@ -1154,14 +1154,14 @@ pub(super) fn substitution_can_expand_to_multiple_fields(
                 .unquoted_substitution_results_can_glob())
 }
 
-pub(super) fn substitution_field_splitting_hazard(
+pub(crate) fn substitution_field_splitting_hazard(
     in_double_quotes: bool,
     behavior: &ShellBehaviorAt<'_>,
 ) -> bool {
     !in_double_quotes && behavior.field_splitting().unquoted_results_can_split()
 }
 
-pub(super) fn substitution_pathname_matching_hazard(
+pub(crate) fn substitution_pathname_matching_hazard(
     in_double_quotes: bool,
     behavior: &ShellBehaviorAt<'_>,
 ) -> bool {
@@ -1171,7 +1171,7 @@ pub(super) fn substitution_pathname_matching_hazard(
             .unquoted_substitution_results_can_glob()
 }
 
-pub(super) fn zsh_modifier_behavior<'model>(
+pub(crate) fn zsh_modifier_behavior<'model>(
     behavior: &ShellBehaviorAt<'model>,
     syntax: &shuck_ast::ZshParameterExpansion,
 ) -> ShellBehaviorAt<'model> {
@@ -1198,7 +1198,7 @@ pub(super) fn zsh_modifier_behavior<'model>(
     })
 }
 
-pub(super) fn apply_toggle_override(value: &mut OptionValue, count: usize) {
+pub(crate) fn apply_toggle_override(value: &mut OptionValue, count: usize) {
     if count == 0 {
         return;
     }
@@ -1210,7 +1210,7 @@ pub(super) fn apply_toggle_override(value: &mut OptionValue, count: usize) {
     };
 }
 
-pub(super) fn scalar_part(
+pub(crate) fn scalar_part(
     can_expand_to_multiple_fields: bool,
     field_splitting_behavior: FieldSplittingBehavior,
     pathname_expansion_behavior: PathnameExpansionBehavior,
@@ -1230,7 +1230,7 @@ pub(super) fn scalar_part(
     }
 }
 
-pub(super) fn array_part(
+pub(crate) fn array_part(
     can_expand_to_multiple_fields: bool,
     field_splitting_behavior: FieldSplittingBehavior,
     pathname_expansion_behavior: PathnameExpansionBehavior,
@@ -1255,7 +1255,7 @@ pub(super) fn array_part(
     }
 }
 
-pub(super) fn parameter_operator_uses_pattern(operator: &shuck_ast::ParameterOp) -> bool {
+pub(crate) fn parameter_operator_uses_pattern(operator: &shuck_ast::ParameterOp) -> bool {
     matches!(
         operator,
         shuck_ast::ParameterOp::RemovePrefixShort { .. }
@@ -1267,7 +1267,7 @@ pub(super) fn parameter_operator_uses_pattern(operator: &shuck_ast::ParameterOp)
     )
 }
 
-pub(super) fn zsh_operation_uses_pattern(operation: &ZshExpansionOperation) -> bool {
+pub(crate) fn zsh_operation_uses_pattern(operation: &ZshExpansionOperation) -> bool {
     matches!(
         operation,
         ZshExpansionOperation::PatternOperation { .. }
@@ -1276,14 +1276,14 @@ pub(super) fn zsh_operation_uses_pattern(operation: &ZshExpansionOperation) -> b
     )
 }
 
-pub(super) fn prefix_match_can_expand_to_multiple_fields(
+pub(crate) fn prefix_match_can_expand_to_multiple_fields(
     kind: PrefixMatchKind,
     in_double_quotes: bool,
 ) -> bool {
     matches!(kind, PrefixMatchKind::At) || !in_double_quotes
 }
 
-pub(super) fn is_plain_command_substitution(parts: &[WordPartNode]) -> bool {
+pub(crate) fn is_plain_command_substitution(parts: &[WordPartNode]) -> bool {
     matches!(
         parts,
         [part] if match &part.kind {
@@ -1294,13 +1294,13 @@ pub(super) fn is_plain_command_substitution(parts: &[WordPartNode]) -> bool {
     )
 }
 
-pub(super) fn is_quoted_part(part: &WordPart) -> bool {
+pub(crate) fn is_quoted_part(part: &WordPart) -> bool {
     matches!(
         part,
         WordPart::SingleQuoted { .. } | WordPart::DoubleQuoted { .. }
     )
 }
 
-pub(super) fn is_fully_quoted(word: &Word) -> bool {
+pub(crate) fn is_fully_quoted(word: &Word) -> bool {
     matches!(word.parts.as_slice(), [part] if is_quoted_part(&part.kind))
 }

--- a/crates/shuck-linter/src/facts/words/occurrence.rs
+++ b/crates/shuck-linter/src/facts/words/occurrence.rs
@@ -1,55 +1,55 @@
 #[derive(Debug)]
 pub struct WordNode<'a> {
-    pub(super) key: FactSpan,
-    pub(super) word: &'a Word,
-    pub(super) analysis: ExpansionAnalysis,
-    pub(super) derived: WordNodeDerived<'a>,
+    pub(crate) key: FactSpan,
+    pub(crate) word: &'a Word,
+    pub(crate) analysis: ExpansionAnalysis,
+    pub(crate) derived: WordNodeDerived<'a>,
 }
 
 #[derive(Debug)]
-pub(super) struct WordNodeDerived<'a> {
-    pub(super) static_text: Option<&'a str>,
-    pub(super) trailing_literal_char: Option<char>,
-    pub(super) starts_with_extglob: bool,
-    pub(super) has_literal_affixes: bool,
-    pub(super) contains_shell_quoting_literals: bool,
-    pub(super) safe_value_plain_scalar_reference_name: Option<Name>,
-    pub(super) safe_value_special_parameter_access: bool,
-    pub(super) safe_value_contains_special_parameter_slice: bool,
-    pub(super) nested_escaped_parameter_template_body_spans: IdRange<Span>,
-    pub(super) active_expansion_spans: IdRange<Span>,
-    pub(super) scalar_expansion_spans: IdRange<Span>,
-    pub(super) unquoted_scalar_expansion_spans: IdRange<Span>,
-    pub(super) array_expansion_spans: IdRange<Span>,
-    pub(super) all_elements_array_expansion_spans: IdRange<Span>,
-    pub(super) direct_all_elements_array_expansion_spans: IdRange<Span>,
-    pub(super) unquoted_all_elements_array_expansion_spans: IdRange<Span>,
-    pub(super) unquoted_array_expansion_spans: IdRange<Span>,
-    pub(super) command_substitution_spans: IdRange<Span>,
-    pub(super) unquoted_command_substitution_spans: IdRange<Span>,
-    pub(super) unquoted_dollar_paren_command_substitution_spans: IdRange<Span>,
-    pub(super) double_quoted_expansion_spans: IdRange<Span>,
-    pub(super) unquoted_literal_between_double_quoted_segments_spans: IdRange<Span>,
+pub(crate) struct WordNodeDerived<'a> {
+    pub(crate) static_text: Option<&'a str>,
+    pub(crate) trailing_literal_char: Option<char>,
+    pub(crate) starts_with_extglob: bool,
+    pub(crate) has_literal_affixes: bool,
+    pub(crate) contains_shell_quoting_literals: bool,
+    pub(crate) safe_value_plain_scalar_reference_name: Option<Name>,
+    pub(crate) safe_value_special_parameter_access: bool,
+    pub(crate) safe_value_contains_special_parameter_slice: bool,
+    pub(crate) nested_escaped_parameter_template_body_spans: IdRange<Span>,
+    pub(crate) active_expansion_spans: IdRange<Span>,
+    pub(crate) scalar_expansion_spans: IdRange<Span>,
+    pub(crate) unquoted_scalar_expansion_spans: IdRange<Span>,
+    pub(crate) array_expansion_spans: IdRange<Span>,
+    pub(crate) all_elements_array_expansion_spans: IdRange<Span>,
+    pub(crate) direct_all_elements_array_expansion_spans: IdRange<Span>,
+    pub(crate) unquoted_all_elements_array_expansion_spans: IdRange<Span>,
+    pub(crate) unquoted_array_expansion_spans: IdRange<Span>,
+    pub(crate) command_substitution_spans: IdRange<Span>,
+    pub(crate) unquoted_command_substitution_spans: IdRange<Span>,
+    pub(crate) unquoted_dollar_paren_command_substitution_spans: IdRange<Span>,
+    pub(crate) double_quoted_expansion_spans: IdRange<Span>,
+    pub(crate) unquoted_literal_between_double_quoted_segments_spans: IdRange<Span>,
 }
 
 #[derive(Debug)]
 pub struct WordOccurrence {
-    pub(super) node_id: WordNodeId,
-    pub(super) command_id: CommandId,
-    pub(super) nested_word_command: bool,
-    pub(super) context: WordFactContext,
-    pub(super) host_kind: WordFactHostKind,
-    pub(super) runtime_literal: RuntimeLiteralAnalysis,
-    pub(super) operand_class: Option<TestOperandClass>,
-    pub(super) enclosing_expansion_context: Option<ExpansionContext>,
-    pub(super) split_sensitive_unquoted_command_substitution_spans: IdRange<Span>,
-    pub(super) array_assignment_split_scalar_expansion_spans: IdRange<Span>,
+    pub(crate) node_id: WordNodeId,
+    pub(crate) command_id: CommandId,
+    pub(crate) nested_word_command: bool,
+    pub(crate) context: WordFactContext,
+    pub(crate) host_kind: WordFactHostKind,
+    pub(crate) runtime_literal: RuntimeLiteralAnalysis,
+    pub(crate) operand_class: Option<TestOperandClass>,
+    pub(crate) enclosing_expansion_context: Option<ExpansionContext>,
+    pub(crate) split_sensitive_unquoted_command_substitution_spans: IdRange<Span>,
+    pub(crate) array_assignment_split_scalar_expansion_spans: IdRange<Span>,
 }
 
 #[derive(Clone, Copy)]
 pub struct WordOccurrenceRef<'facts, 'a> {
-    pub(super) facts: &'facts LinterFacts<'a>,
-    pub(super) id: WordOccurrenceId,
+    pub(crate) facts: &'facts LinterFacts<'a>,
+    pub(crate) id: WordOccurrenceId,
 }
 
 pub struct WordOccurrenceIter<'facts, 'a> {
@@ -58,13 +58,13 @@ pub struct WordOccurrenceIter<'facts, 'a> {
     filter: WordOccurrenceFilter,
 }
 
-pub(super) enum WordOccurrenceIterSource<'facts> {
+pub(crate) enum WordOccurrenceIterSource<'facts> {
     All { next: usize },
     Ids(std::slice::Iter<'facts, WordOccurrenceId>),
 }
 
 #[derive(Clone, Copy)]
-pub(super) enum WordOccurrenceFilter {
+pub(crate) enum WordOccurrenceFilter {
     Any,
     NonArithmetic,
     ArithmeticCommand,
@@ -74,7 +74,7 @@ pub(super) enum WordOccurrenceFilter {
 }
 
 impl<'facts, 'a> WordOccurrenceIter<'facts, 'a> {
-    pub(super) fn all(facts: &'facts LinterFacts<'a>, filter: WordOccurrenceFilter) -> Self {
+    pub(crate) fn all(facts: &'facts LinterFacts<'a>, filter: WordOccurrenceFilter) -> Self {
         Self {
             facts,
             source: WordOccurrenceIterSource::All { next: 0 },
@@ -82,7 +82,7 @@ impl<'facts, 'a> WordOccurrenceIter<'facts, 'a> {
         }
     }
 
-    pub(super) fn ids(
+    pub(crate) fn ids(
         facts: &'facts LinterFacts<'a>,
         ids: &'facts [WordOccurrenceId],
         filter: WordOccurrenceFilter,
@@ -131,7 +131,7 @@ impl<'facts, 'a> Iterator for WordOccurrenceIter<'facts, 'a> {
                 WordOccurrenceIterSource::All { next } => {
                     let id = WordOccurrenceId::new(*next);
                     *next += 1;
-                    (id.index() < self.facts.word_occurrences.len()).then_some(id)
+                    (id.index() < self.facts.words.word_occurrences.len()).then_some(id)
                 }
                 WordOccurrenceIterSource::Ids(ids) => ids.next().copied(),
             }?;
@@ -156,7 +156,7 @@ impl<'facts, 'a> WordOccurrenceRef<'facts, 'a> {
         self.facts.word_node_derived(self.occurrence().node_id)
     }
 
-    pub(super) fn word(self) -> &'a Word {
+    pub(crate) fn word(self) -> &'a Word {
         self.node().word
     }
 
@@ -334,7 +334,7 @@ impl<'facts, 'a> WordOccurrenceRef<'facts, 'a> {
     }
 
     pub fn static_text(self) -> Option<Cow<'a, str>> {
-        self.static_text_from_source(self.facts.source)
+        self.static_text_from_source(self.facts.source_facts.source)
     }
 
     pub fn static_text_cow(self, source: &'a str) -> Option<Cow<'a, str>> {
@@ -409,7 +409,7 @@ impl<'facts, 'a> WordOccurrenceRef<'facts, 'a> {
     }
 
     pub fn active_expansion_spans(self) -> &'facts [Span] {
-        self.facts.fact_store.word_spans(self.derived().active_expansion_spans)
+        self.facts.command.fact_store.word_spans(self.derived().active_expansion_spans)
     }
 
     pub fn expansion_span_is_zsh_force_glob_parameter(self, span: Span) -> bool {
@@ -425,75 +425,86 @@ impl<'facts, 'a> WordOccurrenceRef<'facts, 'a> {
     }
 
     pub fn scalar_expansion_spans(self) -> &'facts [Span] {
-        self.facts.fact_store.word_spans(self.derived().scalar_expansion_spans)
+        self.facts.command.fact_store.word_spans(self.derived().scalar_expansion_spans)
     }
 
     pub fn unquoted_scalar_expansion_spans(self) -> &'facts [Span] {
         self.facts
+            .command
             .fact_store
             .word_spans(self.derived().unquoted_scalar_expansion_spans)
     }
 
     pub fn array_assignment_split_scalar_expansion_spans(self) -> &'facts [Span] {
         self.facts
+            .command
             .fact_store
             .word_spans(self.occurrence().array_assignment_split_scalar_expansion_spans)
     }
 
     pub fn array_expansion_spans(self) -> &'facts [Span] {
-        self.facts.fact_store.word_spans(self.derived().array_expansion_spans)
+        self.facts.command.fact_store.word_spans(self.derived().array_expansion_spans)
     }
 
     pub fn all_elements_array_expansion_spans(self) -> &'facts [Span] {
         self.facts
+            .command
             .fact_store
             .word_spans(self.derived().all_elements_array_expansion_spans)
     }
 
     pub fn direct_all_elements_array_expansion_spans(self) -> &'facts [Span] {
         self.facts
+            .command
             .fact_store
             .word_spans(self.derived().direct_all_elements_array_expansion_spans)
     }
 
     pub fn unquoted_all_elements_array_expansion_spans(self) -> &'facts [Span] {
         self.facts
+            .command
             .fact_store
             .word_spans(self.derived().unquoted_all_elements_array_expansion_spans)
     }
 
     pub fn unquoted_array_expansion_spans(self) -> &'facts [Span] {
         self.facts
+            .command
             .fact_store
             .word_spans(self.derived().unquoted_array_expansion_spans)
     }
 
     pub fn command_substitution_spans(self) -> &'facts [Span] {
         self.facts
+            .command
             .fact_store
             .word_spans(self.derived().command_substitution_spans)
     }
 
     pub fn unquoted_command_substitution_spans(self) -> &'facts [Span] {
         self.facts
+            .command
             .fact_store
             .word_spans(self.derived().unquoted_command_substitution_spans)
     }
 
     pub fn split_sensitive_unquoted_command_substitution_spans(self) -> &'facts [Span] {
         self.facts
+            .command
             .fact_store
             .word_spans(self.occurrence().split_sensitive_unquoted_command_substitution_spans)
     }
 
     pub fn unquoted_dollar_paren_command_substitution_spans(self) -> &'facts [Span] {
         self.facts
+            .command
             .fact_store
             .word_spans(self.derived().unquoted_dollar_paren_command_substitution_spans)
     }
 
     pub fn double_quoted_expansion_spans(self) -> &'facts [Span] {
         self.facts
+            .command
             .fact_store
             .word_spans(self.derived().double_quoted_expansion_spans)
     }
@@ -504,6 +515,7 @@ impl<'facts, 'a> WordOccurrenceRef<'facts, 'a> {
 
     pub fn unquoted_literal_between_double_quoted_segments_spans(self) -> &'facts [Span] {
         self.facts
+            .command
             .fact_store
             .word_spans(self.derived().unquoted_literal_between_double_quoted_segments_spans)
     }
@@ -771,7 +783,7 @@ impl<'facts, 'a> WordOccurrenceRef<'facts, 'a> {
     }
 }
 
-pub(super) fn shellcheck_parameter_span_inside_escaped_quotes(
+pub(crate) fn shellcheck_parameter_span_inside_escaped_quotes(
     span: Span,
     locator: Locator<'_>,
 ) -> Option<Span> {
@@ -822,7 +834,7 @@ pub(super) fn shellcheck_parameter_span_inside_escaped_quotes(
     Some(Span::from_positions(start, end))
 }
 
-pub(super) fn parameter_expansion_end_offset(source: &str, dollar_offset: usize) -> Option<usize> {
+pub(crate) fn parameter_expansion_end_offset(source: &str, dollar_offset: usize) -> Option<usize> {
     let after_dollar = dollar_offset + '$'.len_utf8();
     let bytes = source.as_bytes();
     if bytes.get(after_dollar) == Some(&b'{') {
@@ -847,7 +859,7 @@ pub(super) fn parameter_expansion_end_offset(source: &str, dollar_offset: usize)
 }
 
 #[cfg_attr(shuck_profiling, inline(never))]
-pub(super) fn build_brace_variable_before_bracket_spans<'a>(
+pub(crate) fn build_brace_variable_before_bracket_spans<'a>(
     nodes: &[WordNode<'a>],
     occurrences: &[WordOccurrence],
     source: &str,
@@ -869,39 +881,39 @@ pub(super) fn build_brace_variable_before_bracket_spans<'a>(
     spans
 }
 
-pub(super) fn contains_template_placeholder_text_in_word(text: &str) -> bool {
+pub(crate) fn contains_template_placeholder_text_in_word(text: &str) -> bool {
     let Some(start) = text.find("{{") else {
         return false;
     };
     text[start + 2..].contains("}}")
 }
 
-pub(super) fn occurrence_word<'a>(nodes: &[WordNode<'a>], occurrence: &WordOccurrence) -> &'a Word {
+pub(crate) fn occurrence_word<'a>(nodes: &[WordNode<'a>], occurrence: &WordOccurrence) -> &'a Word {
     nodes[occurrence.node_id.index()].word
 }
 
-pub(super) fn occurrence_key(nodes: &[WordNode<'_>], occurrence: &WordOccurrence) -> FactSpan {
+pub(crate) fn occurrence_key(nodes: &[WordNode<'_>], occurrence: &WordOccurrence) -> FactSpan {
     nodes[occurrence.node_id.index()].key
 }
 
-pub(super) fn occurrence_span(nodes: &[WordNode<'_>], occurrence: &WordOccurrence) -> Span {
+pub(crate) fn occurrence_span(nodes: &[WordNode<'_>], occurrence: &WordOccurrence) -> Span {
     occurrence_word(nodes, occurrence).span
 }
 
-pub(super) fn occurrence_analysis(
+pub(crate) fn occurrence_analysis(
     nodes: &[WordNode<'_>],
     occurrence: &WordOccurrence,
 ) -> ExpansionAnalysis {
     nodes[occurrence.node_id.index()].analysis
 }
 
-pub(super) fn word_node_derived<'node, 'word>(
+pub(crate) fn word_node_derived<'node, 'word>(
     node: &'node WordNode<'word>,
 ) -> &'node WordNodeDerived<'word> {
     &node.derived
 }
 
-pub(super) fn word_is_plain_scalar_reference(word: &Word) -> bool {
+pub(crate) fn word_is_plain_scalar_reference(word: &Word) -> bool {
     word_is_plain_reference(word, false)
 }
 
@@ -950,18 +962,18 @@ fn safe_value_plain_scalar_reference_name_from_part(part: &WordPart) -> Option<N
     }
 }
 
-pub(super) fn word_is_plain_parameter_reference(word: &Word) -> bool {
+pub(crate) fn word_is_plain_parameter_reference(word: &Word) -> bool {
     word_is_plain_reference(word, true)
 }
 
-pub(super) fn word_is_plain_reference(word: &Word, allow_all_elements_parameters: bool) -> bool {
+pub(crate) fn word_is_plain_reference(word: &Word, allow_all_elements_parameters: bool) -> bool {
     let [part] = word.parts.as_slice() else {
         return false;
     };
     word_part_is_plain_reference(&part.kind, allow_all_elements_parameters)
 }
 
-pub(super) fn word_part_is_plain_reference(part: &WordPart, allow_all_elements_parameters: bool) -> bool {
+pub(crate) fn word_part_is_plain_reference(part: &WordPart, allow_all_elements_parameters: bool) -> bool {
     match part {
         WordPart::Variable(name) => {
             allow_all_elements_parameters || !matches!(name.as_str(), "@" | "*")
@@ -979,7 +991,7 @@ pub(super) fn word_part_is_plain_reference(part: &WordPart, allow_all_elements_p
     }
 }
 
-pub(super) fn parameter_is_plain_reference(
+pub(crate) fn parameter_is_plain_reference(
     parameter: &ParameterExpansion,
     allow_all_elements_parameters: bool,
 ) -> bool {
@@ -1009,14 +1021,14 @@ pub(super) fn parameter_is_plain_reference(
     }
 }
 
-pub(super) fn word_is_direct_numeric_expansion(word: &Word) -> bool {
+pub(crate) fn word_is_direct_numeric_expansion(word: &Word) -> bool {
     let [part] = word.parts.as_slice() else {
         return false;
     };
     word_part_is_direct_numeric_expansion(&part.kind)
 }
 
-pub(super) fn word_part_is_direct_numeric_expansion(part: &WordPart) -> bool {
+pub(crate) fn word_part_is_direct_numeric_expansion(part: &WordPart) -> bool {
     match part {
         WordPart::DoubleQuoted { parts, .. } => {
             let [part] = parts.as_slice() else {
@@ -1030,7 +1042,7 @@ pub(super) fn word_part_is_direct_numeric_expansion(part: &WordPart) -> bool {
     }
 }
 
-pub(super) fn parameter_is_direct_numeric_expansion(parameter: &ParameterExpansion) -> bool {
+pub(crate) fn parameter_is_direct_numeric_expansion(parameter: &ParameterExpansion) -> bool {
     match &parameter.syntax {
         ParameterExpansionSyntax::Bourne(BourneParameterExpansion::Length { .. }) => true,
         ParameterExpansionSyntax::Zsh(syntax) => syntax.length_prefix.is_some(),
@@ -1131,7 +1143,7 @@ fn safe_value_special_parameter_slice_reference(reference: &VarRef) -> bool {
 }
 
 
-pub(super) fn build_unquoted_command_argument_use_offsets(
+pub(crate) fn build_unquoted_command_argument_use_offsets(
     semantic: &SemanticModel,
     nodes: &[WordNode<'_>],
     occurrences: &[WordOccurrence],
@@ -1310,7 +1322,7 @@ fn visible_name_is_array_like(
 
 #[cfg_attr(shuck_profiling, inline(never))]
 #[allow(clippy::too_many_arguments)]
-pub(super) fn build_word_facts_for_command<'a>(
+pub(crate) fn build_word_facts_for_command<'a>(
     visit: CommandVisit<'a>,
     source: &'a str,
     locator: Locator<'a>,
@@ -1335,61 +1347,61 @@ pub(super) fn build_word_facts_for_command<'a>(
 }
 
 #[derive(Clone, Copy)]
-pub(super) struct WordFactCommandContext {
-    pub(super) command_id: CommandId,
-    pub(super) nested_word_command: bool,
-    pub(super) scope: ScopeId,
+pub(crate) struct WordFactCommandContext {
+    pub(crate) command_id: CommandId,
+    pub(crate) nested_word_command: bool,
+    pub(crate) scope: ScopeId,
 }
 
-pub(super) struct WordFactOutputs<'out, 'a> {
-    pub(super) command_visits_by_id: &'out [Option<CommandVisit<'a>>],
-    pub(super) word_nodes: &'out mut Vec<WordNode<'a>>,
-    pub(super) word_spans: &'out mut ListArena<Span>,
-    pub(super) word_span_scratch: &'out mut Vec<Span>,
-    pub(super) word_node_ids_by_span: &'out mut FxHashMap<FactSpan, WordNodeId>,
-    pub(super) word_occurrences: &'out mut Vec<WordOccurrence>,
-    pub(super) pending_arithmetic_word_occurrences:
+pub(crate) struct WordFactOutputs<'out, 'a> {
+    pub(crate) command_visits_by_id: &'out [Option<CommandVisit<'a>>],
+    pub(crate) word_nodes: &'out mut Vec<WordNode<'a>>,
+    pub(crate) word_spans: &'out mut ListArena<Span>,
+    pub(crate) word_span_scratch: &'out mut Vec<Span>,
+    pub(crate) word_node_ids_by_span: &'out mut FxHashMap<FactSpan, WordNodeId>,
+    pub(crate) word_occurrences: &'out mut Vec<WordOccurrence>,
+    pub(crate) pending_arithmetic_word_occurrences:
         &'out mut Vec<PendingArithmeticWordOccurrence>,
-    pub(super) pending_parameter_operand_word_occurrences:
+    pub(crate) pending_parameter_operand_word_occurrences:
         &'out mut Vec<PendingParameterOperandWordOccurrence>,
-    pub(super) compound_assignment_value_word_spans: &'out mut FxHashSet<FactSpan>,
-    pub(super) array_assignment_split_word_ids: &'out mut Vec<WordOccurrenceId>,
-    pub(super) seen_word_occurrences: &'out mut FxHashSet<WordOccurrenceSeenKey>,
-    pub(super) seen_pending_arithmetic_word_occurrences:
+    pub(crate) compound_assignment_value_word_spans: &'out mut FxHashSet<FactSpan>,
+    pub(crate) array_assignment_split_word_ids: &'out mut Vec<WordOccurrenceId>,
+    pub(crate) seen_word_occurrences: &'out mut FxHashSet<WordOccurrenceSeenKey>,
+    pub(crate) seen_pending_arithmetic_word_occurrences:
         &'out mut FxHashSet<PendingArithmeticSeenKey>,
-    pub(super) seen_pending_parameter_operand_word_occurrences:
+    pub(crate) seen_pending_parameter_operand_word_occurrences:
         &'out mut FxHashSet<PendingParameterOperandSeenKey>,
-    pub(super) assoc_binding_visibility_memo:
+    pub(crate) assoc_binding_visibility_memo:
         &'out mut FxHashMap<(Name, ScopeId, Option<FactSpan>), bool>,
-    pub(super) semantic_analysis: &'out SemanticAnalysis<'a>,
-    pub(super) case_pattern_expansions: &'out mut Vec<CasePatternExpansionFact>,
-    pub(super) pattern_literal_spans: &'out mut Vec<Span>,
-    pub(super) arithmetic: &'out mut ArithmeticFactSummary,
-    pub(super) surface: &'out mut SurfaceFragmentSink<'a>,
+    pub(crate) semantic_analysis: &'out SemanticAnalysis<'a>,
+    pub(crate) case_pattern_expansions: &'out mut Vec<CasePatternExpansionFact>,
+    pub(crate) pattern_literal_spans: &'out mut Vec<Span>,
+    pub(crate) arithmetic: &'out mut ArithmeticFactSummary,
+    pub(crate) surface: &'out mut SurfaceFragmentSink<'a>,
 }
 
-pub(super) struct PendingArithmeticWordOccurrence {
-    pub(super) node_id: WordNodeId,
-    pub(super) command_id: CommandId,
-    pub(super) nested_word_command: bool,
-    pub(super) host_kind: WordFactHostKind,
-    pub(super) enclosing_expansion_context: ExpansionContext,
+pub(crate) struct PendingArithmeticWordOccurrence {
+    pub(crate) node_id: WordNodeId,
+    pub(crate) command_id: CommandId,
+    pub(crate) nested_word_command: bool,
+    pub(crate) host_kind: WordFactHostKind,
+    pub(crate) enclosing_expansion_context: ExpansionContext,
 }
 
-pub(super) struct PendingParameterOperandWordOccurrence {
-    pub(super) node_id: WordNodeId,
-    pub(super) command_id: CommandId,
-    pub(super) nested_word_command: bool,
-    pub(super) host_kind: WordFactHostKind,
-    pub(super) enclosing_expansion_context: ExpansionContext,
+pub(crate) struct PendingParameterOperandWordOccurrence {
+    pub(crate) node_id: WordNodeId,
+    pub(crate) command_id: CommandId,
+    pub(crate) nested_word_command: bool,
+    pub(crate) host_kind: WordFactHostKind,
+    pub(crate) enclosing_expansion_context: ExpansionContext,
 }
 
-pub(super) type WordOccurrenceSeenKey = (FactSpan, WordFactContext, WordFactHostKind);
-pub(super) type PendingArithmeticSeenKey = (FactSpan, ExpansionContext, WordFactHostKind);
-pub(super) type PendingParameterOperandSeenKey =
+pub(crate) type WordOccurrenceSeenKey = (FactSpan, WordFactContext, WordFactHostKind);
+pub(crate) type PendingArithmeticSeenKey = (FactSpan, ExpansionContext, WordFactHostKind);
+pub(crate) type PendingParameterOperandSeenKey =
     (FactSpan, ExpansionContext, WordFactHostKind);
 
-pub(super) fn derive_word_fact_data<'a>(
+pub(crate) fn derive_word_fact_data<'a>(
     word: &'a Word,
     locator: Locator<'a>,
     shell_dialect: shuck_semantic::ShellDialect,
@@ -1739,7 +1751,7 @@ impl DerivedWordTraversalVisitor<'_> {
     }
 }
 
-pub(super) fn push_word_span_list(
+pub(crate) fn push_word_span_list(
     span_store: &mut ListArena<Span>,
     scratch: &mut Vec<Span>,
     collect: impl FnOnce(&mut Vec<Span>),
@@ -1749,7 +1761,7 @@ pub(super) fn push_word_span_list(
     span_store.push_many(scratch.drain(..))
 }
 
-pub(super) fn push_needed_word_span_list(
+pub(crate) fn push_needed_word_span_list(
     span_store: &mut ListArena<Span>,
     scratch: &mut Vec<Span>,
     needed: bool,
@@ -1762,11 +1774,11 @@ pub(super) fn push_needed_word_span_list(
     }
 }
 
-pub(super) fn word_may_have_runtime_expansion_spans(word: &Word) -> bool {
+pub(crate) fn word_may_have_runtime_expansion_spans(word: &Word) -> bool {
     word_parts_may_have_runtime_expansion_spans(&word.parts)
 }
 
-pub(super) fn word_parts_may_have_runtime_expansion_spans(parts: &[WordPartNode]) -> bool {
+pub(crate) fn word_parts_may_have_runtime_expansion_spans(parts: &[WordPartNode]) -> bool {
     parts.iter().any(|part| match &part.kind {
         WordPart::Literal(_) | WordPart::SingleQuoted { .. } => false,
         WordPart::DoubleQuoted { parts, .. } => word_parts_may_have_runtime_expansion_spans(parts),
@@ -1774,11 +1786,11 @@ pub(super) fn word_parts_may_have_runtime_expansion_spans(parts: &[WordPartNode]
     })
 }
 
-pub(super) fn word_may_have_command_substitution_spans(word: &Word) -> bool {
+pub(crate) fn word_may_have_command_substitution_spans(word: &Word) -> bool {
     word_parts_may_have_command_substitution_spans(&word.parts)
 }
 
-pub(super) fn word_parts_may_have_command_substitution_spans(parts: &[WordPartNode]) -> bool {
+pub(crate) fn word_parts_may_have_command_substitution_spans(parts: &[WordPartNode]) -> bool {
     parts.iter().any(|part| match &part.kind {
         WordPart::DoubleQuoted { parts, .. } => word_parts_may_have_command_substitution_spans(parts),
         WordPart::CommandSubstitution { .. } => true,
@@ -1786,7 +1798,7 @@ pub(super) fn word_parts_may_have_command_substitution_spans(parts: &[WordPartNo
     })
 }
 
-pub(super) fn word_may_have_unquoted_literal_between_double_quoted_segments_spans(
+pub(crate) fn word_may_have_unquoted_literal_between_double_quoted_segments_spans(
     word: &Word,
     source: &str,
 ) -> bool {
@@ -1826,14 +1838,14 @@ pub(super) fn word_may_have_unquoted_literal_between_double_quoted_segments_span
         || mixed_quote_following_line_join_suffix_after_word(word, source).is_some()
 }
 
-pub(super) fn borrowed_static_word_text<'a>(word: &'a Word, source: &'a str) -> Option<&'a str> {
+pub(crate) fn borrowed_static_word_text<'a>(word: &'a Word, source: &'a str) -> Option<&'a str> {
     let [part] = word.parts.as_slice() else {
         return None;
     };
     borrowed_static_word_part_text(part, source)
 }
 
-pub(super) fn borrowed_static_word_part_text<'a>(
+pub(crate) fn borrowed_static_word_part_text<'a>(
     part: &'a WordPartNode,
     source: &'a str,
 ) -> Option<&'a str> {
@@ -1850,11 +1862,11 @@ pub(super) fn borrowed_static_word_part_text<'a>(
     }
 }
 
-pub(super) fn word_trailing_literal_char(word: &Word, source: &str) -> Option<char> {
+pub(crate) fn word_trailing_literal_char(word: &Word, source: &str) -> Option<char> {
     trailing_literal_char_in_parts(&word.parts, source)
 }
 
-pub(super) fn trailing_literal_char_in_parts(parts: &[WordPartNode], source: &str) -> Option<char> {
+pub(crate) fn trailing_literal_char_in_parts(parts: &[WordPartNode], source: &str) -> Option<char> {
     let part = parts.last()?;
 
     match &part.kind {
@@ -1880,7 +1892,7 @@ pub(super) fn trailing_literal_char_in_parts(parts: &[WordPartNode], source: &st
     }
 }
 
-pub(super) struct WordFactCollector<'out, 'a, 'norm> {
+pub(crate) struct WordFactCollector<'out, 'a, 'norm> {
     source: &'a str,
     locator: Locator<'a>,
     semantic: &'a SemanticModel,
@@ -1913,7 +1925,7 @@ pub(super) struct WordFactCollector<'out, 'a, 'norm> {
     surface: &'out mut SurfaceFragmentSink<'a>,
 }
 
-pub(super) fn simple_command_wrapper_target_index(command: &SimpleCommand, source: &str) -> Option<usize> {
+pub(crate) fn simple_command_wrapper_target_index(command: &SimpleCommand, source: &str) -> Option<usize> {
     let command_name = static_command_name_text(&command.name, source)?;
     let word_count = 1 + command.args.len();
     match static_command_wrapper_target_index(word_count, 0, command_name.as_ref(), |index| {
@@ -1924,7 +1936,7 @@ pub(super) fn simple_command_wrapper_target_index(command: &SimpleCommand, sourc
     }
 }
 
-pub(super) fn simple_command_word_at(command: &SimpleCommand, index: usize) -> &Word {
+pub(crate) fn simple_command_word_at(command: &SimpleCommand, index: usize) -> &Word {
     if index == 0 {
         &command.name
     } else {

--- a/crates/shuck-linter/src/facts/words/quote_spans.rs
+++ b/crates/shuck-linter/src/facts/words/quote_spans.rs
@@ -1,4 +1,4 @@
-pub(super) fn word_occurrence_with_context<'a>(
+pub(crate) fn word_occurrence_with_context<'a>(
     nodes: &[WordNode<'a>],
     occurrences: &'a [WordOccurrence],
     word_index: &FxHashMap<FactSpan, SmallVec<[WordOccurrenceId; 2]>>,
@@ -13,7 +13,7 @@ pub(super) fn word_occurrence_with_context<'a>(
         .find(|fact| occurrence_span(nodes, fact) == span && fact.context == context)
 }
 
-pub(super) fn occurrence_static_text<'a>(
+pub(crate) fn occurrence_static_text<'a>(
     nodes: &'a [WordNode<'a>],
     occurrence: &WordOccurrence,
     source: &'a str,
@@ -25,7 +25,7 @@ pub(super) fn occurrence_static_text<'a>(
         .or_else(|| static_word_text(node.word, source))
 }
 
-pub(super) fn word_occurrence_is_pure_quoted_dynamic(
+pub(crate) fn word_occurrence_is_pure_quoted_dynamic(
     nodes: &[WordNode<'_>],
     fact: &WordOccurrence,
     fact_store: &FactStore<'_>,
@@ -42,7 +42,7 @@ pub(super) fn word_occurrence_is_pure_quoted_dynamic(
         )
 }
 
-pub(super) fn collect_unquoted_literal_between_double_quoted_segments_spans(
+pub(crate) fn collect_unquoted_literal_between_double_quoted_segments_spans(
     word: &Word,
     source: &str,
     spans: &mut Vec<Span>,
@@ -115,7 +115,7 @@ pub(super) fn collect_unquoted_literal_between_double_quoted_segments_spans(
     }
 }
 
-pub(super) fn mixed_quote_double_quoted_parts_contain_literal_content(parts: &[WordPartNode]) -> bool {
+pub(crate) fn mixed_quote_double_quoted_parts_contain_literal_content(parts: &[WordPartNode]) -> bool {
     parts.iter().any(|part| match &part.kind {
         WordPart::Literal(_) | WordPart::SingleQuoted { .. } => true,
         WordPart::DoubleQuoted { parts, .. } => {
@@ -140,7 +140,7 @@ pub(super) fn mixed_quote_double_quoted_parts_contain_literal_content(parts: &[W
     })
 }
 
-pub(super) fn mixed_quote_literal_is_warnable_between_double_quotes(text: &str) -> bool {
+pub(crate) fn mixed_quote_literal_is_warnable_between_double_quotes(text: &str) -> bool {
     if text.is_empty() {
         return false;
     }
@@ -185,11 +185,11 @@ pub(super) fn mixed_quote_literal_is_warnable_between_double_quotes(text: &str) 
     })
 }
 
-pub(super) fn mixed_quote_literal_has_shellcheck_skipped_word_operator(text: &str) -> bool {
+pub(crate) fn mixed_quote_literal_has_shellcheck_skipped_word_operator(text: &str) -> bool {
     text.contains('+') || text.contains('@')
 }
 
-pub(super) fn mixed_quote_shell_fragment_balance_delta_for_part(
+pub(crate) fn mixed_quote_shell_fragment_balance_delta_for_part(
     part: &WordPartNode,
     source: &str,
 ) -> (i32, i32) {
@@ -221,12 +221,12 @@ pub(super) fn mixed_quote_shell_fragment_balance_delta_for_part(
 }
 
 #[derive(Clone, Copy)]
-pub(super) enum MixedQuoteShellParenFrame {
+pub(crate) enum MixedQuoteShellParenFrame {
     Command { opened_in_double_quotes: bool },
     Group,
 }
 
-pub(super) fn mixed_quote_shell_fragment_balance_delta(
+pub(crate) fn mixed_quote_shell_fragment_balance_delta(
     text: &str,
     allow_top_level_command_comments: bool,
 ) -> (i32, i32) {
@@ -359,7 +359,7 @@ pub(super) fn mixed_quote_shell_fragment_balance_delta(
     (command_delta, parameter_delta)
 }
 
-pub(super) fn mixed_quote_shell_comment_can_start(
+pub(crate) fn mixed_quote_shell_comment_can_start(
     command_depth: i32,
     allow_top_level_command_comments: bool,
     previous_char: Option<char>,
@@ -370,7 +370,7 @@ pub(super) fn mixed_quote_shell_comment_can_start(
         })
 }
 
-pub(super) fn mixed_quote_trailing_line_join_between_double_quotes_span(
+pub(crate) fn mixed_quote_trailing_line_join_between_double_quotes_span(
     word: &Word,
     source: &str,
 ) -> Option<Span> {
@@ -400,7 +400,7 @@ pub(super) fn mixed_quote_trailing_line_join_between_double_quotes_span(
     Some(Span::from_positions(start, start.advanced_by(suffix)))
 }
 
-pub(super) fn mixed_quote_line_join_between_double_quotes_spans(word: &Word, source: &str) -> Vec<Span> {
+pub(crate) fn mixed_quote_line_join_between_double_quotes_spans(word: &Word, source: &str) -> Vec<Span> {
     if !matches!(
         word.parts.first().map(|part| &part.kind),
         Some(WordPart::DoubleQuoted { .. })
@@ -437,7 +437,7 @@ pub(super) fn mixed_quote_line_join_between_double_quotes_spans(word: &Word, sou
     spans
 }
 
-pub(super) fn mixed_quote_following_line_join_between_double_quotes_span(
+pub(crate) fn mixed_quote_following_line_join_between_double_quotes_span(
     word: &Word,
     source: &str,
 ) -> Option<Span> {
@@ -448,7 +448,7 @@ pub(super) fn mixed_quote_following_line_join_between_double_quotes_span(
     ))
 }
 
-pub(super) fn mixed_quote_following_line_join_suffix_after_word(
+pub(crate) fn mixed_quote_following_line_join_suffix_after_word(
     word: &Word,
     source: &str,
 ) -> Option<&'static str> {
@@ -472,7 +472,7 @@ pub(super) fn mixed_quote_following_line_join_suffix_after_word(
     Some(suffix)
 }
 
-pub(super) fn mixed_quote_chained_line_join_between_double_quotes_spans(
+pub(crate) fn mixed_quote_chained_line_join_between_double_quotes_spans(
     word: &Word,
     source: &str,
 ) -> Vec<Span> {
@@ -519,7 +519,7 @@ pub(super) fn mixed_quote_chained_line_join_between_double_quotes_spans(
     spans
 }
 
-pub(super) fn mixed_quote_closing_double_quote_offset(text: &str) -> Option<usize> {
+pub(crate) fn mixed_quote_closing_double_quote_offset(text: &str) -> Option<usize> {
     let mut chars = text.char_indices().peekable();
     let (_, first) = chars.next()?;
     if first != '"' {
@@ -671,7 +671,7 @@ pub(super) fn mixed_quote_closing_double_quote_offset(text: &str) -> Option<usiz
     None
 }
 
-pub(super) fn mixed_quote_text_ends_with_unescaped_double_quote(text: &str) -> bool {
+pub(crate) fn mixed_quote_text_ends_with_unescaped_double_quote(text: &str) -> bool {
     let Some(prefix) = text.strip_suffix('"') else {
         return false;
     };
@@ -680,7 +680,7 @@ pub(super) fn mixed_quote_text_ends_with_unescaped_double_quote(text: &str) -> b
     backslash_count % 2 == 0
 }
 
-pub(super) fn word_occurrence_is_double_quoted_command_substitution_only(
+pub(crate) fn word_occurrence_is_double_quoted_command_substitution_only(
     nodes: &[WordNode<'_>],
     fact: &WordOccurrence,
     fact_store: &FactStore<'_>,
@@ -703,7 +703,7 @@ pub(super) fn word_occurrence_is_double_quoted_command_substitution_only(
         && &word_text[1..word_text.len() - 1] == command_substitution.slice(source)
 }
 
-pub(super) fn word_occurrence_is_escaped_double_quoted_dynamic(
+pub(crate) fn word_occurrence_is_escaped_double_quoted_dynamic(
     nodes: &[WordNode<'_>],
     fact: &WordOccurrence,
     fact_store: &FactStore<'_>,
@@ -729,7 +729,7 @@ pub(super) fn word_occurrence_is_escaped_double_quoted_dynamic(
 }
 
 
-pub(super) fn pattern_has_glob_structure(pattern: &Pattern, source: &str) -> bool {
+pub(crate) fn pattern_has_glob_structure(pattern: &Pattern, source: &str) -> bool {
     pattern.parts_with_spans().any(|(part, span)| match part {
         PatternPart::AnyString | PatternPart::AnyChar | PatternPart::CharClass(_) => true,
         PatternPart::Group { .. } => true,
@@ -744,11 +744,11 @@ pub(super) fn pattern_has_glob_structure(pattern: &Pattern, source: &str) -> boo
     })
 }
 
-pub(super) fn literal_text_has_glob_bracket(text: &str) -> bool {
+pub(crate) fn literal_text_has_glob_bracket(text: &str) -> bool {
     text.contains('[') || text.contains(']')
 }
 
-pub(super) fn pattern_is_arithmetic_only(pattern: &Pattern) -> bool {
+pub(crate) fn pattern_is_arithmetic_only(pattern: &Pattern) -> bool {
     pattern.parts.iter().all(|part| match &part.kind {
         PatternPart::Literal(_) | PatternPart::AnyString | PatternPart::AnyChar => true,
         PatternPart::Word(word) => word_is_arithmetic_only(word),
@@ -756,11 +756,11 @@ pub(super) fn pattern_is_arithmetic_only(pattern: &Pattern) -> bool {
     })
 }
 
-pub(super) fn word_is_arithmetic_only(word: &Word) -> bool {
+pub(crate) fn word_is_arithmetic_only(word: &Word) -> bool {
     word.parts.iter().all(word_part_is_arithmetic_only)
 }
 
-pub(super) fn word_part_is_arithmetic_only(part: &WordPartNode) -> bool {
+pub(crate) fn word_part_is_arithmetic_only(part: &WordPartNode) -> bool {
     match &part.kind {
         WordPart::Literal(_) | WordPart::SingleQuoted { .. } => true,
         WordPart::ArithmeticExpansion { .. } => true,
@@ -783,7 +783,7 @@ pub(super) fn word_part_is_arithmetic_only(part: &WordPartNode) -> bool {
     }
 }
 
-pub(super) fn standalone_variable_name_from_word_parts(parts: &[WordPartNode]) -> Option<&str> {
+pub(crate) fn standalone_variable_name_from_word_parts(parts: &[WordPartNode]) -> Option<&str> {
     let [part] = parts else {
         return None;
     };
@@ -818,7 +818,7 @@ pub(super) fn standalone_variable_name_from_word_parts(parts: &[WordPartNode]) -
     }
 }
 
-pub(super) fn word_context_supports_operand_class(context: ExpansionContext) -> bool {
+pub(crate) fn word_context_supports_operand_class(context: ExpansionContext) -> bool {
     matches!(
         context,
         ExpansionContext::CommandName
@@ -834,7 +834,7 @@ pub(super) fn word_context_supports_operand_class(context: ExpansionContext) -> 
     )
 }
 
-pub(super) fn word_has_literal_affixes(word: &Word) -> bool {
+pub(crate) fn word_has_literal_affixes(word: &Word) -> bool {
     word.parts.iter().any(|part| {
         matches!(
             part.kind,
@@ -843,11 +843,11 @@ pub(super) fn word_has_literal_affixes(word: &Word) -> bool {
     })
 }
 
-pub(super) fn word_contains_shell_quoting_literals(word: &Word, source: &str) -> bool {
+pub(crate) fn word_contains_shell_quoting_literals(word: &Word, source: &str) -> bool {
     word_parts_contain_shell_quoting_literals(&word.parts, source)
 }
 
-pub(super) fn word_parts_contain_shell_quoting_literals(parts: &[WordPartNode], source: &str) -> bool {
+pub(crate) fn word_parts_contain_shell_quoting_literals(parts: &[WordPartNode], source: &str) -> bool {
     parts.iter().any(|part| match &part.kind {
         WordPart::Literal(text) => text_contains_shell_quoting_literals(
             text.as_str(source, part.span),
@@ -865,12 +865,12 @@ pub(super) fn word_parts_contain_shell_quoting_literals(parts: &[WordPartNode], 
 }
 
 #[derive(Clone, Copy)]
-pub(super) enum ShellQuotingLiteralTextContext {
+pub(crate) enum ShellQuotingLiteralTextContext {
     ShellContinuationAware,
     LiteralBackslashNewlines,
 }
 
-pub(super) fn text_contains_shell_quoting_literals(
+pub(crate) fn text_contains_shell_quoting_literals(
     text: &str,
     context: ShellQuotingLiteralTextContext,
 ) -> bool {
@@ -904,7 +904,7 @@ pub(super) fn text_contains_shell_quoting_literals(
 }
 
 
-pub(super) fn word_classification_from_analysis(analysis: ExpansionAnalysis) -> WordClassification {
+pub(crate) fn word_classification_from_analysis(analysis: ExpansionAnalysis) -> WordClassification {
     WordClassification {
         quote: analysis.quote,
         literalness: analysis.literalness,
@@ -913,13 +913,13 @@ pub(super) fn word_classification_from_analysis(analysis: ExpansionAnalysis) -> 
     }
 }
 
-pub(super) fn double_quoted_expansion_part_spans(word: &Word) -> Vec<Span> {
+pub(crate) fn double_quoted_expansion_part_spans(word: &Word) -> Vec<Span> {
     let mut spans = Vec::new();
     collect_double_quoted_expansion_part_spans(word, &mut spans);
     spans
 }
 
-pub(super) fn collect_double_quoted_expansion_part_spans(word: &Word, spans: &mut Vec<Span>) {
+pub(crate) fn collect_double_quoted_expansion_part_spans(word: &Word, spans: &mut Vec<Span>) {
     let mut visitor = DoubleQuotedExpansionSpanVisitor { spans };
     walk_word_subtree(
         word,
@@ -932,7 +932,7 @@ pub(super) fn collect_double_quoted_expansion_part_spans(word: &Word, spans: &mu
     );
 }
 
-pub(super) fn single_quoted_equivalent_if_plain_double_quoted_word(
+pub(crate) fn single_quoted_equivalent_if_plain_double_quoted_word(
     word: &Word,
     source: &str,
 ) -> Option<String> {
@@ -951,7 +951,7 @@ pub(super) fn single_quoted_equivalent_if_plain_double_quoted_word(
     Some(shell_single_quoted_literal(&cooked))
 }
 
-pub(super) fn push_cooked_double_quoted_word_text(text: &str, out: &mut String) {
+pub(crate) fn push_cooked_double_quoted_word_text(text: &str, out: &mut String) {
     let mut chars = text.chars();
     while let Some(ch) = chars.next() {
         if ch != '\\' {
@@ -971,7 +971,7 @@ pub(super) fn push_cooked_double_quoted_word_text(text: &str, out: &mut String) 
     }
 }
 
-pub(super) fn shell_single_quoted_literal(text: &str) -> String {
+pub(crate) fn shell_single_quoted_literal(text: &str) -> String {
     let mut quoted = String::with_capacity(text.len() + 2);
     quoted.push('\'');
     for ch in text.chars() {
@@ -1024,7 +1024,7 @@ pub fn leading_literal_word_prefix(word: &Word, source: &str) -> String {
     prefix
 }
 
-pub(super) fn collect_leading_literal_word_parts(
+pub(crate) fn collect_leading_literal_word_parts(
     parts: &[WordPartNode],
     source: &str,
     prefix: &mut String,
@@ -1037,7 +1037,7 @@ pub(super) fn collect_leading_literal_word_parts(
     true
 }
 
-pub(super) fn collect_leading_literal_word_part(
+pub(crate) fn collect_leading_literal_word_part(
     part: &WordPartNode,
     source: &str,
     prefix: &mut String,


### PR DESCRIPTION
## Summary

- Split `LinterFacts` into explicit command, word, assignment, source, and compat stores behind the existing facade.
- Replace the top-level `facts/mod.rs` include mega-scope with real modules and explicit re-exports while keeping existing public names available.
- Keep flat fact query methods as compatibility shims and have the builder finalize per-store outputs after the existing semantic-command traversal.

## Validation

- `cargo fmt`
- `cargo test -p shuck-linter --no-default-features`
- `cargo test -p shuck-linter`
- `cargo clippy --all-targets -- -D warnings`
- `make test-large-corpus SHUCK_LARGE_CORPUS_SAMPLE_PERCENT=10`
- `make test-large-corpus` (`blocking=0`, `implementation_diffs=0`, `mapping_issues=0`, `harness_failures=0`)