### PR TITLE
feat(linter): add S082 todo format rule

### DIFF
--- a/crates/shuck-cli/src/commands/check/settings.rs
+++ b/crates/shuck-cli/src/commands/check/settings.rs
@@ -61,6 +61,9 @@ struct EffectiveRuleOptions {
     s080_max_lines: usize,
     s080_count: String,
     s081_ignore_shebang_only_files: bool,
+    s082_kinds: Vec<String>,
+    s082_require_owner: bool,
+    s082_require_message: bool,
     s084_require_globals: bool,
     s084_require_arguments: bool,
     s084_require_outputs: bool,
@@ -199,6 +202,9 @@ impl EffectiveRuleOptions {
             s080_max_lines: rule_options.s080.max_lines,
             s080_count: rule_options.s080.count.clone(),
             s081_ignore_shebang_only_files: rule_options.s081.ignore_shebang_only_files,
+            s082_kinds: rule_options.s082.kinds.clone(),
+            s082_require_owner: rule_options.s082.require_owner,
+            s082_require_message: rule_options.s082.require_message,
             s084_require_globals: rule_options.s084.require_globals,
             s084_require_arguments: rule_options.s084.require_arguments,
             s084_require_outputs: rule_options.s084.require_outputs,
@@ -229,6 +235,9 @@ impl CacheKey for EffectiveRuleOptions {
         self.s080_max_lines.cache_key(state);
         self.s080_count.cache_key(state);
         self.s081_ignore_shebang_only_files.cache_key(state);
+        self.s082_kinds.cache_key(state);
+        self.s082_require_owner.cache_key(state);
+        self.s082_require_message.cache_key(state);
         self.s084_require_globals.cache_key(state);
         self.s084_require_arguments.cache_key(state);
         self.s084_require_outputs.cache_key(state);
@@ -991,6 +1000,30 @@ fn linter_rule_options_for_lint_config(
         .and_then(|c063| c063.report_unreached_nested_definitions)
     {
         rule_options.c063.report_unreached_nested_definitions = value;
+    }
+    if let Some(kinds) = lint
+        .rule_options
+        .as_ref()
+        .and_then(|options| options.s082.as_ref())
+        .and_then(|s082| s082.kinds.as_ref())
+    {
+        rule_options.s082.kinds.clone_from(kinds);
+    }
+    if let Some(value) = lint
+        .rule_options
+        .as_ref()
+        .and_then(|options| options.s082.as_ref())
+        .and_then(|s082| s082.require_owner)
+    {
+        rule_options.s082.require_owner = value;
+    }
+    if let Some(value) = lint
+        .rule_options
+        .as_ref()
+        .and_then(|options| options.s082.as_ref())
+        .and_then(|s082| s082.require_message)
+    {
+        rule_options.s082.require_message = value;
     }
     if let Some(value) = lint
         .rule_options

--- a/crates/shuck-config/src/lib.rs
+++ b/crates/shuck-config/src/lib.rs
@@ -61,8 +61,8 @@ const CONFIG_OVERRIDE_LINT_ZSH_PLUGIN_KEYS: &[&str] = &[
     "entrypoints",
 ];
 const CONFIG_OVERRIDE_LINT_RULE_OPTION_KEYS: &[&str] = &[
-    "c001", "c063", "s078", "s079", "s080", "s081", "s084", "s085", "c158", "c159", "c160", "c161",
-    "c162",
+    "c001", "c063", "s078", "s079", "s080", "s081", "s082", "s084", "s085", "c158", "c159", "c160",
+    "c161", "c162",
 ];
 const CONFIG_OVERRIDE_C001_RULE_OPTION_KEYS: &[&str] =
     &["treat-indirect-expansion-targets-as-used"];
@@ -72,6 +72,8 @@ const CONFIG_OVERRIDE_S079_RULE_OPTION_KEYS: &[&str] = &["allowed-forms", "allow
 const CONFIG_OVERRIDE_S080_RULE_OPTION_KEYS: &[&str] = &["max-lines", "count"];
 const CONFIG_OVERRIDE_S080_COUNT_VALUES: &[&str] = &["physical", "non-comment-non-blank"];
 const CONFIG_OVERRIDE_S081_RULE_OPTION_KEYS: &[&str] = &["ignore-shebang-only-files"];
+const CONFIG_OVERRIDE_S082_RULE_OPTION_KEYS: &[&str] =
+    &["kinds", "require-owner", "require-message"];
 const CONFIG_OVERRIDE_S084_RULE_OPTION_KEYS: &[&str] = &[
     "require-globals",
     "require-arguments",
@@ -351,6 +353,8 @@ pub struct LintRuleOptionsConfig {
     pub s080: Option<S080RuleOptionsConfig>,
     /// Options for rule S081.
     pub s081: Option<S081RuleOptionsConfig>,
+    /// Options for rule S082.
+    pub s082: Option<S082RuleOptionsConfig>,
     /// Options for rule S084.
     pub s084: Option<S084RuleOptionsConfig>,
     /// Options for rule S085.
@@ -386,6 +390,9 @@ impl LintRuleOptionsConfig {
         }
         if let Some(s081) = overrides.s081 {
             self.s081.get_or_insert_default().apply_overrides(s081);
+        }
+        if let Some(s082) = overrides.s082 {
+            self.s082.get_or_insert_default().apply_overrides(s082);
         }
         if let Some(s084) = overrides.s084 {
             self.s084.get_or_insert_default().apply_overrides(s084);
@@ -515,6 +522,32 @@ impl S081RuleOptionsConfig {
     fn apply_overrides(&mut self, overrides: Self) {
         if overrides.ignore_shebang_only_files.is_some() {
             self.ignore_shebang_only_files = overrides.ignore_shebang_only_files;
+        }
+    }
+}
+
+/// Options for rule S082.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Deserialize)]
+#[serde(default, rename_all = "kebab-case", deny_unknown_fields)]
+pub struct S082RuleOptionsConfig {
+    /// Marker names treated as action comments.
+    pub kinds: Option<Vec<String>>,
+    /// Whether action comments must include an owner annotation.
+    pub require_owner: Option<bool>,
+    /// Whether action comments must include explanatory text.
+    pub require_message: Option<bool>,
+}
+
+impl S082RuleOptionsConfig {
+    fn apply_overrides(&mut self, overrides: Self) {
+        if overrides.kinds.is_some() {
+            self.kinds = overrides.kinds;
+        }
+        if overrides.require_owner.is_some() {
+            self.require_owner = overrides.require_owner;
+        }
+        if overrides.require_message.is_some() {
+            self.require_message = overrides.require_message;
         }
     }
 }
@@ -1008,6 +1041,34 @@ const CONFIGURATION_METADATA: [ConfigSectionMetadata; 3] = [
                             value_type: "bool",
                             example: "ignore-shebang-only-files = true",
                         }],
+                        sections: &[],
+                    },
+                    ConfigSectionMetadata {
+                        key: "s082",
+                        docs: "Behavior overrides for `S082` action comment formatting.",
+                        fields: &[
+                            ConfigFieldMetadata {
+                                key: "kinds",
+                                docs: "Comment markers checked at the start of a comment.",
+                                default: r#"["TODO", "FIXME", "XXX"]"#,
+                                value_type: "list[string]",
+                                example: r#"kinds = ["TODO", "FIXME"]"#,
+                            },
+                            ConfigFieldMetadata {
+                                key: "require-owner",
+                                docs: "Require a checked marker to be followed immediately by a parenthesized owner.",
+                                default: "true",
+                                value_type: "bool",
+                                example: "require-owner = false",
+                            },
+                            ConfigFieldMetadata {
+                                key: "require-message",
+                                docs: "Require a checked marker to include non-empty explanatory text.",
+                                default: "true",
+                                value_type: "bool",
+                                example: "require-message = false",
+                            },
+                        ],
                         sections: &[],
                     },
                     ConfigSectionMetadata {
@@ -1828,6 +1889,9 @@ fn validate_lint_rule_options_override(value: &toml::Value) -> std::result::Resu
     if let Some(s081_value) = rule_options.get("s081") {
         validate_s081_rule_options_override(s081_value)?;
     }
+    if let Some(s082_value) = rule_options.get("s082") {
+        validate_s082_rule_options_override(s082_value)?;
+    }
     if let Some(s084_value) = rule_options.get("s084") {
         validate_s084_rule_options_override(s084_value)?;
     }
@@ -1976,6 +2040,22 @@ fn validate_s081_rule_options_override(value: &toml::Value) -> std::result::Resu
             return Err(format!(
                 "unsupported `[lint.rule-options.s081]` option `{key}`; expected one of: {}",
                 CONFIG_OVERRIDE_S081_RULE_OPTION_KEYS.join(", ")
+            ));
+        }
+    }
+
+    Ok(())
+}
+
+fn validate_s082_rule_options_override(value: &toml::Value) -> std::result::Result<(), String> {
+    let s082 = value
+        .as_table()
+        .ok_or_else(|| "`[lint.rule-options.s082]` must be a TOML table".to_owned())?;
+    for key in s082.keys() {
+        if !CONFIG_OVERRIDE_S082_RULE_OPTION_KEYS.contains(&key.as_str()) {
+            return Err(format!(
+                "unsupported `[lint.rule-options.s082]` option `{key}`; expected one of: {}",
+                CONFIG_OVERRIDE_S082_RULE_OPTION_KEYS.join(", ")
             ));
         }
     }
@@ -2378,6 +2458,28 @@ mod tests {
     }
 
     #[test]
+    fn inline_config_overrides_validate_supported_s082_rule_option_keys() {
+        let config = parse_config_override(
+            "lint.rule-options.s082.kinds = ['TODO', 'FIXME']\n\
+             lint.rule-options.s082.require-owner = false\n\
+             lint.rule-options.s082.require-message = true",
+        )
+        .unwrap();
+        let s082 = config
+            .lint
+            .rule_options
+            .as_ref()
+            .and_then(|options| options.s082.as_ref())
+            .expect("missing s082 options");
+        assert_eq!(
+            s082.kinds,
+            Some(vec!["TODO".to_owned(), "FIXME".to_owned()])
+        );
+        assert_eq!(s082.require_owner, Some(false));
+        assert_eq!(s082.require_message, Some(true));
+    }
+
+    #[test]
     fn inline_config_overrides_validate_supported_s084_rule_option_keys() {
         let config = parse_config_override(
             "lint.rule-options.s084.require-globals = false\n\
@@ -2636,6 +2738,12 @@ mod tests {
     }
 
     #[test]
+    fn inline_config_overrides_reject_unknown_s082_rule_option_keys() {
+        let err = parse_config_override("lint.rule-options.s082.preview = true").unwrap_err();
+        assert!(err.contains("unsupported `[lint.rule-options.s082]` option `preview`"));
+    }
+
+    #[test]
     fn inline_config_overrides_reject_unknown_s085_rule_option_keys() {
         let err = parse_config_override("lint.rule-options.s085.preview = true").unwrap_err();
         assert!(err.contains("unsupported `[lint.rule-options.s085]` option `preview`"));
@@ -2864,6 +2972,34 @@ mod tests {
                 .as_ref()
                 .and_then(|options| options.s081.as_ref())
                 .and_then(|s081| s081.ignore_shebang_only_files),
+            Some(false)
+        );
+    }
+
+    #[test]
+    fn s082_rule_option_config_arguments_allow_last_override_to_win() {
+        let tempdir = tempdir().unwrap();
+        let config = ConfigArguments::from_cli(
+            vec![
+                SingleConfigArgument::SettingsOverride(Box::new(
+                    parse_config_override("lint.rule-options.s082.require-owner = true").unwrap(),
+                )),
+                SingleConfigArgument::SettingsOverride(Box::new(
+                    parse_config_override("lint.rule-options.s082.require-owner = false").unwrap(),
+                )),
+            ],
+            false,
+        )
+        .unwrap();
+
+        let loaded = load_project_config(tempdir.path(), &config).unwrap();
+        assert_eq!(
+            loaded
+                .lint
+                .rule_options
+                .as_ref()
+                .and_then(|options| options.s082.as_ref())
+                .and_then(|s082| s082.require_owner),
             Some(false)
         );
     }

--- a/crates/shuck-linter/resources/test/fixtures/style/S082.sh
+++ b/crates/shuck-linter/resources/test/fixtures/style/S082.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# TODO finish later
+echo hi # FIXME(alice)
+
+# TODO(alice): finish the input validation logic
+echo ok # FIXME(bob): address the edge case for empty arrays

--- a/crates/shuck-linter/src/checker.rs
+++ b/crates/shuck-linter/src/checker.rs
@@ -1048,6 +1048,9 @@ impl<'a> Checker<'a> {
         if self.is_rule_enabled(Rule::TrailingDirective) {
             rules::style::trailing_directive::trailing_directive(self);
         }
+        if self.is_rule_enabled(Rule::TodoFormat) {
+            rules::style::todo_format::todo_format(self);
+        }
         if self.is_rule_enabled(Rule::PositionalTenBraces) {
             rules::correctness::positional_ten_braces::positional_ten_braces(self);
         }

--- a/crates/shuck-linter/src/facts/builder.rs
+++ b/crates/shuck-linter/src/facts/builder.rs
@@ -1094,6 +1094,7 @@ impl<'a, 'analysis> LinterFactsBuilder<'a, 'analysis> {
                 comment_double_quote_nesting_spans,
                 escaped_dash_command_name_spans: OnceLock::new(),
                 trailing_directive_comment_spans,
+                todo_comment_facts: OnceLock::new(),
                 backtick_substitution_spans,
                 backtick_escaped_parameters,
                 backtick_escaped_parameter_reference_spans,

--- a/crates/shuck-linter/src/facts/comments.rs
+++ b/crates/shuck-linter/src/facts/comments.rs
@@ -716,6 +716,56 @@ pub(crate) fn build_trailing_directive_comment_spans(
         .collect()
 }
 
+pub(crate) fn build_todo_comment_facts(
+    source: &str,
+    line_index: &LineIndex,
+    comment_index: &CommentIndex,
+) -> Vec<TodoCommentFact> {
+    comment_index
+        .comments()
+        .iter()
+        .filter_map(|comment| {
+            let line = comment.line;
+            let line_start = usize::from(line_index.line_start(line)?);
+            let line_end =
+                usize::from(line_index.line_range(line, source)?.end()).min(source.len());
+            let comment_start = usize::from(comment.range.start());
+            let comment_end = usize::from(comment.range.end()).min(line_end);
+            if comment_start >= comment_end || comment_end > source.len() {
+                return None;
+            }
+
+            let after_hash_start = comment_start.checked_add(1)?;
+            if after_hash_start > comment_end {
+                return None;
+            }
+            let after_hash = &source[after_hash_start..comment_end];
+            let leading_whitespace_len = after_hash
+                .bytes()
+                .take_while(|byte| matches!(byte, b' ' | b'\t'))
+                .count();
+            let content_start = after_hash_start + leading_whitespace_len;
+            let content = &source[content_start..comment_end];
+            if content.is_empty() {
+                return None;
+            }
+
+            let line_start_position = Position {
+                line,
+                column: 1,
+                offset: line_start,
+            };
+            let content_start_position =
+                line_start_position.advanced_by(&source[line_start..content_start]);
+            let content_span = Span::from_positions(
+                content_start_position,
+                content_start_position.advanced_by(content),
+            );
+            Some(TodoCommentFact::new(content_span, content.to_owned()))
+        })
+        .collect()
+}
+
 pub(crate) fn case_item_label_comment(
     case_items: &[CaseItemFact<'_>],
     line: usize,

--- a/crates/shuck-linter/src/facts/model.rs
+++ b/crates/shuck-linter/src/facts/model.rs
@@ -165,6 +165,7 @@ pub(crate) struct SourceFactStore<'a> {
     pub(in crate::facts) comment_double_quote_nesting_spans: Vec<Span>,
     pub(in crate::facts) escaped_dash_command_name_spans: OnceLock<Vec<Span>>,
     pub(in crate::facts) trailing_directive_comment_spans: Vec<Span>,
+    pub(in crate::facts) todo_comment_facts: OnceLock<Vec<TodoCommentFact>>,
     pub(in crate::facts) backtick_substitution_spans: Vec<Span>,
     pub(in crate::facts) backtick_escaped_parameters: Vec<BacktickEscapedParameter>,
     pub(in crate::facts) backtick_escaped_parameter_reference_spans: Vec<Span>,
@@ -1206,6 +1207,16 @@ impl<'facts, 'a> SourceFacts<'facts, 'a> {
         &self.facts.source_facts.trailing_directive_comment_spans
     }
 
+    pub(crate) fn todo_comment_facts(self) -> &'facts [TodoCommentFact] {
+        self.facts.source_facts.todo_comment_facts.get_or_init(|| {
+            build_todo_comment_facts(
+                self.facts.source_facts.source,
+                self.facts.source_facts.line_index,
+                self.facts.source_facts.comment_index,
+            )
+        })
+    }
+
     pub(crate) fn backtick_substitution_spans(self) -> &'facts [Span] {
         &self.facts.source_facts.backtick_substitution_spans
     }
@@ -1746,6 +1757,32 @@ fn stmt_is_zero_arg_call_to(stmt: &Stmt, name: &str, source: &str) -> bool {
     command.assignments.is_empty()
         && command.args.is_empty()
         && static_command_name_text(&command.name, source).as_deref() == Some(name)
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct TodoCommentFact {
+    content_span: Span,
+    content: String,
+}
+
+impl TodoCommentFact {
+    pub(crate) fn new(content_span: Span, content: String) -> Self {
+        Self {
+            content_span,
+            content,
+        }
+    }
+
+    pub(crate) fn content(&self) -> &str {
+        &self.content
+    }
+
+    pub(crate) fn marker_span(&self, marker: &str) -> Span {
+        Span::from_positions(
+            self.content_span.start,
+            self.content_span.start.advanced_by(marker),
+        )
+    }
 }
 
 pub(crate) fn build_possible_variable_misspelling_scope_compat_name_uses(

--- a/crates/shuck-linter/src/lib.rs
+++ b/crates/shuck-linter/src/lib.rs
@@ -109,7 +109,7 @@ pub use settings::{
     AmbientShellOptions, C001RuleOptions, C063RuleOptions, C158RuleOptions, C159RuleOptions,
     C160RuleOptions, C161RuleOptions, C162RuleOptions, CompiledPerFileIgnoreList,
     LinterRuleOptions, LinterSettings, PerFileIgnore, S078RuleOptions, S079RuleOptions,
-    S080RuleOptions, S081RuleOptions, S084RuleOptions, S085RuleOptions,
+    S080RuleOptions, S081RuleOptions, S082RuleOptions, S084RuleOptions, S085RuleOptions,
 };
 /// Shell dialect selection used by the linter.
 pub use shell::ShellDialect;

--- a/crates/shuck-linter/src/registry.rs
+++ b/crates/shuck-linter/src/registry.rs
@@ -716,6 +716,7 @@ declare_rules! {
     ("S079", Category::Style, Severity::Warning, ShebangFormPolicy),
     ("S080", Category::Style, Severity::Warning, ScriptSizeThreshold),
     ("S081", Category::Style, Severity::Warning, MissingFileDescription),
+    ("S082", Category::Style, Severity::Warning, TodoFormat),
     ("S084", Category::Style, Severity::Warning, FunctionDocContent),
     ("S085", Category::Style, Severity::Warning, MissingMainEntrypoint),
 }

--- a/crates/shuck-linter/src/rules/style/mod.rs
+++ b/crates/shuck-linter/src/rules/style/mod.rs
@@ -66,6 +66,7 @@ pub mod spaced_tabstrip_close;
 pub mod su_without_flag;
 pub mod suspect_closing_quote;
 pub mod syntax;
+pub mod todo_format;
 pub mod trailing_directive;
 pub mod trap_signal_numbers;
 pub mod unquoted_array_expansion;
@@ -176,6 +177,7 @@ mod tests {
     #[test_case(Rule::ShebangFormPolicy, Path::new("S079.sh"))]
     #[test_case(Rule::ScriptSizeThreshold, Path::new("S080.sh"))]
     #[test_case(Rule::MissingFileDescription, Path::new("S081.sh"))]
+    #[test_case(Rule::TodoFormat, Path::new("S082.sh"))]
     #[test_case(Rule::FunctionDocContent, Path::new("S084.sh"))]
     #[test_case(Rule::MissingMainEntrypoint, Path::new("S085.sh"))]
     fn rules(rule: Rule, path: &Path) -> anyhow::Result<()> {

--- a/crates/shuck-linter/src/rules/style/snapshots/shuck_linter__rules__style__tests__S082_S082.sh.snap
+++ b/crates/shuck-linter/src/rules/style/snapshots/shuck_linter__rules__style__tests__S082_S082.sh.snap
@@ -1,0 +1,14 @@
+---
+source: crates/shuck-linter/src/rules/style/mod.rs
+---
+S082 add an owner to this action comment
+ --> <source>:2:3
+  |
+2 | # TODO finish later
+  |
+
+S082 add a message to this action comment
+ --> <source>:3:11
+  |
+3 | echo hi # FIXME(alice)
+  |

--- a/crates/shuck-linter/src/rules/style/todo_format.rs
+++ b/crates/shuck-linter/src/rules/style/todo_format.rs
@@ -1,0 +1,201 @@
+use crate::{Checker, Rule, Violation};
+
+pub struct TodoFormat {
+    missing_owner: bool,
+    missing_message: bool,
+}
+
+impl Violation for TodoFormat {
+    fn rule() -> Rule {
+        Rule::TodoFormat
+    }
+
+    fn message(&self) -> String {
+        match (self.missing_owner, self.missing_message) {
+            (true, true) => "add an owner and message to this action comment".to_owned(),
+            (true, false) => "add an owner to this action comment".to_owned(),
+            (false, true) => "add a message to this action comment".to_owned(),
+            (false, false) => "action comment is complete".to_owned(),
+        }
+    }
+}
+
+pub fn todo_format(checker: &mut Checker) {
+    let options = checker.rule_options().s082.clone();
+    let diagnostics = checker
+        .facts()
+        .source_facts()
+        .todo_comment_facts()
+        .iter()
+        .filter_map(|fact| {
+            todo_comment_violation(fact.content(), &options)
+                .map(|(kind, violation)| crate::Diagnostic::new(violation, fact.marker_span(kind)))
+        })
+        .collect::<Vec<_>>();
+
+    for diagnostic in diagnostics {
+        checker.report_diagnostic_dedup(diagnostic);
+    }
+}
+
+fn todo_comment_violation<'a>(
+    content: &'a str,
+    options: &'a crate::S082RuleOptions,
+) -> Option<(&'a str, TodoFormat)> {
+    for kind in options.kinds.iter().filter(|kind| !kind.is_empty()) {
+        let Some(rest) = marker_rest(content, kind) else {
+            continue;
+        };
+        let owner_rest = owner_annotation_rest(rest);
+        let has_owner = owner_rest.is_some();
+        let missing_owner = options.require_owner && !has_owner;
+        let message_rest = owner_rest.unwrap_or(rest);
+        let missing_message = options.require_message && !has_non_empty_message(message_rest);
+        if missing_owner || missing_message {
+            return Some((
+                kind.as_str(),
+                TodoFormat {
+                    missing_owner,
+                    missing_message,
+                },
+            ));
+        }
+    }
+
+    None
+}
+
+fn marker_rest<'a>(content: &'a str, kind: &str) -> Option<&'a str> {
+    let rest = content.strip_prefix(kind)?;
+    if rest
+        .chars()
+        .next()
+        .is_some_and(|char| char.is_ascii_alphanumeric() || char == '_')
+    {
+        return None;
+    }
+
+    Some(rest)
+}
+
+fn owner_annotation_rest(rest: &str) -> Option<&str> {
+    let after_open = rest.strip_prefix('(')?;
+    let close = after_open.find(')')?;
+    let owner = &after_open[..close];
+    if owner.trim().is_empty() {
+        return None;
+    }
+
+    Some(&after_open[close + 1..])
+}
+
+fn has_non_empty_message(rest: &str) -> bool {
+    let message = rest.trim_start();
+    let message = message.strip_prefix(':').unwrap_or(message).trim_start();
+    !message.is_empty()
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::test::test_snippet;
+    use crate::{LinterSettings, Rule};
+
+    #[test]
+    fn reports_missing_owner() {
+        let source = "#!/bin/bash\n# TODO finish the parser case\n";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::TodoFormat));
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(
+            diagnostics[0].message,
+            "add an owner to this action comment"
+        );
+        assert_eq!(diagnostics[0].span.slice(source), "TODO");
+    }
+
+    #[test]
+    fn reports_missing_message() {
+        let source = "#!/bin/bash\n# FIXME(alice):\n";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::TodoFormat));
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(
+            diagnostics[0].message,
+            "add a message to this action comment"
+        );
+        assert_eq!(diagnostics[0].span.slice(source), "FIXME");
+    }
+
+    #[test]
+    fn reports_missing_owner_and_message() {
+        let source = "#!/bin/bash\n# XXX\n";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::TodoFormat));
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(
+            diagnostics[0].message,
+            "add an owner and message to this action comment"
+        );
+        assert_eq!(diagnostics[0].span.slice(source), "XXX");
+    }
+
+    #[test]
+    fn accepts_owner_and_message() {
+        let source = "#!/bin/bash\n# TODO(alice): finish the parser case\n";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::TodoFormat));
+
+        assert!(diagnostics.is_empty());
+    }
+
+    #[test]
+    fn configured_kind_is_case_sensitive() {
+        let source = "#!/bin/bash\n# note(alice): finish the parser case\n# NOTE finish\n";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::TodoFormat).with_s082_kinds(["NOTE".to_owned()]),
+        );
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].span.slice(source), "NOTE");
+    }
+
+    #[test]
+    fn can_disable_owner_requirement() {
+        let source = "#!/bin/bash\n# TODO finish the parser case\n";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::TodoFormat).with_s082_require_owner(false),
+        );
+
+        assert!(diagnostics.is_empty());
+    }
+
+    #[test]
+    fn can_disable_message_requirement() {
+        let source = "#!/bin/bash\n# TODO(alice)\n";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::TodoFormat).with_s082_require_message(false),
+        );
+
+        assert!(diagnostics.is_empty());
+    }
+
+    #[test]
+    fn ignores_non_comment_text_and_longer_words() {
+        let source = "#!/bin/bash\necho TODO\n# TODONOT(alice): leave this alone\n";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::TodoFormat));
+
+        assert!(diagnostics.is_empty());
+    }
+
+    #[test]
+    fn checks_inline_comments() {
+        let source = "#!/bin/bash\necho hi # TODO(alice)\n";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::TodoFormat));
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].span.start.line, 2);
+        assert_eq!(diagnostics[0].span.slice(source), "TODO");
+    }
+}

