### PR TITLE
feat(linter): add S081 file description rule

### DIFF
--- a/crates/shuck-cli/src/commands/check/settings.rs
+++ b/crates/shuck-cli/src/commands/check/settings.rs
@@ -60,6 +60,7 @@ struct EffectiveRuleOptions {
     s079_allowed_paths: Vec<String>,
     s080_max_lines: usize,
     s080_count: String,
+    s081_ignore_shebang_only_files: bool,
     s084_require_globals: bool,
     s084_require_arguments: bool,
     s084_require_outputs: bool,
@@ -197,6 +198,7 @@ impl EffectiveRuleOptions {
             s079_allowed_paths: rule_options.s079.allowed_paths.clone(),
             s080_max_lines: rule_options.s080.max_lines,
             s080_count: rule_options.s080.count.clone(),
+            s081_ignore_shebang_only_files: rule_options.s081.ignore_shebang_only_files,
             s084_require_globals: rule_options.s084.require_globals,
             s084_require_arguments: rule_options.s084.require_arguments,
             s084_require_outputs: rule_options.s084.require_outputs,
@@ -226,6 +228,7 @@ impl CacheKey for EffectiveRuleOptions {
         self.s079_allowed_paths.cache_key(state);
         self.s080_max_lines.cache_key(state);
         self.s080_count.cache_key(state);
+        self.s081_ignore_shebang_only_files.cache_key(state);
         self.s084_require_globals.cache_key(state);
         self.s084_require_arguments.cache_key(state);
         self.s084_require_outputs.cache_key(state);
@@ -1033,6 +1036,14 @@ fn linter_rule_options_for_lint_config(
     if let Some(value) = lint
         .rule_options
         .as_ref()
+        .and_then(|options| options.s081.as_ref())
+        .and_then(|s081| s081.ignore_shebang_only_files)
+    {
+        rule_options.s081.ignore_shebang_only_files = value;
+    }
+    if let Some(value) = lint
+        .rule_options
+        .as_ref()
         .and_then(|options| options.s084.as_ref())
         .and_then(|s084| s084.require_globals)
     {
@@ -1760,7 +1771,7 @@ mod tests {
         let tempdir = tempdir().unwrap();
         fs::write(
             tempdir.path().join("script.sh"),
-            "#!/bin/bash\nprintf '%s\\n' x &;\n",
+            "#!/bin/bash\n# Exercises style-rule selection.\nprintf '%s\\n' x &;\n",
         )
         .unwrap();
 
@@ -1780,7 +1791,7 @@ mod tests {
         let tempdir = tempdir().unwrap();
         fs::write(
             tempdir.path().join("script.sh"),
-            "#!/bin/bash\nprintf '%s\\n' x &;\n",
+            "#!/bin/bash\n# Exercises style-rule selection.\nprintf '%s\\n' x &;\n",
         )
         .unwrap();
 
@@ -1809,7 +1820,7 @@ mod tests {
         let tempdir = tempdir().unwrap();
         fs::write(
             tempdir.path().join("script.sh"),
-            "#!/bin/bash\nprintf '%s\\n' x &;\n",
+            "#!/bin/bash\n# Exercises style-rule selection.\nprintf '%s\\n' x &;\n",
         )
         .unwrap();
 
@@ -1838,7 +1849,7 @@ mod tests {
         let tempdir = tempdir().unwrap();
         fs::write(
             tempdir.path().join("script.sh"),
-            "#!/bin/bash\nprintf '%s\\n' x &;\n",
+            "#!/bin/bash\n# Exercises style-rule selection.\nprintf '%s\\n' x &;\n",
         )
         .unwrap();
 

--- a/crates/shuck-config/src/lib.rs
+++ b/crates/shuck-config/src/lib.rs
@@ -61,7 +61,8 @@ const CONFIG_OVERRIDE_LINT_ZSH_PLUGIN_KEYS: &[&str] = &[
     "entrypoints",
 ];
 const CONFIG_OVERRIDE_LINT_RULE_OPTION_KEYS: &[&str] = &[
-    "c001", "c063", "s078", "s079", "s080", "s084", "s085", "c158", "c159", "c160", "c161", "c162",
+    "c001", "c063", "s078", "s079", "s080", "s081", "s084", "s085", "c158", "c159", "c160", "c161",
+    "c162",
 ];
 const CONFIG_OVERRIDE_C001_RULE_OPTION_KEYS: &[&str] =
     &["treat-indirect-expansion-targets-as-used"];
@@ -70,6 +71,7 @@ const CONFIG_OVERRIDE_S078_RULE_OPTION_KEYS: &[&str] = &["allowed-shells"];
 const CONFIG_OVERRIDE_S079_RULE_OPTION_KEYS: &[&str] = &["allowed-forms", "allowed-paths"];
 const CONFIG_OVERRIDE_S080_RULE_OPTION_KEYS: &[&str] = &["max-lines", "count"];
 const CONFIG_OVERRIDE_S080_COUNT_VALUES: &[&str] = &["physical", "non-comment-non-blank"];
+const CONFIG_OVERRIDE_S081_RULE_OPTION_KEYS: &[&str] = &["ignore-shebang-only-files"];
 const CONFIG_OVERRIDE_S084_RULE_OPTION_KEYS: &[&str] = &[
     "require-globals",
     "require-arguments",
@@ -347,6 +349,8 @@ pub struct LintRuleOptionsConfig {
     pub s079: Option<S079RuleOptionsConfig>,
     /// Options for rule S080.
     pub s080: Option<S080RuleOptionsConfig>,
+    /// Options for rule S081.
+    pub s081: Option<S081RuleOptionsConfig>,
     /// Options for rule S084.
     pub s084: Option<S084RuleOptionsConfig>,
     /// Options for rule S085.
@@ -379,6 +383,9 @@ impl LintRuleOptionsConfig {
         }
         if let Some(s080) = overrides.s080 {
             self.s080.get_or_insert_default().apply_overrides(s080);
+        }
+        if let Some(s081) = overrides.s081 {
+            self.s081.get_or_insert_default().apply_overrides(s081);
         }
         if let Some(s084) = overrides.s084 {
             self.s084.get_or_insert_default().apply_overrides(s084);
@@ -492,6 +499,22 @@ impl S080RuleOptionsConfig {
         }
         if overrides.count.is_some() {
             self.count = overrides.count;
+        }
+    }
+}
+
+/// Options for rule S081.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Deserialize)]
+#[serde(default, rename_all = "kebab-case", deny_unknown_fields)]
+pub struct S081RuleOptionsConfig {
+    /// Whether files that contain only a shebang are exempt from the rule.
+    pub ignore_shebang_only_files: Option<bool>,
+}
+
+impl S081RuleOptionsConfig {
+    fn apply_overrides(&mut self, overrides: Self) {
+        if overrides.ignore_shebang_only_files.is_some() {
+            self.ignore_shebang_only_files = overrides.ignore_shebang_only_files;
         }
     }
 }
@@ -973,6 +996,18 @@ const CONFIGURATION_METADATA: [ConfigSectionMetadata; 3] = [
                                 example: r#"count = "non-comment-non-blank""#,
                             },
                         ],
+                        sections: &[],
+                    },
+                    ConfigSectionMetadata {
+                        key: "s081",
+                        docs: "Behavior overrides for `S081` file description comments.",
+                        fields: &[ConfigFieldMetadata {
+                            key: "ignore-shebang-only-files",
+                            docs: "Do not report scripts whose only content is a shebang line.",
+                            default: "false",
+                            value_type: "bool",
+                            example: "ignore-shebang-only-files = true",
+                        }],
                         sections: &[],
                     },
                     ConfigSectionMetadata {
@@ -1790,6 +1825,9 @@ fn validate_lint_rule_options_override(value: &toml::Value) -> std::result::Resu
     if let Some(s080_value) = rule_options.get("s080") {
         validate_s080_rule_options_override(s080_value)?;
     }
+    if let Some(s081_value) = rule_options.get("s081") {
+        validate_s081_rule_options_override(s081_value)?;
+    }
     if let Some(s084_value) = rule_options.get("s084") {
         validate_s084_rule_options_override(s084_value)?;
     }
@@ -1922,6 +1960,22 @@ fn validate_s084_rule_options_override(value: &toml::Value) -> std::result::Resu
             return Err(format!(
                 "unsupported `[lint.rule-options.s084]` option `{key}`; expected one of: {}",
                 CONFIG_OVERRIDE_S084_RULE_OPTION_KEYS.join(", ")
+            ));
+        }
+    }
+
+    Ok(())
+}
+
+fn validate_s081_rule_options_override(value: &toml::Value) -> std::result::Result<(), String> {
+    let s081 = value
+        .as_table()
+        .ok_or_else(|| "`[lint.rule-options.s081]` must be a TOML table".to_owned())?;
+    for key in s081.keys() {
+        if !CONFIG_OVERRIDE_S081_RULE_OPTION_KEYS.contains(&key.as_str()) {
+            return Err(format!(
+                "unsupported `[lint.rule-options.s081]` option `{key}`; expected one of: {}",
+                CONFIG_OVERRIDE_S081_RULE_OPTION_KEYS.join(", ")
             ));
         }
     }
@@ -2308,6 +2362,22 @@ mod tests {
     }
 
     #[test]
+    fn inline_config_overrides_validate_supported_s081_rule_option_keys() {
+        let config =
+            parse_config_override("lint.rule-options.s081.ignore-shebang-only-files = true")
+                .unwrap();
+        assert_eq!(
+            config
+                .lint
+                .rule_options
+                .as_ref()
+                .and_then(|options| options.s081.as_ref())
+                .and_then(|s081| s081.ignore_shebang_only_files),
+            Some(true)
+        );
+    }
+
+    #[test]
     fn inline_config_overrides_validate_supported_s084_rule_option_keys() {
         let config = parse_config_override(
             "lint.rule-options.s084.require-globals = false\n\
@@ -2554,6 +2624,12 @@ mod tests {
     }
 
     #[test]
+    fn inline_config_overrides_reject_unknown_s081_rule_option_keys() {
+        let err = parse_config_override("lint.rule-options.s081.preview = true").unwrap_err();
+        assert!(err.contains("unsupported `[lint.rule-options.s081]` option `preview`"));
+    }
+
+    #[test]
     fn inline_config_overrides_reject_unknown_s084_rule_option_keys() {
         let err = parse_config_override("lint.rule-options.s084.preview = true").unwrap_err();
         assert!(err.contains("unsupported `[lint.rule-options.s084]` option `preview`"));
@@ -2755,6 +2831,40 @@ mod tests {
                 .and_then(|options| options.s080.as_ref())
                 .and_then(|s080| s080.max_lines),
             Some(80)
+        );
+    }
+
+    #[test]
+    fn s081_rule_option_config_arguments_allow_last_override_to_win() {
+        let tempdir = tempdir().unwrap();
+        let config = ConfigArguments::from_cli(
+            vec![
+                SingleConfigArgument::SettingsOverride(Box::new(
+                    parse_config_override(
+                        "lint.rule-options.s081.ignore-shebang-only-files = true",
+                    )
+                    .unwrap(),
+                )),
+                SingleConfigArgument::SettingsOverride(Box::new(
+                    parse_config_override(
+                        "lint.rule-options.s081.ignore-shebang-only-files = false",
+                    )
+                    .unwrap(),
+                )),
+            ],
+            false,
+        )
+        .unwrap();
+
+        let loaded = load_project_config(tempdir.path(), &config).unwrap();
+        assert_eq!(
+            loaded
+                .lint
+                .rule_options
+                .as_ref()
+                .and_then(|options| options.s081.as_ref())
+                .and_then(|s081| s081.ignore_shebang_only_files),
+            Some(false)
         );
     }
 

--- a/crates/shuck-linter/resources/test/fixtures/style/S081.sh
+++ b/crates/shuck-linter/resources/test/fixtures/style/S081.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+ls -la
+
+#!/bin/bash
+# Lists the current directory.
+ls -la

--- a/crates/shuck-linter/src/checker.rs
+++ b/crates/shuck-linter/src/checker.rs
@@ -1286,6 +1286,9 @@ impl<'a> Checker<'a> {
         if self.is_rule_enabled(Rule::ScriptSizeThreshold) {
             rules::style::script_size_threshold::script_size_threshold(self);
         }
+        if self.is_rule_enabled(Rule::MissingFileDescription) {
+            rules::style::missing_file_description::missing_file_description(self);
+        }
         if self.is_rule_enabled(Rule::NonAbsoluteShebang) {
             rules::correctness::non_absolute_shebang::non_absolute_shebang(self);
         }

--- a/crates/shuck-linter/src/facts/builder.rs
+++ b/crates/shuck-linter/src/facts/builder.rs
@@ -1087,6 +1087,7 @@ impl<'a, 'analysis> LinterFactsBuilder<'a, 'analysis> {
                 non_absolute_shebang_span: shebang_header_facts.non_absolute_shebang_span,
                 shebang_interpreter: OnceLock::new(),
                 shebang_invocation: OnceLock::new(),
+                missing_file_description_comment: OnceLock::new(),
                 errexit_enabled_anywhere,
                 region_index: self._indexer.region_index(),
                 commented_continuation_comment_spans,

--- a/crates/shuck-linter/src/facts/comments.rs
+++ b/crates/shuck-linter/src/facts/comments.rs
@@ -276,6 +276,43 @@ pub(crate) fn build_shebang_invocation_fact(
         })
 }
 
+pub(crate) fn build_missing_file_description_comment_fact(
+    source: &str,
+    line_index: &LineIndex,
+) -> Option<FileDescriptionCommentFact> {
+    let mut leading_shebang_span = None;
+
+    for line_number in 1..=line_index.line_count() {
+        let source_line = source_line(source, line_index, line_number)?;
+        let line = source_line.text;
+        let trimmed = line.trim_start();
+
+        if trimmed.is_empty() {
+            continue;
+        }
+
+        if trimmed.starts_with("#!") {
+            leading_shebang_span
+                .get_or_insert_with(|| line_span(line_number, source_line.offset, line));
+            continue;
+        }
+
+        if trimmed.starts_with('#') {
+            return None;
+        }
+
+        return Some(FileDescriptionCommentFact {
+            span: line_span(line_number, source_line.offset, line),
+            shebang_only_file: false,
+        });
+    }
+
+    leading_shebang_span.map(|span| FileDescriptionCommentFact {
+        span,
+        shebang_only_file: true,
+    })
+}
+
 pub(crate) fn source_line_is_header_like(line: &str) -> bool {
     let trimmed = line.trim_start();
     trimmed.is_empty() || trimmed.starts_with('#')

--- a/crates/shuck-linter/src/facts/mod.rs
+++ b/crates/shuck-linter/src/facts/mod.rs
@@ -153,8 +153,8 @@ pub use self::{
     lists::{ListFact, ListOperatorFact, ListSegmentKind, MixedShortCircuitKind},
     loop_headers::{ForHeaderFact, LoopHeaderWordFact, SelectHeaderFact},
     model::{
-        AssignmentFacts, CommandFactQueries, CompatFacts, LinterFacts, ScriptLineCountFact,
-        SourceFacts, WordFacts,
+        AssignmentFacts, CommandFactQueries, CompatFacts, FileDescriptionCommentFact, LinterFacts,
+        ScriptLineCountFact, SourceFacts, WordFacts,
     },
     pipelines::{PipelineFact, PipelineOperatorFact, PipelineSegmentFact},
     redirects::{RedirectDevNullStatus, RedirectFact, RedirectTargetAnalysis, RedirectTargetKind},

--- a/crates/shuck-linter/src/facts/model.rs
+++ b/crates/shuck-linter/src/facts/model.rs
@@ -157,6 +157,8 @@ pub(crate) struct SourceFactStore<'a> {
     pub(in crate::facts) non_absolute_shebang_span: Option<Span>,
     pub(in crate::facts) shebang_interpreter: OnceLock<Option<ShebangInterpreterFact>>,
     pub(in crate::facts) shebang_invocation: OnceLock<Option<ShebangInvocationFact>>,
+    pub(in crate::facts) missing_file_description_comment:
+        OnceLock<Option<FileDescriptionCommentFact>>,
     pub(in crate::facts) errexit_enabled_anywhere: bool,
     pub(in crate::facts) region_index: &'a RegionIndex,
     pub(in crate::facts) commented_continuation_comment_spans: Vec<Span>,
@@ -237,6 +239,22 @@ impl ScriptLineCountFact {
 
     pub fn report_span(self) -> Span {
         self.report_span
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct FileDescriptionCommentFact {
+    pub(in crate::facts) span: Span,
+    pub(in crate::facts) shebang_only_file: bool,
+}
+
+impl FileDescriptionCommentFact {
+    pub fn span(self) -> Span {
+        self.span
+    }
+
+    pub fn is_shebang_only_file(self) -> bool {
+        self.shebang_only_file
     }
 }
 
@@ -1133,6 +1151,19 @@ impl<'facts, 'a> SourceFacts<'facts, 'a> {
                 )
             })
             .as_ref()
+    }
+
+    pub(crate) fn missing_file_description_comment(self) -> Option<FileDescriptionCommentFact> {
+        *self
+            .facts
+            .source_facts
+            .missing_file_description_comment
+            .get_or_init(|| {
+                build_missing_file_description_comment_fact(
+                    self.facts.source_facts.source,
+                    self.facts.source_facts.line_index,
+                )
+            })
     }
 
     pub(crate) fn errexit_enabled_anywhere(self) -> bool {

--- a/crates/shuck-linter/src/lib.rs
+++ b/crates/shuck-linter/src/lib.rs
@@ -71,15 +71,15 @@ pub use facts::{
     CommandFact, CommandFactRef, CommandFacts, ConditionalBareWordFact, ConditionalBinaryFact,
     ConditionalFact, ConditionalMixedLogicalOperatorFact, ConditionalNodeFact,
     ConditionalOperandFact, ConditionalOperatorFamily, ConditionalPortabilityFacts,
-    ConditionalUnaryFact, ForHeaderFact, FunctionCallArityFacts, FunctionHeaderFact,
-    IndexedArrayReferenceFragment, IndexedArrayReferenceFragmentFact, LegacyArithmeticFragmentFact,
-    ListFact, ListOperatorFact, LoopHeaderWordFact, NativeZshScalarArrayReference, PipelineFact,
-    PipelineOperatorFact, PipelineSegmentFact, PlainUnindexedArrayReferenceFact,
-    PositionalParameterFragmentFact, RedirectDevNullStatus, RedirectFact, RedirectTargetAnalysis,
-    RedirectTargetKind, ScriptLineCountFact, SelectHeaderFact, SelectorRequiredArrayReference,
-    SimpleTestFact, SimpleTestOperatorFamily, SimpleTestShape, SimpleTestSyntax,
-    SingleQuotedFragmentFact, StatementFact, SubstitutionFact, SubstitutionHostKind,
-    SubstitutionOutputIntent, SudoFamilyInvoker,
+    ConditionalUnaryFact, FileDescriptionCommentFact, ForHeaderFact, FunctionCallArityFacts,
+    FunctionHeaderFact, IndexedArrayReferenceFragment, IndexedArrayReferenceFragmentFact,
+    LegacyArithmeticFragmentFact, ListFact, ListOperatorFact, LoopHeaderWordFact,
+    NativeZshScalarArrayReference, PipelineFact, PipelineOperatorFact, PipelineSegmentFact,
+    PlainUnindexedArrayReferenceFact, PositionalParameterFragmentFact, RedirectDevNullStatus,
+    RedirectFact, RedirectTargetAnalysis, RedirectTargetKind, ScriptLineCountFact,
+    SelectHeaderFact, SelectorRequiredArrayReference, SimpleTestFact, SimpleTestOperatorFamily,
+    SimpleTestShape, SimpleTestSyntax, SingleQuotedFragmentFact, StatementFact, SubstitutionFact,
+    SubstitutionHostKind, SubstitutionOutputIntent, SudoFamilyInvoker,
 };
 /// Fact collection types and stable identifiers into those collections.
 pub use facts::{
@@ -109,7 +109,7 @@ pub use settings::{
     AmbientShellOptions, C001RuleOptions, C063RuleOptions, C158RuleOptions, C159RuleOptions,
     C160RuleOptions, C161RuleOptions, C162RuleOptions, CompiledPerFileIgnoreList,
     LinterRuleOptions, LinterSettings, PerFileIgnore, S078RuleOptions, S079RuleOptions,
-    S080RuleOptions, S084RuleOptions, S085RuleOptions,
+    S080RuleOptions, S081RuleOptions, S084RuleOptions, S085RuleOptions,
 };
 /// Shell dialect selection used by the linter.
 pub use shell::ShellDialect;

--- a/crates/shuck-linter/src/registry.rs
+++ b/crates/shuck-linter/src/registry.rs
@@ -715,6 +715,7 @@ declare_rules! {
     ("S078", Category::Style, Severity::Warning, ShebangShellPolicy),
     ("S079", Category::Style, Severity::Warning, ShebangFormPolicy),
     ("S080", Category::Style, Severity::Warning, ScriptSizeThreshold),
+    ("S081", Category::Style, Severity::Warning, MissingFileDescription),
     ("S084", Category::Style, Severity::Warning, FunctionDocContent),
     ("S085", Category::Style, Severity::Warning, MissingMainEntrypoint),
 }

--- a/crates/shuck-linter/src/rules/style/missing_file_description.rs
+++ b/crates/shuck-linter/src/rules/style/missing_file_description.rs
@@ -1,0 +1,128 @@
+use crate::{Checker, Rule, Violation};
+
+pub struct MissingFileDescription;
+
+impl Violation for MissingFileDescription {
+    fn rule() -> Rule {
+        Rule::MissingFileDescription
+    }
+
+    fn message(&self) -> String {
+        "add a file header comment describing the script".to_owned()
+    }
+}
+
+pub fn missing_file_description(checker: &mut Checker) {
+    let Some(fact) = checker
+        .facts()
+        .source_facts()
+        .missing_file_description_comment()
+    else {
+        return;
+    };
+
+    if fact.is_shebang_only_file() && checker.rule_options().s081.ignore_shebang_only_files {
+        return;
+    }
+
+    checker.report(MissingFileDescription, fact.span());
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::test::test_snippet;
+    use crate::{LinterSettings, Rule};
+
+    #[test]
+    fn reports_code_immediately_after_shebang() {
+        let source = "#!/bin/bash\nls -la\n";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::MissingFileDescription),
+        );
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].span.slice(source), "ls -la");
+    }
+
+    #[test]
+    fn reports_code_after_shebang_with_leading_blank_lines() {
+        let source = "\n#!/bin/bash\nls -la\n";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::MissingFileDescription),
+        );
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].span.slice(source), "ls -la");
+    }
+
+    #[test]
+    fn accepts_comment_block_after_shebang() {
+        let source = "#!/bin/bash\n# Lists the current directory.\nls -la\n";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::MissingFileDescription),
+        );
+
+        assert!(diagnostics.is_empty(), "diagnostics: {diagnostics:?}");
+    }
+
+    #[test]
+    fn accepts_comment_block_after_shebang_and_blank_lines() {
+        let source = "#!/bin/bash\n\n# Lists the current directory.\nls -la\n";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::MissingFileDescription),
+        );
+
+        assert!(diagnostics.is_empty(), "diagnostics: {diagnostics:?}");
+    }
+
+    #[test]
+    fn reports_code_first_files_without_shebang() {
+        let source = "ls -la\n";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::MissingFileDescription),
+        );
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].span.slice(source), "ls -la");
+    }
+
+    #[test]
+    fn accepts_comment_first_files_without_shebang() {
+        let source = "# Lists the current directory.\nls -la\n";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::MissingFileDescription),
+        );
+
+        assert!(diagnostics.is_empty(), "diagnostics: {diagnostics:?}");
+    }
+
+    #[test]
+    fn reports_shebang_only_files_by_default() {
+        let source = "#!/bin/bash\n";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::MissingFileDescription),
+        );
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].span.slice(source), "#!/bin/bash");
+    }
+
+    #[test]
+    fn can_ignore_shebang_only_files() {
+        let source = "#!/bin/bash\n";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::MissingFileDescription)
+                .with_s081_ignore_shebang_only_files(true),
+        );
+
+        assert!(diagnostics.is_empty(), "diagnostics: {diagnostics:?}");
+    }
+}

