### PR TITLE
docs: tighten public API docs boundaries

### DIFF
--- a/crates/shuck-ast/src/lib.rs
+++ b/crates/shuck-ast/src/lib.rs
@@ -6,24 +6,24 @@
 //! `shuck-parser` produces these data structures, while crates such as `shuck-indexer`,
 //! `shuck-linter`, `shuck-semantic`, and `shuck-formatter` consume them.
 
-#[allow(missing_docs)]
+#[doc(hidden)]
 mod arena;
-#[allow(missing_docs)]
+#[doc(hidden)]
 mod ast;
-#[allow(missing_docs)]
+#[doc(hidden)]
 mod command_resolution;
-#[allow(missing_docs)]
+#[doc(hidden)]
 mod name;
-#[allow(missing_docs)]
+#[doc(hidden)]
 mod span;
-#[allow(missing_docs)]
+#[doc(hidden)]
 mod tokens;
 
 /// Compact typed arena index and list storage utilities.
 pub use arena::{IdRange, Idx, ListArena};
-/// Parsed shell AST nodes and related syntax tree types.
+#[doc(hidden)]
 pub use ast::*;
-/// Static command-resolution helpers shared by semantic analysis and lint facts.
+#[doc(hidden)]
 pub use command_resolution::*;
 /// Identifier names used throughout the shell AST.
 pub use name::Name;

--- a/crates/shuck-benchmark/src/lib.rs
+++ b/crates/shuck-benchmark/src/lib.rs
@@ -10,18 +10,20 @@ use shuck_parser::parser::{ParseResult, Parser};
 #[cfg(feature = "parser-benchmarking")]
 use shuck_parser::parser::{ParseStatus, ParserBenchmarkCounters};
 
-#[allow(missing_docs)]
 /// Categorize fixtures by expected runtime so Criterion can spend
 /// more time where it is useful without making the slowest cases drag.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum TestCaseSpeed {
+    /// Small fixtures that can use Criterion's default-style sample count.
     Fast,
+    /// Medium fixtures that need fewer iterations.
     Normal,
+    /// Large fixtures that should use the minimum supported sample count.
     Slow,
 }
 