--- a/crates/shuck-linter/src/settings.rs
+++ b/crates/shuck-linter/src/settings.rs
@@ -39,6 +39,8 @@ pub struct LinterRuleOptions {
     pub s080: S080RuleOptions,
     /// Behavior overrides for `S081`.
     pub s081: S081RuleOptions,
+    /// Behavior overrides for `S082`.
+    pub s082: S082RuleOptions,
     /// Behavior overrides for `S084`.
     pub s084: S084RuleOptions,
     /// Behavior overrides for `S085`.
@@ -146,6 +148,27 @@ pub struct S081RuleOptions {
     pub ignore_shebang_only_files: bool,
 }
 
+/// Behavior overrides for `S082` TODO-style comment formatting.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct S082RuleOptions {
+    /// Comment markers that are checked at the start of a comment.
+    pub kinds: Vec<String>,
+    /// Whether a checked marker must be followed immediately by `(owner)`.
+    pub require_owner: bool,
+    /// Whether a checked marker must include non-empty explanatory text.
+    pub require_message: bool,
+}
+
+impl Default for S082RuleOptions {
+    fn default() -> Self {
+        Self {
+            kinds: vec!["TODO".to_owned(), "FIXME".to_owned(), "XXX".to_owned()],
+            require_owner: true,
+            require_message: true,
+        }
+    }
+}
+
 /// Behavior overrides for `S084` function documentation content.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct S084RuleOptions {
