### PR TITLE
feat(linter): add S083 missing function doc rule

### DIFF
--- a/crates/shuck-cli/src/commands/check/settings.rs
+++ b/crates/shuck-cli/src/commands/check/settings.rs
@@ -64,6 +64,8 @@ struct EffectiveRuleOptions {
     s082_kinds: Vec<String>,
     s082_require_owner: bool,
     s082_require_message: bool,
+    s083_require_for: u8,
+    s083_long_function_line_threshold: usize,
     s084_require_globals: bool,
     s084_require_arguments: bool,
     s084_require_outputs: bool,
@@ -205,6 +207,8 @@ impl EffectiveRuleOptions {
             s082_kinds: rule_options.s082.kinds.clone(),
             s082_require_owner: rule_options.s082.require_owner,
             s082_require_message: rule_options.s082.require_message,
+            s083_require_for: s083_require_for_cache_value(rule_options.s083.require_for),
+            s083_long_function_line_threshold: rule_options.s083.long_function_line_threshold,
             s084_require_globals: rule_options.s084.require_globals,
             s084_require_arguments: rule_options.s084.require_arguments,
             s084_require_outputs: rule_options.s084.require_outputs,
@@ -238,6 +242,8 @@ impl CacheKey for EffectiveRuleOptions {
         self.s082_kinds.cache_key(state);
         self.s082_require_owner.cache_key(state);
         self.s082_require_message.cache_key(state);
+        self.s083_require_for.cache_key(state);
+        self.s083_long_function_line_threshold.cache_key(state);
         self.s084_require_globals.cache_key(state);
         self.s084_require_arguments.cache_key(state);
         self.s084_require_outputs.cache_key(state);
@@ -251,6 +257,15 @@ impl CacheKey for EffectiveRuleOptions {
         self.c160_allowed_anchors.cache_key(state);
         self.c161_ignore_after_source.cache_key(state);
         self.c162_treat_as_masking.cache_key(state);
+    }
+}
+
+fn s083_require_for_cache_value(value: shuck_linter::S083FunctionDocRequirement) -> u8 {
+    match value {
+        shuck_linter::S083FunctionDocRequirement::All => 0,
+        shuck_linter::S083FunctionDocRequirement::Exported => 1,
+        shuck_linter::S083FunctionDocRequirement::Long => 2,
+        shuck_linter::S083FunctionDocRequirement::Parameterized => 3,
     }
 }
 
@@ -1113,6 +1128,35 @@ fn linter_rule_options_for_lint_config(
         .and_then(|c162| c162.treat_as_masking.as_ref())
     {
         rule_options.c162.treat_as_masking = value.clone();
+    }
+    if let Some(value) = lint
+        .rule_options
+        .as_ref()
+        .and_then(|options| options.s083.as_ref())
+        .and_then(|s083| s083.require_for)
+    {
+        rule_options.s083.require_for = match value {
+            shuck_config::S083RequireForConfig::All => {
+                shuck_linter::S083FunctionDocRequirement::All
+            }
+            shuck_config::S083RequireForConfig::Exported => {
+                shuck_linter::S083FunctionDocRequirement::Exported
+            }
+            shuck_config::S083RequireForConfig::Long => {
+                shuck_linter::S083FunctionDocRequirement::Long
+            }
+            shuck_config::S083RequireForConfig::Parameterized => {
+                shuck_linter::S083FunctionDocRequirement::Parameterized
+            }
+        };
+    }
+    if let Some(value) = lint
+        .rule_options
+        .as_ref()
+        .and_then(|options| options.s083.as_ref())
+        .and_then(|s083| s083.long_function_line_threshold)
+    {
+        rule_options.s083.long_function_line_threshold = value;
     }
     if let Some(value) = lint
         .rule_options

--- a/crates/shuck-config/src/lib.rs
+++ b/crates/shuck-config/src/lib.rs
@@ -61,8 +61,8 @@ const CONFIG_OVERRIDE_LINT_ZSH_PLUGIN_KEYS: &[&str] = &[
     "entrypoints",
 ];
 const CONFIG_OVERRIDE_LINT_RULE_OPTION_KEYS: &[&str] = &[
-    "c001", "c063", "s078", "s079", "s080", "s081", "s082", "s084", "s085", "c158", "c159", "c160",
-    "c161", "c162",
+    "c001", "c063", "s078", "s079", "s080", "s081", "s082", "s083", "s084", "s085", "c158", "c159",
+    "c160", "c161", "c162",
 ];
 const CONFIG_OVERRIDE_C001_RULE_OPTION_KEYS: &[&str] =
     &["treat-indirect-expansion-targets-as-used"];
@@ -80,6 +80,8 @@ const CONFIG_OVERRIDE_S084_RULE_OPTION_KEYS: &[&str] = &[
     "require-outputs",
     "require-returns",
 ];
+const CONFIG_OVERRIDE_S083_RULE_OPTION_KEYS: &[&str] =
+    &["require-for", "long-function-line-threshold"];
 const CONFIG_OVERRIDE_S085_RULE_OPTION_KEYS: &[&str] = &[
     "non-trivial-line-threshold",
     "non-trivial-function-count",
@@ -355,6 +357,8 @@ pub struct LintRuleOptionsConfig {
     pub s081: Option<S081RuleOptionsConfig>,
     /// Options for rule S082.
     pub s082: Option<S082RuleOptionsConfig>,
+    /// Options for rule S083.
+    pub s083: Option<S083RuleOptionsConfig>,
     /// Options for rule S084.
     pub s084: Option<S084RuleOptionsConfig>,
     /// Options for rule S085.
@@ -393,6 +397,9 @@ impl LintRuleOptionsConfig {
         }
         if let Some(s082) = overrides.s082 {
             self.s082.get_or_insert_default().apply_overrides(s082);
+        }
+        if let Some(s083) = overrides.s083 {
+            self.s083.get_or_insert_default().apply_overrides(s083);
         }
         if let Some(s084) = overrides.s084 {
             self.s084.get_or_insert_default().apply_overrides(s084);
@@ -548,6 +555,44 @@ impl S082RuleOptionsConfig {
         }
         if overrides.require_message.is_some() {
             self.require_message = overrides.require_message;
+        }
+    }
+}
+
+/// Which functions require a leading documentation comment for rule S083.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
+pub enum S083RequireForConfig {
+    /// Require documentation for every function.
+    #[serde(rename = "all")]
+    All,
+    /// Require documentation for functions that do not use a private-style name.
+    #[serde(rename = "exported")]
+    Exported,
+    /// Require documentation for functions whose bodies exceed the configured line threshold.
+    #[serde(rename = "long")]
+    Long,
+    /// Require documentation for functions that read positional parameters.
+    #[serde(rename = "parameterized")]
+    Parameterized,
+}
+
+/// Options for rule S083.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Deserialize)]
+#[serde(default, rename_all = "kebab-case", deny_unknown_fields)]
+pub struct S083RuleOptionsConfig {
+    /// Function subset that requires documentation.
+    pub require_for: Option<S083RequireForConfig>,
+    /// Minimum function body size for the `long` requirement mode.
+    pub long_function_line_threshold: Option<usize>,
+}
+
+impl S083RuleOptionsConfig {
+    fn apply_overrides(&mut self, overrides: Self) {
+        if overrides.require_for.is_some() {
+            self.require_for = overrides.require_for;
+        }
+        if overrides.long_function_line_threshold.is_some() {
+            self.long_function_line_threshold = overrides.long_function_line_threshold;
         }
     }
 }
@@ -1067,6 +1112,27 @@ const CONFIGURATION_METADATA: [ConfigSectionMetadata; 3] = [
                                 default: "true",
                                 value_type: "bool",
                                 example: "require-message = false",
+                            },
+                        ],
+                        sections: &[],
+                    },
+                    ConfigSectionMetadata {
+                        key: "s083",
+                        docs: "Behavior overrides for `S083` missing function documentation.",
+                        fields: &[
+                            ConfigFieldMetadata {
+                                key: "require-for",
+                                docs: "Choose which functions require a leading documentation comment: all, exported, long, or parameterized.",
+                                default: "long",
+                                value_type: "string",
+                                example: r#"require-for = "exported""#,
+                            },
+                            ConfigFieldMetadata {
+                                key: "long-function-line-threshold",
+                                docs: "Minimum body line count for `require-for = \"long\"`.",
+                                default: "10",
+                                value_type: "integer",
+                                example: "long-function-line-threshold = 20",
                             },
                         ],
                         sections: &[],
@@ -1892,6 +1958,9 @@ fn validate_lint_rule_options_override(value: &toml::Value) -> std::result::Resu
     if let Some(s082_value) = rule_options.get("s082") {
         validate_s082_rule_options_override(s082_value)?;
     }
+    if let Some(s083_value) = rule_options.get("s083") {
+        validate_s083_rule_options_override(s083_value)?;
+    }
     if let Some(s084_value) = rule_options.get("s084") {
         validate_s084_rule_options_override(s084_value)?;
     }
@@ -2056,6 +2125,22 @@ fn validate_s082_rule_options_override(value: &toml::Value) -> std::result::Resu
             return Err(format!(
                 "unsupported `[lint.rule-options.s082]` option `{key}`; expected one of: {}",
                 CONFIG_OVERRIDE_S082_RULE_OPTION_KEYS.join(", ")
+            ));
+        }
+    }
+
+    Ok(())
+}
+
+fn validate_s083_rule_options_override(value: &toml::Value) -> std::result::Result<(), String> {
+    let s083 = value
+        .as_table()
+        .ok_or_else(|| "`[lint.rule-options.s083]` must be a TOML table".to_owned())?;
+    for key in s083.keys() {
+        if !CONFIG_OVERRIDE_S083_RULE_OPTION_KEYS.contains(&key.as_str()) {
+            return Err(format!(
+                "unsupported `[lint.rule-options.s083]` option `{key}`; expected one of: {}",
+                CONFIG_OVERRIDE_S083_RULE_OPTION_KEYS.join(", ")
             ));
         }
     }
@@ -2480,6 +2565,23 @@ mod tests {
     }
 
     #[test]
+    fn inline_config_overrides_validate_supported_s083_rule_option_keys() {
+        let config = parse_config_override(
+            "lint.rule-options.s083.require-for = 'exported'\n\
+             lint.rule-options.s083.long-function-line-threshold = 20",
+        )
+        .unwrap();
+        let s083 = config
+            .lint
+            .rule_options
+            .as_ref()
+            .and_then(|options| options.s083.as_ref())
+            .expect("missing s083 options");
+        assert_eq!(s083.require_for, Some(S083RequireForConfig::Exported));
+        assert_eq!(s083.long_function_line_threshold, Some(20));
+    }
+
+    #[test]
     fn inline_config_overrides_validate_supported_s084_rule_option_keys() {
         let config = parse_config_override(
             "lint.rule-options.s084.require-globals = false\n\
@@ -2744,6 +2846,12 @@ mod tests {
     }
 
     #[test]
+    fn inline_config_overrides_reject_unknown_s083_rule_option_keys() {
+        let err = parse_config_override("lint.rule-options.s083.preview = true").unwrap_err();
+        assert!(err.contains("unsupported `[lint.rule-options.s083]` option `preview`"));
+    }
+
+    #[test]
     fn inline_config_overrides_reject_unknown_s085_rule_option_keys() {
         let err = parse_config_override("lint.rule-options.s085.preview = true").unwrap_err();
         assert!(err.contains("unsupported `[lint.rule-options.s085]` option `preview`"));
@@ -3001,6 +3109,34 @@ mod tests {
                 .and_then(|options| options.s082.as_ref())
                 .and_then(|s082| s082.require_owner),
             Some(false)
+        );
+    }
+
+    #[test]
+    fn s083_rule_option_config_arguments_allow_last_override_to_win() {
+        let tempdir = tempdir().unwrap();
+        let config = ConfigArguments::from_cli(
+            vec![
+                SingleConfigArgument::SettingsOverride(Box::new(
+                    parse_config_override("lint.rule-options.s083.require-for = 'all'").unwrap(),
+                )),
+                SingleConfigArgument::SettingsOverride(Box::new(
+                    parse_config_override("lint.rule-options.s083.require-for = 'long'").unwrap(),
+                )),
+            ],
+            false,
+        )
+        .unwrap();
+
+        let loaded = load_project_config(tempdir.path(), &config).unwrap();
+        assert_eq!(
+            loaded
+                .lint
+                .rule_options
+                .as_ref()
+                .and_then(|options| options.s083.as_ref())
+                .and_then(|s083| s083.require_for),
+            Some(S083RequireForConfig::Long)
         );
     }
 

--- a/crates/shuck-linter/resources/test/fixtures/style/S083.sh
+++ b/crates/shuck-linter/resources/test/fixtures/style/S083.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+do_work() {
+  local input=$1
+  echo "processing: $input"
+  echo "validating: $input"
+  echo "loading: $input"
+  echo "normalizing: $input"
+  echo "planning: $input"
+  echo "executing: $input"
+  echo "collecting: $input"
+  echo "summarizing: $input"
+  echo "finished: $input"
+}
+
+# Processes the given input string and writes the result to stdout.
+do_more_work() {
+  local input=$1
+  echo "processing: $input"
+}

--- a/crates/shuck-linter/src/checker.rs
+++ b/crates/shuck-linter/src/checker.rs
@@ -391,6 +391,9 @@ impl<'a> Checker<'a> {
         if self.is_rule_enabled(Rule::FunctionBodyWithoutBraces) {
             rules::style::function_body_without_braces::function_body_without_braces(self);
         }
+        if self.is_rule_enabled(Rule::MissingFunctionDoc) {
+            rules::style::missing_function_doc::missing_function_doc(self);
+        }
         if self.is_rule_enabled(Rule::FunctionDocContent) {
             rules::style::function_doc_content::function_doc_content(self);
         }

--- a/crates/shuck-linter/src/facts/functions.rs
+++ b/crates/shuck-linter/src/facts/functions.rs
@@ -190,6 +190,11 @@ pub(crate) fn build_function_doc_content_facts<'a>(
     comment_index: &CommentIndex,
 ) -> Vec<FunctionDocContentFact> {
     let mut summaries = build_function_doc_body_summaries(semantic, commands, source);
+    let scopes_using_any_positional_parameters = build_function_scopes_using_positional_parameters(
+        semantic,
+        commands,
+        positional_parameter_facts,
+    );
 
     headers
         .iter()
@@ -207,10 +212,13 @@ pub(crate) fn build_function_doc_content_facts<'a>(
             let uses_positional_parameters = positional_parameter_facts
                 .get(&function_scope)
                 .is_some_and(|facts| facts.uses_positional_parameters());
+            let uses_any_positional_parameters =
+                scopes_using_any_positional_parameters.contains(&function_scope);
 
             Some(FunctionDocContentFact::new(
                 name,
                 name_span,
+                span_line_count(header.function().body.span),
                 comment_block.map(|block| block.span),
                 comment_block
                     .map(|block| block.sections)
@@ -218,6 +226,7 @@ pub(crate) fn build_function_doc_content_facts<'a>(
                 FunctionDocBodyBehavior::new(
                     summary.uses_global_variables,
                     uses_positional_parameters,
+                    uses_any_positional_parameters,
                     summary.writes_stdout,
                     summary.has_explicit_return,
                 ),
@@ -520,6 +529,48 @@ fn is_function_doc_comment_body(body: &str) -> bool {
 
     let lower = body.to_ascii_lowercase();
     !lower.starts_with("shellcheck ") && !lower.starts_with("shuck:")
+}
+
+fn build_function_scopes_using_positional_parameters(
+    semantic: &SemanticModel,
+    commands: &[CommandFact<'_>],
+    positional_parameter_facts: &FxHashMap<ScopeId, FunctionPositionalParameterFacts>,
+) -> FxHashSet<ScopeId> {
+    let local_reset_offsets_by_scope = local_positional_reset_offsets_by_scope(semantic, commands);
+    let mut scopes = positional_parameter_facts
+        .iter()
+        .filter_map(|(&scope, facts)| facts.uses_positional_parameters().then_some(scope))
+        .collect::<FxHashSet<_>>();
+
+    for reference in semantic.references() {
+        if !semantic.is_guarded_parameter_reference(reference.id)
+            || !is_positional_parameter_reference_name(reference.name.as_str())
+        {
+            continue;
+        }
+        if reference_has_local_positional_reset(
+            semantic,
+            reference.scope,
+            reference.span.start.offset,
+            &local_reset_offsets_by_scope,
+        ) {
+            continue;
+        }
+        if let Some(scope) = semantic.enclosing_function_scope(reference.scope) {
+            scopes.insert(scope);
+        }
+    }
+
+    scopes
+}
+
+fn is_positional_parameter_reference_name(name: &str) -> bool {
+    matches!(name, "@" | "*" | "#")
+        || (!name.is_empty() && name != "0" && name.bytes().all(|byte| byte.is_ascii_digit()))
+}
+
+fn span_line_count(span: Span) -> usize {
+    span.end.line.saturating_sub(span.start.line) + 1
 }
 
 #[cfg_attr(shuck_profiling, inline(never))]
@@ -1768,6 +1819,69 @@ pub(crate) fn build_function_positional_parameter_facts(
     commands: &[CommandFact<'_>],
     positional_parameter_fragments: &[PositionalParameterFragmentFact],
 ) -> FxHashMap<ScopeId, FunctionPositionalParameterFacts> {
+    let local_reset_offsets_by_scope = local_positional_reset_offsets_by_scope(semantic, commands);
+
+    let mut facts = semantic
+        .function_positional_reference_summary(&local_reset_offsets_by_scope)
+        .into_iter()
+        .map(|(scope, summary)| {
+            (
+                scope,
+                FunctionPositionalParameterFacts {
+                    required_arg_count: summary.required_arg_count(),
+                    uses_unprotected_positional_parameters: summary
+                        .uses_unprotected_positional_parameters(),
+                    resets_positional_parameters: false,
+                },
+            )
+        })
+        .collect::<FxHashMap<_, _>>();
+
+    for fragment in positional_parameter_fragments {
+        let fragment_offset = fragment.span().start.offset;
+        let fragment_scope = semantic.scope_at(fragment_offset);
+        if reference_has_local_positional_reset(
+            semantic,
+            fragment_scope,
+            fragment_offset,
+            &local_reset_offsets_by_scope,
+        ) {
+            continue;
+        }
+
+        let Some(scope) = semantic.enclosing_function_scope(fragment_scope) else {
+            continue;
+        };
+
+        let entry = facts.entry(scope).or_default();
+        if !fragment.is_guarded() {
+            entry.uses_unprotected_positional_parameters = true;
+        }
+    }
+
+    for command in commands {
+        let Some(scope) =
+            semantic.enclosing_function_scope_without_transient_boundary(command.scope())
+        else {
+            continue;
+        };
+
+        if command
+            .options()
+            .set()
+            .is_some_and(|set| set.resets_positional_parameters())
+        {
+            facts.entry(scope).or_default().resets_positional_parameters = true;
+        }
+    }
+
+    facts
+}
+
+fn local_positional_reset_offsets_by_scope(
+    semantic: &SemanticModel,
+    commands: &[CommandFact<'_>],
+) -> FxHashMap<ScopeId, Vec<usize>> {
     let mut local_reset_offsets_by_scope: FxHashMap<ScopeId, Vec<usize>> = FxHashMap::default();
 
     for command in commands {
@@ -1788,65 +1902,7 @@ pub(crate) fn build_function_positional_parameter_facts(
         }
     }
 
-    let mut facts = semantic
-        .function_positional_reference_summary(&local_reset_offsets_by_scope)
-        .into_iter()
-        .map(|(scope, summary)| {
-            (
-                scope,
-                FunctionPositionalParameterFacts {
-                    required_arg_count: summary.required_arg_count(),
-                    uses_unprotected_positional_parameters: summary
-                        .uses_unprotected_positional_parameters(),
-                    resets_positional_parameters: false,
-                },
-            )
-        })
-        .collect::<FxHashMap<_, _>>();
-
-    for fragment in positional_parameter_fragments {
-        if fragment.is_guarded() {
-            continue;
-        }
-
-        let fragment_offset = fragment.span().start.offset;
-        let fragment_scope = semantic.scope_at(fragment_offset);
-        if reference_has_local_positional_reset(
-            semantic,
-            fragment_scope,
-            fragment_offset,
-            &local_reset_offsets_by_scope,
-        ) {
-            continue;
-        }
-
-        let Some(scope) = semantic.enclosing_function_scope(fragment_scope) else {
-            continue;
-        };
-
-        facts
-            .entry(scope)
-            .or_default()
-            .uses_unprotected_positional_parameters = true;
-    }
-
-    for command in commands {
-        let Some(scope) =
-            semantic.enclosing_function_scope_without_transient_boundary(command.scope())
-        else {
-            continue;
-        };
-
-        if command
-            .options()
-            .set()
-            .is_some_and(|set| set.resets_positional_parameters())
-        {
-            facts.entry(scope).or_default().resets_positional_parameters = true;
-        }
-    }
-
-    facts
+    local_reset_offsets_by_scope
 }
 
 pub(crate) fn reference_has_local_positional_reset(

--- a/crates/shuck-linter/src/facts/model.rs
+++ b/crates/shuck-linter/src/facts/model.rs
@@ -1628,6 +1628,7 @@ impl FunctionDocSections {
 pub(crate) struct FunctionDocContentFact {
     name: Name,
     name_span: Span,
+    body_line_count: usize,
     leading_comment_span: Option<Span>,
     documented_sections: FunctionDocSections,
     body_behavior: FunctionDocBodyBehavior,
@@ -1637,6 +1638,7 @@ impl FunctionDocContentFact {
     pub(crate) fn new(
         name: &Name,
         name_span: Span,
+        body_line_count: usize,
         leading_comment_span: Option<Span>,
         documented_sections: FunctionDocSections,
         body_behavior: FunctionDocBodyBehavior,
@@ -1644,6 +1646,7 @@ impl FunctionDocContentFact {
         Self {
             name: name.clone(),
             name_span,
+            body_line_count,
             leading_comment_span,
             documented_sections,
             body_behavior,
@@ -1656,6 +1659,10 @@ impl FunctionDocContentFact {
 
     pub(crate) fn name_span(&self) -> Span {
         self.name_span
+    }
+
+    pub(crate) fn body_line_count(&self) -> usize {
+        self.body_line_count
     }
 
     pub(crate) fn has_leading_comment(&self) -> bool {
@@ -1674,6 +1681,10 @@ impl FunctionDocContentFact {
         self.body_behavior.uses_positional_parameters()
     }
 
+    pub(crate) fn uses_any_positional_parameters(&self) -> bool {
+        self.body_behavior.uses_any_positional_parameters()
+    }
+
     pub(crate) fn writes_stdout(&self) -> bool {
         self.body_behavior.writes_stdout()
     }
@@ -1687,6 +1698,7 @@ impl FunctionDocContentFact {
 pub(crate) struct FunctionDocBodyBehavior {
     uses_global_variables: bool,
     uses_positional_parameters: bool,
+    uses_any_positional_parameters: bool,
     writes_stdout: bool,
     has_explicit_return: bool,
 }
@@ -1695,12 +1707,14 @@ impl FunctionDocBodyBehavior {
     pub(crate) fn new(
         uses_global_variables: bool,
         uses_positional_parameters: bool,
+        uses_any_positional_parameters: bool,
         writes_stdout: bool,
         has_explicit_return: bool,
     ) -> Self {
         Self {
             uses_global_variables,
             uses_positional_parameters,
+            uses_any_positional_parameters,
             writes_stdout,
             has_explicit_return,
         }
@@ -1712,6 +1726,10 @@ impl FunctionDocBodyBehavior {
 
     pub(crate) fn uses_positional_parameters(self) -> bool {
         self.uses_positional_parameters
+    }
+
+    pub(crate) fn uses_any_positional_parameters(self) -> bool {
+        self.uses_any_positional_parameters
     }
 
     pub(crate) fn writes_stdout(self) -> bool {

--- a/crates/shuck-linter/src/lib.rs
+++ b/crates/shuck-linter/src/lib.rs
@@ -109,7 +109,8 @@ pub use settings::{
     AmbientShellOptions, C001RuleOptions, C063RuleOptions, C158RuleOptions, C159RuleOptions,
     C160RuleOptions, C161RuleOptions, C162RuleOptions, CompiledPerFileIgnoreList,
     LinterRuleOptions, LinterSettings, PerFileIgnore, S078RuleOptions, S079RuleOptions,
-    S080RuleOptions, S081RuleOptions, S082RuleOptions, S084RuleOptions, S085RuleOptions,
+    S080RuleOptions, S081RuleOptions, S082RuleOptions, S083FunctionDocRequirement, S083RuleOptions,
+    S084RuleOptions, S085RuleOptions,
 };
 /// Shell dialect selection used by the linter.
 pub use shell::ShellDialect;

--- a/crates/shuck-linter/src/registry.rs
+++ b/crates/shuck-linter/src/registry.rs
@@ -717,6 +717,7 @@ declare_rules! {
     ("S080", Category::Style, Severity::Warning, ScriptSizeThreshold),
     ("S081", Category::Style, Severity::Warning, MissingFileDescription),
     ("S082", Category::Style, Severity::Warning, TodoFormat),
+    ("S083", Category::Style, Severity::Warning, MissingFunctionDoc),
     ("S084", Category::Style, Severity::Warning, FunctionDocContent),
     ("S085", Category::Style, Severity::Warning, MissingMainEntrypoint),
 }

--- a/crates/shuck-linter/src/rules/style/missing_function_doc.rs
+++ b/crates/shuck-linter/src/rules/style/missing_function_doc.rs
@@ -1,0 +1,195 @@
+use crate::{Checker, Rule, S083FunctionDocRequirement, Violation};
+
+pub struct MissingFunctionDoc {
+    name: String,
+}
+
+impl Violation for MissingFunctionDoc {
+    fn rule() -> Rule {
+        Rule::MissingFunctionDoc
+    }
+
+    fn message(&self) -> String {
+        format!("add a leading comment block for function `{}`", self.name)
+    }
+}
+
+pub fn missing_function_doc(checker: &mut Checker) {
+    let options = checker.rule_options().s083.clone();
+    let violations = checker
+        .facts()
+        .command_facts()
+        .function_doc_content()
+        .iter()
+        .filter(|fact| !fact.has_leading_comment())
+        .filter(|fact| function_requires_doc(fact, &options))
+        .map(|fact| {
+            (
+                fact.name_span(),
+                MissingFunctionDoc {
+                    name: fact.name().as_str().to_owned(),
+                },
+            )
+        })
+        .collect::<Vec<_>>();
+
+    for (span, violation) in violations {
+        checker.report(violation, span);
+    }
+}
+
+fn function_requires_doc(
+    fact: &crate::facts::FunctionDocContentFact,
+    options: &crate::S083RuleOptions,
+) -> bool {
+    match options.require_for {
+        S083FunctionDocRequirement::All => true,
+        S083FunctionDocRequirement::Exported => !fact.name().as_str().starts_with('_'),
+        S083FunctionDocRequirement::Long => {
+            fact.body_line_count() > options.long_function_line_threshold
+        }
+        S083FunctionDocRequirement::Parameterized => fact.uses_any_positional_parameters(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::test::test_snippet;
+    use crate::{LinterSettings, Rule, S083FunctionDocRequirement};
+
+    #[test]
+    fn reports_long_function_without_leading_comment_by_default() {
+        let source = "#!/bin/bash\ndo_work() {\n  echo one\n  echo two\n  echo three\n  echo four\n  echo five\n  echo six\n  echo seven\n  echo eight\n  echo nine\n  echo ten\n}\n";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::MissingFunctionDoc));
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].span.slice(source), "do_work");
+    }
+
+    #[test]
+    fn all_mode_reports_short_functions() {
+        let source = "#!/bin/bash\ndo_work() {\n  echo hi\n}\n";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::MissingFunctionDoc)
+                .with_s083_require_for(S083FunctionDocRequirement::All),
+        );
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].span.slice(source), "do_work");
+    }
+
+    #[test]
+    fn accepts_immediate_leading_comment() {
+        let source = "#!/bin/bash\n# Does the work.\ndo_work() {\n  echo hi\n}\n";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::MissingFunctionDoc)
+                .with_s083_require_for(S083FunctionDocRequirement::All),
+        );
+
+        assert!(diagnostics.is_empty());
+    }
+
+    #[test]
+    fn ignores_comment_separated_by_blank_line() {
+        let source = "#!/bin/bash\n# Does the work.\n\ndo_work() {\n  echo hi\n}\n";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::MissingFunctionDoc)
+                .with_s083_require_for(S083FunctionDocRequirement::All),
+        );
+
+        assert_eq!(diagnostics.len(), 1);
+    }
+
+    #[test]
+    fn ignores_directive_comments_as_documentation() {
+        let source = "#!/bin/bash\n# shellcheck disable=SC2034\ndo_work() {\n  echo hi\n}\n";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::MissingFunctionDoc)
+                .with_s083_require_for(S083FunctionDocRequirement::All),
+        );
+
+        assert_eq!(diagnostics.len(), 1);
+    }
+
+    #[test]
+    fn exported_mode_ignores_private_functions() {
+        let source = "#!/bin/bash\n_private() {\n  echo hi\n}\npublic() {\n  echo hi\n}\n";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::MissingFunctionDoc)
+                .with_s083_require_for(S083FunctionDocRequirement::Exported),
+        );
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].span.slice(source), "public");
+    }
+
+    #[test]
+    fn long_mode_uses_body_line_threshold() {
+        let source = "#!/bin/bash\nshort() {\n  echo hi\n}\nlong() {\n  echo one\n  echo two\n  echo three\n  echo four\n}\n";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::MissingFunctionDoc)
+                .with_s083_require_for(S083FunctionDocRequirement::Long)
+                .with_s083_long_function_line_threshold(3),
+        );
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].span.slice(source), "long");
+    }
+
+    #[test]
+    fn long_mode_accepts_body_at_threshold() {
+        let source = "#!/bin/bash\nexact() {\n  echo one\n  echo two\n}\n";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::MissingFunctionDoc)
+                .with_s083_require_for(S083FunctionDocRequirement::Long)
+                .with_s083_long_function_line_threshold(4),
+        );
+
+        assert!(diagnostics.is_empty());
+    }
+
+    #[test]
+    fn parameterized_mode_checks_positional_parameter_use() {
+        let source = "#!/bin/bash\nplain() {\n  echo hi\n}\nwith_arg() {\n  echo \"$1\"\n}\n";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::MissingFunctionDoc)
+                .with_s083_require_for(S083FunctionDocRequirement::Parameterized),
+        );
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].span.slice(source), "with_arg");
+    }
+
+    #[test]
+    fn parameterized_mode_counts_guarded_positional_parameter_use() {
+        let source = "#!/bin/bash\nplain() {\n  echo hi\n}\nwith_default() {\n  printf '%s\\n' \"${1:-default}\"\n}\n";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::MissingFunctionDoc)
+                .with_s083_require_for(S083FunctionDocRequirement::Parameterized),
+        );
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].span.slice(source), "with_default");
+    }
+
+    #[test]
+    fn parameterized_mode_ignores_guarded_positional_parameter_after_local_reset() {
+        let source = "#!/bin/bash\nlocal_args() {\n  (\n    set -- inner\n    printf '%s\\n' \"${1:-default}\"\n  )\n}\n";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::MissingFunctionDoc)
+                .with_s083_require_for(S083FunctionDocRequirement::Parameterized),
+        );
+
+        assert!(diagnostics.is_empty());
+    }
+}