--- a/crates/shuck-linter/src/rules/style/mod.rs
+++ b/crates/shuck-linter/src/rules/style/mod.rs
@@ -46,6 +46,7 @@ pub mod loop_from_command_output;
 pub mod ls_grep_pipeline;
 pub mod ls_in_substitution;
 pub mod ls_piped_to_xargs;
+pub mod missing_file_description;
 pub mod missing_main_entrypoint;
 pub mod missing_shebang_line;
 pub mod mixed_quote_word;
@@ -174,6 +175,7 @@ mod tests {
     #[test_case(Rule::ShebangShellPolicy, Path::new("S078.sh"))]
     #[test_case(Rule::ShebangFormPolicy, Path::new("S079.sh"))]
     #[test_case(Rule::ScriptSizeThreshold, Path::new("S080.sh"))]
+    #[test_case(Rule::MissingFileDescription, Path::new("S081.sh"))]
     #[test_case(Rule::FunctionDocContent, Path::new("S084.sh"))]
     #[test_case(Rule::MissingMainEntrypoint, Path::new("S085.sh"))]
     fn rules(rule: Rule, path: &Path) -> anyhow::Result<()> {

--- a/crates/shuck-linter/src/rules/style/snapshots/shuck_linter__rules__style__tests__S081_S081.sh.snap
+++ b/crates/shuck-linter/src/rules/style/snapshots/shuck_linter__rules__style__tests__S081_S081.sh.snap
@@ -1,0 +1,8 @@
+---
+source: crates/shuck-linter/src/rules/style/mod.rs
+---
+S081 add a file header comment describing the script
+ --> <source>:2:1
+  |
+2 | ls -la
+  |

--- a/crates/shuck-linter/src/settings.rs
+++ b/crates/shuck-linter/src/settings.rs
@@ -37,6 +37,8 @@ pub struct LinterRuleOptions {
     pub s079: S079RuleOptions,
     /// Behavior overrides for `S080`.
     pub s080: S080RuleOptions,
+    /// Behavior overrides for `S081`.
+    pub s081: S081RuleOptions,
     /// Behavior overrides for `S084`.
     pub s084: S084RuleOptions,
     /// Behavior overrides for `S085`.
@@ -135,6 +137,13 @@ impl Default for S079RuleOptions {
             allowed_paths: vec!["/bin/bash".to_owned(), "/usr/bin/env bash".to_owned()],
         }
     }
+}
+
+/// Behavior overrides for `S081` file description comments.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct S081RuleOptions {
+    /// Whether files containing only a shebang are exempt from the rule.
+    pub ignore_shebang_only_files: bool,
 }
 
 /// Behavior overrides for `S084` function documentation content.