-#[allow(missing_docs)]
 impl TestCaseSpeed {
+    /// Return the Criterion sample size associated with this speed bucket.
     pub fn sample_size(self) -> usize {
         match self {
             Self::Fast => 100,
@@ -33,25 +35,29 @@ impl TestCaseSpeed {
 }
 
 /// Benchmark fixture source bundled with this crate.
-#[allow(missing_docs)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct TestFile {
+    /// Stable fixture name used in benchmark labels.
     pub name: &'static str,
+    /// Shell source text for the fixture.
     pub source: &'static str,
+    /// Runtime bucket for this fixture.
     pub speed: TestCaseSpeed,
 }
 
 /// Benchmark case made up of one or more bundled test files.
-#[allow(missing_docs)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct TestCase {
+    /// Stable benchmark case name.
     pub name: &'static str,
+    /// Fixture files included in this benchmark case.
     pub files: &'static [TestFile],
+    /// Runtime bucket for the aggregate case.
     pub speed: TestCaseSpeed,
 }
 
-#[allow(missing_docs)]
 impl TestCase {
+    /// Return the total source size across all files in this case.
     pub fn total_bytes(self) -> u64 {
         self.files.iter().map(|file| file.source.len() as u64).sum()
     }

--- a/crates/shuck-cache/src/lib.rs
+++ b/crates/shuck-cache/src/lib.rs
@@ -42,8 +42,8 @@ pub fn read_project_root_from_cache_file(path: &Path) -> io::Result<Option<PathB
 }
 
 /// Trait for values that can contribute to a deterministic package cache key.
-#[allow(missing_docs)]
 pub trait CacheKey {
+    /// Write this value into the structured cache-key hasher.
     fn cache_key(&self, state: &mut CacheKeyHasher);
 }
 
@@ -52,8 +52,8 @@ pub struct CacheKeyHasher {
     hasher: Sha256,
 }
 
-#[allow(missing_docs)]
 impl CacheKeyHasher {
+    /// Create an empty cache-key hasher.
     #[must_use]
     pub fn new() -> Self {
         Self {
@@ -61,43 +61,53 @@ impl CacheKeyHasher {
         }
     }
 
+    /// Write a caller-defined domain tag into the key.
     pub fn write_tag(&mut self, tag: &[u8]) {
         self.write_bytes(tag);
     }
 
+    /// Write a boolean value into the key.
     pub fn write_bool(&mut self, value: bool) {
         self.hasher.update([u8::from(value)]);
     }
 
+    /// Write an unsigned 8-bit integer into the key.
     pub fn write_u8(&mut self, value: u8) {
         self.hasher.update([value]);
     }
 
+    /// Write an unsigned 32-bit integer into the key.
     pub fn write_u32(&mut self, value: u32) {
         self.hasher.update(value.to_le_bytes());
     }
 
+    /// Write an unsigned 64-bit integer into the key.
     pub fn write_u64(&mut self, value: u64) {
         self.hasher.update(value.to_le_bytes());
     }
 
+    /// Write an unsigned 128-bit integer into the key.
     pub fn write_u128(&mut self, value: u128) {
         self.hasher.update(value.to_le_bytes());
     }
 
+    /// Write a `usize` value into the key using a platform-independent encoding.
     pub fn write_usize(&mut self, value: usize) {
         self.write_u64(value as u64);
     }
 
+    /// Write a UTF-8 string into the key.
     pub fn write_str(&mut self, value: &str) {
         self.write_bytes(value.as_bytes());
     }
 
+    /// Write a byte slice into the key with a length prefix.
     pub fn write_bytes(&mut self, bytes: &[u8]) {
         self.write_u64(bytes.len() as u64);
         self.hasher.update(bytes);
     }
 
+    /// Finish the hasher and return a lowercase hex digest.
     #[must_use]
     pub fn finish_hex(self) -> String {
         let digest = self.hasher.finalize();
@@ -232,20 +242,26 @@ where
 }
 
 /// File metadata used to validate cached entries against a filesystem path.
-#[allow(missing_docs)]
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct FileCacheKey {
+    /// File modification time as nanoseconds since the Unix epoch.
     pub file_last_modified_ns: u128,
+    /// File creation time as nanoseconds since the Unix epoch, when available.
     pub file_created_ns: Option<u128>,
+    /// File status-change time as nanoseconds since the Unix epoch, when available.
     pub file_status_changed_ns: Option<u128>,
+    /// Platform device identifier, when available.
     pub file_device_id: Option<u64>,
+    /// Platform file identifier such as an inode, when available.
     pub file_id: Option<u64>,
+    /// Platform permission bits or readonly flag used to invalidate stale entries.
     pub file_permissions_mode: u32,
+    /// File size in bytes.
     pub file_size_bytes: u64,
 }
 
-#[allow(missing_docs)]
 impl FileCacheKey {
+    /// Read file metadata from `path` and convert it into a cache validation key.
     pub fn from_path(path: &Path) -> io::Result<Self> {
         let metadata = path.metadata()?;
         let file_last_modified_ns = system_time_ns(metadata.modified()?)?;
@@ -338,11 +354,13 @@ pub struct PackageCache<T> {
     last_seen_ms: u64,
 }
 
-#[allow(missing_docs)]
 impl<T> PackageCache<T>
 where
     T: Clone + Serialize + DeserializeOwned,
 {
+    /// Open a package cache file for a canonical project root and tool version.
+    ///
+    /// Corrupt, missing, or root-mismatched cache files are treated as empty caches.
     pub fn open(
         cache_root: &Path,
         canonical_root: PathBuf,
@@ -380,11 +398,13 @@ where
         })
     }
 
+    /// Return the on-disk path backing this package cache.
     #[must_use]
     pub fn path(&self) -> &Path {
         &self.path
     }
 
+    /// Return a cached entry when `relative_path` still matches `key`.
     pub fn get(&mut self, relative_path: &Path, key: &FileCacheKey) -> Option<T> {
         let file = self.package.files.get(relative_path)?;
         if &file.key != key {
@@ -395,11 +415,15 @@ where
         Some(file.data.clone())
     }
 
+    /// Insert or replace a cached entry for a package-relative path.
     pub fn insert(&mut self, relative_path: PathBuf, key: FileCacheKey, data: T) {
         self.seen_paths.insert(relative_path.clone());
         self.changes.insert(relative_path, Change { key, data });
     }
 
+    /// Persist touched and changed entries to disk.
+    ///
+    /// Untouched entries older than the retention window are pruned before writing.
     pub fn persist(mut self) -> io::Result<()> {
         if !self.save() {
             return Ok(());

--- a/crates/shuck-cli/src/config_docs.rs
+++ b/crates/shuck-cli/src/config_docs.rs
@@ -1,5 +1,3 @@
-#![allow(missing_docs)]
-
 //! Documentation generation for Shuck configuration options.
 
 use std::fmt::Write;

--- a/crates/shuck-config/src/lib.rs
+++ b/crates/shuck-config/src/lib.rs
@@ -1,4 +1,10 @@
-#![allow(missing_docs)]
+#![warn(missing_docs)]
+
+//! Configuration loading and override handling for Shuck commands.
+//!
+//! This crate owns the TOML shapes used by `.shuck.toml`, command-line
+//! `--config` overrides, project-root discovery, and the small metadata model
+//! used to render configuration reference docs.
 
 use std::collections::BTreeMap;
 use std::ffi::OsStr;
@@ -15,6 +21,7 @@ use shuck_formatter::{IndentStyle, ShellDialect};
 use shuck_run::RunConfig;
 
 const CONFIG_FILENAMES: [&str; 2] = [".shuck.toml", "shuck.toml"];
+/// Error shown when users try to set formatter dialect in a config file.
 pub const CONFIG_DIALECT_UNSUPPORTED_ERROR: &str = "`[format].dialect` is not supported; formatter dialect is auto-discovered from the file name or shebang. Use `--dialect` for a per-run override";
 const CONFIG_OVERRIDE_ROOT_KEYS: &[&str] = &["check", "format", "lint", "run"];
 const CONFIG_OVERRIDE_CHECK_KEYS: &[&str] = &["embedded"];
@@ -61,165 +68,253 @@ const CONFIG_OVERRIDE_RUN_KEYS: &[&str] = &["shell", "shell-version", "shells"];
 const CONFIG_OVERRIDE_RUN_SHELL_NAMES: &[&str] =
     &["bash", "gbash", "bashkit", "zsh", "dash", "mksh", "busybox"];
 
+/// Top-level Shuck configuration loaded from project config files.
 #[derive(Debug, Clone, Default, PartialEq, Deserialize)]
 #[serde(default)]
 pub struct ShuckConfig {
+    /// File discovery and embedded-script checking options.
     pub check: CheckConfig,
+    /// Shell formatting options.
     pub format: FormatConfig,
+    /// Linter rule selection, contracts, and analysis options.
     pub lint: LintConfig,
+    /// Runtime shell resolution options for `shuck run`.
     pub run: RunConfig,
 }
 
+/// Configuration for file-level checking behavior.
 #[derive(Debug, Clone, Default, PartialEq, Deserialize)]
 #[serde(default, rename_all = "kebab-case")]
 pub struct CheckConfig {
+    /// Whether to lint embedded shell snippets in supported host files.
     pub embedded: Option<bool>,
 }
 
+/// Configuration for shell formatting behavior.
 #[derive(Debug, Clone, Default, PartialEq, Deserialize)]
 #[serde(default, rename_all = "kebab-case")]
 pub struct FormatConfig {
+    /// Deprecated formatter dialect value retained only to reject config-file use clearly.
     pub dialect: Option<toml::Value>,
+    /// Requested indentation style, such as `tab` or `space`.
     pub indent_style: Option<String>,
+    /// Requested indentation width.
     pub indent_width: Option<u8>,
+    /// Whether binary operators should begin continuation lines.
     pub binary_next_line: Option<bool>,
+    /// Whether `case` arms should receive an extra indentation level.
     pub switch_case_indent: Option<bool>,
+    /// Whether redirection operators should be surrounded by spaces.
     pub space_redirects: Option<bool>,
+    /// Whether existing horizontal padding should be preserved.
     pub keep_padding: Option<bool>,
+    /// Whether function bodies should start on the next line.
     pub function_next_line: Option<bool>,
+    /// Whether the formatter should avoid splitting lines.
     pub never_split: Option<bool>,
 }
 
+/// Configuration for lint rule selection and analysis behavior.
 #[derive(Debug, Clone, Default, PartialEq, Deserialize)]
 #[serde(default, rename_all = "kebab-case")]
 pub struct LintConfig {
+    /// Rule selectors that replace the default enabled rule set.
     pub select: Option<Vec<String>>,
+    /// Rule selectors removed from the enabled rule set.
     pub ignore: Option<Vec<String>>,
+    /// Rule selectors added to the enabled rule set.
     pub extend_select: Option<Vec<String>>,
+    /// Per-file ignore selectors keyed by glob pattern.
     pub per_file_ignores: Option<BTreeMap<String, Vec<String>>>,
+    /// Per-file ignore selectors merged into existing per-file ignores.
     pub extend_per_file_ignores: Option<BTreeMap<String, Vec<String>>>,
+    /// Per-file shell dialect overrides keyed by glob pattern.
     pub per_file_shell: Option<BTreeMap<String, String>>,
+    /// Per-file shell dialect overrides merged into existing overrides.
     pub extend_per_file_shell: Option<BTreeMap<String, String>>,
+    /// Rule selectors that replace the set eligible for automatic fixes.
     pub fixable: Option<Vec<String>>,
+    /// Rule selectors excluded from automatic fixes.
     pub unfixable: Option<Vec<String>>,
+    /// Rule selectors added to the fixable set.
     pub extend_fixable: Option<Vec<String>>,
+    /// Rule-specific option values.
     pub rule_options: Option<LintRuleOptionsConfig>,
+    /// Ambient contract configuration for framework and plugin assumptions.
     pub contracts: Option<LintContractsConfig>,
+    /// Zsh-specific analysis configuration.
     pub zsh: Option<LintZshConfig>,
 }
 
+/// Configuration for ambient contracts used during lint analysis.
 #[derive(Debug, Clone, Default, PartialEq, Eq, Deserialize)]
 #[serde(default, rename_all = "kebab-case", deny_unknown_fields)]
 pub struct LintContractsConfig {
+    /// Whether built-in well-known contracts are enabled.
     pub well_known: Option<bool>,
+    /// Contract identifiers that should be disabled.
     pub disabled: Option<Vec<String>>,
+    /// User-defined contract entries.
     pub custom: Option<Vec<LintCustomContractConfig>>,
 }
 
+/// User-defined ambient contract configuration.
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
 #[serde(rename_all = "kebab-case", deny_unknown_fields)]
 pub struct LintCustomContractConfig {
+    /// Stable contract identifier.
     pub id: String,
+    /// Contract identifiers replaced by this contract.
     pub replaces: Option<Vec<String>>,
+    /// Activation condition for this contract.
     pub when: LintContractWhenConfig,
+    /// Glob patterns where this contract applies.
     pub files: Option<Vec<String>>,
+    /// Variables read by the contract before script execution.
     pub reads: Option<Vec<String>>,
+    /// Variable names consumed by the contract.
     pub consumes: Option<LintContractConsumesConfig>,
+    /// Variables or functions provided by the contract.
     pub provides: Option<LintContractProvidesConfig>,
+    /// Function-specific contract entries.
     pub functions: Option<Vec<LintContractFunctionConfig>>,
 }
 
+/// Activation condition for a user-defined contract.
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
 #[serde(untagged)]
 pub enum LintContractWhenConfig {
+    /// Always activate using a literal label.
     Always(String),
+    /// Activate when a configured framework, plugin, or theme is detected.
     Activation(LintContractActivationConfig),
 }
 
+/// Framework, plugin, or theme activation details for a contract.
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
 #[serde(rename_all = "kebab-case", deny_unknown_fields)]
 pub struct LintContractActivationConfig {
     #[serde(rename = "type")]
+    /// Activation class.
     pub activation_type: LintContractActivationTypeConfig,
+    /// Optional framework name.
     pub framework: Option<String>,
+    /// Optional plugin name.
     pub plugin: Option<String>,
+    /// Optional theme name.
     pub theme: Option<String>,
 }
 
+/// Supported contract activation classes.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
 pub enum LintContractActivationTypeConfig {
+    /// Activate for a zsh plugin.
     #[serde(rename = "zsh_plugin")]
     ZshPlugin,
+    /// Activate for a zsh theme.
     #[serde(rename = "zsh_theme")]
     ZshTheme,
 }
 
+/// Variables consumed by an ambient contract.
 #[derive(Debug, Clone, Default, PartialEq, Eq, Deserialize)]
 #[serde(default, rename_all = "kebab-case", deny_unknown_fields)]
 pub struct LintContractConsumesConfig {
+    /// Exact variable names consumed by the contract.
     pub names: Option<Vec<String>>,
+    /// Variable-name prefixes consumed by the contract.
     pub prefixes: Option<Vec<String>>,
+    /// Whether the contract may consume any variable.
     pub all: Option<bool>,
 }
 
+/// Values provided by an ambient contract.
 #[derive(Debug, Clone, Default, PartialEq, Eq, Deserialize)]
 #[serde(default, rename_all = "kebab-case", deny_unknown_fields)]
 pub struct LintContractProvidesConfig {
+    /// Variable names provided by the contract.
     pub variables: Option<Vec<String>>,
+    /// Function names provided by the contract.
     pub functions: Option<Vec<String>>,
 }
 
+/// Function-specific ambient contract entry.
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
 #[serde(rename_all = "kebab-case", deny_unknown_fields)]
 pub struct LintContractFunctionConfig {
+    /// Function name.
     pub name: String,
+    /// Variables read by the function.
     pub reads: Option<Vec<String>>,
+    /// Variables set by the function.
     pub sets: Option<Vec<String>>,
 }
 
+/// Zsh-specific lint configuration.
 #[derive(Debug, Clone, Default, PartialEq, Eq, Deserialize)]
 #[serde(default, rename_all = "kebab-case", deny_unknown_fields)]
 pub struct LintZshConfig {
+    /// Zsh plugin resolution settings.
     pub plugins: Option<ZshPluginsConfig>,
 }
 
+/// Configuration for zsh plugin and theme resolution.
 #[derive(Debug, Clone, Default, PartialEq, Eq, Deserialize)]
 #[serde(default, rename_all = "kebab-case", deny_unknown_fields)]
 pub struct ZshPluginsConfig {
+    /// Whether plugin resolution is enabled.
     pub resolution: Option<bool>,
+    /// Named plugin root directories.
     pub roots: Option<BTreeMap<String, String>>,
+    /// Patterns that identify plugin loads.
     pub plugin_loads: Option<Vec<ZshPluginLoadConfig>>,
+    /// Patterns that identify theme loads.
     pub theme_loads: Option<Vec<ZshThemeLoadConfig>>,
+    /// Patterns that provide plugin entrypoint paths.
     pub entrypoints: Option<Vec<ZshPluginEntrypointConfig>>,
 }
 
+/// A configured zsh plugin load pattern.
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
 #[serde(rename_all = "kebab-case", deny_unknown_fields)]
 pub struct ZshPluginLoadConfig {
+    /// Pattern matched against shell source.
     pub pattern: String,
+    /// Framework name that owns the plugin.
     pub framework: String,
+    /// Plugin name.
     pub name: String,
 }
 
+/// A configured zsh theme load pattern.
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
 #[serde(rename_all = "kebab-case", deny_unknown_fields)]
 pub struct ZshThemeLoadConfig {
+    /// Pattern matched against shell source.
     pub pattern: String,
+    /// Framework name that owns the theme.
     pub framework: String,
+    /// Theme name.
     pub name: String,
 }
 
+/// A configured zsh plugin entrypoint pattern.
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
 #[serde(rename_all = "kebab-case", deny_unknown_fields)]
 pub struct ZshPluginEntrypointConfig {
+    /// Pattern matched against shell source.
     pub pattern: String,
+    /// Entrypoint paths associated with the pattern.
     pub paths: Vec<String>,
 }
 
+/// Rule-specific lint options.
 #[derive(Debug, Clone, Default, PartialEq, Eq, Deserialize)]
 #[serde(default, rename_all = "kebab-case", deny_unknown_fields)]
 pub struct LintRuleOptionsConfig {
+    /// Options for rule C001.
     pub c001: Option<C001RuleOptionsConfig>,
+    /// Options for rule C063.
     pub c063: Option<C063RuleOptionsConfig>,
 }
 
@@ -234,9 +329,11 @@ impl LintRuleOptionsConfig {
     }
 }
 
+/// Options for rule C001.
 #[derive(Debug, Clone, Default, PartialEq, Eq, Deserialize)]
 #[serde(default, rename_all = "kebab-case", deny_unknown_fields)]
 pub struct C001RuleOptionsConfig {
+    /// Whether indirect expansion target names should count as variable usage.
     pub treat_indirect_expansion_targets_as_used: Option<bool>,
 }
 
@@ -249,9 +346,11 @@ impl C001RuleOptionsConfig {
     }
 }
 
+/// Options for rule C063.
 #[derive(Debug, Clone, Default, PartialEq, Eq, Deserialize)]
 #[serde(default, rename_all = "kebab-case", deny_unknown_fields)]
 pub struct C063RuleOptionsConfig {
+    /// Whether nested function definitions in unreachable branches should be reported.
     pub report_unreached_nested_definitions: Option<bool>,
 }
 
@@ -264,38 +363,62 @@ impl C063RuleOptionsConfig {
     }
 }
 
+/// Partial formatter settings supplied by CLI flags or config files.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub struct FormatSettingsPatch {
+    /// Optional dialect override.
     pub dialect: Option<ShellDialect>,
+    /// Optional indentation style override.
     pub indent_style: Option<IndentStyle>,
+    /// Optional indentation width override.
     pub indent_width: Option<u8>,
+    /// Optional binary-next-line override.
     pub binary_next_line: Option<bool>,
+    /// Optional switch-case indentation override.
     pub switch_case_indent: Option<bool>,
+    /// Optional spaced-redirection override.
     pub space_redirects: Option<bool>,
+    /// Optional padding-preservation override.
     pub keep_padding: Option<bool>,
+    /// Optional function-next-line override.
     pub function_next_line: Option<bool>,
+    /// Optional never-split override.
     pub never_split: Option<bool>,
+    /// Optional simplification override.
     pub simplify: Option<bool>,
+    /// Optional minification override.
     pub minify: Option<bool>,
 }
 
+/// Documentation metadata for a configuration section.
 #[derive(Debug, Clone, Copy)]
 pub struct ConfigSectionMetadata {
+    /// TOML key for the section.
     pub key: &'static str,
+    /// Human-readable section description.
     pub docs: &'static str,
+    /// Documented scalar fields in this section.
     pub fields: &'static [ConfigFieldMetadata],
+    /// Nested subsections.
     pub sections: &'static [ConfigSectionMetadata],
 }
 
+/// Documentation metadata for a configuration field.
 #[derive(Debug, Clone, Copy)]
 pub struct ConfigFieldMetadata {
+    /// TOML key for the field.
     pub key: &'static str,
+    /// Human-readable field description.
     pub docs: &'static str,
+    /// Display form of the default value.
     pub default: &'static str,
+    /// Display form of the accepted value type.
     pub value_type: &'static str,
+    /// Example TOML assignment.
     pub example: &'static str,
 }
 
+/// Return metadata used to render the configuration reference.
 pub fn configuration_metadata() -> &'static [ConfigSectionMetadata] {
     &CONFIGURATION_METADATA
 }
@@ -652,6 +775,7 @@ const CONFIGURATION_METADATA: [ConfigSectionMetadata; 3] = [
     },
 ];
 
+/// Resolved command-line configuration arguments.
 #[derive(Debug, Clone, Default, PartialEq)]
 pub struct ConfigArguments {
     isolated: bool,
@@ -660,6 +784,7 @@ pub struct ConfigArguments {
 }
 
 impl ConfigArguments {
+    /// Parse `--config` occurrences and `--isolated` into config-loading arguments.
     pub fn from_cli(
         config_options: Vec<SingleConfigArgument>,
         isolated: bool,
@@ -717,21 +842,27 @@ You cannot specify more than one configuration file on the command line.
         })
     }
 
+    /// Return whether project-root discovery should use config files as roots.
     pub fn use_config_roots(&self) -> bool {
         !self.isolated && self.config_file.is_none()
     }
 
+    /// Return the explicitly requested config file, if one was provided.
     pub fn explicit_config_file(&self) -> Option<&Path> {
         self.config_file.as_deref()
     }
 }
 