--- a/crates/shuck-linter/src/rules/style/mod.rs
+++ b/crates/shuck-linter/src/rules/style/mod.rs
@@ -47,6 +47,7 @@ pub mod ls_grep_pipeline;
 pub mod ls_in_substitution;
 pub mod ls_piped_to_xargs;
 pub mod missing_file_description;
+pub mod missing_function_doc;
 pub mod missing_main_entrypoint;
 pub mod missing_shebang_line;
 pub mod mixed_quote_word;
@@ -178,6 +179,7 @@ mod tests {
     #[test_case(Rule::ScriptSizeThreshold, Path::new("S080.sh"))]
     #[test_case(Rule::MissingFileDescription, Path::new("S081.sh"))]
     #[test_case(Rule::TodoFormat, Path::new("S082.sh"))]
+    #[test_case(Rule::MissingFunctionDoc, Path::new("S083.sh"))]
     #[test_case(Rule::FunctionDocContent, Path::new("S084.sh"))]
     #[test_case(Rule::MissingMainEntrypoint, Path::new("S085.sh"))]
     fn rules(rule: Rule, path: &Path) -> anyhow::Result<()> {

--- a/crates/shuck-linter/src/rules/style/snapshots/shuck_linter__rules__style__tests__S083_S083.sh.snap
+++ b/crates/shuck-linter/src/rules/style/snapshots/shuck_linter__rules__style__tests__S083_S083.sh.snap
@@ -1,0 +1,8 @@
+---
+source: crates/shuck-linter/src/rules/style/mod.rs
+---
+S083 add a leading comment block for function `do_work`
+ --> <source>:2:1
+  |
+2 | do_work() {
+  |

--- a/crates/shuck-linter/src/settings.rs
+++ b/crates/shuck-linter/src/settings.rs
@@ -41,6 +41,8 @@ pub struct LinterRuleOptions {
     pub s081: S081RuleOptions,
     /// Behavior overrides for `S082`.
     pub s082: S082RuleOptions,
+    /// Behavior overrides for `S083`.
+    pub s083: S083RuleOptions,
     /// Behavior overrides for `S084`.
     pub s084: S084RuleOptions,
     /// Behavior overrides for `S085`.
@@ -169,6 +171,32 @@ impl Default for S082RuleOptions {
     }
 }
 
+/// Which functions require a leading documentation comment for `S083`.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum S083FunctionDocRequirement {
+    All,
+    Exported,
+    #[default]
+    Long,
+    Parameterized,
+}
+
+/// Behavior overrides for `S083` missing function documentation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct S083RuleOptions {
+    pub require_for: S083FunctionDocRequirement,
+    pub long_function_line_threshold: usize,
+}
+
+impl Default for S083RuleOptions {
+    fn default() -> Self {
+        Self {
+            require_for: S083FunctionDocRequirement::Long,
+            long_function_line_threshold: 10,
+        }
+    }
+}
+
 /// Behavior overrides for `S084` function documentation content.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct S084RuleOptions {
@@ -209,6 +237,7 @@ impl Default for S085RuleOptions {
         }
     }
 }