@@ -449,6 +458,11 @@ impl LinterSettings {
 
     pub fn with_s080_count(mut self, value: impl Into<String>) -> Self {
         self.rule_options.s080.count = value.into();
+        self
+    }
+
+    pub fn with_s081_ignore_shebang_only_files(mut self, value: bool) -> Self {
+        self.rule_options.s081.ignore_shebang_only_files = value;
         self
     }
 

--- a/website/app/lib/rules-data.generated.json
+++ b/website/app/lib/rules-data.generated.json
@@ -6586,10 +6586,10 @@
       "bash"
     ],
     "shellcheckCode": null,
-    "implemented": false,
-    "status": "planned",
+    "implemented": true,
+    "status": "implemented",
     "hasKnownShellcheckDivergences": false,
-    "severity": null,
+    "severity": "Warning",
     "fixStatus": "none",
     "fixAvailability": "none",
     "fixSafety": null,


### PR DESCRIPTION
## Summary
- add S081 missing file description style rule
- add a reusable file-description header fact
- wire S081 options through config/cache, registry, dispatch, fixture, and snapshot

## Validation
- `cargo test -p shuck-linter missing_file_description -- --nocapture`
- `cargo test -p shuck-config s081_rule_option -- --nocapture`
- `cargo test -p shuck-cli commands::check::settings::tests -- --nocapture`
- `INSTA_UPDATE=always cargo test -p shuck-linter rules::style::tests::rules::rule_missingfiledescription_path_new_s081_sh_expects -- --nocapture`
- `make test-large-corpus SHUCK_LARGE_CORPUS_RULES=S081`
- `make test`
- `make check`