+/// A single `--config` command-line value.
 #[derive(Clone, Debug, PartialEq)]
 pub enum SingleConfigArgument {
+    /// Path to a config file.
     FilePath(PathBuf),
+    /// Inline TOML override value.
     SettingsOverride(Box<ShuckConfig>),
 }
 
+/// Clap value parser for [`SingleConfigArgument`].
 #[derive(Clone)]
 pub struct ConfigArgumentParser;
 
@@ -768,6 +899,10 @@ impl TypedValueParser for ConfigArgumentParser {
     }
 }
 
+/// Resolve the project root for an input path.
+///
+/// When `use_config_roots` is true, parent directories are searched for
+/// `.shuck.toml` or `shuck.toml` and the closest match becomes the root.
 pub fn resolve_project_root_for_input(input: &Path, use_config_roots: bool) -> io::Result<PathBuf> {
     let base_dir = base_dir_for_input(input)?;
     if use_config_roots {
@@ -777,6 +912,10 @@ pub fn resolve_project_root_for_input(input: &Path, use_config_roots: bool) -> i
     }
 }
 
+/// Resolve the project root for a file path with a fallback starting directory.
+///
+/// This is used for inputs such as standard input where the logical file path
+/// may differ from the current working directory.
 pub fn resolve_project_root_for_file(
     file: &Path,
     fallback_start: &Path,
@@ -793,6 +932,7 @@ pub fn resolve_project_root_for_file(
     }
 }
 