+
 /// Behavior overrides for `C158` implicit global assignment analysis.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct C158RuleOptions {
@@ -500,6 +529,16 @@ impl LinterSettings {
 
     pub fn with_s082_require_message(mut self, value: bool) -> Self {
         self.rule_options.s082.require_message = value;
+        self
+    }
+
+    pub fn with_s083_require_for(mut self, value: S083FunctionDocRequirement) -> Self {
+        self.rule_options.s083.require_for = value;
+        self
+    }
+
+    pub fn with_s083_long_function_line_threshold(mut self, value: usize) -> Self {
+        self.rule_options.s083.long_function_line_threshold = value;
         self
     }
 

--- a/docs/rules/S083.yaml
+++ b/docs/rules/S083.yaml
@@ -14,25 +14,26 @@ rationale: >
   tells callers what the function does, what arguments it expects, which global variables
   it touches, and what it returns — information that is not recoverable from the
   implementation alone without reading every line. Because mandating a doc block for every
-  trivial two-liner would produce more noise than signal, the rule is configurable: teams
-  can require documentation only for all functions, only for long functions (those above a
-  configurable line threshold), only for functions that accept positional parameters, or
-  only for functions whose names follow a "public" naming convention. The rule fires when a
-  function matching the configured policy has no associated comment block at all; the
-  companion rule S084 checks whether a present comment block covers the required content.
+  trivial two-liner would produce more noise than signal, the default policy only checks long
+  functions. The rule is configurable: teams can require documentation for all functions, only
+  for long functions (those above a configurable line threshold), only for functions that
+  accept positional parameters, or only for functions whose names follow a "public" naming
+  convention. The rule fires when a function matching the configured policy has no associated
+  comment block at all; the companion rule S084 checks whether a present comment block covers
+  the required content.
 safe_fix: false
 fix_description: ~
 default_enabled: false
 options:
   - name: require-for
     type: string
-    default: "all"
+    default: "long"
     description: >
       Controls which functions are required to have a doc comment. Accepted values:
       "all" — every function definition; "exported" — functions whose names do not start
       with an underscore (treated as the public API); "long" — functions whose body
       exceeds long-function-line-threshold lines; "parameterized" — functions that
-      reference positional parameters ($1, $@, $*, etc.) in their body. Defaults to "all".
+      reference positional parameters ($1, $@, $*, etc.) in their body. Defaults to "long".
   - name: long-function-line-threshold
     type: integer
     default: 10
@@ -47,6 +48,14 @@ examples:
       do_work() {
         local input=$1
         echo "processing: $input"
+        echo "validating: $input"
+        echo "loading: $input"
+        echo "normalizing: $input"
+        echo "planning: $input"
+        echo "executing: $input"
+        echo "collecting: $input"
+        echo "summarizing: $input"
+        echo "finished: $input"
       }
       do_work "$1"
   - kind: valid

--- a/website/app/lib/rules-data.generated.json
+++ b/website/app/lib/rules-data.generated.json
@@ -6641,15 +6641,15 @@
     "category": "Style",
     "categoryPrefix": "S",
     "description": "A function definition lacks a leading comment block describing its purpose.",
-    "rationale": "Well-documented functions reduce the cognitive overhead of reading, reviewing, and maintaining shell scripts. A comment block immediately before a function definition tells callers what the function does, what arguments it expects, which global variables it touches, and what it returns — information that is not recoverable from the implementation alone without reading every line. Because mandating a doc block for every trivial two-liner would produce more noise than signal, the rule is configurable: teams can require documentation only for all functions, only for long functions (those above a configurable line threshold), only for functions that accept positional parameters, or only for functions whose names follow a \"public\" naming convention. The rule fires when a function matching the configured policy has no associated comment block at all; the companion rule S084 checks whether a present comment block covers the required content.\n",
+    "rationale": "Well-documented functions reduce the cognitive overhead of reading, reviewing, and maintaining shell scripts. A comment block immediately before a function definition tells callers what the function does, what arguments it expects, which global variables it touches, and what it returns — information that is not recoverable from the implementation alone without reading every line. Because mandating a doc block for every trivial two-liner would produce more noise than signal, the default policy only checks long functions. The rule is configurable: teams can require documentation for all functions, only for long functions (those above a configurable line threshold), only for functions that accept positional parameters, or only for functions whose names follow a \"public\" naming convention. The rule fires when a function matching the configured policy has no associated comment block at all; the companion rule S084 checks whether a present comment block covers the required content.\n",
     "shells": [
       "bash"
     ],
     "shellcheckCode": null,
-    "implemented": false,
-    "status": "planned",
+    "implemented": true,
+    "status": "implemented",
     "hasKnownShellcheckDivergences": false,
-    "severity": null,
+    "severity": "Warning",
     "fixStatus": "none",
     "fixAvailability": "none",
     "fixSafety": null,
@@ -6657,7 +6657,7 @@
     "examples": [
       {
         "kind": "invalid",
-        "code": "#!/bin/bash\ndo_work() {\n  local input=$1\n  echo \"processing: $input\"\n}\ndo_work \"$1\""
+        "code": "#!/bin/bash\ndo_work() {\n  local input=$1\n  echo \"processing: $input\"\n  echo \"validating: $input\"\n  echo \"loading: $input\"\n  echo \"normalizing: $input\"\n  echo \"planning: $input\"\n  echo \"executing: $input\"\n  echo \"collecting: $input\"\n  echo \"summarizing: $input\"\n  echo \"finished: $input\"\n}\ndo_work \"$1\""
       },
       {
         "kind": "valid",


### PR DESCRIPTION
## Summary
- add S083 missing-function-doc as a style rule
- build reusable function documentation facts for leading comment detection, body size, and positional parameter policy inputs
- wire S083 rule options through config, cache keys, registry, dispatch, fixture, and snapshot

## Validation
- `cargo test -p shuck-linter missing_function_doc -- --nocapture`
- `cargo test -p shuck-config s083_rule_option -- --nocapture`
- `cargo test -p shuck-cli commands::check::settings::tests -- --nocapture`
- `INSTA_UPDATE=always cargo test -p shuck-linter rules::style::tests::rules::rule_missingfunctiondoc_path_new_s083_sh_expects -- --nocapture`
- `make test-large-corpus SHUCK_LARGE_CORPUS_RULES=S083`
- `make test`
- `make check`