@@ -186,7 +209,6 @@ impl Default for S085RuleOptions {
         }
     }
 }
-
 /// Behavior overrides for `C158` implicit global assignment analysis.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct C158RuleOptions {
@@ -463,6 +485,21 @@ impl LinterSettings {
 
     pub fn with_s081_ignore_shebang_only_files(mut self, value: bool) -> Self {
         self.rule_options.s081.ignore_shebang_only_files = value;
+        self
+    }
+
+    pub fn with_s082_kinds(mut self, kinds: impl IntoIterator<Item = String>) -> Self {
+        self.rule_options.s082.kinds = kinds.into_iter().collect();
+        self
+    }
+
+    pub fn with_s082_require_owner(mut self, value: bool) -> Self {
+        self.rule_options.s082.require_owner = value;
+        self
+    }
+
+    pub fn with_s082_require_message(mut self, value: bool) -> Self {
+        self.rule_options.s082.require_message = value;
         self
     }
 

--- a/website/app/lib/rules-data.generated.json
+++ b/website/app/lib/rules-data.generated.json
@@ -6616,10 +6616,10 @@
       "bash"
     ],
     "shellcheckCode": null,
-    "implemented": false,
-    "status": "planned",
+    "implemented": true,
+    "status": "implemented",
     "hasKnownShellcheckDivergences": false,
-    "severity": null,
+    "severity": "Warning",
     "fixStatus": "none",
     "fixAvailability": "none",
     "fixSafety": null,


### PR DESCRIPTION
## Summary
- add S082 TODO/FIXME/XXX action-comment formatting rule
- add reusable comment facts for marker scanning on the refactored source fact store
- wire S082 rule options through config/cache, registry, dispatch, fixture, and snapshot

## Validation
- `cargo test -p shuck-linter todo_format -- --nocapture`
- `cargo test -p shuck-config s082_rule_option -- --nocapture`
- `cargo test -p shuck-cli commands::check::settings::tests -- --nocapture`
- `INSTA_UPDATE=always cargo test -p shuck-linter rules::style::tests::rules::rule_todoformat_path_new_s082_sh_expects -- --nocapture`
- `make test-large-corpus SHUCK_LARGE_CORPUS_RULES=S082`
- `make test`
- `make check`