+/// Load project configuration and apply command-line overrides.
 pub fn load_project_config(
     project_root: &Path,
     config_arguments: &ConfigArguments,
@@ -812,11 +952,13 @@ pub fn load_project_config(
     Ok(config)
 }
 
+/// Apply override values to an already loaded config.
 pub fn apply_config_overrides(config: &mut ShuckConfig, overrides: ShuckConfig) {
     config.apply_overrides(overrides);
 }
 
 impl FormatConfig {
+    /// Convert formatter config-file values into a formatter settings patch.
     pub fn to_patch(&self) -> Result<FormatSettingsPatch> {
         if self.dialect.is_some() {
             return Err(anyhow!(CONFIG_DIALECT_UNSUPPORTED_ERROR));
@@ -1261,6 +1403,7 @@ A `--config` flag must either be a path to a `.toml` configuration file
     error
 }
 
+/// Parse a config-file indentation style value.
 pub fn parse_config_indent_style(value: &str) -> Result<IndentStyle> {
     match value.trim().to_ascii_lowercase().as_str() {
         "tab" => Ok(IndentStyle::Tab),
@@ -1325,6 +1468,7 @@ fn config_path_for_root(root: &Path) -> io::Result<Option<PathBuf>> {
     Ok(None)
 }
 
+/// Return the config file path located directly under `root`, if any.
 pub fn discovered_config_path_for_root(root: &Path) -> io::Result<Option<PathBuf>> {
     config_path_for_root(root)
 }

--- a/crates/shuck-formatter/src/lib.rs
+++ b/crates/shuck-formatter/src/lib.rs
@@ -5,7 +5,6 @@
 //! The previous formatter implementation has been removed so the formatter can
 //! be rebuilt from stubs.
 
-#[allow(missing_docs)]
 mod options;
 
 use std::path::Path;

--- a/crates/shuck-formatter/src/options.rs
+++ b/crates/shuck-formatter/src/options.rs
@@ -1,30 +1,43 @@
 use std::path::Path;
 
+/// Indentation style used by the shell formatter.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum IndentStyle {
+    /// Use tab characters for indentation.
     #[default]
     Tab,
+    /// Use spaces for indentation.
     Space,
 }
 
+/// Line ending style detected or emitted by formatter operations.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum LineEnding {
+    /// Unix line endings.
     #[default]
     Lf,
+    /// Windows line endings.
     CrLf,
 }
 
+/// Shell dialect requested for formatting.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum ShellDialect {
+    /// Infer the dialect from the shebang or path.
     #[default]
     Auto,
+    /// Bash syntax.
     Bash,
+    /// POSIX `sh` syntax.
     Posix,
+    /// MirBSD Korn shell syntax.
     Mksh,
+    /// Z shell syntax.
     Zsh,
 }
 
 impl ShellDialect {
+    /// Resolve [`Self::Auto`] using source text and an optional path.
     #[must_use]
     pub fn resolve(self, source: &str, path: Option<&Path>) -> Self {
         match self {
@@ -34,6 +47,7 @@ impl ShellDialect {
     }
 }
 
+/// User-configurable shell formatter options.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ShellFormatOptions {
     dialect: ShellDialect,
@@ -68,127 +82,152 @@ impl Default for ShellFormatOptions {
 }
 
 impl ShellFormatOptions {
+    /// Return the requested shell dialect.
     #[must_use]
     pub fn dialect(&self) -> ShellDialect {
         self.dialect
     }
 
+    /// Return the requested indentation style.
     #[must_use]
     pub fn indent_style(&self) -> IndentStyle {
         self.indent_style
     }
 
+    /// Return the requested indentation width.
     #[must_use]
     pub fn indent_width(&self) -> u8 {
         self.indent_width
     }
 
+    /// Return whether binary operators should begin continuation lines.
     #[must_use]
     pub fn binary_next_line(&self) -> bool {
         self.binary_next_line
     }
 
+    /// Return whether `case` arms should receive an extra indentation level.
     #[must_use]
     pub fn switch_case_indent(&self) -> bool {
         self.switch_case_indent
     }
 
+    /// Return whether redirection operators should be surrounded by spaces.
     #[must_use]
     pub fn space_redirects(&self) -> bool {
         self.space_redirects
     }
 
+    /// Return whether existing horizontal padding should be preserved.
     #[must_use]
     pub fn keep_padding(&self) -> bool {
         self.keep_padding
     }
 
+    /// Return whether function bodies should start on the next line.
     #[must_use]
     pub fn function_next_line(&self) -> bool {
         self.function_next_line
     }
 
+    /// Return whether the formatter should avoid splitting lines.
     #[must_use]
     pub fn never_split(&self) -> bool {
         self.never_split
     }
 
+    /// Return whether simplification passes are enabled.
     #[must_use]
     pub fn simplify(&self) -> bool {
         self.simplify
     }
 
+    /// Return whether compact minified output is requested.
     #[must_use]
     pub fn minify(&self) -> bool {
         self.minify
     }
 
+    /// Return a copy with a different shell dialect setting.
     #[must_use]
     pub fn with_dialect(mut self, dialect: ShellDialect) -> Self {
         self.dialect = dialect;
         self
     }
 
+    /// Return a copy with a different indentation style.
     #[must_use]
     pub fn with_indent_style(mut self, indent_style: IndentStyle) -> Self {
         self.indent_style = indent_style;
         self
     }
 
+    /// Return a copy with a different indentation width.
+    ///
+    /// Values less than one are clamped to one.
     #[must_use]
     pub fn with_indent_width(mut self, indent_width: u8) -> Self {
         self.indent_width = indent_width.max(1);
         self
     }
 
+    /// Return a copy with binary-next-line formatting enabled or disabled.
     #[must_use]
     pub fn with_binary_next_line(mut self, enabled: bool) -> Self {
         self.binary_next_line = enabled;
         self
     }
 
+    /// Return a copy with switch-case indentation enabled or disabled.
     #[must_use]
     pub fn with_switch_case_indent(mut self, enabled: bool) -> Self {
         self.switch_case_indent = enabled;
         self
     }
 
+    /// Return a copy with spaced redirections enabled or disabled.
     #[must_use]
     pub fn with_space_redirects(mut self, enabled: bool) -> Self {
         self.space_redirects = enabled;
         self
     }
 
+    /// Return a copy with padding preservation enabled or disabled.
     #[must_use]
     pub fn with_keep_padding(mut self, enabled: bool) -> Self {
         self.keep_padding = enabled;
         self
     }
 
+    /// Return a copy with function-next-line formatting enabled or disabled.
     #[must_use]
     pub fn with_function_next_line(mut self, enabled: bool) -> Self {
         self.function_next_line = enabled;
         self
     }
 
+    /// Return a copy with line splitting enabled or disabled.
     #[must_use]
     pub fn with_never_split(mut self, enabled: bool) -> Self {
         self.never_split = enabled;
         self
     }
 
+    /// Return a copy with simplification enabled or disabled.
     #[must_use]
     pub fn with_simplify(mut self, enabled: bool) -> Self {
         self.simplify = enabled;
         self
     }
 
+    /// Return a copy with minified output enabled or disabled.
     #[must_use]
     pub fn with_minify(mut self, enabled: bool) -> Self {
         self.minify = enabled;
         self
     }
 
+    /// Resolve inferred options against concrete source text and path metadata.
     #[must_use]
     pub fn resolve(&self, source: &str, path: Option<&Path>) -> ResolvedShellFormatOptions {
         ResolvedShellFormatOptions {
@@ -208,6 +247,7 @@ impl ShellFormatOptions {
     }
 }
 
+/// Formatter options after source-dependent defaults have been resolved.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ResolvedShellFormatOptions {
     dialect: ShellDialect,
@@ -225,66 +265,79 @@ pub struct ResolvedShellFormatOptions {
 }
 
 impl ResolvedShellFormatOptions {
+    /// Return the resolved shell dialect.
     #[must_use]
     pub fn dialect(&self) -> ShellDialect {
         self.dialect
     }
 
+    /// Return the resolved indentation style.
     #[must_use]
     pub fn indent_style(&self) -> IndentStyle {
         self.indent_style
     }
 
+    /// Return the resolved indentation width.
     #[must_use]
     pub fn indent_width(&self) -> u8 {
         self.indent_width
     }
 
+    /// Return whether binary operators should begin continuation lines.
     #[must_use]
     pub fn binary_next_line(&self) -> bool {
         self.binary_next_line
     }
 
+    /// Return whether `case` arms should receive an extra indentation level.
     #[must_use]
     pub fn switch_case_indent(&self) -> bool {
         self.switch_case_indent
     }
 
+    /// Return whether redirection operators should be surrounded by spaces.
     #[must_use]
     pub fn space_redirects(&self) -> bool {
         self.space_redirects
     }
 
+    /// Return whether existing horizontal padding should be preserved.
     #[must_use]
     pub fn keep_padding(&self) -> bool {
         self.keep_padding
     }
 
+    /// Return whether function bodies should start on the next line.
     #[must_use]
     pub fn function_next_line(&self) -> bool {
         self.function_next_line
     }
 
+    /// Return whether the formatter should avoid splitting lines.
     #[must_use]
     pub fn never_split(&self) -> bool {
         self.never_split
     }
 
+    /// Return whether simplification passes are enabled.
     #[must_use]
     pub fn simplify(&self) -> bool {
         self.simplify
     }
 
+    /// Return whether compact minified output is requested.
     #[must_use]
     pub fn minify(&self) -> bool {
         self.minify
     }
 
+    /// Return whether the resolved configuration prefers compact layout.
     #[must_use]
     pub fn compact_layout(&self) -> bool {
         self.minify || self.never_split
     }
 
+    /// Return the detected line ending style.
     #[must_use]
     pub fn line_ending(&self) -> LineEnding {
         self.line_ending

--- a/crates/shuck-indexer/src/lib.rs
+++ b/crates/shuck-indexer/src/lib.rs
@@ -19,9 +19,7 @@
 //! only need line mapping or that already have an AST-shaped source of comments
 //! or regions.
 mod comment_index;
-#[allow(missing_docs)]
 mod line_index;
-#[allow(missing_docs)]
 mod region_index;
 
 /// Comment lookup types derived from parser output.

--- a/crates/shuck-parser/src/lib.rs
+++ b/crates/shuck-parser/src/lib.rs
@@ -5,9 +5,7 @@
 //! `shuck-parser` turns shell source text into `shuck-ast` syntax trees and also exposes a
 //! source-backed lexer for lower-level tooling.
 
-#[allow(missing_docs)]
 mod error;
-#[allow(missing_docs)]
 /// Parsing entrypoints, lexer types, and shell-profile configuration.
 pub mod parser;
 /// Shebang parsing helpers shared by Shuck crates.

--- a/crates/shuck-run/src/lib.rs
+++ b/crates/shuck-run/src/lib.rs
@@ -1,3 +1,7 @@
+#![warn(missing_docs)]
+
+//! Shell runtime discovery, version resolution, and managed installation.
+
 mod download;
 mod environment;
 mod managed;
@@ -24,6 +28,7 @@ pub use types::{
     Version, VersionConstraint, VersionPredicate,
 };
 
+/// Resolve a shell interpreter using direct arguments plus optional config.
 pub fn resolve(
     shell: Option<Shell>,
     version: Option<VersionConstraint>,
@@ -34,15 +39,18 @@ pub fn resolve(
     resolve_with_options(ResolveOptions::new(shell, version, system, script, config))
 }
 
+/// Resolve a shell interpreter using a fully constructed options value.
 pub fn resolve_with_options(options: ResolveOptions<'_>) -> Result<ResolvedInterpreter> {
     let environment = Environment::from_process()?;
     resolve_with_environment(&environment, options)
 }
 
+/// Install a managed shell version if needed, then return its interpreter path.
 pub fn install(shell: Shell, version: &VersionConstraint) -> Result<ResolvedInterpreter> {
     install_with_options(shell, version, false, false)
 }
 
+/// Install a managed shell version with control over logging and registry refresh.
 pub fn install_with_options(
     shell: Shell,
     version: &VersionConstraint,
@@ -53,10 +61,12 @@ pub fn install_with_options(
     install_with_environment(&environment, shell, version, verbose, refresh_registry)
 }
 
+/// List managed shell versions known to the local or remote registry.
 pub fn list_available(shell: Option<Shell>) -> Result<Vec<AvailableShell>> {
     list_available_with_options(shell, false, false)
 }
 
+/// List managed shell versions with control over logging and registry refresh.
 pub fn list_available_with_options(
     shell: Option<Shell>,
     refresh_registry: bool,

--- a/crates/shuck-run/src/types.rs
+++ b/crates/shuck-run/src/types.rs
@@ -6,18 +6,27 @@ use std::path::{Path, PathBuf};
 use anyhow::{Result, anyhow, bail};
 use serde::Deserialize;
 
+/// Supported shell families for `shuck run`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum Shell {
+    /// GNU Bash.
     Bash,
+    /// Homebrew-style GNU Bash alias.
     Gbash,
+    /// Bashkit-managed Bash.
     Bashkit,
+    /// Z shell.
     Zsh,
+    /// Debian Almquist shell or POSIX `sh`.
     Dash,
+    /// MirBSD Korn shell.
     Mksh,
+    /// BusyBox shell applet.
     Busybox,
 }
 
 impl Shell {
+    /// Return the canonical config and CLI spelling for this shell.
     pub fn as_str(self) -> &'static str {
         match self {
             Self::Bash => "bash",
@@ -30,6 +39,7 @@ impl Shell {
         }
     }
 
+    /// Parse a shell name or common alias.
     pub fn from_name(name: &str) -> Option<Self> {
         match name.trim().to_ascii_lowercase().as_str() {
             "bash" => Some(Self::Bash),
@@ -72,6 +82,7 @@ impl fmt::Display for Shell {
     }
 }
 
+/// Parsed shell version with ordering semantics for registry selection.
 #[derive(Debug, Clone)]
 pub struct Version {
     raw: String,
@@ -81,6 +92,7 @@ pub struct Version {
 }
 
 impl Version {
+    /// Parse a version string accepted by Shuck's shell registry.
     pub fn parse(raw: &str) -> Result<Self> {
         let raw = raw.trim();
         if raw.is_empty() {
@@ -112,6 +124,7 @@ impl Version {
         })
     }
 
+    /// Return the original version string.
     pub fn as_str(&self) -> &str {
         &self.raw
     }
@@ -246,15 +259,21 @@ fn should_treat_as_prefix(raw: &str, tokens: &[VersionToken], segment_count: usi
             .all(|token| matches!(token, VersionToken::Numeric(_)))
 }
 
+/// Version requirement used when resolving or installing a shell.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum VersionConstraint {
+    /// Select the newest available version.
     Latest,
+    /// Select exactly this version.
     Exact(Version),
+    /// Select versions matching this dotted numeric prefix.
     ExactPrefix(Version),
+    /// Select versions satisfying every predicate.
     Range(Vec<VersionPredicate>),
 }
 
 impl VersionConstraint {
+    /// Parse `latest`, an exact version, or a comma-separated predicate range.
     pub fn parse(raw: &str) -> Result<Self> {
         let raw = raw.trim();
         if raw.eq_ignore_ascii_case("latest") {
@@ -281,6 +300,7 @@ impl VersionConstraint {
         }
     }
 
+    /// Return whether `version` satisfies this constraint.
     pub fn matches(&self, version: &Version) -> bool {
         match self {
             Self::Latest => true,
@@ -305,47 +325,72 @@ impl VersionConstraint {
     }
 }
 
+/// Managed versions available for one shell family.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct AvailableShell {
+    /// Shell family.
     pub shell: Shell,
+    /// Available versions for that shell.
     pub versions: Vec<Version>,
 }
 
+/// Runtime shell settings loaded from Shuck config.
 #[derive(Debug, Clone, Default, PartialEq, Eq, Deserialize)]
 #[serde(default, rename_all = "kebab-case")]
 pub struct RunConfig {
+    /// Default shell name.
     pub shell: Option<String>,
+    /// Default shell version constraint.
     pub shell_version: Option<String>,
+    /// Per-shell version constraints keyed by shell name.
     pub shells: BTreeMap<String, String>,
 }
 
+/// Concrete interpreter selected for a run.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ResolvedInterpreter {
+    /// Shell family that was resolved.
     pub shell: Shell,
+    /// Shell version selected for execution.
     pub version: Version,
+    /// Filesystem path to the executable interpreter.
     pub path: PathBuf,
+    /// Where the interpreter was found.
     pub source: ResolutionSource,
 }
 
+/// Source used to resolve an interpreter.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ResolutionSource {
+    /// Interpreter came from Shuck's managed shell cache.
     Managed,
+    /// Interpreter came from the host system.
     System,
 }
 
+/// Options controlling interpreter resolution.
 #[derive(Debug, Clone)]
 pub struct ResolveOptions<'a> {
+    /// Requested shell family.
     pub shell: Option<Shell>,
+    /// Requested shell version constraint.
     pub version: Option<VersionConstraint>,
+    /// Whether to require a system interpreter.
     pub system: bool,
+    /// Whether managed resolution may fall back to the system interpreter.
     pub implicit_system_fallback: bool,
+    /// Optional script path used for shell inference.
     pub script: Option<&'a Path>,
+    /// Optional config values used as defaults.
     pub config: Option<&'a RunConfig>,
+    /// Whether resolution should print progress details.
     pub verbose: bool,
+    /// Whether to refresh the registry before resolving.
     pub refresh_registry: bool,
 }
 
 impl<'a> ResolveOptions<'a> {
+    /// Create resolution options from the common CLI inputs.
     pub fn new(
         shell: Option<Shell>,
         version: Option<VersionConstraint>,
@@ -374,6 +419,7 @@ pub(crate) fn parse_shell_name(raw: &str) -> Result<Shell> {
     })
 }
 
+/// A single comparison predicate inside a version range.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct VersionPredicate {
     operator: VersionOperator,

--- a/crates/shuck-server/src/edit.rs
+++ b/crates/shuck-server/src/edit.rs
@@ -11,16 +11,22 @@ pub(crate) use text_document::DocumentVersion;
 pub(crate) use text_document::LanguageId;
 pub use text_document::TextDocument;
 
+/// Client/server position encoding negotiated for LSP text ranges.
 #[derive(Default, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub enum PositionEncoding {
+    /// UTF-16 code-unit positions, the LSP default.
     #[default]
     UTF16,
+    /// UTF-32 code-point positions.
     UTF32,
+    /// UTF-8 byte positions.
     UTF8,
 }
 
+/// Key identifying an open document in the server index.
 #[derive(Clone, Debug)]
 pub enum DocumentKey {
+    /// Text document identified by its URI.
     Text(Url),
 }
 

--- a/crates/shuck-server/src/edit/text_document.rs
+++ b/crates/shuck-server/src/edit/text_document.rs
@@ -7,6 +7,7 @@ use super::RangeExt;
 
 pub(crate) type DocumentVersion = i32;
 
+/// In-memory representation of an open LSP text document.
 #[derive(Debug, Clone)]
 pub struct TextDocument {
     contents: String,
@@ -39,6 +40,7 @@ impl From<&str> for LanguageId {
 }
 
 impl TextDocument {
+    /// Create a document with initial contents and version.
     pub fn new(contents: String, version: DocumentVersion) -> Self {
         let index = LineIndex::new(&contents);
         Self {
@@ -49,28 +51,34 @@ impl TextDocument {
         }
     }
 
+    /// Return a copy with the LSP language identifier attached.
     #[must_use]
     pub fn with_language_id(mut self, language_id: &str) -> Self {
         self.language_id = Some(LanguageId::from(language_id));
         self
     }
 
+    /// Return the current document contents.
     pub fn contents(&self) -> &str {
         &self.contents
     }
 
+    /// Return the current line index for the document.
     pub fn index(&self) -> &LineIndex {
         &self.index
     }
 
+    /// Return the current LSP document version.
     pub fn version(&self) -> DocumentVersion {
         self.version
     }
 
+    /// Return the parsed language identifier, if one was supplied by the client.
     pub fn language_id(&self) -> Option<LanguageId> {
         self.language_id
     }
 
+    /// Apply LSP content changes and update the document version.
     pub fn apply_changes(
         &mut self,
         changes: Vec<TextDocumentContentChangeEvent>,
@@ -110,6 +118,7 @@ impl TextDocument {
         self.version = new_version;
     }
 
+    /// Update the document version without changing contents.
     pub fn update_version(&mut self, new_version: DocumentVersion) {
         debug_assert!(new_version >= self.version);
         self.version = new_version;

--- a/crates/shuck-server/src/lib.rs
+++ b/crates/shuck-server/src/lib.rs
@@ -1,5 +1,11 @@
-#![allow(missing_docs)]
+#![warn(missing_docs)]
 #![cfg_attr(not(test), warn(clippy::unwrap_used))]
+
+//! Language Server Protocol support for Shuck.
+//!
+//! The primary entrypoint is [`run`], which starts the server over standard
+//! input and output. A small set of document/session types is also exposed for
+//! integration tests and embedding scenarios that need an in-memory LSP server.
 
 use std::num::NonZeroUsize;
 
@@ -31,6 +37,7 @@ pub(crate) fn version() -> &'static str {
     env!("CARGO_PKG_VERSION")
 }
 
+/// Run the Shuck language server over standard input and output.
 pub fn run() -> Result<()> {
     let four = NonZeroUsize::try_from(4usize)
         .map_err(|_| anyhow::anyhow!("failed to create non-zero worker count"))?;

--- a/crates/shuck-server/src/lint.rs
+++ b/crates/shuck-server/src/lint.rs
@@ -50,6 +50,7 @@ pub(crate) struct ParseErrorDiagnostic {
     pub(crate) message: String,
 }
 
+/// Generate LSP diagnostics for a document snapshot.
 pub fn generate_diagnostics(snapshot: &DocumentSnapshot) -> Vec<types::Diagnostic> {
     let query = snapshot.query();
     let source = query.document().contents();

--- a/crates/shuck-server/src/server.rs
+++ b/crates/shuck-server/src/server.rs
@@ -25,6 +25,7 @@ mod schedule;
 
 pub(crate) type Result<T> = std::result::Result<T, api::Error>;
 
+/// Initialized Shuck LSP server.
 pub struct Server {
     connection: Connection,
     client_capabilities: ClientCapabilities,
@@ -96,6 +97,7 @@ impl Server {
         })
     }
 
+    /// Run the server main loop until shutdown or error.
     pub fn run(mut self) -> crate::Result<()> {
         let panic_client = Client::new(
             self.main_loop_sender.clone(),

--- a/crates/shuck-server/src/session.rs
+++ b/crates/shuck-server/src/session.rs
@@ -24,6 +24,7 @@ mod options;
 mod request_queue;
 mod settings;
 
+/// Mutable LSP session state for open documents, workspaces, and settings.
 pub struct Session {
     index: index::Index,
     position_encoding: PositionEncoding,
@@ -33,6 +34,7 @@ pub struct Session {
     shutdown_requested: bool,
 }
 
+/// Immutable view of one document plus resolved settings.
 #[derive(Clone)]
 pub struct DocumentSnapshot {
     resolved_client_capabilities: Arc<ResolvedClientCapabilities>,
@@ -42,6 +44,7 @@ pub struct DocumentSnapshot {
 }
 
 impl Session {
+    /// Create a session from client capabilities, global settings, and workspaces.
     pub fn new(
         client_capabilities: &ClientCapabilities,
         position_encoding: PositionEncoding,
@@ -77,10 +80,12 @@ impl Session {
         self.shutdown_requested = requested;
     }
 
+    /// Return the document key for an LSP document URL.
     pub fn key_from_url(&self, url: Url) -> DocumentKey {
         self.index.key_from_url(url)
     }
 
+    /// Capture a document snapshot for diagnostics, hovers, or code actions.
     pub fn take_snapshot(&self, url: Url) -> Option<DocumentSnapshot> {
         let (settings, client_settings) = self
             .index
@@ -104,6 +109,7 @@ impl Session {
             .update_text_document(key, content_changes, new_version, self.encoding())
     }
 
+    /// Open or replace an in-memory text document.
     pub fn open_text_document(&mut self, url: Url, document: TextDocument) {
         self.index.open_text_document(url, document);
     }
@@ -181,6 +187,7 @@ impl DocumentSnapshot {
         self.document_ref.settings()
     }
 
+    /// Return the query object used to access the underlying document and settings.
     pub fn query(&self) -> &index::DocumentQuery {
         &self.document_ref
     }

--- a/crates/shuck-server/src/session/client.rs
+++ b/crates/shuck-server/src/session/client.rs
@@ -11,6 +11,7 @@ use crate::server::{ConnectionSender, Event, MainLoopSender};
 pub(crate) type ClientResponseHandler =
     Box<dyn FnOnce(&Client, &mut Session, lsp_server::Response) + Send>;
 
+/// Handle used by the server to send LSP messages back to the client.
 #[derive(Clone, Debug)]
 pub struct Client {
     main_loop_sender: MainLoopSender,
@@ -18,6 +19,7 @@ pub struct Client {
 }
 
 impl Client {
+    /// Create a client handle from main-loop and LSP connection channels.
     pub fn new(main_loop_sender: MainLoopSender, client_sender: ConnectionSender) -> Self {
         Self {
             main_loop_sender,

--- a/crates/shuck-server/src/session/index.rs
+++ b/crates/shuck-server/src/session/index.rs
@@ -39,11 +39,16 @@ struct ProjectSettingsCacheKey {
     workspace_root: Option<PathBuf>,
 }
 
+/// Query handle for a document known to the server.
 #[derive(Clone)]
 pub enum DocumentQuery {
+    /// Open text document plus its resolved settings.
     Text {
+        /// URL of the text document.
         file_url: Url,
+        /// Current document contents and line index.
         document: Arc<TextDocument>,
+        /// Resolved Shuck settings for the document.
         settings: Arc<ShuckSettings>,
     },
 }

--- a/crates/shuck-server/src/session/options.rs
+++ b/crates/shuck-server/src/session/options.rs
@@ -8,6 +8,7 @@ use crate::{Client, logging};
 
 pub(crate) type WorkspaceOptionsMap = FxHashMap<Url, ClientOptions>;
 
+/// Global initialization options accepted by the Shuck LSP server.
 #[derive(Debug, Deserialize, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct GlobalOptions {
@@ -18,23 +19,30 @@ pub struct GlobalOptions {
 }
 
 impl GlobalOptions {
+    /// Resolve client-provided options into runtime global settings.
     pub fn into_settings(self, client: Client) -> GlobalClientSettings {
         GlobalClientSettings::new(self.client, client)
     }
 }
 
+/// Per-client or per-workspace Shuck options supplied through LSP settings.
 #[derive(Clone, Debug, Default, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ClientOptions {
     #[serde(default)]
+    /// Lint configuration overrides.
     pub lint: Option<LintConfig>,
     #[serde(default)]
+    /// Format configuration overrides.
     pub format: Option<FormatConfig>,
     #[serde(default)]
+    /// Whether source-level fix-all actions are enabled.
     pub fix_all: Option<bool>,
     #[serde(default)]
+    /// Whether unsafe fixes may be offered.
     pub unsafe_fixes: Option<bool>,
     #[serde(default)]
+    /// Whether parser diagnostics should be shown.
     pub show_syntax_errors: Option<bool>,
 }
 

--- a/crates/shuck-server/src/workspace.rs
+++ b/crates/shuck-server/src/workspace.rs
@@ -7,10 +7,12 @@ use lsp_types::{Url, WorkspaceFolder};
 
 use crate::session::{ClientOptions, WorkspaceOptionsMap};
 
+/// Collection of workspace folders known to the LSP session.
 #[derive(Debug)]
 pub struct Workspaces(Vec<Workspace>);
 
 impl Workspaces {
+    /// Create a workspace collection from explicit workspace entries.
     pub fn new(workspaces: Vec<Workspace>) -> Self {
         Self(workspaces)
     }
@@ -67,6 +69,7 @@ impl Deref for Workspaces {
     }
 }
 
+/// One LSP workspace folder plus optional Shuck settings.
 #[derive(Debug)]
 pub struct Workspace {
     url: Url,
@@ -75,6 +78,7 @@ pub struct Workspace {
 }
 
 impl Workspace {
+    /// Create a non-default workspace for `url`.
     pub fn new(url: Url) -> Self {
         Self {
             url,
@@ -83,6 +87,7 @@ impl Workspace {
         }
     }
 
+    /// Create the default workspace for clients without workspace-folder support.
     pub fn default(url: Url) -> Self {
         Self {
             url,
@@ -91,6 +96,7 @@ impl Workspace {
         }
     }
 
+    /// Return a copy with workspace-specific client options.
     #[must_use]
     pub fn with_options(mut self, options: ClientOptions) -> Self {
         self.options = Some(options);


### PR DESCRIPTION
## Summary

- Remove non-linter `allow(missing_docs)` carve-outs and turn `shuck-config`/`shuck-server` into documented public crates.
- Document intentional public APIs for config, runtime resolution, cache, benchmark, formatter, and LSP support surfaces.
- Hide broad `shuck-ast` internal re-exports from generated public docs while keeping workspace access intact.

## Validation

- `cargo fmt --check`
- `cargo check --workspace --message-format short`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test --workspace --lib`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps`