### PR TITLE
refactor(linter): remove legacy fact accessors

### DIFF
--- a/crates/shuck-benchmark/benches/linter.rs
+++ b/crates/shuck-benchmark/benches/linter.rs
@@ -21,13 +21,13 @@ fn build_linter_facts(
 
     black_box(
         facts.commands().len()
-            + facts.word_facts().count()
-            + facts.single_quoted_fragments().len()
-            + facts.backtick_fragments().len()
-            + facts.pattern_charclass_spans().len()
-            + facts.substring_expansion_fragments().len()
-            + facts.case_modification_fragments().len()
-            + facts.replacement_expansion_fragments().len(),
+            + facts.words().word_facts().count()
+            + facts.words().single_quoted_fragments().len()
+            + facts.words().backtick_fragments().len()
+            + facts.words().pattern_charclass_spans().len()
+            + facts.words().substring_expansion_fragments().len()
+            + facts.words().case_modification_fragments().len()
+            + facts.words().replacement_expansion_fragments().len(),
     )
 }
 

--- a/crates/shuck-benchmark/examples/linter_memory.rs
+++ b/crates/shuck-benchmark/examples/linter_memory.rs
@@ -228,13 +228,13 @@ fn measured_facts_size(input: &PreparedInput) -> (Frame, usize) {
         );
 
         facts.commands().len()
-            + facts.word_facts().count()
-            + facts.single_quoted_fragments().len()
-            + facts.backtick_fragments().len()
-            + facts.pattern_charclass_spans().len()
-            + facts.substring_expansion_fragments().len()
-            + facts.case_modification_fragments().len()
-            + facts.replacement_expansion_fragments().len()
+            + facts.words().word_facts().count()
+            + facts.words().single_quoted_fragments().len()
+            + facts.words().backtick_fragments().len()
+            + facts.words().pattern_charclass_spans().len()
+            + facts.words().substring_expansion_fragments().len()
+            + facts.words().case_modification_fragments().len()
+            + facts.words().replacement_expansion_fragments().len()
     })
 }
 

--- a/crates/shuck-cli/tests/zsh_option_state.rs
+++ b/crates/shuck-cli/tests/zsh_option_state.rs
@@ -217,6 +217,7 @@ fn run_fixture(fixture: &Fixture) -> Result<()> {
         })?;
         let word_fact = checker
             .facts()
+            .words()
             .word_fact(
                 target.span,
                 WordFactContext::Expansion(ExpansionContext::CommandArgument),
@@ -353,6 +354,7 @@ fn find_probe_command<'checker, 'ast>(
 ) -> Result<shuck_linter::CommandFactRef<'checker, 'ast>> {
     checker
         .facts()
+        .command_facts()
         .structural_commands()
         .find(|fact| {
             fact.effective_name_is(command_name)

--- a/crates/shuck-linter/src/facts/arrays.rs
+++ b/crates/shuck-linter/src/facts/arrays.rs
@@ -87,7 +87,7 @@ impl<'a, 'src> PlainUnindexedArrayReferenceContext<'a, 'src> {
         reference: &Reference,
         policy: shuck_semantic::ArrayReferencePolicy,
     ) -> bool {
-        if self.facts.source_facts.shell != ShellDialect::Zsh
+        if self.facts.source_facts().shell() != ShellDialect::Zsh
             || matches!(
                 policy,
                 shuck_semantic::ArrayReferencePolicy::RequiresExplicitSelector
@@ -96,12 +96,12 @@ impl<'a, 'src> PlainUnindexedArrayReferenceContext<'a, 'src> {
             return false;
         }
 
-        self.facts.word_facts().any(|word| {
-            self.facts.is_compound_assignment_value_word(word)
+        self.facts.words().word_facts().any(|word| {
+            self.facts.words().is_compound_assignment_value_word(word)
                 && self
                     .semantic
                     .references_in_command_span(
-                        self.facts.command(word.command_id()).span(),
+                        self.facts.command_facts().command(word.command_id()).span(),
                         word.span(),
                     )
                     .any(|direct_reference| direct_reference.id == reference.id)
@@ -112,7 +112,7 @@ impl<'a, 'src> PlainUnindexedArrayReferenceContext<'a, 'src> {
         &self,
         reference: &Reference,
     ) -> shuck_semantic::ArrayReferencePolicy {
-        if self.facts.source_facts.shell != ShellDialect::Zsh {
+        if self.facts.source_facts().shell() != ShellDialect::Zsh {
             return shuck_semantic::ArrayReferencePolicy::RequiresExplicitSelector;
         }
 
@@ -152,6 +152,7 @@ impl<'a, 'src> PlainUnindexedArrayReferenceContext<'a, 'src> {
             shuck_semantic::ArrayReferencePolicy::RequiresExplicitSelector
         ) && self
             .facts
+            .assignments()
             .presence_test_references(&reference.name)
             .iter()
             .any(|test| test.reference_id() == reference.id)
@@ -177,7 +178,7 @@ impl<'a, 'src> PlainUnindexedArrayReferenceContext<'a, 'src> {
         if !self.presence_test_ends_by_name_binding.contains_key(name) {
             let mut by_binding = FxHashMap::<Option<BindingId>, Vec<usize>>::default();
 
-            for test in self.facts.presence_test_references(name) {
+            for test in self.facts.assignments().presence_test_references(name) {
                 let binding_id = self.resolved_binding_id(test.reference_id());
                 by_binding
                     .entry(binding_id)
@@ -185,7 +186,7 @@ impl<'a, 'src> PlainUnindexedArrayReferenceContext<'a, 'src> {
                     .push(test.command_span().end.offset);
             }
 
-            for test in self.facts.presence_test_names(name) {
+            for test in self.facts.assignments().presence_test_names(name) {
                 let binding_id = self
                     .semantic
                     .visible_binding(name, test.tested_span())
@@ -252,16 +253,19 @@ impl<'a, 'src> PlainUnindexedArrayReferenceContext<'a, 'src> {
             .entry(offset)
             .or_insert_with(|| {
                 let mut ancestors = Vec::new();
-                let mut current = self.facts.innermost_command_id_containing_offset(offset);
+                let mut current = self
+                    .facts
+                    .command_facts()
+                    .innermost_command_id_containing_offset(offset);
                 while let Some(command_id) = current {
-                    let command = self.facts.command(command_id);
+                    let command = self.facts.command_facts().command(command_id);
                     if matches!(command.command(), Command::Simple(_)) {
                         ancestors.push(SimpleCommandAncestor {
                             id: command_id,
                             assignment_only: command.literal_name() == Some(""),
                         });
                     }
-                    current = self.facts.command_parent_id(command_id);
+                    current = self.facts.command_facts().command_parent_id(command_id);
                 }
                 ancestors
             })
@@ -304,11 +308,13 @@ pub(crate) fn span_is_within(outer: Span, inner: Span) -> bool {
 
 pub(crate) fn loop_header_word_quote(facts: &LinterFacts<'_>, span: Span) -> Option<WordQuote> {
     facts
+        .command_facts()
         .for_headers()
         .iter()
         .flat_map(|header| header.words().iter())
         .chain(
             facts
+                .command_facts()
                 .select_headers()
                 .iter()
                 .flat_map(|header| header.words().iter()),

--- a/crates/shuck-linter/src/facts/builder.rs
+++ b/crates/shuck-linter/src/facts/builder.rs
@@ -759,6 +759,7 @@ impl<'a, 'analysis> LinterFactsBuilder<'a, 'analysis> {
             &suppressed_subscript_spans,
             &arithmetic_only_suppressed_subscript_spans,
         );
+        #[cfg(test)]
         let subscript_later_suppression_reference_spans =
             build_subscript_later_suppression_reference_spans(
                 self.semantic,
@@ -863,11 +864,6 @@ impl<'a, 'analysis> LinterFactsBuilder<'a, 'analysis> {
             &word_occurrences,
             &word_index,
             source,
-        );
-        let unquoted_command_argument_use_offsets = build_unquoted_command_argument_use_offsets(
-            self.semantic,
-            &word_nodes,
-            &word_occurrences,
         );
         let brace_variable_before_bracket_spans =
             build_brace_variable_before_bracket_spans(&word_nodes, &word_occurrences, source);
@@ -983,12 +979,12 @@ impl<'a, 'analysis> LinterFactsBuilder<'a, 'analysis> {
             words: WordFactStore {
                 plain_unindexed_array_references: OnceLock::new(),
                 suppressed_subscript_reference_spans,
+                #[cfg(test)]
                 subscript_later_suppression_reference_spans,
                 compound_assignment_value_word_flags,
                 word_nodes,
                 word_occurrences,
                 word_index,
-                unquoted_command_argument_use_offsets,
                 array_assignment_split_word_ids,
                 brace_variable_before_bracket_spans,
                 array_index_arithmetic_spans: arithmetic_summary.array_index_arithmetic_spans,
@@ -1013,10 +1009,9 @@ impl<'a, 'analysis> LinterFactsBuilder<'a, 'analysis> {
                 echo_backslash_escape_word_spans,
                 echo_to_sed_substitution_spans,
                 unicode_smart_quote_spans,
-                pattern_exactly_one_extglob_spans,
+                #[cfg(test)]
                 pattern_literal_spans,
                 pattern_charclass_spans,
-                nested_pattern_charclass_spans,
                 nested_parameter_expansion_fragments: nested_parameter_expansions,
                 indirect_expansion_fragments: indirect_expansions,
                 indexed_array_reference_fragments: indexed_array_references,

--- a/crates/shuck-linter/src/facts/case_patterns.rs
+++ b/crates/shuck-linter/src/facts/case_patterns.rs
@@ -3,17 +3,12 @@ use super::*;
 #[derive(Debug, Clone, Copy)]
 pub struct CaseItemFact<'a> {
     item: &'a CaseItem,
-    command_id: CommandId,
     case_span: Span,
 }
 
 impl<'a> CaseItemFact<'a> {
     pub fn item(&self) -> &'a CaseItem {
         self.item
-    }
-
-    pub fn command_id(&self) -> CommandId {
-        self.command_id
     }
 
     pub fn terminator(&self) -> CaseTerminator {
@@ -55,10 +50,6 @@ impl GetoptsOptionSpec {
     pub fn option(self) -> char {
         self.option
     }
-
-    pub fn requires_argument(self) -> bool {
-        self.requires_argument
-    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -76,16 +67,11 @@ impl GetoptsCaseLabelFact {
     pub fn span(self) -> Span {
         self.span
     }
-
-    pub fn is_bare_single_letter(self) -> bool {
-        self.is_bare_single_letter
-    }
 }
 
 #[derive(Debug, Clone)]
 pub struct GetoptsCaseFact {
     case_span: Span,
-    declared_options: Box<[GetoptsOptionSpec]>,
     handled_case_labels: Box<[GetoptsCaseLabelFact]>,
     unexpected_case_labels: Box<[GetoptsCaseLabelFact]>,
     invalid_case_pattern_spans: Box<[Span]>,
@@ -99,10 +85,7 @@ impl GetoptsCaseFact {
         self.case_span
     }
 
-    pub fn declared_options(&self) -> &[GetoptsOptionSpec] {
-        &self.declared_options
-    }
-
+    #[cfg(test)]
     pub fn handled_case_labels(&self) -> &[GetoptsCaseLabelFact] {
         &self.handled_case_labels
     }
@@ -115,10 +98,7 @@ impl GetoptsCaseFact {
         &self.invalid_case_pattern_spans
     }
 
-    pub fn has_fallback_pattern(&self) -> bool {
-        self.has_fallback_pattern
-    }
-
+    #[cfg(test)]
     pub fn has_unknown_coverage(&self) -> bool {
         self.has_unknown_coverage
     }
@@ -149,11 +129,12 @@ pub(crate) fn build_case_item_facts<'a>(
             };
 
             let case_span = fact.span_in_source(source);
-            Some(command.cases.iter().map(move |item| CaseItemFact {
-                item,
-                command_id: fact.id(),
-                case_span,
-            }))
+            Some(
+                command
+                    .cases
+                    .iter()
+                    .map(move |item| CaseItemFact { item, case_span }),
+            )
         })
         .flatten()
         .collect()
@@ -1265,7 +1246,6 @@ pub(crate) fn build_getopts_case_fact_for_while(
 
     Some(GetoptsCaseFact {
         case_span,
-        declared_options: parsed.declared_options.into_boxed_slice(),
         handled_case_labels: handled_case_labels.into_boxed_slice(),
         unexpected_case_labels: unexpected_case_labels.into_boxed_slice(),
         invalid_case_pattern_spans: invalid_case_pattern_spans.into_boxed_slice(),

--- a/crates/shuck-linter/src/facts/command_options/mod.rs
+++ b/crates/shuck-linter/src/facts/command_options/mod.rs
@@ -547,10 +547,6 @@ impl FunctionPositionalParameterFacts {
         self.uses_unprotected_positional_parameters
     }
 
-    pub fn uses_unprotected_positional_parameters(&self) -> bool {
-        self.uses_unprotected_positional_parameters
-    }
-
     pub fn resets_positional_parameters(&self) -> bool {
         self.resets_positional_parameters
     }

--- a/crates/shuck-linter/src/facts/commands.rs
+++ b/crates/shuck-linter/src/facts/commands.rs
@@ -711,6 +711,7 @@ pub(crate) fn build_redundant_echo_space_facts(
     facts: &LinterFacts<'_>,
 ) -> Vec<RedundantEchoSpaceFact> {
     facts
+        .command_facts()
         .structural_commands()
         .filter_map(|command| redundant_echo_space_fact(command, facts.source_facts.source))
         .collect()

--- a/crates/shuck-linter/src/facts/escape_scan.rs
+++ b/crates/shuck-linter/src/facts/escape_scan.rs
@@ -516,7 +516,7 @@ mod tests {
         let indexer = Indexer::new(source, &output);
         let semantic = LinterSemanticArtifacts::build(&output.file, source, &indexer);
         let facts = LinterFacts::build(&output.file, source, &semantic, &indexer);
-        visit(facts.escape_scan_matches());
+        visit(facts.words().escape_scan_matches());
     }
 
     #[test]

--- a/crates/shuck-linter/src/facts/mod.rs
+++ b/crates/shuck-linter/src/facts/mod.rs
@@ -41,6 +41,8 @@ mod traversal;
 pub(crate) mod word_spans;
 pub(crate) mod words;
 
+#[cfg(test)]
+use self::surface::build_subscript_later_suppression_reference_spans;
 use self::word_spans::{expansion_part_spans, word_unbraced_variable_before_bracket_spans};
 use self::{
     conditional_portability::{ConditionalPortabilityInputs, build_conditional_portability_facts},
@@ -59,7 +61,6 @@ use self::{
         PositionalParameterTrimFragmentFact, ReplacementExpansionFragmentFact,
         SubstringExpansionFragmentFact, SurfaceFragmentFacts, SurfaceFragmentSink,
         SurfaceScanContext, SuspectClosingQuoteFragmentFact, ZshParameterIndexFlagFragmentFact,
-        build_subscript_later_suppression_reference_spans,
         build_suppressed_subscript_reference_spans, rewrite_pattern_as_single_double_quoted_string,
         rewrite_word_as_single_double_quoted_string,
     },
@@ -150,7 +151,9 @@ pub use self::{
     functions::{FunctionCallArityFacts, FunctionHeaderFact},
     lists::{ListFact, ListOperatorFact, ListSegmentKind, MixedShortCircuitKind},
     loop_headers::{ForHeaderFact, LoopHeaderWordFact, SelectHeaderFact},
-    model::LinterFacts,
+    model::{
+        AssignmentFacts, CommandFactQueries, CompatFacts, LinterFacts, SourceFacts, WordFacts,
+    },
     pipelines::{PipelineFact, PipelineOperatorFact, PipelineSegmentFact},
     redirects::{RedirectDevNullStatus, RedirectFact, RedirectTargetAnalysis, RedirectTargetKind},
     simple_tests::{SimpleTestFact, SimpleTestOperatorFamily, SimpleTestShape, SimpleTestSyntax},

--- a/crates/shuck-linter/src/facts/model.rs
+++ b/crates/shuck-linter/src/facts/model.rs
@@ -52,12 +52,12 @@ pub(crate) struct WordFactStore<'a> {
     pub(in crate::facts) plain_unindexed_array_references:
         OnceLock<Vec<PlainUnindexedArrayReferenceFact>>,
     pub(in crate::facts) suppressed_subscript_reference_spans: FxHashSet<FactSpan>,
+    #[cfg(test)]
     pub(in crate::facts) subscript_later_suppression_reference_spans: FxHashSet<FactSpan>,
     pub(in crate::facts) compound_assignment_value_word_flags: Box<[bool]>,
     pub(in crate::facts) word_nodes: Vec<WordNode<'a>>,
     pub(in crate::facts) word_occurrences: Vec<WordOccurrence>,
     pub(in crate::facts) word_index: FxHashMap<FactSpan, SmallVec<[WordOccurrenceId; 2]>>,
-    pub(in crate::facts) unquoted_command_argument_use_offsets: FxHashMap<Name, Vec<usize>>,
     pub(in crate::facts) array_assignment_split_word_ids: Vec<WordOccurrenceId>,
     pub(in crate::facts) brace_variable_before_bracket_spans: Vec<Span>,
     pub(in crate::facts) array_index_arithmetic_spans: Vec<Span>,
@@ -81,10 +81,9 @@ pub(crate) struct WordFactStore<'a> {
     pub(in crate::facts) echo_backslash_escape_word_spans: Vec<Span>,
     pub(in crate::facts) echo_to_sed_substitution_spans: Vec<Span>,
     pub(in crate::facts) unicode_smart_quote_spans: Vec<Span>,
-    pub(in crate::facts) pattern_exactly_one_extglob_spans: Vec<Span>,
+    #[cfg(test)]
     pub(in crate::facts) pattern_literal_spans: Vec<Span>,
     pub(in crate::facts) pattern_charclass_spans: Vec<Span>,
-    pub(in crate::facts) nested_pattern_charclass_spans: FxHashSet<FactSpan>,
     pub(in crate::facts) nested_parameter_expansion_fragments:
         Vec<NestedParameterExpansionFragmentFact>,
     pub(in crate::facts) indirect_expansion_fragments: Vec<IndirectExpansionFragmentFact>,
@@ -175,6 +174,31 @@ pub struct LinterFacts<'a> {
     pub(in crate::facts) compat: CompatFactStore,
 }
 
+#[derive(Clone, Copy)]
+pub struct CommandFactQueries<'facts, 'a> {
+    facts: &'facts LinterFacts<'a>,
+}
+
+#[derive(Clone, Copy)]
+pub struct WordFacts<'facts, 'a> {
+    facts: &'facts LinterFacts<'a>,
+}
+
+#[derive(Clone, Copy)]
+pub struct AssignmentFacts<'facts, 'a> {
+    facts: &'facts LinterFacts<'a>,
+}
+
+#[derive(Clone, Copy)]
+pub struct SourceFacts<'facts, 'a> {
+    facts: &'facts LinterFacts<'a>,
+}
+
+#[derive(Clone, Copy)]
+pub struct CompatFacts<'facts, 'a> {
+    facts: &'facts LinterFacts<'a>,
+}
+
 impl<'a> LinterFacts<'a> {
     pub fn build(
         file: &'a File,
@@ -257,122 +281,79 @@ impl<'a> LinterFacts<'a> {
         )
     }
 
-    pub(crate) fn words(&self) -> &WordFactStore<'a> {
-        &self.words
+    pub fn command_facts(&self) -> CommandFactQueries<'_, 'a> {
+        CommandFactQueries { facts: self }
     }
 
-    pub(crate) fn assignments(&self) -> &AssignmentFactStore<'a> {
-        &self.assignments
+    pub fn words(&self) -> WordFacts<'_, 'a> {
+        WordFacts { facts: self }
     }
 
-    pub(crate) fn source_facts(&self) -> &SourceFactStore<'a> {
-        &self.source_facts
+    pub fn assignments(&self) -> AssignmentFacts<'_, 'a> {
+        AssignmentFacts { facts: self }
     }
 
-    pub(crate) fn compat(&self) -> &CompatFactStore {
-        &self.compat
+    pub fn source_facts(&self) -> SourceFacts<'_, 'a> {
+        SourceFacts { facts: self }
     }
 
-    pub fn malformed_bracket_test_spans(&self, source: &str) -> Vec<Span> {
-        self.command
-            .commands
-            .iter()
-            .filter(|fact| fact.static_utility_name_is("["))
-            .filter(|fact| {
-                fact.body_args()
-                    .last()
-                    .and_then(|word| static_word_text(word, source))
-                    .as_deref()
-                    != Some("]")
-            })
-            .map(|fact| fact.body_name_word().map_or(fact.span(), |word| word.span))
-            .collect()
+    pub fn compat(&self) -> CompatFacts<'_, 'a> {
+        CompatFacts { facts: self }
     }
+}
 
-    pub fn abort_like_bracket_test_spans(&self, source: &str) -> Vec<Span> {
-        self.command
-            .commands
-            .iter()
-            .filter_map(|fact| {
-                let simple_test = fact.simple_test()?;
-                simple_test
-                    .is_abort_like_bracket_test(source)
-                    .then_some(simple_test)
-            })
-            .map(|simple_test| {
-                simple_test
-                    .effective_operator_word()
-                    .map_or_else(|| simple_test.operands()[0].span, |word| word.span)
-            })
-            .collect()
-    }
-
-    pub fn function_positional_parameter_facts(
-        &self,
+impl<'facts, 'a> CommandFactQueries<'facts, 'a> {
+    pub(crate) fn function_positional_parameter_facts(
+        self,
         scope: ScopeId,
     ) -> FunctionPositionalParameterFacts {
-        self.command
+        self.facts
+            .command
             .function_positional_parameter_facts
             .get(&scope)
             .copied()
             .unwrap_or_default()
     }
 
-    pub(crate) fn function_cli_dispatch_facts(&self, scope: ScopeId) -> FunctionCliDispatchFacts {
-        self.command
+    pub(crate) fn function_cli_dispatch_facts(self, scope: ScopeId) -> FunctionCliDispatchFacts {
+        self.facts
+            .command
             .function_cli_dispatch_facts
             .get(&scope)
             .copied()
             .unwrap_or_default()
     }
 
-    pub fn structural_commands(&self) -> impl Iterator<Item = CommandFactRef<'_, 'a>> + '_ {
-        self.command
+    pub fn structural_commands(self) -> impl Iterator<Item = CommandFactRef<'facts, 'a>> + 'facts {
+        self.facts
+            .command
             .structural_command_ids
             .iter()
             .copied()
-            .map(|id| self.command(id))
+            .map(move |id| self.command(id))
     }
 
-    pub(crate) fn unset_commands_for_name(
-        &self,
-        name: &Name,
-    ) -> impl Iterator<Item = CommandFactRef<'_, 'a>> + '_ {
-        self.assignments
-            .unset_command_ids_by_target_name
-            .get(name)
-            .into_iter()
-            .flatten()
-            .copied()
-            .map(|id| self.command(id))
-    }
-
-    pub(crate) fn function_unset_commands_for_name(
-        &self,
-        name: &Name,
-    ) -> impl Iterator<Item = CommandFactRef<'_, 'a>> + '_ {
-        self.assignments
-            .function_unset_command_ids_by_target_name
-            .get(name)
-            .into_iter()
-            .flatten()
-            .copied()
-            .map(|id| self.command(id))
-    }
-
-    pub fn command(&self, id: CommandId) -> CommandFactRef<'_, 'a> {
+    pub(crate) fn command(self, id: CommandId) -> CommandFactRef<'facts, 'a> {
         let index = self
+            .facts
             .command
             .command_fact_indices_by_id
             .get(id.index())
             .and_then(|index| *index)
             .unwrap_or_else(|| panic!("command id {} must exist", id.index()));
 
-        CommandFactRef::new(&self.command.commands[index], &self.command.fact_store)
+        CommandFactRef::new(
+            &self.facts.command.commands[index],
+            &self.facts.command.fact_store,
+        )
     }
 
-    pub fn command_for_name_word_span(&self, span: Span) -> Option<CommandFactRef<'_, 'a>> {
-        self.command
+    pub(crate) fn command_for_name_word_span(
+        self,
+        span: Span,
+    ) -> Option<CommandFactRef<'facts, 'a>> {
+        self.facts
+            .command
             .command_ids_by_name_word_span
             .get(&FactSpan::new(span))
             .copied()
@@ -380,30 +361,32 @@ impl<'a> LinterFacts<'a> {
             .map(|id| self.command(id))
     }
 
-    pub fn innermost_command_at(&self, offset: usize) -> Option<CommandFactRef<'_, 'a>> {
+    pub(crate) fn innermost_command_at(self, offset: usize) -> Option<CommandFactRef<'facts, 'a>> {
         self.innermost_command_id_at(offset)
             .map(|id| self.command(id))
     }
 
-    pub(crate) fn expansion_behavior_at(&self, offset: usize) -> ShellBehaviorAt<'a> {
+    pub(crate) fn expansion_behavior_at(self, offset: usize) -> ShellBehaviorAt<'a> {
         self.innermost_command_at(offset).map_or_else(
-            || self.semantic.shell_behavior_at(offset),
+            || self.facts.semantic.shell_behavior_at(offset),
             |command| command.shell_behavior().clone(),
         )
     }
 
-    pub fn innermost_command_id_at(&self, offset: usize) -> Option<CommandId> {
-        precomputed_command_id_for_offset(&self.command.innermost_command_ids_by_offset, offset)
+    pub(crate) fn innermost_command_id_at(self, offset: usize) -> Option<CommandId> {
+        precomputed_command_id_for_offset(
+            &self.facts.command.innermost_command_ids_by_offset,
+            offset,
+        )
     }
 
-    pub(crate) fn innermost_command_id_containing_offset(
-        &self,
-        offset: usize,
-    ) -> Option<CommandId> {
-        self.semantic
+    pub(crate) fn innermost_command_id_containing_offset(self, offset: usize) -> Option<CommandId> {
+        self.facts
+            .semantic
             .innermost_command_id_containing_offset(offset)
             .filter(|id| {
-                self.command
+                self.facts
+                    .command
                     .command_fact_indices_by_id
                     .get(id.index())
                     .is_some_and(Option::is_some)
@@ -411,54 +394,64 @@ impl<'a> LinterFacts<'a> {
     }
 
     pub(crate) fn innermost_command_at_binding_offset(
-        &self,
+        self,
         offset: usize,
-    ) -> Option<CommandFactRef<'_, 'a>> {
+    ) -> Option<CommandFactRef<'facts, 'a>> {
         precomputed_command_id_for_offset(
-            &self.command.innermost_command_ids_by_binding_offset,
+            &self.facts.command.innermost_command_ids_by_binding_offset,
             offset,
         )
         .map(|id| self.command(id))
     }
 
-    pub fn command_parent_id(&self, id: CommandId) -> Option<CommandId> {
-        self.semantic
+    pub(crate) fn command_parent_id(self, id: CommandId) -> Option<CommandId> {
+        self.facts
+            .semantic
             .syntax_backed_command_parent_id(id)
             .filter(|parent_id| {
-                self.command
+                self.facts
+                    .command
                     .command_fact_indices_by_id
                     .get(parent_id.index())
                     .is_some_and(Option::is_some)
             })
     }
 
-    pub fn command_parent(&self, id: CommandId) -> Option<CommandFactRef<'_, 'a>> {
+    #[cfg(test)]
+    pub(crate) fn command_parent(self, id: CommandId) -> Option<CommandFactRef<'facts, 'a>> {
         self.command_parent_id(id)
             .map(|parent_id| self.command(parent_id))
     }
 
-    pub fn redundant_echo_space_facts(&self) -> &[RedundantEchoSpaceFact] {
-        self.command
+    pub(crate) fn redundant_echo_space_facts(self) -> &'facts [RedundantEchoSpaceFact] {
+        self.facts
+            .command
             .redundant_echo_space_facts
-            .get_or_init(|| build_redundant_echo_space_facts(self))
+            .get_or_init(|| build_redundant_echo_space_facts(self.facts))
     }
 
-    pub fn function_definition_command(&self, scope: ScopeId) -> Option<CommandFactRef<'_, 'a>> {
-        self.command
+    pub(crate) fn function_definition_command(
+        self,
+        scope: ScopeId,
+    ) -> Option<CommandFactRef<'facts, 'a>> {
+        self.facts
+            .command
             .function_definition_command_ids_by_scope
             .get(&scope)
             .copied()
             .map(|id| self.command(id))
     }
 
-    pub fn is_case_cli_reachable_function_scope(&self, scope: ScopeId) -> bool {
-        self.command
+    pub(crate) fn is_case_cli_reachable_function_scope(self, scope: ScopeId) -> bool {
+        self.facts
+            .command
             .case_cli_reachable_function_scopes
             .contains(&scope)
     }
 
-    pub fn command_is_dominance_barrier(&self, id: CommandId) -> bool {
-        self.command
+    pub(crate) fn command_is_dominance_barrier(self, id: CommandId) -> bool {
+        self.facts
+            .command
             .command_dominance_barrier_flags
             .get(id.index())
             .copied()
@@ -466,16 +459,16 @@ impl<'a> LinterFacts<'a> {
     }
 
     #[cfg(test)]
-    pub(crate) fn command_id_for_stmt(&self, stmt: &Stmt) -> Option<CommandId> {
+    pub(crate) fn command_id_for_stmt(self, stmt: &Stmt) -> Option<CommandId> {
         self.command_id_for_command(&stmt.command)
     }
 
     #[cfg(test)]
-    pub(crate) fn command_id_for_command(&self, command: &Command) -> Option<CommandId> {
-        command_id_for_command(command, &self.command.command_ids_by_span)
+    pub(crate) fn command_id_for_command(self, command: &Command) -> Option<CommandId> {
+        command_id_for_command(command, &self.facts.command.command_ids_by_span)
     }
 
-    fn command_id_for_exact_span(&self, span: Span) -> Option<CommandId> {
+    fn command_id_for_exact_span(self, span: Span) -> Option<CommandId> {
         let mut current = self.innermost_command_id_at(span.start.offset)?;
         loop {
             if self.command(current).span() == span {
@@ -485,88 +478,240 @@ impl<'a> LinterFacts<'a> {
         }
     }
 
-    pub fn binding_value(&self, binding_id: BindingId) -> Option<&BindingValueFact<'a>> {
-        self.assignments().binding_values.get(&binding_id)
+    pub(crate) fn is_if_condition_command(self, id: CommandId) -> bool {
+        self.facts.command.if_condition_command_ids.contains(id)
     }
 
-    pub fn broken_assoc_key_spans(&self) -> &[Span] {
-        &self.assignments.broken_assoc_key_spans
+    pub(crate) fn is_elif_condition_command(self, id: CommandId) -> bool {
+        self.facts.command.elif_condition_command_ids.contains(id)
     }
 
-    pub fn comma_array_assignment_spans(&self) -> &[Span] {
-        &self.assignments.comma_array_assignment_spans
+    pub(crate) fn command_is_in_completion_registered_function(self, id: CommandId) -> bool {
+        self.facts
+            .command
+            .completion_registered_function_command_flags
+            .get(id.index())
+            .copied()
+            .unwrap_or(false)
     }
 
-    pub fn ifs_literal_backslash_assignment_value_spans(&self) -> &[Span] {
+    pub(crate) fn function_is_completion_registered(self, scope: ScopeId) -> bool {
+        self.facts
+            .command
+            .completion_registered_function_scopes
+            .contains(&scope)
+    }
+
+    pub(crate) fn function_is_external_entrypoint(self, scope: ScopeId) -> bool {
+        self.facts
+            .command
+            .external_entrypoint_function_scopes
+            .contains(&scope)
+    }
+
+    pub(crate) fn function_headers(self) -> &'facts [FunctionHeaderFact<'a>] {
+        &self.facts.command.function_headers
+    }
+
+    pub(crate) fn function_in_alias_spans(self) -> &'facts [Span] {
+        &self.facts.command.function_in_alias_spans
+    }
+
+    pub(crate) fn alias_definition_expansion_spans(self) -> &'facts [Span] {
+        &self.facts.command.alias_definition_expansion_spans
+    }
+
+    pub(crate) fn function_body_without_braces_spans(self) -> &'facts [Span] {
+        &self.facts.command.function_body_without_braces_spans
+    }
+
+    pub(crate) fn function_parameter_fallback_spans(self) -> &'facts [Span] {
+        &self.facts.command.function_parameter_fallback_spans
+    }
+
+    pub(crate) fn redundant_return_status_spans(self) -> &'facts [Span] {
+        &self.facts.command.redundant_return_status_spans
+    }
+
+    pub(crate) fn for_headers(self) -> &'facts [ForHeaderFact<'a>] {
+        &self.facts.command.for_headers
+    }
+
+    pub(crate) fn select_headers(self) -> &'facts [SelectHeaderFact<'a>] {
+        &self.facts.command.select_headers
+    }
+
+    pub(crate) fn case_items(self) -> &'facts [CaseItemFact<'a>] {
+        &self.facts.command.case_items
+    }
+
+    pub(crate) fn case_pattern_shadows(self) -> &'facts [CasePatternShadowFact] {
+        &self.facts.command.case_pattern_shadows
+    }
+
+    pub(crate) fn case_pattern_impossible_spans(self) -> &'facts [Span] {
+        &self.facts.command.case_pattern_impossible_spans
+    }
+
+    pub(crate) fn case_pattern_expansions(self) -> &'facts [CasePatternExpansionFact] {
+        &self.facts.command.case_pattern_expansions
+    }
+
+    pub(crate) fn getopts_cases(self) -> &'facts [GetoptsCaseFact] {
+        &self.facts.command.getopts_cases
+    }
+
+    pub(crate) fn pipelines(self) -> &'facts [PipelineFact<'a>] {
+        &self.facts.command.pipelines
+    }
+
+    pub(crate) fn lists(self) -> &'facts [ListFact<'a>] {
+        &self.facts.command.lists
+    }
+
+    pub(crate) fn statement_facts(self) -> &'facts [StatementFact] {
+        &self.facts.command.statement_facts
+    }
+
+    pub(crate) fn background_semicolon_spans(self) -> &'facts [Span] {
+        &self.facts.command.background_semicolon_spans
+    }
+
+    pub(crate) fn single_test_subshell_spans(self) -> &'facts [Span] {
+        &self.facts.command.single_test_subshell_spans
+    }
+
+    pub(crate) fn subshell_test_group_spans(self) -> &'facts [Span] {
+        &self.facts.command.subshell_test_group_spans
+    }
+
+    pub(crate) fn condition_status_capture_spans(self) -> &'facts [Span] {
+        &self.facts.command.condition_status_capture_spans
+    }
+
+    pub(crate) fn command_substitution_command_spans(self) -> &'facts [Span] {
+        &self.facts.command.command_substitution_command_spans
+    }
+
+    pub(crate) fn backtick_command_name_spans(self) -> &'facts [Span] {
+        &self.facts.command.backtick_command_name_spans
+    }
+
+    pub(crate) fn assignment_like_command_name_spans(self) -> &'facts [Span] {
+        &self.facts.command.assignment_like_command_name_spans
+    }
+
+    pub(crate) fn bare_command_name_assignment_spans(self) -> &'facts [Span] {
+        &self.facts.command.bare_command_name_assignment_spans
+    }
+}
+
+impl<'facts, 'a> AssignmentFacts<'facts, 'a> {
+    pub(crate) fn binding_value(
+        self,
+        binding_id: BindingId,
+    ) -> Option<&'facts BindingValueFact<'a>> {
+        self.facts.assignments.binding_values.get(&binding_id)
+    }
+
+    pub(crate) fn broken_assoc_key_spans(self) -> &'facts [Span] {
+        &self.facts.assignments.broken_assoc_key_spans
+    }
+
+    pub(crate) fn comma_array_assignment_spans(self) -> &'facts [Span] {
+        &self.facts.assignments.comma_array_assignment_spans
+    }
+
+    pub(crate) fn ifs_literal_backslash_assignment_value_spans(self) -> &'facts [Span] {
         &self
+            .facts
             .assignments
             .ifs_literal_backslash_assignment_value_spans
     }
 
-    pub fn env_prefix_assignment_scope_spans(&self) -> &[Span] {
-        &self.assignments.env_prefix_assignment_scope_spans
+    pub(crate) fn env_prefix_assignment_scope_spans(self) -> &'facts [Span] {
+        &self.facts.assignments.env_prefix_assignment_scope_spans
     }
 
-    pub fn env_prefix_expansion_scope_spans(&self) -> &[Span] {
-        &self.assignments.env_prefix_expansion_scope_spans
+    pub(crate) fn env_prefix_expansion_scope_spans(self) -> &'facts [Span] {
+        &self.facts.assignments.env_prefix_expansion_scope_spans
     }
 
-    pub fn env_prefix_expansion_fix_facts(&self) -> &[EnvPrefixExpansionFixFact] {
-        &self.assignments.env_prefix_expansion_fix_facts
+    pub(crate) fn env_prefix_expansion_fix_facts(self) -> &'facts [EnvPrefixExpansionFixFact] {
+        &self.facts.assignments.env_prefix_expansion_fix_facts
     }
 
-    pub fn is_if_condition_command(&self, id: CommandId) -> bool {
-        self.command.if_condition_command_ids.contains(id)
+    pub(crate) fn unset_commands_for_name(
+        self,
+        name: &Name,
+    ) -> impl Iterator<Item = CommandFactRef<'facts, 'a>> + 'facts {
+        self.facts
+            .assignments
+            .unset_command_ids_by_target_name
+            .get(name)
+            .into_iter()
+            .flatten()
+            .copied()
+            .map(move |id| self.facts.command_facts().command(id))
     }
 
-    pub fn is_elif_condition_command(&self, id: CommandId) -> bool {
-        self.command.elif_condition_command_ids.contains(id)
-    }
-
-    pub fn presence_tested_names(&self) -> &FxHashSet<Name> {
-        &self.assignments.presence_tested_names
+    pub(crate) fn function_unset_commands_for_name(
+        self,
+        name: &Name,
+    ) -> impl Iterator<Item = CommandFactRef<'facts, 'a>> + 'facts {
+        self.facts
+            .assignments
+            .function_unset_command_ids_by_target_name
+            .get(name)
+            .into_iter()
+            .flatten()
+            .copied()
+            .map(move |id| self.facts.command_facts().command(id))
     }
 
     pub(crate) fn possible_variable_misspelling_candidate(
-        &self,
+        self,
         semantic: &SemanticModel,
         target_name: &str,
     ) -> Option<String> {
         if *self
+            .facts
             .assignments
             .possible_variable_misspelling_use_scan
             .get_or_init(|| {
                 should_scan_possible_variable_misspelling_candidates(
                     semantic,
-                    &self.assignments.presence_test_references_by_name,
-                    &self.assignments.presence_test_names_by_name,
+                    &self.facts.assignments.presence_test_references_by_name,
+                    &self.facts.assignments.presence_test_names_by_name,
                 )
             })
         {
             return scan_possible_variable_misspelling_candidate(
                 semantic,
-                &self.assignments.presence_test_references_by_name,
-                &self.assignments.presence_test_names_by_name,
+                &self.facts.assignments.presence_test_references_by_name,
+                &self.facts.assignments.presence_test_names_by_name,
                 target_name,
             );
         }
 
-        self.assignments
+        self.facts
+            .assignments
             .possible_variable_misspelling_index
             .get_or_init(|| {
                 build_possible_variable_misspelling_index(
                     semantic,
-                    &self.assignments.presence_test_references_by_name,
-                    &self.assignments.presence_test_names_by_name,
+                    &self.facts.assignments.presence_test_references_by_name,
+                    &self.facts.assignments.presence_test_names_by_name,
                 )
             })
             .candidate_name(target_name)
             .map(ToOwned::to_owned)
     }
 
-    pub fn is_presence_tested_name(&self, name: &Name, span: Span) -> bool {
-        self.assignments.presence_tested_names.contains(name)
+    pub(crate) fn is_presence_tested_name(self, name: &Name, span: Span) -> bool {
+        self.facts.assignments.presence_tested_names.contains(name)
             || self
+                .facts
                 .assignments
                 .nested_presence_test_spans
                 .get(name)
@@ -578,16 +723,21 @@ impl<'a> LinterFacts<'a> {
                 })
     }
 
-    pub fn is_c006_presence_tested_name(&self, name: &Name, _span: Span) -> bool {
-        self.assignments.c006_presence_tested_names.contains(name)
+    pub(crate) fn is_c006_presence_tested_name(self, name: &Name, _span: Span) -> bool {
+        self.facts
+            .assignments
+            .c006_presence_tested_names
+            .contains(name)
             || self
+                .facts
                 .assignments
                 .c006_nested_presence_test_spans
                 .contains_key(name)
     }
 
-    pub fn has_prior_c006_suppressing_reference(&self, name: &Name, span: Span) -> bool {
-        self.assignments
+    pub(crate) fn has_prior_c006_suppressing_reference(self, name: &Name, span: Span) -> bool {
+        self.facts
+            .assignments
             .c006_suppressing_reference_offsets_by_name
             .get(name)
             .is_some_and(|offsets| {
@@ -595,30 +745,36 @@ impl<'a> LinterFacts<'a> {
             })
     }
 
-    pub fn assignment_value_target_name_for_span(&self, span: Span) -> Option<&Name> {
+    pub(crate) fn assignment_value_target_name_for_span(self, span: Span) -> Option<&'facts Name> {
         let query_start = span.start.offset;
         let query_end = span.end.offset;
         let upper = self
+            .facts
             .assignments
             .assignment_value_target_index
             .partition_point(|entry| entry.value_start <= query_start);
-        self.assignments.assignment_value_target_index[..upper]
+        self.facts.assignments.assignment_value_target_index[..upper]
             .iter()
             .rev()
             .find(|entry| entry.value_end >= query_end)
             .map(|entry| &entry.target_name)
     }
 
-    pub(crate) fn presence_test_references(&self, name: &Name) -> &[PresenceTestReferenceFact] {
-        self.assignments
+    pub(crate) fn presence_test_references(
+        self,
+        name: &Name,
+    ) -> &'facts [PresenceTestReferenceFact] {
+        self.facts
+            .assignments
             .presence_test_references_by_name
             .get(name)
             .map(Vec::as_slice)
             .unwrap_or(&[])
     }
 
-    pub(crate) fn presence_test_names(&self, name: &Name) -> &[PresenceTestNameFact] {
-        self.assignments
+    pub(crate) fn presence_test_names(self, name: &Name) -> &'facts [PresenceTestNameFact] {
+        self.facts
+            .assignments
             .presence_test_names_by_name
             .get(name)
             .map(Vec::as_slice)
@@ -626,17 +782,24 @@ impl<'a> LinterFacts<'a> {
     }
 
     pub(crate) fn presence_test_candidate_spans(
-        &self,
+        self,
         semantic: &SemanticModel,
     ) -> Vec<(Name, Span)> {
         let mut names = FxHashSet::<Name>::default();
         names.extend(
-            self.assignments
+            self.facts
+                .assignments
                 .presence_test_references_by_name
                 .keys()
                 .cloned(),
         );
-        names.extend(self.assignments.presence_test_names_by_name.keys().cloned());
+        names.extend(
+            self.facts
+                .assignments
+                .presence_test_names_by_name
+                .keys()
+                .cloned(),
+        );
 
         names
             .into_iter()
@@ -648,18 +811,20 @@ impl<'a> LinterFacts<'a> {
     }
 
     fn first_presence_test_candidate_span(
-        &self,
+        self,
         semantic: &SemanticModel,
         candidate_name: &Name,
     ) -> Option<Span> {
-        self.assignments
+        self.facts
+            .assignments
             .presence_test_references_by_name
             .get(candidate_name)
             .into_iter()
             .flatten()
             .map(|presence| semantic.reference(presence.reference_id()).span)
             .chain(
-                self.assignments
+                self.facts
+                    .assignments
                     .presence_test_names_by_name
                     .get(candidate_name)
                     .into_iter()
@@ -669,52 +834,203 @@ impl<'a> LinterFacts<'a> {
             .min_by_key(|span| (span.start.offset, span.end.offset))
     }
 
-    pub fn is_suppressed_subscript_reference(&self, span: Span) -> bool {
-        self.words()
+    pub(crate) fn subshell_assignment_sites(self) -> &'facts [NamedSpan] {
+        &self.facts.assignments.subshell_assignment_sites
+    }
+
+    pub(crate) fn subshell_later_use_sites(self) -> &'facts [NamedSpan] {
+        &self.facts.assignments.subshell_later_use_sites
+    }
+
+    pub(crate) fn plus_equals_assignment_spans(self) -> &'facts [Span] {
+        &self.facts.assignments.plus_equals_assignment_spans
+    }
+}
+
+impl<'facts, 'a> SourceFacts<'facts, 'a> {
+    pub(crate) fn source(self) -> &'facts str {
+        self.facts.source_facts.source
+    }
+
+    pub(crate) fn line_index(self) -> &'facts LineIndex {
+        self.facts.source_facts.line_index
+    }
+
+    pub(crate) fn shell(self) -> ShellDialect {
+        self.facts.source_facts.shell
+    }
+
+    pub(crate) fn indented_shebang_span(self) -> Option<Span> {
+        self.facts.source_facts.indented_shebang_span
+    }
+
+    pub(crate) fn indented_shebang_indent_span(self) -> Option<Span> {
+        self.facts.source_facts.indented_shebang_indent_span
+    }
+
+    pub(crate) fn space_after_hash_bang_span(self) -> Option<Span> {
+        self.facts.source_facts.space_after_hash_bang_span
+    }
+
+    pub(crate) fn space_after_hash_bang_whitespace_span(self) -> Option<Span> {
+        self.facts
+            .source_facts
+            .space_after_hash_bang_whitespace_span
+    }
+
+    pub(crate) fn shebang_not_on_first_line_span(self) -> Option<Span> {
+        self.facts.source_facts.shebang_not_on_first_line_span
+    }
+
+    pub(crate) fn shebang_not_on_first_line_fix_span(self) -> Option<Span> {
+        self.facts.source_facts.shebang_not_on_first_line_fix_span
+    }
+
+    pub(crate) fn shebang_not_on_first_line_preferred_newline(self) -> Option<&'static str> {
+        self.facts
+            .source_facts
+            .shebang_not_on_first_line_preferred_newline
+    }
+
+    pub(crate) fn missing_shebang_line_span(self) -> Option<Span> {
+        self.facts.source_facts.missing_shebang_line_span
+    }
+
+    pub(crate) fn duplicate_shebang_flag_span(self) -> Option<Span> {
+        self.facts.source_facts.duplicate_shebang_flag_span
+    }
+
+    pub(crate) fn non_absolute_shebang_span(self) -> Option<Span> {
+        self.facts.source_facts.non_absolute_shebang_span
+    }
+
+    pub(crate) fn errexit_enabled_anywhere(self) -> bool {
+        self.facts.source_facts.errexit_enabled_anywhere
+    }
+
+    pub(crate) fn commented_continuation_comment_spans(self) -> &'facts [Span] {
+        &self.facts.source_facts.commented_continuation_comment_spans
+    }
+
+    pub(crate) fn comment_double_quote_nesting_spans(self) -> &'facts [Span] {
+        &self.facts.source_facts.comment_double_quote_nesting_spans
+    }
+
+    pub(crate) fn trailing_directive_comment_spans(self) -> &'facts [Span] {
+        &self.facts.source_facts.trailing_directive_comment_spans
+    }
+
+    pub(crate) fn backtick_substitution_spans(self) -> &'facts [Span] {
+        &self.facts.source_facts.backtick_substitution_spans
+    }
+
+    pub(crate) fn backtick_escaped_parameters(self) -> &'facts [BacktickEscapedParameter] {
+        &self.facts.source_facts.backtick_escaped_parameters
+    }
+
+    pub(crate) fn backtick_escaped_parameter_reference_spans(self) -> &'facts [Span] {
+        &self
+            .facts
+            .source_facts
+            .backtick_escaped_parameter_reference_spans
+    }
+
+    pub(crate) fn is_backtick_double_escaped_parameter_reference(self, span: Span) -> bool {
+        self.facts
+            .source_facts
+            .backtick_double_escaped_parameter_spans
+            .contains(&span)
+    }
+
+    pub(crate) fn dollar_question_after_command_spans(self) -> &'facts [Span] {
+        &self.facts.source_facts.dollar_question_after_command_spans
+    }
+
+    pub(crate) fn unused_heredoc_spans(self) -> &'facts [Span] {
+        &self.facts.source_facts.unused_heredoc_spans
+    }
+
+    pub(crate) fn heredoc_missing_end_spans(self) -> &'facts [Span] {
+        &self.facts.source_facts.heredoc_missing_end_spans
+    }
+
+    pub(crate) fn heredoc_closer_not_alone_spans(self) -> &'facts [Span] {
+        &self.facts.source_facts.heredoc_closer_not_alone_spans
+    }
+
+    pub(crate) fn misquoted_heredoc_close_spans(self) -> &'facts [Span] {
+        &self.facts.source_facts.misquoted_heredoc_close_spans
+    }
+
+    pub(crate) fn heredoc_end_space_spans(self) -> &'facts [Span] {
+        &self.facts.source_facts.heredoc_end_space_spans
+    }
+
+    pub(crate) fn echo_here_doc_spans(self) -> &'facts [Span] {
+        &self.facts.source_facts.echo_here_doc_spans
+    }
+
+    pub(crate) fn spaced_tabstrip_close_spans(self) -> &'facts [Span] {
+        &self.facts.source_facts.spaced_tabstrip_close_spans
+    }
+}
+
+impl<'facts, 'a> WordFacts<'facts, 'a> {
+    pub(crate) fn is_suppressed_subscript_reference(self, span: Span) -> bool {
+        self.facts
+            .words
             .suppressed_subscript_reference_spans
             .contains(&FactSpan::new(span))
     }
 
-    pub fn is_subscript_later_suppression_reference(&self, span: Span) -> bool {
-        self.words
+    #[cfg(test)]
+    pub(crate) fn is_subscript_later_suppression_reference(self, span: Span) -> bool {
+        self.facts
+            .words
             .subscript_later_suppression_reference_spans
             .contains(&FactSpan::new(span))
     }
 
-    pub fn word_facts(&self) -> WordOccurrenceIter<'_, 'a> {
-        WordOccurrenceIter::all(self, WordOccurrenceFilter::NonArithmetic)
+    pub fn word_facts(self) -> WordOccurrenceIter<'facts, 'a> {
+        WordOccurrenceIter::all(self.facts, WordOccurrenceFilter::NonArithmetic)
     }
 
-    pub fn arithmetic_command_word_facts(&self) -> WordOccurrenceIter<'_, 'a> {
-        WordOccurrenceIter::all(self, WordOccurrenceFilter::ArithmeticCommand)
+    pub(crate) fn arithmetic_command_word_facts(self) -> WordOccurrenceIter<'facts, 'a> {
+        WordOccurrenceIter::all(self.facts, WordOccurrenceFilter::ArithmeticCommand)
     }
 
-    pub fn parameter_operand_word_facts(&self) -> WordOccurrenceIter<'_, 'a> {
-        WordOccurrenceIter::all(self, WordOccurrenceFilter::ParameterOperand)
+    #[cfg(test)]
+    pub(crate) fn parameter_operand_word_facts(self) -> WordOccurrenceIter<'facts, 'a> {
+        WordOccurrenceIter::all(self.facts, WordOccurrenceFilter::ParameterOperand)
     }
 
-    pub fn is_compound_assignment_value_word(&self, fact: WordOccurrenceRef<'_, '_>) -> bool {
-        self.words
+    pub(crate) fn is_compound_assignment_value_word(self, fact: WordOccurrenceRef<'_, '_>) -> bool {
+        self.facts
+            .words
             .compound_assignment_value_word_flags
             .get(fact.occurrence_id().index())
             .copied()
             .unwrap_or(false)
     }
 
-    pub fn expansion_word_facts(&self, context: ExpansionContext) -> WordOccurrenceIter<'_, 'a> {
-        WordOccurrenceIter::all(self, WordOccurrenceFilter::Expansion(context))
+    pub(crate) fn expansion_word_facts(
+        self,
+        context: ExpansionContext,
+    ) -> WordOccurrenceIter<'facts, 'a> {
+        WordOccurrenceIter::all(self.facts, WordOccurrenceFilter::Expansion(context))
     }
 
-    pub fn case_subject_facts(&self) -> WordOccurrenceIter<'_, 'a> {
-        WordOccurrenceIter::all(self, WordOccurrenceFilter::CaseSubject)
+    pub(crate) fn case_subject_facts(self) -> WordOccurrenceIter<'facts, 'a> {
+        WordOccurrenceIter::all(self.facts, WordOccurrenceFilter::CaseSubject)
     }
 
     pub fn word_fact(
-        &self,
+        self,
         span: Span,
         context: WordFactContext,
-    ) -> Option<WordOccurrenceRef<'_, 'a>> {
-        self.words
+    ) -> Option<WordOccurrenceRef<'facts, 'a>> {
+        self.facts
+            .words
             .word_index
             .get(&FactSpan::new(span))
             .into_iter()
@@ -724,449 +1040,215 @@ impl<'a> LinterFacts<'a> {
             .find(|fact| fact.context() == context)
     }
 
-    pub fn any_word_fact(&self, span: Span) -> Option<WordOccurrenceRef<'_, 'a>> {
-        self.words
+    pub(crate) fn any_word_fact(self, span: Span) -> Option<WordOccurrenceRef<'facts, 'a>> {
+        self.facts
+            .words
             .word_index
             .get(&FactSpan::new(span))
             .and_then(|indices| indices.first().copied())
             .map(|id| self.word_occurrence_ref(id))
     }
 
-    pub fn has_later_unquoted_command_argument_use(
-        &self,
-        name: &Name,
-        after_offset: usize,
-    ) -> bool {
-        self.words
-            .unquoted_command_argument_use_offsets
-            .get(name)
-            .is_some_and(|offsets| {
-                offsets.partition_point(|offset| *offset <= after_offset) < offsets.len()
-            })
-    }
-
-    pub fn array_assignment_split_word_facts(&self) -> WordOccurrenceIter<'_, 'a> {
+    pub(crate) fn array_assignment_split_word_facts(self) -> WordOccurrenceIter<'facts, 'a> {
         WordOccurrenceIter::ids(
-            self,
-            &self.words.array_assignment_split_word_ids,
+            self.facts,
+            &self.facts.words.array_assignment_split_word_ids,
             WordOccurrenceFilter::Any,
         )
     }
 
-    pub(crate) fn word_occurrence_ref(&self, id: WordOccurrenceId) -> WordOccurrenceRef<'_, 'a> {
-        WordOccurrenceRef { facts: self, id }
+    pub(crate) fn word_occurrence_ref(self, id: WordOccurrenceId) -> WordOccurrenceRef<'facts, 'a> {
+        WordOccurrenceRef {
+            facts: self.facts,
+            id,
+        }
     }
 
-    pub(crate) fn word_occurrence(&self, id: WordOccurrenceId) -> &WordOccurrence {
-        &self.words.word_occurrences[id.index()]
+    pub(crate) fn word_occurrence(self, id: WordOccurrenceId) -> &'facts WordOccurrence {
+        &self.facts.words.word_occurrences[id.index()]
     }
 
-    pub(crate) fn word_node(&self, id: WordNodeId) -> &WordNode<'a> {
-        &self.words.word_nodes[id.index()]
+    pub(crate) fn word_node(self, id: WordNodeId) -> &'facts WordNode<'a> {
+        &self.facts.words.word_nodes[id.index()]
     }
 
-    pub(crate) fn word_node_derived(&self, id: WordNodeId) -> &WordNodeDerived<'a> {
+    pub(crate) fn word_node_derived(self, id: WordNodeId) -> &'facts WordNodeDerived<'a> {
         word_node_derived(self.word_node(id))
     }
 
-    pub fn brace_variable_before_bracket_spans(&self) -> &[Span] {
-        &self.words.brace_variable_before_bracket_spans
+    pub(crate) fn brace_variable_before_bracket_spans(self) -> &'facts [Span] {
+        &self.facts.words.brace_variable_before_bracket_spans
     }
 
-    pub fn command_is_in_completion_registered_function(&self, id: CommandId) -> bool {
-        self.command
-            .completion_registered_function_command_flags
-            .get(id.index())
-            .copied()
-            .unwrap_or(false)
+    pub(crate) fn array_index_arithmetic_spans(self) -> &'facts [Span] {
+        &self.facts.words.array_index_arithmetic_spans
     }
 
-    pub fn function_is_completion_registered(&self, scope: ScopeId) -> bool {
-        self.command
-            .completion_registered_function_scopes
-            .contains(&scope)
+    pub(crate) fn arithmetic_score_line_spans(self) -> &'facts [Span] {
+        &self.facts.words.arithmetic_score_line_spans
     }
 
-    pub fn function_is_external_entrypoint(&self, scope: ScopeId) -> bool {
-        self.command
-            .external_entrypoint_function_scopes
-            .contains(&scope)
+    pub(crate) fn dollar_in_arithmetic_spans(self) -> &'facts [Span] {
+        &self.facts.words.dollar_in_arithmetic_spans
     }
 
-    pub fn function_headers(&self) -> &[FunctionHeaderFact<'a>] {
-        &self.command.function_headers
+    pub fn single_quoted_fragments(self) -> &'facts [SingleQuotedFragmentFact] {
+        &self.facts.words.single_quoted_fragments
     }
 
-    pub fn function_in_alias_spans(&self) -> &[Span] {
-        &self.command.function_in_alias_spans
+    pub(crate) fn dollar_double_quoted_fragments(self) -> &'facts [DollarDoubleQuotedFragmentFact] {
+        &self.facts.words.dollar_double_quoted_fragments
     }
 
-    pub fn alias_definition_expansion_spans(&self) -> &[Span] {
-        &self.command.alias_definition_expansion_spans
+    pub(crate) fn open_double_quote_fragments(self) -> &'facts [OpenDoubleQuoteFragmentFact] {
+        &self.facts.words.open_double_quote_fragments
     }
 
-    pub fn function_body_without_braces_spans(&self) -> &[Span] {
-        &self.command.function_body_without_braces_spans
+    pub(crate) fn suspect_closing_quote_fragments(
+        self,
+    ) -> &'facts [SuspectClosingQuoteFragmentFact] {
+        &self.facts.words.suspect_closing_quote_fragments
     }
 
-    pub fn function_parameter_fallback_spans(&self) -> &[Span] {
-        &self.command.function_parameter_fallback_spans
+    pub(crate) fn literal_brace_spans(self) -> &'facts [Span] {
+        &self.facts.words.literal_brace_spans
     }
 
-    pub fn redundant_return_status_spans(&self) -> &[Span] {
-        &self.command.redundant_return_status_spans
+    pub fn backtick_fragments(self) -> &'facts [BacktickFragmentFact] {
+        &self.facts.words.backtick_fragments
     }
 
-    pub fn for_headers(&self) -> &[ForHeaderFact<'a>] {
-        &self.command.for_headers
+    pub(crate) fn legacy_arithmetic_fragments(self) -> &'facts [LegacyArithmeticFragmentFact] {
+        &self.facts.words.legacy_arithmetic_fragments
     }
 
-    pub fn select_headers(&self) -> &[SelectHeaderFact<'a>] {
-        &self.command.select_headers
+    pub(crate) fn positional_parameter_fragments(
+        self,
+    ) -> &'facts [PositionalParameterFragmentFact] {
+        &self.facts.words.positional_parameter_fragments
     }
 
-    pub fn case_items(&self) -> &[CaseItemFact<'a>] {
-        &self.command.case_items
+    pub(crate) fn positional_parameter_operator_spans(self) -> &'facts [Span] {
+        &self.facts.words.positional_parameter_operator_spans
     }
 
-    pub fn case_pattern_shadows(&self) -> &[CasePatternShadowFact] {
-        &self.command.case_pattern_shadows
+    pub(crate) fn double_paren_grouping_spans(self) -> &'facts [Span] {
+        &self.facts.words.double_paren_grouping_spans
     }
 
-    pub fn case_pattern_impossible_spans(&self) -> &[Span] {
-        &self.command.case_pattern_impossible_spans
+    pub(crate) fn arithmetic_update_operator_spans(self) -> &'facts [Span] {
+        &self.facts.words.arithmetic_update_operator_spans
     }
 
-    pub fn case_pattern_expansions(&self) -> &[CasePatternExpansionFact] {
-        &self.command.case_pattern_expansions
+    pub(crate) fn arithmetic_update_operator_fix_facts(
+        self,
+    ) -> &'facts [ArithmeticUpdateOperatorFixFact] {
+        &self.facts.words.arithmetic_update_operator_fix_facts
     }
 
-    pub fn getopts_cases(&self) -> &[GetoptsCaseFact] {
-        &self.command.getopts_cases
+    pub(crate) fn arithmetic_literal_facts(self) -> &'facts [ArithmeticLiteralFact] {
+        &self.facts.words.arithmetic_literal_facts
     }
 
-    pub fn pipelines(&self) -> &[PipelineFact<'a>] {
-        &self.command.pipelines
+    pub(crate) fn escape_scan_matches(self) -> &'facts [EscapeScanMatch] {
+        &self.facts.words.escape_scan_matches
     }
 
-    pub fn lists(&self) -> &[ListFact<'a>] {
-        &self.command.lists
+    pub(crate) fn echo_backslash_escape_word_spans(self) -> &'facts [Span] {
+        &self.facts.words.echo_backslash_escape_word_spans
     }
 
-    pub fn statement_facts(&self) -> &[StatementFact] {
-        &self.command.statement_facts
+    pub(crate) fn echo_to_sed_substitution_spans(self) -> &'facts [Span] {
+        &self.facts.words.echo_to_sed_substitution_spans
     }
 
-    pub fn background_semicolon_spans(&self) -> &[Span] {
-        &self.command.background_semicolon_spans
+    pub(crate) fn arithmetic_command_substitution_spans(self) -> &'facts [Span] {
+        &self.facts.words.arithmetic_command_substitution_spans
     }
 
-    pub fn single_test_subshell_spans(&self) -> &[Span] {
-        &self.command.single_test_subshell_spans
+    pub(crate) fn unicode_smart_quote_spans(self) -> &'facts [Span] {
+        &self.facts.words.unicode_smart_quote_spans
     }
 
-    pub fn subshell_test_group_spans(&self) -> &[Span] {
-        &self.command.subshell_test_group_spans
+    #[cfg(test)]
+    pub(crate) fn pattern_literal_spans(self) -> &'facts [Span] {
+        &self.facts.words.pattern_literal_spans
     }
 
-    pub fn indented_shebang_span(&self) -> Option<Span> {
-        self.source_facts.indented_shebang_span
+    pub fn pattern_charclass_spans(self) -> &'facts [Span] {
+        &self.facts.words.pattern_charclass_spans
     }
 
-    pub fn indented_shebang_indent_span(&self) -> Option<Span> {
-        self.source_facts.indented_shebang_indent_span
+    pub(crate) fn nested_parameter_expansion_fragments(
+        self,
+    ) -> &'facts [NestedParameterExpansionFragmentFact] {
+        &self.facts.words.nested_parameter_expansion_fragments
     }
 
-    pub fn space_after_hash_bang_span(&self) -> Option<Span> {
-        self.source_facts.space_after_hash_bang_span
+    pub(crate) fn indirect_expansion_fragments(self) -> &'facts [IndirectExpansionFragmentFact] {
+        &self.facts.words.indirect_expansion_fragments
     }
 
-    pub fn space_after_hash_bang_whitespace_span(&self) -> Option<Span> {
-        self.source_facts.space_after_hash_bang_whitespace_span
+    pub(crate) fn indexed_array_reference_fragments(
+        self,
+    ) -> &'facts [IndexedArrayReferenceFragmentFact] {
+        &self.facts.words.indexed_array_reference_fragments
     }
 
-    pub fn shebang_not_on_first_line_span(&self) -> Option<Span> {
-        self.source_facts.shebang_not_on_first_line_span
-    }
-
-    pub fn shebang_not_on_first_line_fix_span(&self) -> Option<Span> {
-        self.source_facts.shebang_not_on_first_line_fix_span
-    }
-
-    pub fn shebang_not_on_first_line_preferred_newline(&self) -> Option<&'static str> {
-        self.source_facts
-            .shebang_not_on_first_line_preferred_newline
-    }
-
-    pub fn missing_shebang_line_span(&self) -> Option<Span> {
-        self.source_facts.missing_shebang_line_span
-    }
-
-    pub fn duplicate_shebang_flag_span(&self) -> Option<Span> {
-        self.source_facts.duplicate_shebang_flag_span
-    }
-
-    pub fn non_absolute_shebang_span(&self) -> Option<Span> {
-        self.source_facts.non_absolute_shebang_span
-    }
-
-    pub fn errexit_enabled_anywhere(&self) -> bool {
-        self.source_facts.errexit_enabled_anywhere
-    }
-
-    pub fn commented_continuation_comment_spans(&self) -> &[Span] {
-        &self.source_facts.commented_continuation_comment_spans
-    }
-
-    pub fn comment_double_quote_nesting_spans(&self) -> &[Span] {
-        &self.source_facts.comment_double_quote_nesting_spans
-    }
-
-    pub fn trailing_directive_comment_spans(&self) -> &[Span] {
-        &self.source_facts.trailing_directive_comment_spans
-    }
-
-    pub fn condition_status_capture_spans(&self) -> &[Span] {
-        &self.command.condition_status_capture_spans
-    }
-
-    pub fn command_substitution_command_spans(&self) -> &[Span] {
-        &self.command.command_substitution_command_spans
-    }
-
-    pub fn backtick_substitution_spans(&self) -> &[Span] {
-        &self.source_facts.backtick_substitution_spans
-    }
-
-    pub fn backtick_escaped_parameters(&self) -> &[BacktickEscapedParameter] {
-        &self.source_facts.backtick_escaped_parameters
-    }
-
-    pub fn backtick_escaped_parameter_reference_spans(&self) -> &[Span] {
-        &self.source_facts.backtick_escaped_parameter_reference_spans
-    }
-
-    pub fn is_backtick_double_escaped_parameter_reference(&self, span: Span) -> bool {
-        self.source_facts
-            .backtick_double_escaped_parameter_spans
-            .contains(&span)
-    }
-
-    pub fn backtick_command_name_spans(&self) -> &[Span] {
-        &self.command.backtick_command_name_spans
-    }
-
-    pub fn dollar_question_after_command_spans(&self) -> &[Span] {
-        &self.source_facts.dollar_question_after_command_spans
-    }
-
-    pub fn assignment_like_command_name_spans(&self) -> &[Span] {
-        &self.command.assignment_like_command_name_spans
-    }
-
-    pub fn bare_command_name_assignment_spans(&self) -> &[Span] {
-        &self.command.bare_command_name_assignment_spans
-    }
-
-    pub fn subshell_assignment_sites(&self) -> &[NamedSpan] {
-        &self.assignments.subshell_assignment_sites
-    }
-
-    pub fn subshell_later_use_sites(&self) -> &[NamedSpan] {
-        &self.assignments.subshell_later_use_sites
-    }
-
-    pub fn unused_heredoc_spans(&self) -> &[Span] {
-        &self.source_facts.unused_heredoc_spans
-    }
-
-    pub fn heredoc_missing_end_spans(&self) -> &[Span] {
-        &self.source_facts.heredoc_missing_end_spans
-    }
-
-    pub fn heredoc_closer_not_alone_spans(&self) -> &[Span] {
-        &self.source_facts.heredoc_closer_not_alone_spans
-    }
-
-    pub fn misquoted_heredoc_close_spans(&self) -> &[Span] {
-        &self.source_facts.misquoted_heredoc_close_spans
-    }
-
-    pub fn heredoc_end_space_spans(&self) -> &[Span] {
-        &self.source_facts.heredoc_end_space_spans
-    }
-
-    pub fn echo_here_doc_spans(&self) -> &[Span] {
-        &self.source_facts.echo_here_doc_spans
-    }
-
-    pub fn spaced_tabstrip_close_spans(&self) -> &[Span] {
-        &self.source_facts.spaced_tabstrip_close_spans
-    }
-
-    pub fn plus_equals_assignment_spans(&self) -> &[Span] {
-        &self.assignments.plus_equals_assignment_spans
-    }
-
-    pub fn array_index_arithmetic_spans(&self) -> &[Span] {
-        &self.words.array_index_arithmetic_spans
-    }
-
-    pub fn arithmetic_score_line_spans(&self) -> &[Span] {
-        &self.words.arithmetic_score_line_spans
-    }
-
-    pub fn dollar_in_arithmetic_spans(&self) -> &[Span] {
-        &self.words.dollar_in_arithmetic_spans
-    }
-
-    pub fn single_quoted_fragments(&self) -> &[SingleQuotedFragmentFact] {
-        &self.words.single_quoted_fragments
-    }
-
-    pub fn dollar_double_quoted_fragments(&self) -> &[DollarDoubleQuotedFragmentFact] {
-        &self.words.dollar_double_quoted_fragments
-    }
-
-    pub fn open_double_quote_fragments(&self) -> &[OpenDoubleQuoteFragmentFact] {
-        &self.words.open_double_quote_fragments
-    }
-
-    pub fn suspect_closing_quote_fragments(&self) -> &[SuspectClosingQuoteFragmentFact] {
-        &self.words.suspect_closing_quote_fragments
-    }
-
-    pub fn literal_brace_spans(&self) -> &[Span] {
-        &self.words.literal_brace_spans
-    }
-
-    pub fn backtick_fragments(&self) -> &[BacktickFragmentFact] {
-        &self.words.backtick_fragments
-    }
-
-    pub fn legacy_arithmetic_fragments(&self) -> &[LegacyArithmeticFragmentFact] {
-        &self.words.legacy_arithmetic_fragments
-    }
-
-    pub fn positional_parameter_fragments(&self) -> &[PositionalParameterFragmentFact] {
-        &self.words.positional_parameter_fragments
-    }
-
-    pub fn positional_parameter_operator_spans(&self) -> &[Span] {
-        &self.words.positional_parameter_operator_spans
-    }
-
-    pub fn double_paren_grouping_spans(&self) -> &[Span] {
-        &self.words.double_paren_grouping_spans
-    }
-
-    pub fn arithmetic_update_operator_spans(&self) -> &[Span] {
-        &self.words.arithmetic_update_operator_spans
-    }
-
-    pub fn arithmetic_update_operator_fix_facts(&self) -> &[ArithmeticUpdateOperatorFixFact] {
-        &self.words.arithmetic_update_operator_fix_facts
-    }
-
-    pub fn arithmetic_literal_facts(&self) -> &[ArithmeticLiteralFact] {
-        &self.words.arithmetic_literal_facts
-    }
-
-    pub(crate) fn escape_scan_matches(&self) -> &[EscapeScanMatch] {
-        &self.words.escape_scan_matches
-    }
-
-    pub fn echo_backslash_escape_word_spans(&self) -> &[Span] {
-        &self.words.echo_backslash_escape_word_spans
-    }
-
-    pub fn echo_to_sed_substitution_spans(&self) -> &[Span] {
-        &self.words.echo_to_sed_substitution_spans
-    }
-
-    pub fn arithmetic_command_substitution_spans(&self) -> &[Span] {
-        &self.words.arithmetic_command_substitution_spans
-    }
-    pub fn unicode_smart_quote_spans(&self) -> &[Span] {
-        &self.words.unicode_smart_quote_spans
-    }
-
-    pub fn pattern_exactly_one_extglob_spans(&self) -> &[Span] {
-        &self.words.pattern_exactly_one_extglob_spans
-    }
-
-    pub fn pattern_literal_spans(&self) -> &[Span] {
-        &self.words.pattern_literal_spans
-    }
-
-    pub fn pattern_charclass_spans(&self) -> &[Span] {
-        &self.words.pattern_charclass_spans
-    }
-
-    pub fn is_nested_pattern_charclass_span(&self, span: Span) -> bool {
-        self.words
-            .nested_pattern_charclass_spans
-            .contains(&FactSpan::new(span))
-    }
-
-    pub fn nested_parameter_expansion_fragments(&self) -> &[NestedParameterExpansionFragmentFact] {
-        &self.words.nested_parameter_expansion_fragments
-    }
-
-    pub fn indirect_expansion_fragments(&self) -> &[IndirectExpansionFragmentFact] {
-        &self.words.indirect_expansion_fragments
-    }
-
-    pub fn indexed_array_reference_fragments(&self) -> &[IndexedArrayReferenceFragmentFact] {
-        &self.words.indexed_array_reference_fragments
-    }
-
-    pub fn plain_unindexed_array_references(
-        &self,
-    ) -> impl Iterator<Item = PlainUnindexedArrayReferenceFact> + '_ {
-        self.words
+    pub(crate) fn plain_unindexed_array_references(
+        self,
+    ) -> impl Iterator<Item = PlainUnindexedArrayReferenceFact> + 'facts {
+        self.facts
+            .words
             .plain_unindexed_array_references
-            .get_or_init(|| build_plain_unindexed_array_reference_facts(self))
+            .get_or_init(|| build_plain_unindexed_array_reference_facts(self.facts))
             .iter()
             .copied()
     }
 
-    pub fn parameter_pattern_special_target_fragments(
-        &self,
-    ) -> &[ParameterPatternSpecialTargetFragmentFact] {
-        &self.words.parameter_pattern_special_target_fragments
+    pub(crate) fn parameter_pattern_special_target_fragments(
+        self,
+    ) -> &'facts [ParameterPatternSpecialTargetFragmentFact] {
+        &self.facts.words.parameter_pattern_special_target_fragments
     }
 
-    pub fn zsh_parameter_index_flag_fragments(&self) -> &[ZshParameterIndexFlagFragmentFact] {
-        &self.words.zsh_parameter_index_flag_fragments
+    pub(crate) fn zsh_parameter_index_flag_fragments(
+        self,
+    ) -> &'facts [ZshParameterIndexFlagFragmentFact] {
+        &self.facts.words.zsh_parameter_index_flag_fragments
     }
 
-    pub fn substring_expansion_fragments(&self) -> &[SubstringExpansionFragmentFact] {
-        &self.words.substring_expansion_fragments
+    pub fn substring_expansion_fragments(self) -> &'facts [SubstringExpansionFragmentFact] {
+        &self.facts.words.substring_expansion_fragments
     }
 
-    pub fn case_modification_fragments(&self) -> &[CaseModificationFragmentFact] {
-        &self.words.case_modification_fragments
+    pub fn case_modification_fragments(self) -> &'facts [CaseModificationFragmentFact] {
+        &self.facts.words.case_modification_fragments
     }
 
-    pub fn replacement_expansion_fragments(&self) -> &[ReplacementExpansionFragmentFact] {
-        &self.words.replacement_expansion_fragments
+    pub fn replacement_expansion_fragments(self) -> &'facts [ReplacementExpansionFragmentFact] {
+        &self.facts.words.replacement_expansion_fragments
     }
 
-    pub fn positional_parameter_trim_fragments(&self) -> &[PositionalParameterTrimFragmentFact] {
-        &self.words.positional_parameter_trim_fragments
+    pub(crate) fn positional_parameter_trim_fragments(
+        self,
+    ) -> &'facts [PositionalParameterTrimFragmentFact] {
+        &self.facts.words.positional_parameter_trim_fragments
     }
+}
 
-    pub fn conditional_portability(&self) -> &ConditionalPortabilityFacts {
-        &self.compat().conditional_portability
+impl<'facts, 'a> CompatFacts<'facts, 'a> {
+    pub(crate) fn conditional_portability(self) -> &'facts ConditionalPortabilityFacts {
+        &self.facts.compat.conditional_portability
     }
 
     pub(crate) fn possible_variable_misspelling_scope_compat_name_uses(
-        &self,
-    ) -> &[ComparableNameUse] {
-        self.compat
+        self,
+    ) -> &'facts [ComparableNameUse] {
+        self.facts
+            .compat
             .possible_variable_misspelling_scope_compat_name_uses
-            .get_or_init(|| build_possible_variable_misspelling_scope_compat_name_uses(self))
+            .get_or_init(|| build_possible_variable_misspelling_scope_compat_name_uses(self.facts))
     }
 }
 
@@ -1174,15 +1256,21 @@ pub(crate) fn build_possible_variable_misspelling_scope_compat_name_uses(
     facts: &LinterFacts<'_>,
 ) -> Vec<ComparableNameUse> {
     let source_facts = facts.source_facts();
-    if !source_may_have_scope_compat_misspelling(source_facts.source) {
+    let source = source_facts.source();
+    if !source_may_have_scope_compat_misspelling(source) {
         return Vec::new();
     }
 
     let mut uses = Vec::new();
     for word_fact in facts
+        .words()
         .expansion_word_facts(ExpansionContext::DeclarationAssignmentValue)
-        .chain(facts.expansion_word_facts(ExpansionContext::AssignmentValue))
-        .chain(facts.case_subject_facts())
+        .chain(
+            facts
+                .words()
+                .expansion_word_facts(ExpansionContext::AssignmentValue),
+        )
+        .chain(facts.words().case_subject_facts())
     {
         if let Some(name_use) = scope_compat_standalone_parameter_name_use(word_fact.word()) {
             uses.push(name_use);
@@ -1192,23 +1280,25 @@ pub(crate) fn build_possible_variable_misspelling_scope_compat_name_uses(
         visit_command_words_for_substitutions(
             command.command(),
             command.redirects(),
-            source_facts.source,
+            source,
             &mut |word| {
                 collect_scope_compat_derived_name_uses(
                     word,
                     facts.semantic_artifacts,
-                    source_facts.source,
+                    source,
                     &mut uses,
                 );
             },
         );
     }
     for word in facts
+        .command_facts()
         .for_headers()
         .iter()
         .flat_map(|header| header.words())
         .chain(
             facts
+                .command_facts()
                 .select_headers()
                 .iter()
                 .flat_map(|header| header.words()),
@@ -1217,7 +1307,7 @@ pub(crate) fn build_possible_variable_misspelling_scope_compat_name_uses(
         if let Some(mut name_use) = scope_compat_standalone_parameter_name_use(word.word()) {
             name_use.mark_derived();
             if is_interesting_scope_compat_name_use(
-                source_facts.source,
+                source,
                 name_use.key().as_str(),
                 name_use.kind(),
                 name_use.span(),
@@ -1227,19 +1317,16 @@ pub(crate) fn build_possible_variable_misspelling_scope_compat_name_uses(
         }
     }
     uses.extend(
-        build_flag_for_loop_source_name_uses(Locator::new(
-            source_facts.source,
-            source_facts.line_index,
-        ))
-        .into_iter()
-        .filter(|name_use| {
-            is_interesting_scope_compat_name_use(
-                source_facts.source,
-                name_use.key().as_str(),
-                name_use.kind(),
-                name_use.span(),
-            )
-        }),
+        build_flag_for_loop_source_name_uses(Locator::new(source, source_facts.line_index()))
+            .into_iter()
+            .filter(|name_use| {
+                is_interesting_scope_compat_name_use(
+                    source,
+                    name_use.key().as_str(),
+                    name_use.kind(),
+                    name_use.span(),
+                )
+            }),
     );
     dedup_comparable_name_uses(&mut uses);
     uses

--- a/crates/shuck-linter/src/facts/surface.rs
+++ b/crates/shuck-linter/src/facts/surface.rs
@@ -2631,6 +2631,7 @@ pub(crate) fn build_suppressed_subscript_reference_spans(
     spans
 }
 
+#[cfg(test)]
 pub(crate) fn build_subscript_later_suppression_reference_spans(
     semantic: &SemanticModel,
     subscript_later_suppression_spans: &[Span],

--- a/crates/shuck-linter/src/facts/tests/assignments.rs
+++ b/crates/shuck-linter/src/facts/tests/assignments.rs
@@ -16,6 +16,7 @@ fn indexes_scalar_bindings_from_assignments_and_declarations() {
     let first_binding_id = semantic.bindings_for(&Name::from("foo"))[0];
     assert_eq!(
         facts
+            .assignments()
             .binding_value(first_binding_id)
             .and_then(|value| value.scalar_word())
             .map(|word| word.span.slice(source)),
@@ -32,6 +33,7 @@ fn indexes_scalar_bindings_from_assignments_and_declarations() {
     let second_binding_id = semantic.bindings_for(&Name::from("bar"))[0];
     assert_eq!(
         facts
+            .assignments()
             .binding_value(second_binding_id)
             .and_then(|value| value.scalar_word())
             .map(|word| word.span.slice(source)),
@@ -66,6 +68,7 @@ pid=$!
         let binding_id = semantic.bindings_for(&Name::from(name))[0];
         assert!(
             facts
+                .assignments()
                 .binding_value(binding_id)
                 .is_some_and(|value| value.standalone_status_or_pid_capture()),
             "expected {name} binding value to be a status or pid capture"
@@ -94,6 +97,7 @@ fn indexes_loop_bindings_from_for_words() {
 
     assert_eq!(
         facts
+            .assignments()
             .binding_value(loop_binding_id)
             .and_then(|value| value.loop_words())
             .expect("expected loop binding values")
@@ -126,6 +130,7 @@ one_sided='-b' || one_sided='-y'
         .copied()
         .map(|binding_id| {
             facts
+                .assignments()
                 .binding_value(binding_id)
                 .expect("expected w binding value fact")
                 .conditional_assignment_shortcut()
@@ -139,6 +144,7 @@ one_sided='-b' || one_sided='-y'
         .copied()
         .map(|binding_id| {
             facts
+                .assignments()
                 .binding_value(binding_id)
                 .expect("expected opt binding value fact")
                 .conditional_assignment_shortcut()
@@ -152,6 +158,7 @@ one_sided='-b' || one_sided='-y'
         .copied()
         .map(|binding_id| {
             facts
+                .assignments()
                 .binding_value(binding_id)
                 .expect("expected flag binding value fact")
                 .conditional_assignment_shortcut()
@@ -165,6 +172,7 @@ one_sided='-b' || one_sided='-y'
         .copied()
         .map(|binding_id| {
             facts
+                .assignments()
                 .binding_value(binding_id)
                 .expect("expected one_sided binding value fact")
                 .one_sided_short_circuit_assignment()
@@ -190,6 +198,7 @@ printf '%s\\n' \"$foo\"
     assert_eq!(foo_bindings.len(), 1);
     assert_eq!(
         facts
+            .assignments()
             .binding_value(foo_bindings[0])
             .and_then(|value| value.scalar_word())
             .map(|word| word.span.slice(source)),
@@ -234,6 +243,7 @@ f() {
 
     assert_eq!(
         facts
+            .assignments()
             .binding_value(shadow_binding)
             .and_then(|value| value.scalar_word())
             .map(|word| word.span.slice(source)),
@@ -241,6 +251,7 @@ f() {
     );
     assert_eq!(
         facts
+            .assignments()
             .binding_value(local_binding)
             .and_then(|value| value.scalar_word())
             .map(|word| word.span.slice(source)),
@@ -263,6 +274,7 @@ complex[$((i+=1))]+=x
     with_facts(source, None, |_, facts| {
         assert_eq!(
             facts
+                .assignments()
                 .plus_equals_assignment_spans()
                 .iter()
                 .map(|span| span.slice(source))
@@ -287,6 +299,7 @@ name+=still_ok
     with_facts(source, None, |_, facts| {
         assert_eq!(
             facts
+                .command_facts()
                 .assignment_like_command_name_spans()
                 .iter()
                 .map(|span| span.slice(source))
@@ -325,6 +338,7 @@ maybe==grep run
         |_, facts| {
             assert_eq!(
                 facts
+                    .command_facts()
                     .bare_command_name_assignment_spans()
                     .iter()
                     .map(|span| span.slice(source))
@@ -346,7 +360,10 @@ rvm_info="
 
     with_facts(source, None, |_, facts| {
         assert!(
-            facts.assignment_like_command_name_spans().is_empty(),
+            facts
+                .command_facts()
+                .assignment_like_command_name_spans()
+                .is_empty(),
             "quoted arrow text should not look like an assignment command name"
         );
     });
@@ -362,6 +379,7 @@ fn collects_broken_assoc_key_spans_from_compound_array_assignments() {
 
     assert_eq!(
         facts
+            .assignments()
             .broken_assoc_key_spans()
             .iter()
             .map(|span| span.slice(source))
@@ -380,6 +398,7 @@ fn collects_comma_array_assignment_spans_from_compound_values() {
 
     assert_eq!(
         facts
+            .assignments()
             .comma_array_assignment_spans()
             .iter()
             .map(|span| span.slice(source))
@@ -410,6 +429,7 @@ IFS=$'\\n'
     with_facts(source, None, |_, facts| {
         assert_eq!(
             facts
+                .assignments()
                 .ifs_literal_backslash_assignment_value_spans()
                 .iter()
                 .map(|span| span.slice(source))
@@ -428,9 +448,13 @@ fn ignores_commas_after_even_backslashes_before_quote_regions() {
     let facts = LinterFacts::build(&output.file, source, &semantic, &indexer);
 
     assert!(
-        facts.comma_array_assignment_spans().is_empty(),
+        facts
+            .assignments()
+            .comma_array_assignment_spans()
+            .is_empty(),
         "{:#?}",
         facts
+            .assignments()
             .comma_array_assignment_spans()
             .iter()
             .map(|span| span.slice(source))
@@ -447,9 +471,13 @@ fn ignores_commas_inside_ansi_c_quoted_array_elements() {
     let facts = LinterFacts::build(&output.file, source, &semantic, &indexer);
 
     assert!(
-        facts.comma_array_assignment_spans().is_empty(),
+        facts
+            .assignments()
+            .comma_array_assignment_spans()
+            .is_empty(),
         "{:#?}",
         facts
+            .assignments()
             .comma_array_assignment_spans()
             .iter()
             .map(|span| span.slice(source))
@@ -466,9 +494,13 @@ fn ignores_commas_inside_quoted_command_substitution_array_elements() {
     let facts = LinterFacts::build(&output.file, source, &semantic, &indexer);
 
     assert!(
-        facts.comma_array_assignment_spans().is_empty(),
+        facts
+            .assignments()
+            .comma_array_assignment_spans()
+            .is_empty(),
         "{:#?}",
         facts
+            .assignments()
             .comma_array_assignment_spans()
             .iter()
             .map(|span| span.slice(source))
@@ -485,9 +517,13 @@ fn ignores_commas_inside_separator_started_command_substitution_comments() {
     let facts = LinterFacts::build(&output.file, source, &semantic, &indexer);
 
     assert!(
-        facts.comma_array_assignment_spans().is_empty(),
+        facts
+            .assignments()
+            .comma_array_assignment_spans()
+            .is_empty(),
         "{:#?}",
         facts
+            .assignments()
             .comma_array_assignment_spans()
             .iter()
             .map(|span| span.slice(source))
@@ -504,9 +540,13 @@ fn ignores_commas_inside_grouped_command_substitution_comments() {
     let facts = LinterFacts::build(&output.file, source, &semantic, &indexer);
 
     assert!(
-        facts.comma_array_assignment_spans().is_empty(),
+        facts
+            .assignments()
+            .comma_array_assignment_spans()
+            .is_empty(),
         "{:#?}",
         facts
+            .assignments()
             .comma_array_assignment_spans()
             .iter()
             .map(|span| span.slice(source))
@@ -523,9 +563,13 @@ fn ignores_commas_inside_compact_grouped_command_substitution_comments() {
     let facts = LinterFacts::build(&output.file, source, &semantic, &indexer);
 
     assert!(
-        facts.comma_array_assignment_spans().is_empty(),
+        facts
+            .assignments()
+            .comma_array_assignment_spans()
+            .is_empty(),
         "{:#?}",
         facts
+            .assignments()
             .comma_array_assignment_spans()
             .iter()
             .map(|span| span.slice(source))
@@ -542,9 +586,13 @@ fn ignores_commas_inside_command_substitution_case_patterns() {
     let facts = LinterFacts::build(&output.file, source, &semantic, &indexer);
 
     assert!(
-        facts.comma_array_assignment_spans().is_empty(),
+        facts
+            .assignments()
+            .comma_array_assignment_spans()
+            .is_empty(),
         "{:#?}",
         facts
+            .assignments()
             .comma_array_assignment_spans()
             .iter()
             .map(|span| span.slice(source))
@@ -562,9 +610,13 @@ fn ignores_commas_inside_piped_heredoc_command_substitution_array_elements() {
     let facts = LinterFacts::build(&output.file, source, &semantic, &indexer);
 
     assert!(
-        facts.comma_array_assignment_spans().is_empty(),
+        facts
+            .assignments()
+            .comma_array_assignment_spans()
+            .is_empty(),
         "{:#?}",
         facts
+            .assignments()
             .comma_array_assignment_spans()
             .iter()
             .map(|span| span.slice(source))
@@ -581,9 +633,13 @@ fn ignores_commas_inside_parameter_expansions_with_right_parens_in_command_subst
     let facts = LinterFacts::build(&output.file, source, &semantic, &indexer);
 
     assert!(
-        facts.comma_array_assignment_spans().is_empty(),
+        facts
+            .assignments()
+            .comma_array_assignment_spans()
+            .is_empty(),
         "{:#?}",
         facts
+            .assignments()
             .comma_array_assignment_spans()
             .iter()
             .map(|span| span.slice(source))
@@ -600,9 +656,13 @@ fn ignores_commas_inside_parameter_expansions_with_literal_braces() {
     let facts = LinterFacts::build(&output.file, source, &semantic, &indexer);
 
     assert!(
-        facts.comma_array_assignment_spans().is_empty(),
+        facts
+            .assignments()
+            .comma_array_assignment_spans()
+            .is_empty(),
         "{:#?}",
         facts
+            .assignments()
             .comma_array_assignment_spans()
             .iter()
             .map(|span| span.slice(source))
@@ -619,9 +679,13 @@ fn ignores_commas_inside_parameter_expansions_with_ansi_c_single_quotes() {
     let facts = LinterFacts::build(&output.file, source, &semantic, &indexer);
 
     assert!(
-        facts.comma_array_assignment_spans().is_empty(),
+        facts
+            .assignments()
+            .comma_array_assignment_spans()
+            .is_empty(),
         "{:#?}",
         facts
+            .assignments()
             .comma_array_assignment_spans()
             .iter()
             .map(|span| span.slice(source))
@@ -639,9 +703,13 @@ fn ignores_commas_inside_case_pattern_comments_after_right_parens() {
     let facts = LinterFacts::build(&output.file, source, &semantic, &indexer);
 
     assert!(
-        facts.comma_array_assignment_spans().is_empty(),
+        facts
+            .assignments()
+            .comma_array_assignment_spans()
+            .is_empty(),
         "{:#?}",
         facts
+            .assignments()
             .comma_array_assignment_spans()
             .iter()
             .map(|span| span.slice(source))
@@ -658,9 +726,13 @@ fn ignores_commas_inside_process_substitution_array_elements() {
     let facts = LinterFacts::build(&output.file, source, &semantic, &indexer);
 
     assert!(
-        facts.comma_array_assignment_spans().is_empty(),
+        facts
+            .assignments()
+            .comma_array_assignment_spans()
+            .is_empty(),
         "{:#?}",
         facts
+            .assignments()
             .comma_array_assignment_spans()
             .iter()
             .map(|span| span.slice(source))
@@ -677,9 +749,13 @@ fn ignores_commas_inside_comments_after_quoted_double_parens() {
     let facts = LinterFacts::build(&output.file, source, &semantic, &indexer);
 
     assert!(
-        facts.comma_array_assignment_spans().is_empty(),
+        facts
+            .assignments()
+            .comma_array_assignment_spans()
+            .is_empty(),
         "{:#?}",
         facts
+            .assignments()
             .comma_array_assignment_spans()
             .iter()
             .map(|span| span.slice(source))
@@ -696,9 +772,13 @@ fn ignores_commas_inside_arithmetic_shift_command_substitutions() {
     let facts = LinterFacts::build(&output.file, source, &semantic, &indexer);
 
     assert!(
-        facts.comma_array_assignment_spans().is_empty(),
+        facts
+            .assignments()
+            .comma_array_assignment_spans()
+            .is_empty(),
         "{:#?}",
         facts
+            .assignments()
             .comma_array_assignment_spans()
             .iter()
             .map(|span| span.slice(source))
@@ -733,9 +813,13 @@ g=($(printf %s `echo foo)`; printf %s 13,14))
     let facts = LinterFacts::build(&output.file, source, &semantic, &indexer);
 
     assert!(
-        facts.comma_array_assignment_spans().is_empty(),
+        facts
+            .assignments()
+            .comma_array_assignment_spans()
+            .is_empty(),
         "{:#?}",
         facts
+            .assignments()
             .comma_array_assignment_spans()
             .iter()
             .map(|span| span.slice(source))
@@ -752,9 +836,13 @@ fn ignores_commas_inside_nested_case_patterns_in_command_substitutions() {
     let facts = LinterFacts::build(&output.file, source, &semantic, &indexer);
 
     assert!(
-        facts.comma_array_assignment_spans().is_empty(),
+        facts
+            .assignments()
+            .comma_array_assignment_spans()
+            .is_empty(),
         "{:#?}",
         facts
+            .assignments()
             .comma_array_assignment_spans()
             .iter()
             .map(|span| span.slice(source))
@@ -771,9 +859,13 @@ fn ignores_commas_inside_command_substitutions_with_plain_case_words() {
     let facts = LinterFacts::build(&output.file, source, &semantic, &indexer);
 
     assert!(
-        facts.comma_array_assignment_spans().is_empty(),
+        facts
+            .assignments()
+            .comma_array_assignment_spans()
+            .is_empty(),
         "{:#?}",
         facts
+            .assignments()
             .comma_array_assignment_spans()
             .iter()
             .map(|span| span.slice(source))
@@ -790,9 +882,13 @@ fn ignores_commas_inside_command_substitutions_with_ansi_c_single_quotes() {
     let facts = LinterFacts::build(&output.file, source, &semantic, &indexer);
 
     assert!(
-        facts.comma_array_assignment_spans().is_empty(),
+        facts
+            .assignments()
+            .comma_array_assignment_spans()
+            .is_empty(),
         "{:#?}",
         facts
+            .assignments()
             .comma_array_assignment_spans()
             .iter()
             .map(|span| span.slice(source))
@@ -809,9 +905,13 @@ fn ignores_commas_inside_command_substitutions_with_backticks() {
     let facts = LinterFacts::build(&output.file, source, &semantic, &indexer);
 
     assert!(
-        facts.comma_array_assignment_spans().is_empty(),
+        facts
+            .assignments()
+            .comma_array_assignment_spans()
+            .is_empty(),
         "{:#?}",
         facts
+            .assignments()
             .comma_array_assignment_spans()
             .iter()
             .map(|span| span.slice(source))
@@ -828,9 +928,13 @@ fn ignores_commas_inside_backticks_inside_parameter_expansions() {
     let facts = LinterFacts::build(&output.file, source, &semantic, &indexer);
 
     assert!(
-        facts.comma_array_assignment_spans().is_empty(),
+        facts
+            .assignments()
+            .comma_array_assignment_spans()
+            .is_empty(),
         "{:#?}",
         facts
+            .assignments()
             .comma_array_assignment_spans()
             .iter()
             .map(|span| span.slice(source))
@@ -847,9 +951,13 @@ fn ignores_commas_inside_process_substitutions_inside_parameter_expansions() {
     let facts = LinterFacts::build(&output.file, source, &semantic, &indexer);
 
     assert!(
-        facts.comma_array_assignment_spans().is_empty(),
+        facts
+            .assignments()
+            .comma_array_assignment_spans()
+            .is_empty(),
         "{:#?}",
         facts
+            .assignments()
             .comma_array_assignment_spans()
             .iter()
             .map(|span| span.slice(source))
@@ -866,9 +974,13 @@ fn ignores_commas_after_backticks_inside_parameter_expansions_in_command_substit
     let facts = LinterFacts::build(&output.file, source, &semantic, &indexer);
 
     assert!(
-        facts.comma_array_assignment_spans().is_empty(),
+        facts
+            .assignments()
+            .comma_array_assignment_spans()
+            .is_empty(),
         "{:#?}",
         facts
+            .assignments()
             .comma_array_assignment_spans()
             .iter()
             .map(|span| span.slice(source))
@@ -886,9 +998,13 @@ fn ignores_commas_after_process_substitutions_inside_parameter_expansions_in_com
     let facts = LinterFacts::build(&output.file, source, &semantic, &indexer);
 
     assert!(
-        facts.comma_array_assignment_spans().is_empty(),
+        facts
+            .assignments()
+            .comma_array_assignment_spans()
+            .is_empty(),
         "{:#?}",
         facts
+            .assignments()
             .comma_array_assignment_spans()
             .iter()
             .map(|span| span.slice(source))
@@ -1062,6 +1178,7 @@ fn subshell_assignment_slices(source: &str, shell: ShellDialect) -> Vec<&str> {
     );
 
     facts
+        .assignments()
         .subshell_assignment_sites()
         .iter()
         .map(|site| site.span.slice(source))
@@ -1082,6 +1199,7 @@ fn subshell_later_use_slices(source: &str, shell: ShellDialect) -> Vec<&str> {
     );
 
     facts
+        .assignments()
         .subshell_later_use_sites()
         .iter()
         .map(|site| site.span.slice(source))

--- a/crates/shuck-linter/src/facts/tests/braces.rs
+++ b/crates/shuck-linter/src/facts/tests/braces.rs
@@ -11,6 +11,7 @@ echo \\${${name}}/\\${fallback}
 
     with_facts(source, None, |_, facts| {
         let positions = facts
+            .words()
             .literal_brace_spans()
             .iter()
             .map(|span| (span.start.line, span.start.column))

--- a/crates/shuck-linter/src/facts/tests/commands.rs
+++ b/crates/shuck-linter/src/facts/tests/commands.rs
@@ -5,6 +5,7 @@ fn word_static_text_preserves_multi_part_literals() {
     let source = "echo foo\"bar\" 'baz'qux\n";
     with_facts(source, None, |_output, facts| {
         let mut static_args = facts
+            .words()
             .expansion_word_facts(ExpansionContext::CommandArgument)
             .map(|fact| {
                 (
@@ -28,7 +29,10 @@ fn word_static_text_preserves_multi_part_literals() {
 fn structural_commands_skip_synthetic_semantic_commands() {
     let source = "case \"$x\" in $(echo \"$v\")) ;; esac\n";
     with_facts(source, None, |_output, facts| {
-        let commands = facts.structural_commands().collect::<Vec<_>>();
+        let commands = facts
+            .command_facts()
+            .structural_commands()
+            .collect::<Vec<_>>();
 
         assert!(!commands.is_empty());
         assert!(commands.iter().all(|command| {
@@ -42,7 +46,10 @@ fn structural_commands_skip_synthetic_semantic_commands() {
             .iter()
             .find(|command| command.span().slice(source).starts_with("echo"))
             .unwrap();
-        let parent = facts.command_parent(pattern_command.id()).unwrap();
+        let parent = facts
+            .command_facts()
+            .command_parent(pattern_command.id())
+            .unwrap();
         assert!(parent.span().slice(source).starts_with("case"));
     });
 }
@@ -96,6 +103,7 @@ fn summarizes_command_options_and_invokers() {
     );
     assert_eq!(
         facts
+            .words()
             .echo_backslash_escape_word_spans()
             .iter()
             .map(|span| span.slice(source))
@@ -741,6 +749,7 @@ fn tracks_quote_like_echo_escapes_inside_double_quotes_from_syntax_text() {
 
     assert_eq!(
         facts
+            .words()
             .echo_backslash_escape_word_spans()
             .iter()
             .map(|span| span.slice(source))
@@ -759,6 +768,7 @@ fn tracks_echo_backslash_double_quote_escape_shapes() {
 
     assert_eq!(
         facts
+            .words()
             .echo_backslash_escape_word_spans()
             .iter()
             .map(|span| span.slice(source))
@@ -778,7 +788,7 @@ fn ignores_json_like_backslash_quote_wrappers_around_variables() {
     let semantic = LinterSemanticArtifacts::build(&output.file, source, &indexer);
     let facts = LinterFacts::build(&output.file, source, &semantic, &indexer);
 
-    assert!(facts.echo_backslash_escape_word_spans().is_empty());
+    assert!(facts.words().echo_backslash_escape_word_spans().is_empty());
 }
 
 #[test]
@@ -798,7 +808,7 @@ echo Saved to \\\"\"$FILENAME\"\\\" \\(\"$(du -h \"$OUTPUT\" | cut -f1)\"\\)
     let semantic = LinterSemanticArtifacts::build(&output.file, source, &indexer);
     let facts = LinterFacts::build(&output.file, source, &semantic, &indexer);
 
-    assert!(facts.echo_backslash_escape_word_spans().is_empty());
+    assert!(facts.words().echo_backslash_escape_word_spans().is_empty());
 }
 
 #[test]
@@ -956,6 +966,7 @@ literal=$(sed 's/[[:space:]]*$//' <<<literal)
     with_facts(source, None, |_, facts| {
         assert_eq!(
             facts
+                .words()
                 .echo_to_sed_substitution_spans()
                 .iter()
                 .map(|span| span.slice(source))
@@ -1012,7 +1023,7 @@ echo \"prefix$(printf %s foo)\" | sed 's/foo/bar/'
 ";
 
     with_facts(source, None, |_, facts| {
-        assert!(facts.echo_to_sed_substitution_spans().is_empty());
+        assert!(facts.words().echo_to_sed_substitution_spans().is_empty());
     });
 }
 
@@ -1024,7 +1035,7 @@ EC2_REGION=\"`echo \\\"$EC2_AVAIL_ZONE\\\" | sed -e 's:\\([0-9][0-9]*\\)[a-z]*\\
 ";
 
     with_facts(source, None, |_, facts| {
-        let spans = facts.echo_to_sed_substitution_spans();
+        let spans = facts.words().echo_to_sed_substitution_spans();
         assert_eq!(spans.len(), 1);
         let span = spans[0];
         assert_eq!(span.start.line, 2);
@@ -1042,7 +1053,7 @@ A=\"`echo \\\"$A\\\" | sed 's/foo\\\\$/é/'`\"
 ";
 
     with_facts(source, None, |_, facts| {
-        let spans = facts.echo_to_sed_substitution_spans();
+        let spans = facts.words().echo_to_sed_substitution_spans();
         assert_eq!(spans.len(), 1);
         let span = spans[0];
         assert_eq!(span.start.line, 2);
@@ -1184,58 +1195,81 @@ time timed
             .expect("expected binary command");
 
         let init_parent = facts
+            .command_facts()
             .command_parent(init_if.id())
             .expect("expected if parent");
         assert!(matches!(
             init_parent.command(),
             shuck_ast::Command::Compound(shuck_ast::CompoundCommand::If(_))
         ));
-        assert!(facts.command_is_dominance_barrier(init_parent.id()));
+        assert!(
+            facts
+                .command_facts()
+                .command_is_dominance_barrier(init_parent.id())
+        );
 
         let brace_parent = facts
+            .command_facts()
             .command_parent(brace_inner.id())
             .expect("expected brace-group parent");
         assert!(matches!(
             brace_parent.command(),
             shuck_ast::Command::Compound(shuck_ast::CompoundCommand::BraceGroup(_))
         ));
-        assert!(!facts.command_is_dominance_barrier(brace_parent.id()));
+        assert!(
+            !facts
+                .command_facts()
+                .command_is_dominance_barrier(brace_parent.id())
+        );
 
         let timed_parent = facts
+            .command_facts()
             .command_parent(timed.id())
             .expect("expected time parent");
         assert!(matches!(
             timed_parent.command(),
             shuck_ast::Command::Compound(shuck_ast::CompoundCommand::Time(_))
         ));
-        assert!(!facts.command_is_dominance_barrier(timed_parent.id()));
-        assert!(facts.command_is_dominance_barrier(binary.id()));
+        assert!(
+            !facts
+                .command_facts()
+                .command_is_dominance_barrier(timed_parent.id())
+        );
+        assert!(
+            facts
+                .command_facts()
+                .command_is_dominance_barrier(binary.id())
+        );
 
         let brace_offset = source.find("brace_inner").expect("brace_inner offset");
         let right_offset = source.find("right").expect("right offset");
         assert_eq!(
             facts
+                .command_facts()
                 .innermost_command_at(brace_offset)
                 .and_then(|fact| fact.effective_name()),
             Some("brace_inner")
         );
         assert_eq!(
             facts
+                .command_facts()
                 .innermost_command_at(right_offset)
                 .and_then(|fact| fact.effective_name()),
             Some("right")
         );
         assert_eq!(
             facts
+                .command_facts()
                 .innermost_command_id_containing_offset(brace_offset + 2)
-                .map(|id| facts.command(id))
+                .map(|id| facts.command_facts().command(id))
                 .and_then(|fact| fact.effective_name()),
             Some("brace_inner")
         );
         assert_eq!(
             facts
+                .command_facts()
                 .innermost_command_id_containing_offset(right_offset + 2)
-                .map(|id| facts.command(id))
+                .map(|id| facts.command_facts().command(id))
                 .and_then(|fact| fact.effective_name()),
             Some("right")
         );
@@ -1834,6 +1868,7 @@ echo ${foo:-$((10#1))}
 
     assert_eq!(
         facts
+            .words()
             .arithmetic_literal_facts()
             .iter()
             .filter(|literal| literal.kind() == ArithmeticLiteralKind::ExplicitBasePrefix)
@@ -1873,6 +1908,7 @@ echo $((10#6))
 
     assert_eq!(
         facts
+            .words()
             .arithmetic_literal_facts()
             .iter()
             .map(|literal| {
@@ -1942,6 +1978,7 @@ echo $((010))
 
     assert_eq!(
         facts
+            .words()
             .arithmetic_literal_facts()
             .iter()
             .map(|literal| {
@@ -1985,6 +2022,7 @@ echo ${value:-$((010#7))}
 
     assert_eq!(
         facts
+            .words()
             .arithmetic_literal_facts()
             .iter()
             .map(|literal| {
@@ -2036,6 +2074,7 @@ esac
 
     assert_eq!(
         facts
+            .words()
             .arithmetic_literal_facts()
             .iter()
             .filter(|literal| literal.kind() == ArithmeticLiteralKind::ExplicitBasePrefix)
@@ -2062,6 +2101,7 @@ EOF
 
     assert_eq!(
         facts
+            .words()
             .arithmetic_update_operator_spans()
             .iter()
             .map(|span| span.slice(source))
@@ -2085,6 +2125,7 @@ EOF
 
     assert_eq!(
         facts
+            .words()
             .arithmetic_update_operator_spans()
             .iter()
             .map(|span| span.slice(source))
@@ -2107,6 +2148,7 @@ echo ${foo:-${1##*/}}
 
     assert!(
         facts
+            .words()
             .arithmetic_literal_facts()
             .iter()
             .all(|literal| literal.kind() != ArithmeticLiteralKind::ExplicitBasePrefix)
@@ -2128,6 +2170,7 @@ echo $((42949 - ${1#-} / 100000))
 
     assert!(
         facts
+            .words()
             .arithmetic_literal_facts()
             .iter()
             .all(|literal| literal.kind() != ArithmeticLiteralKind::ExplicitBasePrefix)
@@ -2149,6 +2192,7 @@ echo $(( ${foo:-10#1} ))
 
     assert_eq!(
         facts
+            .words()
             .arithmetic_literal_facts()
             .iter()
             .filter(|literal| literal.kind() == ArithmeticLiteralKind::ExplicitBasePrefix)
@@ -2955,7 +2999,7 @@ fn summarizes_directory_change_commands_and_errexit_hints() {
     let semantic = LinterSemanticArtifacts::build(&output.file, source, &indexer);
     let facts = LinterFacts::build(&output.file, source, &semantic, &indexer);
 
-    assert!(facts.errexit_enabled_anywhere());
+    assert!(facts.source_facts().errexit_enabled_anywhere());
 
     let directory_changes = facts
         .commands()
@@ -2992,7 +3036,7 @@ fn does_not_treat_long_shebang_options_as_errexit() {
     let semantic = LinterSemanticArtifacts::build(&output.file, source, &indexer);
     let facts = LinterFacts::build(&output.file, source, &semantic, &indexer);
 
-    assert!(!facts.errexit_enabled_anywhere());
+    assert!(!facts.source_facts().errexit_enabled_anywhere());
 }
 
 #[test]
@@ -3466,6 +3510,7 @@ fn builds_redirect_facts_with_cached_target_analysis() {
 
     with_facts(source, None, |_, facts| {
         let command = facts
+            .command_facts()
             .structural_commands()
             .find(|fact| fact.effective_name_is("echo"))
             .expect("expected echo fact");
@@ -3520,6 +3565,7 @@ fn builds_redirect_facts_with_cached_target_analysis() {
         );
 
         let pure_arithmetic = facts
+            .command_facts()
             .structural_commands()
             .filter(|fact| fact.effective_name_is("echo"))
             .nth(1)

--- a/crates/shuck-linter/src/facts/tests/comments.rs
+++ b/crates/shuck-linter/src/facts/tests/comments.rs
@@ -6,9 +6,11 @@ fn captures_c074_anchor_and_whitespace_span() {
 
     with_facts(source, None, |_, facts| {
         let anchor = facts
+            .source_facts()
             .space_after_hash_bang_span()
             .expect("expected C074 anchor span");
         let whitespace = facts
+            .source_facts()
             .space_after_hash_bang_whitespace_span()
             .expect("expected C074 whitespace span");
 
@@ -23,8 +25,13 @@ fn captures_c074_anchor_and_whitespace_span() {
 #[test]
 fn ignores_non_header_like_c074_lines_in_facts() {
     with_facts("echo ok\n# !/bin/sh\n", None, |_, facts| {
-        assert!(facts.space_after_hash_bang_span().is_none());
-        assert!(facts.space_after_hash_bang_whitespace_span().is_none());
+        assert!(facts.source_facts().space_after_hash_bang_span().is_none());
+        assert!(
+            facts
+                .source_facts()
+                .space_after_hash_bang_whitespace_span()
+                .is_none()
+        );
     });
 }
 
@@ -34,9 +41,11 @@ fn captures_c075_move_span_with_existing_newline() {
 
     with_facts(source, None, |_, facts| {
         let anchor = facts
+            .source_facts()
             .shebang_not_on_first_line_span()
             .expect("expected C075 anchor span");
         let fix_span = facts
+            .source_facts()
             .shebang_not_on_first_line_fix_span()
             .expect("expected C075 move span");
 
@@ -44,7 +53,9 @@ fn captures_c075_move_span_with_existing_newline() {
         assert_eq!(anchor.start.column, 1);
         assert_eq!(fix_span.slice(source), "#!/bin/sh\n");
         assert_eq!(
-            facts.shebang_not_on_first_line_preferred_newline(),
+            facts
+                .source_facts()
+                .shebang_not_on_first_line_preferred_newline(),
             Some("\n")
         );
     });
@@ -56,12 +67,15 @@ fn captures_c075_preferred_newline_for_eof_shebangs() {
 
     with_facts(source, None, |_, facts| {
         let fix_span = facts
+            .source_facts()
             .shebang_not_on_first_line_fix_span()
             .expect("expected C075 move span");
 
         assert_eq!(fix_span.slice(source), "#!/bin/sh");
         assert_eq!(
-            facts.shebang_not_on_first_line_preferred_newline(),
+            facts
+                .source_facts()
+                .shebang_not_on_first_line_preferred_newline(),
             Some("\r\n")
         );
     });

--- a/crates/shuck-linter/src/facts/tests/conditions.rs
+++ b/crates/shuck-linter/src/facts/tests/conditions.rs
@@ -54,6 +54,7 @@ query {
 
     with_facts(source, None, |_, facts| {
         let header = facts
+            .command_facts()
             .for_headers()
             .first()
             .expect("expected nested for header");
@@ -275,6 +276,7 @@ test
 
     with_facts(source, None, |_, facts| {
         let commands = facts
+            .command_facts()
             .structural_commands()
             .map(|fact| (fact.span().slice(source).trim_end().to_owned(), fact))
             .collect::<Vec<_>>();
@@ -427,6 +429,7 @@ test \\! -n foo
 
     with_facts(source, None, |_, facts| {
         let commands = facts
+            .command_facts()
             .structural_commands()
             .map(|fact| (fact.span().slice(source).trim_end().to_owned(), fact))
             .collect::<Vec<_>>();
@@ -507,6 +510,7 @@ fn simple_test_fact_tracks_truthy_string_unary_and_string_binary_subexpressions(
 
     with_facts(source, None, |_, facts| {
         let commands = facts
+            .command_facts()
             .structural_commands()
             .map(|fact| (fact.span().slice(source).trim_end().to_owned(), fact))
             .collect::<Vec<_>>();
@@ -842,6 +846,7 @@ fn simple_test_fact_tracks_operator_expression_operands() {
 
     with_facts(source, None, |_, facts| {
         let commands = facts
+            .command_facts()
             .structural_commands()
             .map(|fact| (fact.span().slice(source).trim_end().to_owned(), fact))
             .collect::<Vec<_>>();
@@ -954,6 +959,7 @@ fn collects_compound_operator_spans_for_grouped_bracket_tests() {
 
     with_facts(source, None, |_, facts| {
         let tests = facts
+            .command_facts()
             .structural_commands()
             .filter_map(|fact| fact.simple_test())
             .collect::<Vec<_>>();
@@ -995,6 +1001,7 @@ fn skips_compound_operator_spans_for_malformed_grouped_bracket_tests() {
 
     with_facts(source, None, |_, facts| {
         let test = facts
+            .command_facts()
             .structural_commands()
             .find_map(|fact| fact.simple_test())
             .expect("expected malformed simple test fact");
@@ -1012,6 +1019,7 @@ fn skips_compound_operator_spans_for_quoted_negation_before_grouped_subexpressio
 
     with_facts(source, None, |_, facts| {
         let test = facts
+            .command_facts()
             .structural_commands()
             .find_map(|fact| fact.simple_test())
             .expect("expected grouped simple test fact");
@@ -1031,7 +1039,10 @@ fn records_glued_closing_bracket_operand_spans_for_unary_tests() {
 ";
 
     with_facts(source, None, |_, facts| {
-        let commands = facts.structural_commands().collect::<Vec<_>>();
+        let commands = facts
+            .command_facts()
+            .structural_commands()
+            .collect::<Vec<_>>();
         assert_eq!(commands.len(), 4);
 
         assert_eq!(
@@ -1077,7 +1088,10 @@ if [ \"$x\" = y ]; then :; fi
 ";
 
     with_facts(source, None, |_, facts| {
-        let commands = facts.structural_commands().collect::<Vec<_>>();
+        let commands = facts
+            .command_facts()
+            .structural_commands()
+            .collect::<Vec<_>>();
         let broken = commands
             .iter()
             .find(|fact| fact.static_utility_name_is("[") && fact.span().start.line == 2)
@@ -1129,6 +1143,7 @@ f() {
     with_facts(source, None, |_, facts| {
         assert_eq!(
             facts
+                .command_facts()
                 .bare_command_name_assignment_spans()
                 .iter()
                 .map(|span| span.slice(source))
@@ -1160,6 +1175,7 @@ true && `echo and_redirect` 2>/dev/null
     with_facts(source, None, |_, facts| {
         assert_eq!(
             facts
+                .command_facts()
                 .backtick_command_name_spans()
                 .iter()
                 .map(|span| span.slice(source))
@@ -1188,9 +1204,9 @@ true && false || printf '%s\\n' fallback
 ";
 
     with_facts(source, None, |_, facts| {
-        assert_eq!(facts.for_headers().len(), 2);
+        assert_eq!(facts.command_facts().for_headers().len(), 2);
 
-        let top_level_for = &facts.for_headers()[0];
+        let top_level_for = &facts.command_facts().for_headers()[0];
         assert!(!top_level_for.is_nested_word_command());
         assert_eq!(top_level_for.words().len(), 3);
         assert!(top_level_for.words()[0].has_unquoted_command_substitution());
@@ -1198,16 +1214,17 @@ true && false || printf '%s\\n' fallback
         assert!(top_level_for.has_command_substitution());
         assert!(top_level_for.has_find_substitution());
 
-        let nested_for = &facts.for_headers()[1];
+        let nested_for = &facts.command_facts().for_headers()[1];
         assert!(nested_for.is_nested_word_command());
         assert!(nested_for.words()[0].has_unquoted_command_substitution());
 
-        let select = &facts.select_headers()[0];
+        let select = &facts.command_facts().select_headers()[0];
         assert_eq!(select.words().len(), 3);
         assert!(select.words()[0].has_command_substitution());
         assert!(select.words()[1].contains_find_substitution());
 
         let pipeline_segments = facts
+            .command_facts()
             .pipelines()
             .iter()
             .map(|pipeline| {
@@ -1232,7 +1249,7 @@ true && false || printf '%s\\n' fallback
             ]
         );
 
-        let first_pipeline = &facts.pipelines()[0];
+        let first_pipeline = &facts.command_facts().pipelines()[0];
         assert_eq!(
             first_pipeline
                 .operators()
@@ -1244,12 +1261,17 @@ true && false || printf '%s\\n' fallback
         let first_segment = &first_pipeline.segments()[0];
         assert_eq!(
             facts
+                .command_facts()
                 .command(first_segment.command_id())
                 .effective_or_literal_name(),
             Some("printf")
         );
 
-        let list = facts.lists().first().expect("expected list fact");
+        let list = facts
+            .command_facts()
+            .lists()
+            .first()
+            .expect("expected list fact");
         assert_eq!(
             list.operators()
                 .iter()
@@ -1291,9 +1313,10 @@ fn classifies_mixed_short_circuit_lists_by_shape() {
 ";
 
     with_facts(source, None, |_, facts| {
-        assert_eq!(facts.lists().len(), 4);
+        assert_eq!(facts.command_facts().lists().len(), 4);
         assert_eq!(
             facts
+                .command_facts()
                 .lists()
                 .iter()
                 .map(|list| list.mixed_short_circuit_kind())
@@ -1316,12 +1339,17 @@ echo \"\\\"$BUILDSCRIPT\\\" --library $(test \"${PKG_DIR%/*}\" = \"gpkg\" && ech
 ";
 
     with_facts(source, None, |_, facts| {
-        let list = facts.lists().first().expect("expected mixed list");
+        let list = facts
+            .command_facts()
+            .lists()
+            .first()
+            .expect("expected mixed list");
         let names = list
             .segments()
             .iter()
             .map(|segment| {
                 facts
+                    .command_facts()
                     .command(segment.command_id())
                     .effective_or_literal_name()
                     .map(str::to_owned)
@@ -1348,9 +1376,9 @@ true && declare -x flag=1
 ";
 
     with_facts(source, None, |_, facts| {
-        assert_eq!(facts.lists().len(), 2);
+        assert_eq!(facts.command_facts().lists().len(), 2);
 
-        let ternary = &facts.lists()[0];
+        let ternary = &facts.command_facts().lists()[0];
         assert_eq!(
             ternary.mixed_short_circuit_kind(),
             Some(crate::facts::MixedShortCircuitKind::AssignmentTernary)
@@ -1372,7 +1400,7 @@ true && declare -x flag=1
             vec![false, true, true]
         );
 
-        let shortcut = &facts.lists()[1];
+        let shortcut = &facts.command_facts().lists()[1];
         assert_eq!(
             shortcut
                 .segments()
@@ -1399,15 +1427,15 @@ for entry in $(find . -type f); do :; done
 ";
 
     with_facts(source, None, |_, facts| {
-        let words = facts.for_headers()[0].words();
+        let words = facts.command_facts().for_headers()[0].words();
         assert!(words[0].has_unquoted_command_substitution());
         assert!(words[0].contains_ls_substitution());
 
-        let command_ls = facts.for_headers()[1].words();
+        let command_ls = facts.command_facts().for_headers()[1].words();
         assert!(command_ls[0].has_unquoted_command_substitution());
         assert!(!command_ls[0].contains_ls_substitution());
 
-        let find_words = facts.for_headers()[2].words();
+        let find_words = facts.command_facts().for_headers()[2].words();
         assert!(find_words[0].has_unquoted_command_substitution());
         assert!(!find_words[0].contains_ls_substitution());
     });
@@ -1422,11 +1450,11 @@ for entry in $(command find . -type f -exec basename {} \\;); do :; done
 ";
 
     with_facts(source, None, |_, facts| {
-        let first = facts.for_headers()[0].words();
+        let first = facts.command_facts().for_headers()[0].words();
         assert!(first[0].has_unquoted_command_substitution());
         assert!(first[0].contains_find_substitution());
 
-        let second = facts.for_headers()[1].words();
+        let second = facts.command_facts().for_headers()[1].words();
         assert!(second[0].has_unquoted_command_substitution());
         assert!(second[0].contains_find_substitution());
     });
@@ -1446,6 +1474,7 @@ for entry in $(find . -type f); do :; done
 
     with_facts(source, None, |_, facts| {
         let words = facts
+            .command_facts()
             .for_headers()
             .iter()
             .map(|header| header.words()[0].contains_line_oriented_substitution())
@@ -1464,9 +1493,14 @@ for entry in $(find . -type f -exec grep -Pl '\\r$' {} \\;); do :; done
 ";
 
     with_facts(source, None, |_, facts| {
-        assert_eq!(facts.for_headers().len(), 2);
-        assert!(facts.for_headers()[0].words()[1].contains_line_oriented_substitution());
-        assert!(!facts.for_headers()[1].words()[0].contains_line_oriented_substitution());
+        assert_eq!(facts.command_facts().for_headers().len(), 2);
+        assert!(
+            facts.command_facts().for_headers()[0].words()[1].contains_line_oriented_substitution()
+        );
+        assert!(
+            !facts.command_facts().for_headers()[1].words()[0]
+                .contains_line_oriented_substitution()
+        );
     });
 }
 
@@ -1484,9 +1518,9 @@ for version ($versions); do :; done
         ParseShellDialect::Zsh,
         ShellDialect::Zsh,
         |_, facts| {
-            assert_eq!(facts.for_headers().len(), 2);
+            assert_eq!(facts.command_facts().for_headers().len(), 2);
 
-            let first = &facts.for_headers()[0];
+            let first = &facts.command_facts().for_headers()[0];
             assert_eq!(first.words().len(), 2);
             assert!(first.words()[0].has_command_substitution());
             assert_eq!(
@@ -1498,7 +1532,7 @@ for version ($versions); do :; done
                 vec!["$(printf '%s\\n' a b)", "literal"]
             );
 
-            let second = &facts.for_headers()[1];
+            let second = &facts.command_facts().for_headers()[1];
             assert_eq!(second.words().len(), 1);
             assert_eq!(second.words()[0].word().span.slice(source), "$versions");
         },
@@ -1515,6 +1549,7 @@ fn builds_conditional_facts_with_root_normalization_and_nested_inventory() {
 
     with_facts(source, None, |_, facts| {
         let conditionals = facts
+            .command_facts()
             .structural_commands()
             .filter_map(|fact| fact.conditional())
             .collect::<Vec<_>>();
@@ -1665,6 +1700,7 @@ fn keeps_parenthesized_logical_groups_separate_for_mixed_operator_detection() {
 
     with_facts(source, None, |_, facts| {
         let conditionals = facts
+            .command_facts()
             .structural_commands()
             .filter_map(|fact| fact.conditional())
             .collect::<Vec<_>>();
@@ -1728,7 +1764,7 @@ test -O \"$file\"
 ";
 
     with_facts(source, None, |_, facts| {
-        let portability = facts.conditional_portability();
+        let portability = facts.compat().conditional_portability();
 
         assert_eq!(portability.double_bracket_in_sh().len(), 9);
         assert_eq!(
@@ -1847,6 +1883,7 @@ fn array_subscript_test_follows_sc2202_simple_test_operand_positions() {
     with_facts(source, None, |_, facts| {
         assert_eq!(
             facts
+                .compat()
                 .conditional_portability()
                 .array_subscript_test()
                 .iter()
@@ -1879,6 +1916,7 @@ for item in [^c]*; do :; done
 
     with_facts(source, None, |_, facts| {
         let extglobs = facts
+            .compat()
             .conditional_portability()
             .extglob_in_sh()
             .iter()
@@ -1889,6 +1927,7 @@ for item in [^c]*; do :; done
         assert!(extglobs.contains(&"@($suffix|zz)"));
 
         let caret_negations = facts
+            .compat()
             .conditional_portability()
             .caret_negation_in_bracket()
             .iter()

--- a/crates/shuck-linter/src/facts/tests/flow.rs
+++ b/crates/shuck-linter/src/facts/tests/flow.rs
@@ -11,6 +11,7 @@ fn assignment_value_facts_ignore_line_continuation_backslashes_for_shell_quoting
 
     with_facts(source, None, |_, facts| {
         let fact = facts
+            .words()
             .expansion_word_facts(ExpansionContext::AssignmentValue)
             .next()
             .expect("assignment value fact should exist");
@@ -25,6 +26,7 @@ fn assignment_value_facts_keep_single_quoted_backslash_newlines_for_shell_quotin
 
     with_facts(source, None, |_, facts| {
         let fact = facts
+            .words()
             .expansion_word_facts(ExpansionContext::AssignmentValue)
             .next()
             .expect("assignment value fact should exist");
@@ -38,7 +40,7 @@ fn background_semicolon_facts_report_plain_semicolons() {
     let source = "#!/bin/bash\necho x &;\necho y & ;\n";
 
     with_facts(source, None, |_, facts| {
-        let spans = facts.background_semicolon_spans();
+        let spans = facts.command_facts().background_semicolon_spans();
 
         assert_eq!(spans.len(), 2);
         assert_eq!(spans[0].slice(source), ";");
@@ -61,7 +63,12 @@ esac
 ";
 
     with_facts(source, None, |_, facts| {
-        assert!(facts.background_semicolon_spans().is_empty());
+        assert!(
+            facts
+                .command_facts()
+                .background_semicolon_spans()
+                .is_empty()
+        );
     });
 }
 
@@ -70,7 +77,7 @@ fn redundant_echo_space_facts_capture_diagnostic_and_edit_spans() {
     let source = "#!/bin/bash\necho foo    bar    baz\necho foo  bar\n";
 
     with_facts(source, None, |_, facts| {
-        let facts = facts.redundant_echo_space_facts();
+        let facts = facts.command_facts().redundant_echo_space_facts();
 
         assert_eq!(facts.len(), 1);
         assert_eq!(
@@ -88,7 +95,12 @@ fn commented_continuation_facts_ignore_plain_comment_only_lines() {
     let source = "#!/bin/sh\necho hello \\\n  #world\n  foo\n";
 
     with_facts(source, None, |_, facts| {
-        assert!(facts.commented_continuation_comment_spans().is_empty());
+        assert!(
+            facts
+                .source_facts()
+                .commented_continuation_comment_spans()
+                .is_empty()
+        );
     });
 }
 
@@ -97,7 +109,7 @@ fn commented_continuation_facts_anchor_at_comment_backslash() {
     let source = "#!/bin/sh\necho hello \\\n  #world \\\n  foo\n";
 
     with_facts(source, None, |_, facts| {
-        let spans = facts.commented_continuation_comment_spans();
+        let spans = facts.source_facts().commented_continuation_comment_spans();
         assert_eq!(spans.len(), 1);
         assert_eq!(spans[0].start.line, 3);
         assert_eq!(spans[0].start.column, 11);
@@ -118,6 +130,7 @@ fn builds_command_facts_for_wrapped_and_nested_commands() {
     let facts = LinterFacts::build(&output.file, source, &semantic, &indexer);
 
     let outer = facts
+        .command_facts()
         .structural_commands()
         .find(|fact| fact.effective_name_is("printf"))
         .expect("expected structural printf fact");
@@ -161,6 +174,7 @@ fn exposes_structural_commands_and_id_lookups() {
     let facts = LinterFacts::build(&output.file, source, &semantic, &indexer);
 
     let structural = facts
+        .command_facts()
         .structural_commands()
         .map(|fact| fact.effective_or_literal_name().unwrap().to_owned())
         .collect::<Vec<_>>();
@@ -174,14 +188,20 @@ fn exposes_structural_commands_and_id_lookups() {
     assert_eq!(all, vec!["echo", "printf"]);
 
     let echo_id = facts
+        .command_facts()
         .command_id_for_stmt(&output.file.body[0])
         .expect("expected command id for top-level stmt");
     assert_eq!(
-        facts.command(echo_id).effective_or_literal_name(),
+        facts
+            .command_facts()
+            .command(echo_id)
+            .effective_or_literal_name(),
         Some("echo")
     );
     assert_eq!(
-        facts.command_id_for_command(&output.file.body[0].command),
+        facts
+            .command_facts()
+            .command_id_for_command(&output.file.body[0].command),
         Some(echo_id)
     );
 }
@@ -263,8 +283,16 @@ fi
             .find(|fact| fact.span().slice(source) == "[[ -f if_path ]]")
             .expect("expected nested if condition command");
         assert!(if_nested.scope_read_source_words().is_empty());
-        assert!(facts.is_if_condition_command(if_nested.id()));
-        assert!(!facts.is_elif_condition_command(if_nested.id()));
+        assert!(
+            facts
+                .command_facts()
+                .is_if_condition_command(if_nested.id())
+        );
+        assert!(
+            !facts
+                .command_facts()
+                .is_elif_condition_command(if_nested.id())
+        );
 
         let elif_nested = facts
             .commands()
@@ -272,7 +300,11 @@ fi
             .find(|fact| fact.span().slice(source) == "[[ -f elif_path ]]")
             .expect("expected nested elif condition command");
         assert!(elif_nested.scope_read_source_words().is_empty());
-        assert!(facts.is_elif_condition_command(elif_nested.id()));
+        assert!(
+            facts
+                .command_facts()
+                .is_elif_condition_command(elif_nested.id())
+        );
     });
 }
 
@@ -359,6 +391,7 @@ fn includes_nested_jq_file_operands_in_writer_scope_reads() {
         );
 
         let cat = facts
+            .command_facts()
             .structural_commands()
             .find(|fact| fact.effective_name_is("cat"))
             .expect("expected structural cat command");
@@ -388,6 +421,7 @@ jq -Lnewmods '.x=1' \"$cfg\"
 
     with_facts(source, None, |_, facts| {
         let jq_commands = facts
+            .command_facts()
             .structural_commands()
             .filter(|fact| fact.effective_name_is("jq"))
             .collect::<Vec<_>>();
@@ -437,8 +471,16 @@ done
             .find(|fact| fact.span().slice(source) == "[[ -f if_path ]]")
             .expect("expected nested if condition command");
         assert!(if_nested.scope_read_source_words().is_empty());
-        assert!(facts.is_if_condition_command(if_nested.id()));
-        assert!(!facts.is_elif_condition_command(if_nested.id()));
+        assert!(
+            facts
+                .command_facts()
+                .is_if_condition_command(if_nested.id())
+        );
+        assert!(
+            !facts
+                .command_facts()
+                .is_elif_condition_command(if_nested.id())
+        );
 
         let elif_nested = facts
             .commands()
@@ -446,7 +488,11 @@ done
             .find(|fact| fact.span().slice(source) == "[[ -f elif_path ]]")
             .expect("expected nested elif condition command");
         assert!(elif_nested.scope_read_source_words().is_empty());
-        assert!(facts.is_elif_condition_command(elif_nested.id()));
+        assert!(
+            facts
+                .command_facts()
+                .is_elif_condition_command(elif_nested.id())
+        );
     });
 }
 
@@ -472,8 +518,16 @@ fi
             .find(|fact| fact.span().slice(source) == "[[ -f if_path ]]")
             .expect("expected nested while condition command");
         assert!(if_nested.scope_read_source_words().is_empty());
-        assert!(facts.is_if_condition_command(if_nested.id()));
-        assert!(!facts.is_elif_condition_command(if_nested.id()));
+        assert!(
+            facts
+                .command_facts()
+                .is_if_condition_command(if_nested.id())
+        );
+        assert!(
+            !facts
+                .command_facts()
+                .is_elif_condition_command(if_nested.id())
+        );
 
         let elif_nested = facts
             .commands()
@@ -481,8 +535,16 @@ fi
             .find(|fact| fact.span().slice(source) == "[[ -f elif_path ]]")
             .expect("expected nested until condition command");
         assert!(elif_nested.scope_read_source_words().is_empty());
-        assert!(facts.is_if_condition_command(elif_nested.id()));
-        assert!(facts.is_elif_condition_command(elif_nested.id()));
+        assert!(
+            facts
+                .command_facts()
+                .is_if_condition_command(elif_nested.id())
+        );
+        assert!(
+            facts
+                .command_facts()
+                .is_elif_condition_command(elif_nested.id())
+        );
     });
 }
 
@@ -525,6 +587,7 @@ done
     with_facts(source, None, |_, facts| {
         assert_eq!(
             facts
+                .command_facts()
                 .command_substitution_command_spans()
                 .iter()
                 .map(|span| span.slice(source))
@@ -539,6 +602,7 @@ done
         );
         assert_eq!(
             facts
+                .command_facts()
                 .condition_status_capture_spans()
                 .iter()
                 .map(|span| span.slice(source))
@@ -564,6 +628,7 @@ while [[ $? -ne 0 ]]; do break; done
     with_facts(source, None, |_, facts| {
         assert_eq!(
             facts
+                .source_facts()
                 .dollar_question_after_command_spans()
                 .iter()
                 .map(|span| span.slice(source))
@@ -592,6 +657,7 @@ again=$?
     with_facts(source, None, |_, facts| {
         assert_eq!(
             facts
+                .command_facts()
                 .condition_status_capture_spans()
                 .iter()
                 .map(|span| span.slice(source))
@@ -612,7 +678,10 @@ nextcmd
 
     with_facts(source, None, |_, facts| {
         assert!(
-            facts.condition_status_capture_spans().is_empty(),
+            facts
+                .command_facts()
+                .condition_status_capture_spans()
+                .is_empty(),
             "expected no C056 spans for one-off sequential test followup"
         );
     });
@@ -637,6 +706,7 @@ done
     with_facts(source, None, |_, facts| {
         assert_eq!(
             facts
+                .command_facts()
                 .condition_status_capture_spans()
                 .iter()
                 .map(|span| span.slice(source))
@@ -662,6 +732,7 @@ fi
     with_facts(source, None, |_, facts| {
         assert_eq!(
             facts
+                .command_facts()
                 .condition_status_capture_spans()
                 .iter()
                 .map(|span| span.slice(source))
@@ -685,6 +756,7 @@ helper() {
     with_facts(source, None, |_, facts| {
         assert_eq!(
             facts
+                .command_facts()
                 .condition_status_capture_spans()
                 .iter()
                 .map(|span| span.slice(source))
@@ -728,6 +800,7 @@ tend $?
     with_facts(source, None, |_, facts| {
         assert_eq!(
             facts
+                .command_facts()
                 .condition_status_capture_spans()
                 .iter()
                 .map(|span| span.slice(source))
@@ -755,6 +828,7 @@ fn collects_c056_for_shellspec_style_followup_chains_when_sibling_groups_continu
     with_facts(source, None, |_, facts| {
         assert_eq!(
             facts
+                .command_facts()
                 .condition_status_capture_spans()
                 .iter()
                 .map(|span| span.slice(source))
@@ -778,6 +852,7 @@ check_status() {
     with_facts(source, None, |_, facts| {
         assert_eq!(
             facts
+                .source_facts()
                 .dollar_question_after_command_spans()
                 .iter()
                 .map(|span| span.slice(source))
@@ -804,7 +879,7 @@ done
 ";
 
     with_facts(source, None, |_, facts| {
-        let [case] = facts.getopts_cases() else {
+        let [case] = facts.command_facts().getopts_cases() else {
             panic!("expected one getopts case fact");
         };
 
@@ -862,7 +937,7 @@ done
 ";
 
     with_facts(source, None, |_, facts| {
-        let cases = facts.getopts_cases();
+        let cases = facts.command_facts().getopts_cases();
         assert_eq!(cases.len(), 5);
         assert!(cases[0].missing_invalid_flag_handler());
         assert!(!cases[1].missing_invalid_flag_handler());

--- a/crates/shuck-linter/src/facts/tests/functions.rs
+++ b/crates/shuck-linter/src/facts/tests/functions.rs
@@ -7,6 +7,7 @@ fn function_header_fact_span_in_source_stops_at_header() {
 
     with_facts(source, None, |_, facts| {
         let header = facts
+            .command_facts()
             .function_headers()
             .first()
             .expect("expected function header fact");
@@ -24,6 +25,7 @@ fn function_header_fact_tracks_binding_scope_and_call_arity() {
 
     with_facts(source, None, |_, facts| {
         let header = facts
+            .command_facts()
             .function_headers()
             .iter()
             .find(|header| {
@@ -52,6 +54,7 @@ fn function_definition_command_lookup_returns_header_command() {
 
     with_facts(source, None, |_, facts| {
         let header = facts
+            .command_facts()
             .function_headers()
             .iter()
             .find(|header| {
@@ -64,6 +67,7 @@ fn function_definition_command_lookup_returns_header_command() {
             .function_scope()
             .expect("expected greet function scope");
         let definition_command = facts
+            .command_facts()
             .function_definition_command(scope)
             .expect("expected definition command");
 
@@ -78,6 +82,7 @@ fn command_for_name_word_span_resolves_definition_and_call_commands() {
 
     with_facts(source, None, |_, facts| {
         let header = facts
+            .command_facts()
             .function_headers()
             .iter()
             .find(|header| {
@@ -86,17 +91,19 @@ fn command_for_name_word_span_resolves_definition_and_call_commands() {
                     .is_some_and(|(name, _)| name == "greet")
             })
             .expect("expected greet header fact");
-        let definition_command = facts.command(header.command_id());
+        let definition_command = facts.command_facts().command(header.command_id());
         let call_name_span = header.call_arity().zero_arg_call_spans()[0];
 
         assert_eq!(
             facts
+                .command_facts()
                 .command_for_name_word_span(definition_command.span())
                 .map(|command| command.id()),
             Some(header.command_id())
         );
         assert_eq!(
             facts
+                .command_facts()
                 .command_for_name_word_span(call_name_span)
                 .and_then(|command| command.body_name_word().map(|word| word.span.slice(source))),
             Some("greet")
@@ -117,6 +124,7 @@ BUILD_VERSION=\"${BUILD_VERSION:-\"$(GetBuildVersion \"${BUILD_REVISION}\")\"}\"
 
     with_facts(source, None, |_, facts| {
         let header = facts
+            .command_facts()
             .function_headers()
             .iter()
             .find(|header| {
@@ -144,6 +152,7 @@ greet
 
     with_facts(source, None, |_, facts| {
         let header = facts
+            .command_facts()
             .function_headers()
             .iter()
             .find(|header| {
@@ -175,6 +184,7 @@ greet
 
     with_facts(source, None, |_, facts| {
         let header = facts
+            .command_facts()
             .function_headers()
             .iter()
             .find(|header| {
@@ -205,6 +215,7 @@ value=\"`greet`\"
 
     with_facts(source, None, |_, facts| {
         let header = facts
+            .command_facts()
             .function_headers()
             .iter()
             .find(|header| {
@@ -238,6 +249,7 @@ EOF
 
     with_facts(source, None, |_, facts| {
         let header = facts
+            .command_facts()
             .function_headers()
             .iter()
             .find(|header| {
@@ -274,6 +286,7 @@ exit $?
     with_facts(source, None, |_, facts| {
         for name in ["start", "stop"] {
             let header = facts
+                .command_facts()
                 .function_headers()
                 .iter()
                 .find(|header| {
@@ -283,7 +296,7 @@ exit $?
                 })
                 .expect("expected dispatched function header");
             let scope = header.function_scope().expect("expected function scope");
-            let dispatch = facts.function_cli_dispatch_facts(scope);
+            let dispatch = facts.command_facts().function_cli_dispatch_facts(scope);
 
             assert!(
                 dispatch.exported_from_case_cli(),
@@ -314,6 +327,7 @@ late() { echo later; }
 
     with_facts(source, None, |_, facts| {
         let start = facts
+            .command_facts()
             .function_headers()
             .iter()
             .find(|header| {
@@ -323,6 +337,7 @@ late() { echo later; }
             })
             .expect("expected start header fact");
         let late = facts
+            .command_facts()
             .function_headers()
             .iter()
             .find(|header| {
@@ -332,10 +347,10 @@ late() { echo later; }
             })
             .expect("expected late header fact");
 
-        assert!(facts.is_case_cli_reachable_function_scope(
+        assert!(facts.command_facts().is_case_cli_reachable_function_scope(
             start.function_scope().expect("expected start scope")
         ));
-        assert!(!facts.is_case_cli_reachable_function_scope(
+        assert!(!facts.command_facts().is_case_cli_reachable_function_scope(
             late.function_scope().expect("expected late scope")
         ));
     });
@@ -361,6 +376,7 @@ function {
         ShellDialect::Zsh,
         |_, facts| {
             let helper = facts
+                .command_facts()
                 .function_headers()
                 .iter()
                 .find(|header| {
@@ -370,7 +386,7 @@ function {
                 })
                 .expect("expected helper header fact");
 
-            assert!(facts.is_case_cli_reachable_function_scope(
+            assert!(facts.command_facts().is_case_cli_reachable_function_scope(
                 helper.function_scope().expect("expected helper scope")
             ));
         },
@@ -390,6 +406,7 @@ exit 0
 
     with_facts(source, None, |_, facts| {
         let header = facts
+            .command_facts()
             .function_headers()
             .iter()
             .find(|header| {
@@ -402,6 +419,7 @@ exit 0
 
         assert!(
             facts
+                .command_facts()
                 .function_cli_dispatch_facts(scope)
                 .exported_from_case_cli()
         );
@@ -420,6 +438,7 @@ esac
 
     with_facts(source, None, |_, facts| {
         let header = facts
+            .command_facts()
             .function_headers()
             .iter()
             .find(|header| {
@@ -432,6 +451,7 @@ esac
 
         assert!(
             !facts
+                .command_facts()
                 .function_cli_dispatch_facts(scope)
                 .exported_from_case_cli()
         );
@@ -451,6 +471,7 @@ exit $?
 
     with_facts(source, None, |_, facts| {
         let header = facts
+            .command_facts()
             .function_headers()
             .iter()
             .find(|header| {
@@ -463,6 +484,7 @@ exit $?
 
         assert!(
             !facts
+                .command_facts()
                 .function_cli_dispatch_facts(scope)
                 .exported_from_case_cli()
         );
@@ -483,6 +505,7 @@ start() { echo hi; }
 
     with_facts(source, None, |_, facts| {
         let header = facts
+            .command_facts()
             .function_headers()
             .iter()
             .find(|header| {
@@ -495,6 +518,7 @@ start() { echo hi; }
 
         assert!(
             !facts
+                .command_facts()
                 .function_cli_dispatch_facts(scope)
                 .exported_from_case_cli()
         );
@@ -565,6 +589,7 @@ o() {
     with_facts(source, None, |_, facts| {
         assert_eq!(
             facts
+                .command_facts()
                 .function_body_without_braces_spans()
                 .iter()
                 .map(|span| span.slice(source))
@@ -580,6 +605,7 @@ o() {
         );
         assert_eq!(
             facts
+                .command_facts()
                 .redundant_return_status_spans()
                 .iter()
                 .map(|span| span.slice(source))
@@ -607,7 +633,11 @@ complete -F _comp_cmd_later later
         let flagged_lines = facts
             .commands()
             .iter()
-            .filter(|command| facts.command_is_in_completion_registered_function(command.id()))
+            .filter(|command| {
+                facts
+                    .command_facts()
+                    .command_is_in_completion_registered_function(command.id())
+            })
             .map(|command| command.span().start.line)
             .collect::<Vec<_>>();
 
@@ -630,7 +660,11 @@ compdef __grunt grunt
         let flagged_lines = facts
             .commands()
             .iter()
-            .filter(|command| facts.command_is_in_completion_registered_function(command.id()))
+            .filter(|command| {
+                facts
+                    .command_facts()
+                    .command_is_in_completion_registered_function(command.id())
+            })
             .map(|command| command.span().start.line)
             .collect::<Vec<_>>();
 
@@ -655,7 +689,11 @@ setup_completion() {
         let flagged_lines = facts
             .commands()
             .iter()
-            .filter(|command| facts.command_is_in_completion_registered_function(command.id()))
+            .filter(|command| {
+                facts
+                    .command_facts()
+                    .command_is_in_completion_registered_function(command.id())
+            })
             .map(|command| command.span().start.line)
             .collect::<Vec<_>>();
 
@@ -679,7 +717,11 @@ compdef __grunt grunt
         let flagged_lines = facts
             .commands()
             .iter()
-            .filter(|command| facts.command_is_in_completion_registered_function(command.id()))
+            .filter(|command| {
+                facts
+                    .command_facts()
+                    .command_is_in_completion_registered_function(command.id())
+            })
             .map(|command| command.span().start.line)
             .collect::<Vec<_>>();
 
@@ -701,7 +743,11 @@ compdef __grunt=grunt
         let flagged_lines = facts
             .commands()
             .iter()
-            .filter(|command| facts.command_is_in_completion_registered_function(command.id()))
+            .filter(|command| {
+                facts
+                    .command_facts()
+                    .command_is_in_completion_registered_function(command.id())
+            })
             .map(|command| command.span().start.line)
             .collect::<Vec<_>>();
 
@@ -723,7 +769,11 @@ compdef -d grunt
         let flagged_lines = facts
             .commands()
             .iter()
-            .filter(|command| facts.command_is_in_completion_registered_function(command.id()))
+            .filter(|command| {
+                facts
+                    .command_facts()
+                    .command_is_in_completion_registered_function(command.id())
+            })
             .map(|command| command.span().start.line)
             .collect::<Vec<_>>();
 
@@ -745,7 +795,11 @@ __grunt() {
         let flagged_lines = facts
             .commands()
             .iter()
-            .filter(|command| facts.command_is_in_completion_registered_function(command.id()))
+            .filter(|command| {
+                facts
+                    .command_facts()
+                    .command_is_in_completion_registered_function(command.id())
+            })
             .map(|command| command.span().start.line)
             .collect::<Vec<_>>();
 
@@ -767,7 +821,11 @@ compdef -P 'grunt-*' __grunt grunt
         let flagged_lines = facts
             .commands()
             .iter()
-            .filter(|command| facts.command_is_in_completion_registered_function(command.id()))
+            .filter(|command| {
+                facts
+                    .command_facts()
+                    .command_is_in_completion_registered_function(command.id())
+            })
             .map(|command| command.span().start.line)
             .collect::<Vec<_>>();
 
@@ -790,7 +848,11 @@ compdef -P 'grunt-*' -N __grunt grunt
         let flagged_lines = facts
             .commands()
             .iter()
-            .filter(|command| facts.command_is_in_completion_registered_function(command.id()))
+            .filter(|command| {
+                facts
+                    .command_facts()
+                    .command_is_in_completion_registered_function(command.id())
+            })
             .map(|command| command.span().start.line)
             .collect::<Vec<_>>();
 
@@ -813,7 +875,11 @@ __grunt() {
         let flagged_lines = facts
             .commands()
             .iter()
-            .filter(|command| facts.command_is_in_completion_registered_function(command.id()))
+            .filter(|command| {
+                facts
+                    .command_facts()
+                    .command_is_in_completion_registered_function(command.id())
+            })
             .map(|command| command.span().start.line)
             .collect::<Vec<_>>();
 
@@ -883,11 +949,13 @@ setup_hook() { add-zsh-hook precmd latent_hook_impl; }
         ShellDialect::Zsh,
         |_, facts| {
             let external_names = facts
+                .command_facts()
                 .function_headers()
                 .iter()
                 .filter_map(|header| {
                     let scope = header.function_scope()?;
                     facts
+                        .command_facts()
                         .function_is_external_entrypoint(scope)
                         .then(|| header.static_name_entry().map(|(name, _)| name.as_str()))
                         .flatten()

--- a/crates/shuck-linter/src/facts/tests/surface.rs
+++ b/crates/shuck-linter/src/facts/tests/surface.rs
@@ -69,6 +69,7 @@ if [[ \"$@\" =~ x ]]; then :; fi
     with_facts(source, None, |_, facts| {
         assert_eq!(
             facts
+                .words()
                 .backtick_fragments()
                 .iter()
                 .map(|fragment| fragment.span().slice(source))
@@ -77,6 +78,7 @@ if [[ \"$@\" =~ x ]]; then :; fi
         );
         assert_eq!(
             facts
+                .words()
                 .legacy_arithmetic_fragments()
                 .iter()
                 .map(|fragment| fragment.span().slice(source))
@@ -85,6 +87,7 @@ if [[ \"$@\" =~ x ]]; then :; fi
         );
         assert_eq!(
             facts
+                .words()
                 .positional_parameter_fragments()
                 .iter()
                 .map(|fragment| {
@@ -143,6 +146,7 @@ if [[ \"$@\" =~ x ]]; then :; fi
         );
         assert_eq!(
             facts
+                .words()
                 .open_double_quote_fragments()
                 .iter()
                 .map(|fragment| fragment.span().slice(source))
@@ -151,6 +155,7 @@ if [[ \"$@\" =~ x ]]; then :; fi
         );
         assert_eq!(
             facts
+                .words()
                 .open_double_quote_fragments()
                 .iter()
                 .map(|fragment| fragment.replacement_span().slice(source))
@@ -159,6 +164,7 @@ if [[ \"$@\" =~ x ]]; then :; fi
         );
         assert_eq!(
             facts
+                .words()
                 .open_double_quote_fragments()
                 .iter()
                 .map(|fragment| fragment.replacement().to_owned())
@@ -167,19 +173,21 @@ if [[ \"$@\" =~ x ]]; then :; fi
         );
         assert_eq!(
             facts
+                .words()
                 .suspect_closing_quote_fragments()
                 .iter()
                 .map(|fragment| fragment.span().slice(source))
                 .collect::<Vec<_>>(),
             vec![""]
         );
-        assert_eq!(facts.positional_parameter_operator_spans().len(), 1);
-        let operator_span = facts.positional_parameter_operator_spans()[0];
+        assert_eq!(facts.words().positional_parameter_operator_spans().len(), 1);
+        let operator_span = facts.words().positional_parameter_operator_spans()[0];
         assert_eq!(operator_span.start.line, 6);
         assert_eq!(operator_span.start.column, 7);
         assert_eq!(operator_span.end, operator_span.start);
 
         let single_quoted = facts
+            .words()
             .single_quoted_fragments()
             .iter()
             .map(|fragment| {
@@ -222,6 +230,7 @@ if [[ \"$@\" =~ x ]]; then :; fi
         );
         assert_eq!(
             facts
+                .words()
                 .dollar_double_quoted_fragments()
                 .iter()
                 .map(|fragment| fragment.span().slice(source))
@@ -230,6 +239,7 @@ if [[ \"$@\" =~ x ]]; then :; fi
         );
         assert_eq!(
             facts
+                .words()
                 .indirect_expansion_fragments()
                 .iter()
                 .map(|fragment| (fragment.span().slice(source), fragment.array_keys()))
@@ -243,6 +253,7 @@ if [[ \"$@\" =~ x ]]; then :; fi
         );
         assert_eq!(
             facts
+                .words()
                 .indexed_array_reference_fragments()
                 .iter()
                 .map(|fragment| {
@@ -272,11 +283,15 @@ if [[ \"$@\" =~ x ]]; then :; fi
             ]
         );
         assert!(
-            facts.zsh_parameter_index_flag_fragments().is_empty(),
+            facts
+                .words()
+                .zsh_parameter_index_flag_fragments()
+                .is_empty(),
             "did not expect quoted-target index facts in the baseline surface fixture"
         );
         assert_eq!(
             facts
+                .words()
                 .substring_expansion_fragments()
                 .iter()
                 .map(|fragment| fragment.span().slice(source))
@@ -293,6 +308,7 @@ if [[ \"$@\" =~ x ]]; then :; fi
         );
         assert_eq!(
             facts
+                .words()
                 .case_modification_fragments()
                 .iter()
                 .map(|fragment| fragment.span().slice(source))
@@ -307,6 +323,7 @@ if [[ \"$@\" =~ x ]]; then :; fi
         );
         assert_eq!(
             facts
+                .words()
                 .replacement_expansion_fragments()
                 .iter()
                 .map(|fragment| fragment.span().slice(source))
@@ -324,12 +341,14 @@ if [[ \"$@\" =~ x ]]; then :; fi
         );
 
         let jq = facts
+            .command_facts()
             .structural_commands()
             .find(|fact| fact.static_utility_name_is("jq"))
             .expect("expected jq command fact");
         assert_eq!(jq.static_utility_name(), Some("jq"));
 
         let tail = facts
+            .command_facts()
             .pipelines()
             .first()
             .and_then(|pipeline| pipeline.last_segment())
@@ -353,7 +372,7 @@ EOF
 
     with_facts(source, None, |_, facts| {
         assert!(
-            facts.single_quoted_fragments().is_empty(),
+            facts.words().single_quoted_fragments().is_empty(),
             "expected heredoc payload quotes to stay out of single-quoted shell fragments"
         );
     });
@@ -368,6 +387,7 @@ bash --init-file \"${BASH_IT?}/bash_it.sh\" -i <<< '_bash-it-flash-term \"${#BAS
 
     with_facts(source, None, |_, facts| {
         let fragment = facts
+            .words()
             .single_quoted_fragments()
             .iter()
             .find(|fragment| {
@@ -391,6 +411,7 @@ bash > '$HOME'
 
     with_facts(source, None, |_, facts| {
         let fragment = facts
+            .words()
             .single_quoted_fragments()
             .iter()
             .find(|fragment| fragment.span().slice(source) == "'$HOME'")
@@ -418,6 +439,7 @@ printf '%s\\n' a'\\'bc
 
     with_facts(source, None, |_, facts| {
         let flagged = facts
+            .words()
             .single_quoted_fragments()
             .iter()
             .filter_map(|fragment| {
@@ -454,6 +476,7 @@ eval "$(printf '%s\n' x | "$10_rework")"
 
     with_facts(source, None, |_, facts| {
         let above_nine = facts
+            .words()
             .positional_parameter_fragments()
             .iter()
             .filter(|fragment| fragment.is_above_nine())
@@ -481,6 +504,7 @@ echo $[$[1 + 2] + 3]
     with_facts(source, None, |_, facts| {
         assert_eq!(
             facts
+                .words()
                 .legacy_arithmetic_fragments()
                 .iter()
                 .map(|fragment| fragment.span().slice(source))
@@ -516,11 +540,13 @@ LD_LIBRARY_PATH=\"$JVM_LD_LIBRARY_PATH\":\\$this_dir \\
 
     with_facts(source, None, |_, facts| {
         let open = facts
+            .words()
             .open_double_quote_fragments()
             .iter()
             .map(|fragment| (fragment.span().start.line, fragment.span().start.column))
             .collect::<Vec<_>>();
         let close = facts
+            .words()
             .suspect_closing_quote_fragments()
             .iter()
             .map(|fragment| (fragment.span().start.line, fragment.span().start.column))
@@ -551,8 +577,8 @@ LD_LIBRARY_PATH=\\\"\\$JVM_LD_LIBRARY_PATH\\\":\\$this_dir \\
 ";
 
     with_facts(source, None, |_, facts| {
-        assert!(facts.open_double_quote_fragments().is_empty());
-        assert!(facts.suspect_closing_quote_fragments().is_empty());
+        assert!(facts.words().open_double_quote_fragments().is_empty());
+        assert!(facts.words().suspect_closing_quote_fragments().is_empty());
     });
 }
 
@@ -567,11 +593,13 @@ say \"configure\" now
 
     with_facts(source, None, |_, facts| {
         let open = facts
+            .words()
             .open_double_quote_fragments()
             .iter()
             .map(|fragment| (fragment.span().start.line, fragment.span().start.column))
             .collect::<Vec<_>>();
         let close = facts
+            .words()
             .suspect_closing_quote_fragments()
             .iter()
             .map(|fragment| (fragment.span().start.line, fragment.span().start.column))
@@ -580,7 +608,7 @@ say \"configure\" now
         assert_eq!(open, vec![(2, 6)]);
         assert_eq!(close, vec![(3, 5)]);
         assert_eq!(
-            facts.open_double_quote_fragments()[0].replacement(),
+            facts.words().open_double_quote_fragments()[0].replacement(),
             "\"help text\nsay configure now\n\""
         );
     });
@@ -595,7 +623,7 @@ beta''tail'
 ";
 
     with_facts(source, None, |_, facts| {
-        let fragment = &facts.open_double_quote_fragments()[0];
+        let fragment = &facts.words().open_double_quote_fragments()[0];
 
         assert_eq!(
             fragment.replacement_span().slice(source),
@@ -615,11 +643,13 @@ line two\"\\foo\"tail\"
 
     with_facts(source, None, |_, facts| {
         let open = facts
+            .words()
             .open_double_quote_fragments()
             .iter()
             .map(|fragment| (fragment.span().start.line, fragment.span().start.column))
             .collect::<Vec<_>>();
         let close = facts
+            .words()
             .suspect_closing_quote_fragments()
             .iter()
             .map(|fragment| (fragment.span().start.line, fragment.span().start.column))
@@ -640,11 +670,13 @@ line two\"suffix
 
     with_facts(source, None, |_, facts| {
         let open = facts
+            .words()
             .open_double_quote_fragments()
             .iter()
             .map(|fragment| (fragment.span().start.line, fragment.span().start.column))
             .collect::<Vec<_>>();
         let close = facts
+            .words()
             .suspect_closing_quote_fragments()
             .iter()
             .map(|fragment| (fragment.span().start.line, fragment.span().start.column))
@@ -665,11 +697,13 @@ line two\"$suffix
 
     with_facts(source, None, |_, facts| {
         let open = facts
+            .words()
             .open_double_quote_fragments()
             .iter()
             .map(|fragment| (fragment.span().start.line, fragment.span().start.column))
             .collect::<Vec<_>>();
         let close = facts
+            .words()
             .suspect_closing_quote_fragments()
             .iter()
             .map(|fragment| (fragment.span().start.line, fragment.span().start.column))
@@ -690,11 +724,13 @@ line two\"$suffix
 
     with_facts(source, None, |_, facts| {
         let open = facts
+            .words()
             .open_double_quote_fragments()
             .iter()
             .map(|fragment| (fragment.span().start.line, fragment.span().start.column))
             .collect::<Vec<_>>();
         let close = facts
+            .words()
             .suspect_closing_quote_fragments()
             .iter()
             .map(|fragment| (fragment.span().start.line, fragment.span().start.column))
@@ -715,11 +751,13 @@ line two''tail'
 
     with_facts(source, None, |_, facts| {
         let open = facts
+            .words()
             .open_double_quote_fragments()
             .iter()
             .map(|fragment| (fragment.span().start.line, fragment.span().start.column))
             .collect::<Vec<_>>();
         let close = facts
+            .words()
             .suspect_closing_quote_fragments()
             .iter()
             .map(|fragment| (fragment.span().start.line, fragment.span().start.column))
@@ -747,11 +785,13 @@ enable_shared_with_static_runtimes=yes
 
     with_facts(source, None, |_, facts| {
         let open = facts
+            .words()
             .open_double_quote_fragments()
             .iter()
             .map(|fragment| (fragment.span().start.line, fragment.span().start.column))
             .collect::<Vec<_>>();
         let close = facts
+            .words()
             .suspect_closing_quote_fragments()
             .iter()
             .map(|fragment| (fragment.span().start.line, fragment.span().start.column))
@@ -774,11 +814,13 @@ then \"install\" later
 
     with_facts(source, None, |_, facts| {
         let open = facts
+            .words()
             .open_double_quote_fragments()
             .iter()
             .map(|fragment| (fragment.span().start.line, fragment.span().start.column))
             .collect::<Vec<_>>();
         let close = facts
+            .words()
             .suspect_closing_quote_fragments()
             .iter()
             .map(|fragment| (fragment.span().start.line, fragment.span().start.column))
@@ -799,6 +841,7 @@ fn builds_double_paren_grouping_spans() {
 
     with_facts(source, None, |_, facts| {
         let anchors = facts
+            .words()
             .double_paren_grouping_spans()
             .iter()
             .map(|span| {
@@ -827,6 +870,7 @@ echo 'hello ‘world’'
     with_facts(source, None, |_, facts| {
         assert_eq!(
             facts
+                .words()
                 .unicode_smart_quote_spans()
                 .iter()
                 .map(|span| span.slice(source))
@@ -843,6 +887,7 @@ fn builds_unicode_smart_quote_spans_from_source_offsets_for_escaped_literals() {
     with_facts(source, None, |_, facts| {
         assert_eq!(
             facts
+                .words()
                 .unicode_smart_quote_spans()
                 .iter()
                 .map(|span| span.slice(source))
@@ -862,7 +907,7 @@ EOF
 ";
 
     with_facts(source, None, |_, facts| {
-        assert!(facts.unicode_smart_quote_spans().is_empty());
+        assert!(facts.words().unicode_smart_quote_spans().is_empty());
     });
 }
 
@@ -876,13 +921,14 @@ case x in *[!a-zA-Z0-9._/+\\-]*) continue ;; esac
     with_facts(source, None, |_, facts| {
         assert_eq!(
             facts
+                .words()
                 .pattern_literal_spans()
                 .iter()
                 .map(|span| span.slice(source))
                 .collect::<Vec<_>>(),
             vec!["*[!a-zA-Z0-9._/+\\-]*"]
         );
-        assert!(facts.pattern_charclass_spans().is_empty());
+        assert!(facts.words().pattern_charclass_spans().is_empty());
     });
 }
 
@@ -923,24 +969,88 @@ write_target
             .any(|reference| reference.name.as_str() == name)
     };
 
-    assert!(facts.is_suppressed_subscript_reference(reference_span("read_idx")));
-    assert!(facts.is_suppressed_subscript_reference(reference_span("assoc_read_idx")));
-    assert!(facts.is_suppressed_subscript_reference(reference_span("bare_check")));
-    assert!(facts.is_suppressed_subscript_reference(reference_span("assoc_bare_key")));
+    assert!(
+        facts
+            .words()
+            .is_suppressed_subscript_reference(reference_span("read_idx"))
+    );
+    assert!(
+        facts
+            .words()
+            .is_suppressed_subscript_reference(reference_span("assoc_read_idx"))
+    );
+    assert!(
+        facts
+            .words()
+            .is_suppressed_subscript_reference(reference_span("bare_check"))
+    );
+    assert!(
+        facts
+            .words()
+            .is_suppressed_subscript_reference(reference_span("assoc_bare_key"))
+    );
     assert!(!has_reference("assoc_target_bare"));
-    assert!(!facts.is_suppressed_subscript_reference(reference_span("dynamic_check")));
-    assert!(!facts.is_suppressed_subscript_reference(reference_span("bare_target")));
-    assert!(!facts.is_suppressed_subscript_reference(reference_span("dynamic_target")));
-    assert!(!facts.is_suppressed_subscript_reference(reference_span("bare_key")));
-    assert!(!facts.is_suppressed_subscript_reference(reference_span("dynamic_key")));
-    assert!(!facts.is_suppressed_subscript_reference(reference_span("assoc_target_id")));
-    assert!(!facts.is_suppressed_subscript_reference(reference_span("assoc_dynamic_key")));
-    assert!(!facts.is_suppressed_subscript_reference(reference_span("free")));
+    assert!(
+        !facts
+            .words()
+            .is_suppressed_subscript_reference(reference_span("dynamic_check"))
+    );
+    assert!(
+        !facts
+            .words()
+            .is_suppressed_subscript_reference(reference_span("bare_target"))
+    );
+    assert!(
+        !facts
+            .words()
+            .is_suppressed_subscript_reference(reference_span("dynamic_target"))
+    );
+    assert!(
+        !facts
+            .words()
+            .is_suppressed_subscript_reference(reference_span("bare_key"))
+    );
+    assert!(
+        !facts
+            .words()
+            .is_suppressed_subscript_reference(reference_span("dynamic_key"))
+    );
+    assert!(
+        !facts
+            .words()
+            .is_suppressed_subscript_reference(reference_span("assoc_target_id"))
+    );
+    assert!(
+        !facts
+            .words()
+            .is_suppressed_subscript_reference(reference_span("assoc_dynamic_key"))
+    );
+    assert!(
+        !facts
+            .words()
+            .is_suppressed_subscript_reference(reference_span("free"))
+    );
 
-    assert!(facts.is_subscript_later_suppression_reference(reference_span("read_idx")));
-    assert!(facts.is_subscript_later_suppression_reference(reference_span("assoc_read_idx")));
-    assert!(!facts.is_subscript_later_suppression_reference(reference_span("bare_check")));
-    assert!(!facts.is_subscript_later_suppression_reference(reference_span("dynamic_check")));
+    assert!(
+        facts
+            .words()
+            .is_subscript_later_suppression_reference(reference_span("read_idx"))
+    );
+    assert!(
+        facts
+            .words()
+            .is_subscript_later_suppression_reference(reference_span("assoc_read_idx"))
+    );
+    assert!(
+        !facts
+            .words()
+            .is_subscript_later_suppression_reference(reference_span("bare_check"))
+    );
+    assert!(
+        !facts
+            .words()
+            .is_subscript_later_suppression_reference(reference_span("dynamic_check"))
+    );
 }
 
 #[test]
@@ -960,6 +1070,7 @@ printf '%s\\n' \"${arr[$((read+1))]}\"
     with_facts(source, None, |_, facts| {
         assert_eq!(
             facts
+                .words()
                 .array_index_arithmetic_spans()
                 .iter()
                 .map(|span| span.slice(source))
@@ -992,6 +1103,7 @@ X=1 A=$[ $X + 1 ] true
     with_facts(source, None, |_, facts| {
         assert_eq!(
             facts
+                .assignments()
                 .env_prefix_assignment_scope_spans()
                 .iter()
                 .map(|span| span.slice(source))
@@ -1011,6 +1123,7 @@ X=1 A=$[ $X + 1 ] true
         );
         assert_eq!(
             facts
+                .assignments()
                 .env_prefix_expansion_scope_spans()
                 .iter()
                 .map(|span| span.slice(source))
@@ -1041,6 +1154,7 @@ foo=\"$foo\" foo=2 cmd
     with_facts(source, None, |_, facts| {
         assert_eq!(
             facts
+                .assignments()
                 .env_prefix_expansion_scope_spans()
                 .iter()
                 .map(|span| span.slice(source))
@@ -1060,18 +1174,26 @@ x=1 export PS4=\"+ \\${x} \"
 
     with_facts(source, None, |_, facts| {
         assert!(
-            facts.env_prefix_assignment_scope_spans().is_empty(),
+            facts
+                .assignments()
+                .env_prefix_assignment_scope_spans()
+                .is_empty(),
             "unexpected assignment scope spans: {:?}",
             facts
+                .assignments()
                 .env_prefix_assignment_scope_spans()
                 .iter()
                 .map(|span| span.slice(source))
                 .collect::<Vec<_>>()
         );
         assert!(
-            facts.env_prefix_expansion_scope_spans().is_empty(),
+            facts
+                .assignments()
+                .env_prefix_expansion_scope_spans()
+                .is_empty(),
             "unexpected expansion scope spans: {:?}",
             facts
+                .assignments()
                 .env_prefix_expansion_scope_spans()
                 .iter()
                 .map(|span| span.slice(source))
@@ -1099,6 +1221,7 @@ printf '%s\\n' prefix${name}suffix ${items[@]}
 
     with_facts(source, None, |_, facts| {
         let case_subject = facts
+            .words()
             .case_subject_facts()
             .find(|fact| fact.span().slice(source) == "literal")
             .expect("expected case subject fact");
@@ -1106,6 +1229,7 @@ printf '%s\\n' prefix${name}suffix ${items[@]}
         assert!(case_subject.classification().is_fixed_literal());
 
         let trap_action = facts
+            .words()
             .expansion_word_facts(ExpansionContext::TrapAction)
             .next()
             .expect("expected trap action fact");
@@ -1119,6 +1243,7 @@ printf '%s\\n' prefix${name}suffix ${items[@]}
         );
 
         let trap_signal = facts
+            .words()
             .expansion_word_facts(ExpansionContext::CommandArgument)
             .find(|fact| fact.span().slice(source) == "${signals[@]}")
             .expect("expected trap signal argument fact");
@@ -1132,6 +1257,7 @@ printf '%s\\n' prefix${name}suffix ${items[@]}
         );
 
         let declaration_name_subscript = facts
+            .words()
             .expansion_word_facts(ExpansionContext::DeclarationAssignmentValue)
             .find(|fact| fact.span().slice(source) == "$(printf decl-name-subscript)")
             .expect("expected declaration name subscript fact");
@@ -1149,6 +1275,7 @@ printf '%s\\n' prefix${name}suffix ${items[@]}
         );
 
         let declaration_assignment_subscript = facts
+            .words()
             .expansion_word_facts(ExpansionContext::DeclarationAssignmentValue)
             .find(|fact| fact.span().slice(source) == "$(printf decl-subscript)")
             .expect("expected declaration assignment subscript fact");
@@ -1158,6 +1285,7 @@ printf '%s\\n' prefix${name}suffix ${items[@]}
         );
 
         let assignment_subscript = facts
+            .words()
             .expansion_word_facts(ExpansionContext::AssignmentValue)
             .find(|fact| fact.span().slice(source) == "$(printf assign-subscript)")
             .expect("expected assignment subscript fact");
@@ -1167,12 +1295,14 @@ printf '%s\\n' prefix${name}suffix ${items[@]}
         );
 
         let array_key = facts
+            .words()
             .expansion_word_facts(ExpansionContext::DeclarationAssignmentValue)
             .find(|fact| fact.span().slice(source) == "$(printf key-subscript)")
             .expect("expected array key fact");
         assert_eq!(array_key.host_kind(), WordFactHostKind::ArrayKeySubscript);
 
         let conditional_subscript = facts
+            .words()
             .expansion_word_facts(ExpansionContext::ConditionalVarRefSubscript)
             .find(|fact| fact.span().slice(source) == "\"$(printf cond-subscript)\"")
             .expect("expected conditional subscript fact");
@@ -1182,12 +1312,14 @@ printf '%s\\n' prefix${name}suffix ${items[@]}
         );
 
         let parameter_pattern = facts
+            .words()
             .expansion_word_facts(ExpansionContext::ParameterPattern)
             .find(|fact| fact.span().slice(source) == "$suffix")
             .expect("expected parameter pattern fact");
         assert!(parameter_pattern.classification().is_expanded());
         assert_eq!(
             facts
+                .words()
                 .expansion_word_facts(ExpansionContext::ParameterPattern)
                 .filter(|fact| fact.span().slice(source) == "$suffix")
                 .count(),
@@ -1195,6 +1327,7 @@ printf '%s\\n' prefix${name}suffix ${items[@]}
         );
 
         let scalar = facts
+            .words()
             .expansion_word_facts(ExpansionContext::CommandArgument)
             .find(|fact| fact.span().slice(source) == "prefix${name}suffix")
             .expect("expected mixed command argument fact");
@@ -1209,6 +1342,7 @@ printf '%s\\n' prefix${name}suffix ${items[@]}
         );
 
         let array = facts
+            .words()
             .expansion_word_facts(ExpansionContext::CommandArgument)
             .find(|fact| fact.span().slice(source) == "${items[@]}")
             .expect("expected array argument fact");
@@ -1247,6 +1381,7 @@ esac
     with_facts(source, None, |_, facts| {
         assert_eq!(
             facts
+                .command_facts()
                 .case_pattern_impossible_spans()
                 .iter()
                 .map(|span| span.slice(source))
@@ -1270,6 +1405,7 @@ fn word_facts_track_only_literal_command_trailers() {
     with_facts(source, None, |_, facts| {
         let trailing_literal_char = |text: &str| {
             facts
+                .words()
                 .word_facts()
                 .find(|fact| fact.span().slice(source) == text)
                 .and_then(|fact| fact.trailing_literal_char())
@@ -1293,6 +1429,7 @@ printf '%s\n' \"$name\" \"${name:-fallback}\" \"${@:1}\" ${@:1} \"$@\" $@
     with_facts(source, None, |_, facts| {
         let word_fact = |text: &str| {
             facts
+                .words()
                 .word_facts()
                 .find(|fact| fact.span().slice(source) == text)
                 .expect("expected word fact")
@@ -1338,10 +1475,12 @@ printf '%s\n' \"prefix $((x + 1)) suffix\" plain
 
     with_facts(source, None, |_, facts| {
         let arithmetic = facts
+            .words()
             .word_facts()
             .find(|fact| fact.span().slice(source) == "\"prefix $((x + 1)) suffix\"")
             .expect("expected arithmetic word fact");
         let plain = facts
+            .words()
             .word_facts()
             .find(|fact| fact.span().slice(source) == "plain")
             .expect("expected plain word fact");
@@ -1366,6 +1505,7 @@ esac
     with_facts(source, None, |_, facts| {
         assert_eq!(
             facts
+                .command_facts()
                 .case_pattern_expansions()
                 .iter()
                 .map(|fact| (fact.span().slice(source), fact.replacement().to_owned()))
@@ -1397,7 +1537,7 @@ esac
 ";
 
     with_facts(source, None, |_, facts| {
-        assert!(facts.case_pattern_expansions().is_empty());
+        assert!(facts.command_facts().case_pattern_expansions().is_empty());
     });
 }
 
@@ -1407,11 +1547,13 @@ fn collects_dollar_spans_for_wrapped_substring_offset_arithmetic() {
 
     with_facts(source, None, |_, facts| {
         let spans = facts
+            .words()
             .dollar_in_arithmetic_spans()
             .iter()
             .map(|span| span.slice(source))
             .collect::<Vec<_>>();
         let words = facts
+            .words()
             .expansion_word_facts(ExpansionContext::CommandArgument)
             .map(|fact| {
                 format!(
@@ -1434,11 +1576,13 @@ fn collects_dollar_spans_for_wrapped_substring_length_arithmetic() {
 
     with_facts(source, None, |_, facts| {
         let spans = facts
+            .words()
             .dollar_in_arithmetic_spans()
             .iter()
             .map(|span| span.slice(source))
             .collect::<Vec<_>>();
         let words = facts
+            .words()
             .expansion_word_facts(ExpansionContext::CommandArgument)
             .map(|fact| {
                 format!(
@@ -1460,6 +1604,7 @@ fn ignores_plain_substring_offset_parameter_expansions_for_dollar_in_arithmetic(
 
     with_facts(source, None, |_, facts| {
         let spans = facts
+            .words()
             .dollar_in_arithmetic_spans()
             .iter()
             .map(|span| span.slice(source))
@@ -1475,6 +1620,7 @@ fn ignores_plain_positional_slice_parameter_expansions_for_dollar_in_arithmetic(
 
     with_facts(source, None, |_, facts| {
         let spans = facts
+            .words()
             .dollar_in_arithmetic_spans()
             .iter()
             .map(|span| span.slice(source))
@@ -1490,11 +1636,13 @@ fn collects_dollar_spans_for_parameter_replacement_arithmetic() {
 
     with_facts(source, None, |_, facts| {
         let spans = facts
+            .words()
             .dollar_in_arithmetic_spans()
             .iter()
             .map(|span| span.slice(source))
             .collect::<Vec<_>>();
         let words = facts
+            .words()
             .expansion_word_facts(ExpansionContext::CommandArgument)
             .map(|fact| {
                 format!(
@@ -1521,6 +1669,7 @@ declare -A assoc
 
     with_facts(source, None, |_, facts| {
         let spans = facts
+            .words()
             .dollar_in_arithmetic_spans()
             .iter()
             .map(|span| span.slice(source))
@@ -1541,6 +1690,7 @@ printf '%s\\n' \"${rest:$((${arr[0]}))}\"
 
     with_facts(source, None, |_, facts| {
         let spans = facts
+            .words()
             .dollar_in_arithmetic_spans()
             .iter()
             .map(|span| span.slice(source))
@@ -1565,6 +1715,7 @@ arr[${lang},27]=q
 
     with_facts(source, None, |_, facts| {
         let spans = facts
+            .words()
             .dollar_in_arithmetic_spans()
             .iter()
             .map(|span| span.slice(source))
@@ -1588,6 +1739,7 @@ assoc[$key/sfx]=z
 
     with_facts(source, None, |_, facts| {
         let spans = facts
+            .words()
             .dollar_in_arithmetic_spans()
             .iter()
             .map(|span| span.slice(source))
@@ -1608,6 +1760,7 @@ arr[\"${wash_counter}\"]=x
 
     with_facts(source, None, |_, facts| {
         let spans = facts
+            .words()
             .dollar_in_arithmetic_spans()
             .iter()
             .map(|span| span.slice(source))
@@ -1628,6 +1781,7 @@ arr[$(printf '%s' \"$i\")]=x
 
     with_facts(source, None, |_, facts| {
         let spans = facts
+            .words()
             .dollar_in_arithmetic_spans()
             .iter()
             .map(|span| span.slice(source))
@@ -1649,6 +1803,7 @@ two[$key]+=y
 
     with_facts(source, None, |_, facts| {
         let spans = facts
+            .words()
             .dollar_in_arithmetic_spans()
             .iter()
             .map(|span| span.slice(source))
@@ -1671,6 +1826,7 @@ map[$key]+=\"${values[*]}\"
 
     with_facts(source, None, |_, facts| {
         let spans = facts
+            .words()
             .dollar_in_arithmetic_spans()
             .iter()
             .map(|span| span.slice(source))
@@ -1700,6 +1856,7 @@ main
 
     with_facts(source, None, |_, facts| {
         let spans = facts
+            .words()
             .dollar_in_arithmetic_spans()
             .iter()
             .map(|span| span.slice(source))
@@ -1729,6 +1886,7 @@ main
 
     with_facts(source, None, |_, facts| {
         let spans = facts
+            .words()
             .dollar_in_arithmetic_spans()
             .iter()
             .map(|span| span.slice(source))
@@ -1758,6 +1916,7 @@ main
 
     with_facts(source, None, |_, facts| {
         let spans = facts
+            .words()
             .dollar_in_arithmetic_spans()
             .iter()
             .map(|span| span.slice(source))
@@ -1785,6 +1944,7 @@ main
 
     with_facts(source, None, |_, facts| {
         let spans = facts
+            .words()
             .dollar_in_arithmetic_spans()
             .iter()
             .map(|span| span.slice(source))
@@ -1813,6 +1973,7 @@ main
 
     with_facts(source, None, |_, facts| {
         let spans = facts
+            .words()
             .dollar_in_arithmetic_spans()
             .iter()
             .map(|span| span.slice(source))
@@ -1841,6 +2002,7 @@ main
 
     with_facts(source, None, |_, facts| {
         let spans = facts
+            .words()
             .dollar_in_arithmetic_spans()
             .iter()
             .map(|span| span.slice(source))
@@ -1871,6 +2033,7 @@ main
 
     with_facts(source, None, |_, facts| {
         let spans = facts
+            .words()
             .dollar_in_arithmetic_spans()
             .iter()
             .map(|span| span.slice(source))
@@ -1889,6 +2052,7 @@ declare -A map=([$key]=1)
 
     with_facts(source, None, |_, facts| {
         let spans = facts
+            .words()
             .dollar_in_arithmetic_spans()
             .iter()
             .map(|span| span.slice(source))
@@ -1909,6 +2073,7 @@ printf '%s\\n' \"${tools[$(($choice-1))]}\"
 
     with_facts(source, None, |_, facts| {
         let spans = facts
+            .words()
             .dollar_in_arithmetic_spans()
             .iter()
             .map(|span| span.slice(source))
@@ -1929,6 +2094,7 @@ assoc[$(($choice-1))]=x
 
     with_facts(source, None, |_, facts| {
         let spans = facts
+            .words()
             .dollar_in_arithmetic_spans()
             .iter()
             .map(|span| span.slice(source))
@@ -1944,6 +2110,7 @@ fn collects_command_substitution_spans_for_wrapped_substring_offset_arithmetic()
 
     with_facts(source, None, |_, facts| {
         let spans = facts
+            .words()
             .arithmetic_command_substitution_spans()
             .iter()
             .map(|span| span.slice(source))
@@ -1967,6 +2134,7 @@ done
 
     with_facts(source, None, |_, facts| {
         let nested_args = facts
+            .words()
             .word_facts()
             .filter(|fact| fact.is_nested_word_command())
             .filter(|fact| fact.host_expansion_context() == Some(ExpansionContext::CommandArgument))
@@ -1984,6 +2152,7 @@ fn ignores_quoted_dollar_words_in_arithmetic_command_contexts() {
 
     with_facts(source, None, |_, facts| {
         let spans = facts
+            .words()
             .dollar_in_arithmetic_spans()
             .iter()
             .map(|span| span.slice(source))
@@ -1999,6 +2168,7 @@ fn indexes_pending_arithmetic_word_facts_by_span() {
 
     with_facts(source, None, |_, facts| {
         let arithmetic = facts
+            .words()
             .arithmetic_command_word_facts()
             .find(|fact| fact.span().slice(source) == "$name")
             .expect("expected arithmetic word fact");
@@ -2006,12 +2176,14 @@ fn indexes_pending_arithmetic_word_facts_by_span() {
         assert!(arithmetic.is_arithmetic_command());
         assert_eq!(
             facts
+                .words()
                 .word_fact(arithmetic.span(), arithmetic.context())
                 .map(|fact| fact.span().slice(source)),
             Some("$name")
         );
         assert_eq!(
             facts
+                .words()
                 .any_word_fact(arithmetic.span())
                 .map(|fact| fact.span().slice(source)),
             Some("$name")
@@ -2025,6 +2197,7 @@ fn indexes_parameter_operand_word_facts_by_span_without_exposing_them_in_word_fa
 
     with_facts(source, None, |_, facts| {
         let operand = facts
+            .words()
             .parameter_operand_word_facts()
             .find(|fact| fact.span().slice(source) == "$name")
             .expect("expected parameter operand word fact");
@@ -2032,18 +2205,21 @@ fn indexes_parameter_operand_word_facts_by_span_without_exposing_them_in_word_fa
         assert!(operand.is_parameter_operand());
         assert_eq!(
             facts
+                .words()
                 .word_fact(operand.span(), operand.context())
                 .map(|fact| fact.span().slice(source)),
             Some("$name")
         );
         assert_eq!(
             facts
+                .words()
                 .any_word_fact(operand.span())
                 .map(|fact| fact.span().slice(source)),
             Some("$name")
         );
         assert!(
             facts
+                .words()
                 .word_facts()
                 .all(|fact| fact.span().slice(source) != "$name"),
             "parameter operand fact should stay out of the normal word_facts stream"
@@ -2057,6 +2233,7 @@ fn indexes_arithmetic_word_facts_inside_parameter_replacement_operands() {
 
     with_facts(source, None, |_, facts| {
         let arithmetic = facts
+            .words()
             .arithmetic_command_word_facts()
             .find(|fact| fact.span().slice(source) == "$name")
             .expect("expected arithmetic word fact");
@@ -2068,6 +2245,7 @@ fn indexes_arithmetic_word_facts_inside_parameter_replacement_operands() {
         );
         assert_eq!(
             facts
+                .words()
                 .word_fact(arithmetic.span(), arithmetic.context())
                 .map(|fact| fact.span().slice(source)),
             Some("$name")
@@ -2084,14 +2262,18 @@ printf '%s\\n' \"${value:-$(( $default + 1 ))}\" \"${value:=$(( $assign + 1 ))}\
 
     with_facts(source, None, |_, facts| {
         let spans = facts
+            .words()
             .arithmetic_command_word_facts()
             .map(|fact| fact.span().slice(source))
             .collect::<Vec<_>>();
 
         assert_eq!(spans, vec!["$default", "$assign", "$replace", "$error"]);
-        assert!(facts.arithmetic_command_word_facts().all(|fact| {
+        assert!(facts.words().arithmetic_command_word_facts().all(|fact| {
             fact.host_expansion_context() == Some(ExpansionContext::CommandArgument)
-                && facts.word_fact(fact.span(), fact.context()).is_some()
+                && facts
+                    .words()
+                    .word_fact(fact.span(), fact.context())
+                    .is_some()
         }));
     });
 }
@@ -2109,6 +2291,7 @@ key=name
 
     with_facts(source, None, |_, facts| {
         let spans = facts
+            .words()
             .dollar_in_arithmetic_spans()
             .iter()
             .map(|span| span.slice(source))
@@ -2124,6 +2307,7 @@ fn ignores_escaped_command_substitution_tokens_in_wrapped_substring_offset_arith
 
     with_facts(source, None, |_, facts| {
         let spans = facts
+            .words()
             .arithmetic_command_substitution_spans()
             .iter()
             .map(|span| span.slice(source))
@@ -2144,6 +2328,7 @@ fn builds_word_facts_for_zsh_qualified_globs() {
         ShellDialect::Zsh,
         |_, facts| {
             let glob = facts
+                .words()
                 .expansion_word_facts(ExpansionContext::CommandArgument)
                 .find(|fact| fact.span().slice(source) == "prefix*(.N)")
                 .expect("expected zsh glob fact");
@@ -2171,14 +2356,17 @@ print ${~~name}
         ShellDialect::Zsh,
         |_, facts| {
             let split = facts
+                .words()
                 .expansion_word_facts(ExpansionContext::CommandArgument)
                 .find(|fact| fact.span().slice(source) == "$name")
                 .expect("expected split-sensitive fact");
             let wrapped_glob = facts
+                .words()
                 .expansion_word_facts(ExpansionContext::CommandArgument)
                 .find(|fact| fact.span().slice(source) == "*")
                 .expect("expected wrapped glob fact");
             let double_tilde = facts
+                .words()
                 .expansion_word_facts(ExpansionContext::CommandArgument)
                 .find(|fact| fact.span().slice(source) == "${~~name}")
                 .expect("expected double-tilde fact");
@@ -2215,6 +2403,7 @@ print $name
         ShellDialect::Zsh,
         |_, facts| {
             let ambiguous = facts
+                .words()
                 .expansion_word_facts(ExpansionContext::CommandArgument)
                 .find(|fact| fact.span().slice(source) == "$name")
                 .expect("expected ambiguous scalar fact");
@@ -2245,10 +2434,12 @@ for item in $literal; do :; done
         ShellDialect::Zsh,
         |_, facts| {
             let glob_subst = facts
+                .words()
                 .expansion_word_facts(ExpansionContext::ForList)
                 .find(|fact| fact.span().slice(source) == "$name")
                 .expect("expected glob_subst for-list fact");
             let no_glob = facts
+                .words()
                 .expansion_word_facts(ExpansionContext::ForList)
                 .find(|fact| fact.span().slice(source) == "$literal")
                 .expect("expected no_glob for-list fact");
@@ -2287,10 +2478,12 @@ rm *
         ShellDialect::Zsh,
         |_, facts| {
             let scalar = facts
+                .words()
                 .expansion_word_facts(ExpansionContext::CommandArgument)
                 .find(|fact| fact.span().slice(source) == "$name")
                 .expect("expected scalar fact");
             let glob = facts
+                .words()
                 .expansion_word_facts(ExpansionContext::CommandArgument)
                 .find(|fact| fact.span().slice(source) == "*")
                 .expect("expected glob fact");
@@ -2328,6 +2521,7 @@ rm *
         ShellDialect::Zsh,
         |_, facts| {
             let glob = facts
+                .words()
                 .expansion_word_facts(ExpansionContext::CommandArgument)
                 .find(|fact| fact.span().slice(source) == "*")
                 .expect("expected glob fact");
@@ -2368,6 +2562,7 @@ rm *
         ShellDialect::Zsh,
         |_, facts| {
             let glob_behaviors = facts
+                .words()
                 .expansion_word_facts(ExpansionContext::CommandArgument)
                 .filter(|fact| fact.span().slice(source) == "*")
                 .map(|fact| {
@@ -2450,6 +2645,7 @@ rm ?(*.txt)
         ShellDialect::Zsh,
         |_, facts| {
             let active_spans = facts
+                .words()
                 .expansion_word_facts(ExpansionContext::CommandArgument)
                 .filter(|fact| {
                     matches!(
@@ -2498,6 +2694,7 @@ rm ?(*.txt)
             );
 
             let pathname_hazards = facts
+                .words()
                 .expansion_word_facts(ExpansionContext::CommandArgument)
                 .filter(|fact| {
                     matches!(
@@ -2534,6 +2731,7 @@ printf '%s\\n' $0 $1 $* $@
 
     with_facts(source, None, |_, facts| {
         let argument_words = facts
+            .words()
             .expansion_word_facts(ExpansionContext::CommandArgument)
             .map(|fact| fact.span().slice(source).to_owned())
             .collect::<Vec<_>>();
@@ -2554,6 +2752,7 @@ fn builds_word_facts_for_filename_builder_command_substitutions() {
 
     with_facts(source, None, |_, facts| {
         let fact = facts
+            .words()
             .expansion_word_facts(ExpansionContext::CommandArgument)
             .find(|fact| {
                 fact.span()
@@ -2592,6 +2791,7 @@ docker inspect -f '{{ if ne \"true\" (index .Config.Labels \"com.dokku.devcontai
 
     with_facts(source, None, |_, facts| {
         let fact = facts
+            .words()
             .expansion_word_facts(ExpansionContext::CommandArgument)
             .find(|fact| fact.span().slice(source) == "$(docker ps -q)")
             .expect("expected docker inspect argument fact");
@@ -2624,6 +2824,7 @@ EOF
     with_facts(source, None, |_, facts| {
         assert_eq!(
             facts
+                .words()
                 .plain_unindexed_array_references()
                 .map(|fact| match fact {
                     PlainUnindexedArrayReferenceFact::SelectorRequired(reference) => {
@@ -2667,6 +2868,7 @@ print -r -- $arr
         |_, facts| {
             assert_eq!(
                 facts
+                    .words()
                     .plain_unindexed_array_references()
                     .map(|fact| match fact {
                         PlainUnindexedArrayReferenceFact::SelectorRequired(reference) => {
@@ -2706,6 +2908,7 @@ print -r -- $arr
         |_, facts| {
             assert_eq!(
                 facts
+                    .words()
                     .plain_unindexed_array_references()
                     .map(|fact| match fact {
                         PlainUnindexedArrayReferenceFact::SelectorRequired(reference) => {
@@ -2745,6 +2948,7 @@ print -r -- $arr
         |_, facts| {
             assert_eq!(
                 facts
+                    .words()
                     .plain_unindexed_array_references()
                     .map(|fact| match fact {
                         PlainUnindexedArrayReferenceFact::SelectorRequired(reference) => {
@@ -2785,6 +2989,7 @@ print -r -- $arr
         |_, facts| {
             assert_eq!(
                 facts
+                    .words()
                     .plain_unindexed_array_references()
                     .map(|fact| match fact {
                         PlainUnindexedArrayReferenceFact::SelectorRequired(reference) => {
@@ -2828,6 +3033,7 @@ print -r -- $arr
         |_, facts| {
             assert_eq!(
                 facts
+                    .words()
                     .plain_unindexed_array_references()
                     .map(|fact| match fact {
                         PlainUnindexedArrayReferenceFact::SelectorRequired(reference) => {
@@ -2874,6 +3080,7 @@ $fn
         |_, facts| {
             assert_eq!(
                 facts
+                    .words()
                     .plain_unindexed_array_references()
                     .map(|fact| match fact {
                         PlainUnindexedArrayReferenceFact::SelectorRequired(reference) => {
@@ -2905,6 +3112,7 @@ eval \"${shims[@]}\"
 
     with_facts(source, None, |_, facts| {
         let fact = facts
+            .words()
             .expansion_word_facts(ExpansionContext::CommandArgument)
             .find(|fact| fact.span().slice(source) == "\"${shims[@]}\"")
             .expect("expected eval argument fact");
@@ -2930,6 +3138,7 @@ if [[ x == *${shims[@]}* ]]; then :; fi
 
     with_facts(source, None, |_, facts| {
         let fact = facts
+            .words()
             .expansion_word_facts(ExpansionContext::ConditionalPattern)
             .find(|fact| fact.span().slice(source) == "${shims[@]}")
             .expect("expected conditional pattern word fact");
@@ -2963,6 +3172,7 @@ eval \"conda_shim() { case \\\"\\${1##*/}\\\" in ${shims[@]} *) return 1;; esac 
 
     with_facts(source, None, |_, facts| {
         let fact = facts
+            .words()
             .expansion_word_facts(ExpansionContext::CommandArgument)
             .find(|fact| fact.span().slice(source).contains("${shims[@]}"))
             .expect("expected eval argument fact");
@@ -2995,6 +3205,7 @@ eval shellspec_join SHELLSPEC_EXPECTATION '\" \"' The ${1+'\"$@\"'}
 
     with_facts(source, None, |_, facts| {
         let fact = facts
+            .words()
             .expansion_word_facts(ExpansionContext::CommandArgument)
             .find(|fact| fact.span().slice(source).contains("${1+'\"$@\"'}"))
             .expect("expected eval argument fact");
@@ -3023,6 +3234,7 @@ printf '%s\\n' $@ ${@:2} ${items[@]} ${items[@]:1} ${!items[@]} ${items[@]/#/#} 
 
     with_facts(source, None, |_, facts| {
         let spans = facts
+            .words()
             .expansion_word_facts(ExpansionContext::CommandArgument)
             .flat_map(|fact| {
                 fact.unquoted_all_elements_array_expansion_spans()
@@ -3057,6 +3269,7 @@ printf '%s\\n' \"foo\"bar\"baz\" \"foo\"-\"bar\" \"foo\"$(printf '%s' x)\"bar\" 
 
     with_facts(source, None, |_, facts| {
         let spans = facts
+            .words()
             .expansion_word_facts(ExpansionContext::CommandArgument)
             .filter(|fact| fact.host_kind() == WordFactHostKind::Direct)
             .flat_map(|fact| {
@@ -3095,6 +3308,7 @@ export EASYRSA_REQ_SERIAL=\\\"$EASYRSA_REQ_SERIAL\\\"\\
 
     with_facts(source, None, |_, facts| {
         let spans = facts
+            .words()
             .expansion_word_facts(ExpansionContext::CommandArgument)
             .filter(|fact| fact.host_kind() == WordFactHostKind::Direct)
             .flat_map(|fact| {
@@ -3137,6 +3351,7 @@ param_hash=\"$AWK '\"\\
 
     with_facts(source, None, |_, facts| {
         let spans = facts
+            .words()
             .expansion_word_facts(ExpansionContext::AssignmentValue)
             .filter(|fact| fact.host_kind() == WordFactHostKind::Direct)
             .flat_map(|fact| {
@@ -3167,6 +3382,7 @@ value=\"foo\"\\
 
     with_facts(source, None, |_, facts| {
         let spans = facts
+            .words()
             .expansion_word_facts(ExpansionContext::AssignmentValue)
             .filter(|fact| fact.host_kind() == WordFactHostKind::Direct)
             .flat_map(|fact| {
@@ -3191,6 +3407,7 @@ echo $(echo x # $(
 
     with_facts(source, None, |_, facts| {
         let spans = facts
+            .words()
             .expansion_word_facts(ExpansionContext::CommandArgument)
             .flat_map(|fact| {
                 fact.unquoted_literal_between_double_quoted_segments_spans()
@@ -3214,6 +3431,7 @@ echo `echo x # $(
 
     with_facts(source, None, |_, facts| {
         let spans = facts
+            .words()
             .expansion_word_facts(ExpansionContext::CommandArgument)
             .flat_map(|fact| {
                 fact.unquoted_literal_between_double_quoted_segments_spans()
@@ -3236,6 +3454,7 @@ echo $(printf \"%s\" \"x # $(printf y)\")\"foo\"bar\"baz\"
 
     with_facts(source, None, |_, facts| {
         let spans = facts
+            .words()
             .expansion_word_facts(ExpansionContext::CommandArgument)
             .flat_map(|fact| {
                 fact.unquoted_literal_between_double_quoted_segments_spans()
@@ -3259,6 +3478,7 @@ echo <(echo x # ${
 
     with_facts(source, None, |_, facts| {
         let spans = facts
+            .words()
             .expansion_word_facts(ExpansionContext::CommandArgument)
             .flat_map(|fact| {
                 fact.unquoted_literal_between_double_quoted_segments_spans()
@@ -3285,6 +3505,7 @@ $cmd[0] arg
 
     with_facts(source, None, |_, facts| {
         let spans = facts
+            .words()
             .brace_variable_before_bracket_spans()
             .iter()
             .map(|span| (span.start.line, span.start.column))
@@ -3313,6 +3534,7 @@ alias runtime=$BAR
     with_facts(source, None, |_, facts| {
         assert_eq!(
             facts
+                .command_facts()
                 .function_in_alias_spans()
                 .iter()
                 .map(|span| span.slice(source))
@@ -3339,6 +3561,7 @@ alias \"$a=$b\"
     with_facts(source, None, |_, facts| {
         assert_eq!(
             facts
+                .command_facts()
                 .alias_definition_expansion_spans()
                 .iter()
                 .map(|span| span.slice(source))
@@ -3361,6 +3584,7 @@ arr+=($tail)
 
     with_facts(source, None, |_, facts| {
         let split_words = facts
+            .words()
             .array_assignment_split_word_facts()
             .map(|fact| fact.span().slice(source).to_owned())
             .collect::<Vec<_>>();
@@ -3382,6 +3606,7 @@ arr+=($tail)
         );
 
         let unquoted_scalar = facts
+            .words()
             .array_assignment_split_word_facts()
             .flat_map(|fact| {
                 fact.array_assignment_split_scalar_expansion_spans()
@@ -3396,6 +3621,7 @@ arr+=($tail)
         );
 
         let unquoted_array = facts
+            .words()
             .array_assignment_split_word_facts()
             .flat_map(|fact| {
                 fact.unquoted_array_expansion_spans()
@@ -3417,6 +3643,7 @@ arr=(\"$(printf '%s\\n' \"$x\")\")
 
     with_facts(source, None, |_, facts| {
         let split_facts = facts
+            .words()
             .array_assignment_split_word_facts()
             .collect::<Vec<_>>();
         assert_eq!(split_facts.len(), 1);
@@ -3448,6 +3675,7 @@ arr=($(printf '%s\\n' \"$x\" ${y} prefix$z))
 
     with_facts(source, None, |_, facts| {
         let split_facts = facts
+            .words()
             .array_assignment_split_word_facts()
             .collect::<Vec<_>>();
         assert_eq!(split_facts.len(), 1);
@@ -3487,6 +3715,7 @@ EOF
 
     with_facts(source, None, |_, facts| {
         let split_words = facts
+            .words()
             .array_assignment_split_word_facts()
             .map(|fact| fact.span().slice(source).to_owned())
             .collect::<Vec<_>>();
@@ -3519,6 +3748,7 @@ EOF
 
     with_facts(source, None, |_, facts| {
         let split_words = facts
+            .words()
             .array_assignment_split_word_facts()
             .map(|fact| fact.span().slice(source).to_owned())
             .collect::<Vec<_>>();
@@ -3554,6 +3784,7 @@ EOF
 
     with_facts(source, None, |_, facts| {
         let split_facts = facts
+            .words()
             .array_assignment_split_word_facts()
             .collect::<Vec<_>>();
 
@@ -3581,6 +3812,7 @@ arr=(${flag:+-f} ${flag:+$fallback} ${name:+\"$name\" \"$regex\"} ${items[@]+\"$
 
     with_facts(source, None, |_, facts| {
         let split_sensitive = facts
+            .words()
             .array_assignment_split_word_facts()
             .flat_map(|fact| {
                 fact.array_assignment_split_scalar_expansion_spans()
@@ -3604,6 +3836,7 @@ arr=($prefix{a,b} {a,b}$suffix {pre$inside,other})
 
     with_facts(source, None, |_, facts| {
         let split_sensitive = facts
+            .words()
             .array_assignment_split_word_facts()
             .flat_map(|fact| {
                 fact.array_assignment_split_scalar_expansion_spans()
@@ -3631,6 +3864,7 @@ arr=({pre$inside,other})
         ShellDialect::Sh,
         |_, facts| {
             let split_sensitive = facts
+                .words()
                 .array_assignment_split_word_facts()
                 .flat_map(|fact| {
                     fact.array_assignment_split_scalar_expansion_spans()
@@ -3658,6 +3892,7 @@ EOF
     with_facts(source, None, |_, facts| {
         assert_eq!(
             facts
+                .words()
                 .substring_expansion_fragments()
                 .iter()
                 .map(|fragment| fragment.span().slice(source))
@@ -3666,6 +3901,7 @@ EOF
         );
         assert_eq!(
             facts
+                .words()
                 .replacement_expansion_fragments()
                 .iter()
                 .map(|fragment| fragment.span().slice(source))
@@ -3674,6 +3910,7 @@ EOF
         );
         assert_eq!(
             facts
+                .words()
                 .case_modification_fragments()
                 .iter()
                 .map(|fragment| fragment.span().slice(source))
@@ -3695,6 +3932,7 @@ crypt=${crypt//\\//\\\\\\/}
     with_facts(source, None, |_, facts| {
         assert_eq!(
             facts
+                .words()
                 .replacement_expansion_fragments()
                 .iter()
                 .map(|fragment| fragment.span().slice(source))
@@ -3719,6 +3957,7 @@ printf '%s\\n' '${\"$bar\"[1]}'
     with_facts(source, None, |_, facts| {
         assert_eq!(
             facts
+                .words()
                 .zsh_parameter_index_flag_fragments()
                 .iter()
                 .map(|fragment| fragment.span().slice(source))
@@ -3741,6 +3980,7 @@ printf '%s\\n' ${name%$suffix} `printf backtick`
 
     with_facts(source, None, |_, facts| {
         let parameter_pattern = facts
+            .words()
             .expansion_word_facts(ExpansionContext::ParameterPattern)
             .find(|fact| fact.span().slice(source) == "$suffix")
             .expect("expected parameter pattern fact");
@@ -3748,6 +3988,7 @@ printf '%s\\n' ${name%$suffix} `printf backtick`
 
         assert_eq!(
             facts
+                .words()
                 .backtick_fragments()
                 .iter()
                 .map(|fragment| fragment.span().slice(source))
@@ -3767,6 +4008,7 @@ printf '%s\\n' \"${items[@]#$prefix/}\" \"${items[i]%$suffix}\"
     with_facts(source, None, |_, facts| {
         assert_eq!(
             facts
+                .words()
                 .indexed_array_reference_fragments()
                 .iter()
                 .map(|fragment| {
@@ -3804,6 +4046,7 @@ printf '%s\\n' ${arr[0]}
     with_facts(source, None, |_, facts| {
         assert_eq!(
             facts
+                .words()
                 .indexed_array_reference_fragments()
                 .iter()
                 .filter_map(|fragment| {
@@ -3833,6 +4076,7 @@ printf '%s\\n' ${arr[0]}
     with_facts(source, None, |_, facts| {
         assert_eq!(
             facts
+                .words()
                 .indexed_array_reference_fragments()
                 .iter()
                 .filter_map(|fragment| {
@@ -3858,6 +4102,7 @@ nested=${items[i]%${name%$suffix}}
     with_facts(source, None, |_, facts| {
         assert_eq!(
             facts
+                .words()
                 .parameter_pattern_special_target_fragments()
                 .iter()
                 .map(|fragment| fragment.span().slice(source))
@@ -3879,6 +4124,7 @@ printf '%s\\n' \"${name%%dBm*}\"
     with_facts(source, None, |_, facts| {
         assert_eq!(
             facts
+                .words()
                 .positional_parameter_trim_fragments()
                 .iter()
                 .map(|fragment| fragment.span().slice(source))
@@ -3907,6 +4153,7 @@ echo \"Resolve the conflict and run ``${PROGRAM} --continue`` plus `date`.\"
     with_facts(source, None, |_, facts| {
         assert_eq!(
             facts
+                .words()
                 .backtick_fragments()
                 .iter()
                 .map(|fragment| (fragment.span().slice(source), fragment.is_empty()))
@@ -3926,6 +4173,7 @@ fn collects_declaration_assignment_probes_for_process_substitution_subscripts() 
 
     with_facts(source, None, |_, facts| {
         let probes = facts
+            .command_facts()
             .structural_commands()
             .flat_map(|fact| fact.declaration_assignment_probes().iter())
             .map(|probe| (probe.target_name(), probe.has_command_substitution()))
@@ -3946,6 +4194,7 @@ demo() {
 
     with_facts(source, None, |_, facts| {
         let probes = facts
+            .command_facts()
             .structural_commands()
             .flat_map(|fact| fact.declaration_assignment_probes().iter())
             .map(|probe| {

--- a/crates/shuck-linter/src/facts/words/occurrence.rs
+++ b/crates/shuck-linter/src/facts/words/occurrence.rs
@@ -68,6 +68,7 @@ pub(crate) enum WordOccurrenceFilter {
     Any,
     NonArithmetic,
     ArithmeticCommand,
+    #[cfg(test)]
     ParameterOperand,
     Expansion(ExpansionContext),
     CaseSubject,
@@ -99,7 +100,7 @@ impl<'facts, 'a> WordOccurrenceIter<'facts, 'a> {
     }
 
     fn accepts(&self, id: WordOccurrenceId) -> bool {
-        let occurrence = self.facts.word_occurrence(id);
+        let occurrence = self.facts.words().word_occurrence(id);
         match self.filter {
             WordOccurrenceFilter::Any => true,
             WordOccurrenceFilter::NonArithmetic => {
@@ -111,13 +112,14 @@ impl<'facts, 'a> WordOccurrenceIter<'facts, 'a> {
             WordOccurrenceFilter::ArithmeticCommand => {
                 occurrence.context == WordFactContext::ArithmeticCommand
             }
+            #[cfg(test)]
             WordOccurrenceFilter::ParameterOperand => {
                 occurrence.context == WordFactContext::ParameterOperand
             }
             WordOccurrenceFilter::Expansion(context) => {
                 occurrence.context == WordFactContext::Expansion(context)
             }
-            WordOccurrenceFilter::CaseSubject => self.facts.word_occurrence_ref(id).is_case_subject(),
+            WordOccurrenceFilter::CaseSubject => self.facts.words().word_occurrence_ref(id).is_case_subject(),
         }
     }
 }
@@ -137,7 +139,7 @@ impl<'facts, 'a> Iterator for WordOccurrenceIter<'facts, 'a> {
             }?;
 
             if self.accepts(id) {
-                return Some(self.facts.word_occurrence_ref(id));
+                return Some(self.facts.words().word_occurrence_ref(id));
             }
         }
     }
@@ -145,15 +147,15 @@ impl<'facts, 'a> Iterator for WordOccurrenceIter<'facts, 'a> {
 
 impl<'facts, 'a> WordOccurrenceRef<'facts, 'a> {
     fn occurrence(self) -> &'facts WordOccurrence {
-        self.facts.word_occurrence(self.id)
+        self.facts.words().word_occurrence(self.id)
     }
 
     fn node(self) -> &'facts WordNode<'a> {
-        self.facts.word_node(self.occurrence().node_id)
+        self.facts.words().word_node(self.occurrence().node_id)
     }
 
     fn derived(self) -> &'facts WordNodeDerived<'a> {
-        self.facts.word_node_derived(self.occurrence().node_id)
+        self.facts.words().word_node_derived(self.occurrence().node_id)
     }
 
     pub(crate) fn word(self) -> &'a Word {
@@ -220,8 +222,7 @@ impl<'facts, 'a> WordOccurrenceRef<'facts, 'a> {
         source: &str,
     ) -> bool {
         let Some(backtick_span) =
-            self.facts
-                .backtick_substitution_spans()
+            self.facts.source_facts().backtick_substitution_spans()
                 .iter()
                 .copied()
                 .find(|span| {
@@ -571,7 +572,7 @@ impl<'facts, 'a> WordOccurrenceRef<'facts, 'a> {
         word_spans::shellcheck_collapsed_backtick_part_span(
             adjusted,
             locator,
-            self.facts.backtick_substitution_spans(),
+            self.facts.source_facts().backtick_substitution_spans(),
         )
     }
 
@@ -579,8 +580,7 @@ impl<'facts, 'a> WordOccurrenceRef<'facts, 'a> {
         word_spans::word_has_direct_all_elements_array_expansion_in_source(
             self.word(),
             locator,
-            self.facts
-                .command(self.command_id())
+            self.facts.command_facts().command(self.command_id())
                 .shell_behavior()
                 .shell_dialect(),
         )
@@ -590,8 +590,7 @@ impl<'facts, 'a> WordOccurrenceRef<'facts, 'a> {
         word_spans::word_zsh_positional_parameter_range_spans(
             self.word(),
             locator.source(),
-            self.facts
-                .command(self.command_id())
+            self.facts.command_facts().command(self.command_id())
                 .shell_behavior()
                 .shell_dialect(),
         )
@@ -659,8 +658,7 @@ impl<'facts, 'a> WordOccurrenceRef<'facts, 'a> {
             return true;
         }
 
-        self.facts
-            .command(self.command_id())
+        self.facts.command_facts().command(self.command_id())
             .shell_behavior()
             .shell_dialect()
             != shuck_semantic::ShellDialect::Zsh
@@ -733,8 +731,7 @@ impl<'facts, 'a> WordOccurrenceRef<'facts, 'a> {
         word_spans::word_folded_all_elements_array_span_in_source(
             self.word(),
             locator,
-            self.facts
-                .command(self.command_id())
+            self.facts.command_facts().command(self.command_id())
                 .shell_behavior()
                 .shell_dialect(),
         )
@@ -1140,49 +1137,6 @@ fn safe_value_parameter_contains_special_parameter_slice(parameter: &ParameterEx
 
 fn safe_value_special_parameter_slice_reference(reference: &VarRef) -> bool {
     matches!(reference.name.as_str(), "@" | "*")
-}
-
-
-pub(crate) fn build_unquoted_command_argument_use_offsets(
-    semantic: &SemanticModel,
-    nodes: &[WordNode<'_>],
-    occurrences: &[WordOccurrence],
-) -> FxHashMap<Name, Vec<usize>> {
-    let unquoted_command_argument_word_spans = occurrences
-        .iter()
-        .filter(|fact| {
-            fact.context == WordFactContext::Expansion(ExpansionContext::CommandArgument)
-        })
-        .filter(|fact| occurrence_analysis(nodes, fact).quote == WordQuote::Unquoted)
-        .map(|fact| occurrence_span(nodes, fact))
-        .collect::<Vec<_>>();
-    if unquoted_command_argument_word_spans.is_empty() {
-        return FxHashMap::default();
-    }
-
-    let mut offsets_by_name = FxHashMap::<Name, Vec<usize>>::default();
-    for word_span in unquoted_command_argument_word_spans {
-        for reference in semantic.references_in_span(word_span) {
-            if matches!(
-                reference.kind,
-                shuck_semantic::ReferenceKind::DeclarationName
-            ) {
-                continue;
-            }
-
-            offsets_by_name
-                .entry(reference.name.clone())
-                .or_default()
-                .push(word_span.start.offset);
-        }
-    }
-
-    for offsets in offsets_by_name.values_mut() {
-        offsets.sort_unstable();
-        offsets.dedup();
-    }
-
-    offsets_by_name
 }
 
 struct ZshArrayFanoutContext<'a, 'flow> {

--- a/crates/shuck-linter/src/lib.rs
+++ b/crates/shuck-linter/src/lib.rs
@@ -83,8 +83,8 @@ pub use facts::{
 };
 /// Fact collection types and stable identifiers into those collections.
 pub use facts::{
-    CommandId, DeclarationKind, FactSpan, LinterFacts, NormalizedCommand, NormalizedDeclaration,
-    WrapperKind,
+    AssignmentFacts, CommandFactQueries, CommandId, CompatFacts, DeclarationKind, FactSpan,
+    LinterFacts, NormalizedCommand, NormalizedDeclaration, SourceFacts, WordFacts, WrapperKind,
 };
 pub(crate) use facts::{
     ComparableNameKey, ComparableNameUseKind, ComparablePathKey, ComparablePathMatchKey,

--- a/crates/shuck-linter/src/rules/correctness/append_to_array_as_string.rs
+++ b/crates/shuck-linter/src/rules/correctness/append_to_array_as_string.rs
@@ -48,7 +48,11 @@ pub fn append_to_array_as_string(checker: &mut Checker) {
                 return None;
             }
 
-            let value = checker.facts().binding_value(binding.id)?.scalar_word()?;
+            let value = checker
+                .facts()
+                .assignments()
+                .binding_value(binding.id)?
+                .scalar_word()?;
             if !leading_literal_word_prefix(value, source).starts_with(' ') {
                 return None;
             }

--- a/crates/shuck-linter/src/rules/correctness/array_slice_in_comparison.rs
+++ b/crates/shuck-linter/src/rules/correctness/array_slice_in_comparison.rs
@@ -31,7 +31,7 @@ pub fn array_slice_in_comparison(checker: &mut Checker) {
         ExpansionContext::RegexOperand,
     ]
     .into_iter()
-    .flat_map(|context| checker.facts().expansion_word_facts(context))
+    .flat_map(|context| checker.facts().words().expansion_word_facts(context))
     .filter(|fact| !fact.is_nested_word_command())
     .filter(|fact| fact.has_direct_all_elements_array_expansion_in_source(locator))
     .map(|fact| {
@@ -44,6 +44,7 @@ pub fn array_slice_in_comparison(checker: &mut Checker) {
 
     let risky_pattern_words = checker
         .facts()
+        .words()
         .expansion_word_facts(ExpansionContext::ConditionalPattern)
         .filter(|fact| !fact.is_nested_word_command())
         .filter(|fact| fact.command_substitution_spans().is_empty())

--- a/crates/shuck-linter/src/rules/correctness/array_to_string_conversion.rs
+++ b/crates/shuck-linter/src/rules/correctness/array_to_string_conversion.rs
@@ -90,7 +90,11 @@ pub fn array_to_string_conversion(checker: &mut Checker) {
                 return None;
             }
 
-            checker.facts().binding_value(binding.id)?.scalar_word()?;
+            checker
+                .facts()
+                .assignments()
+                .binding_value(binding.id)?
+                .scalar_word()?;
 
             if zsh_selectorless_subscript_value_resets_scalar_history(
                 checker,
@@ -231,6 +235,7 @@ fn zsh_selectorless_subscript_value_resets_scalar_history(
         )
         && checker
             .facts()
+            .assignments()
             .binding_value(binding.id)
             .is_some_and(|value| {
                 value.zsh_selectorless_subscript_value()
@@ -367,7 +372,11 @@ fn presence_test_reset_events(
     let mut seen = HashSet::<(usize, Name)>::new();
     let mut events = Vec::new();
     for name in names {
-        for fact in checker.facts().presence_test_references(&name) {
+        for fact in checker
+            .facts()
+            .assignments()
+            .presence_test_references(&name)
+        {
             push_reset_event(
                 checker,
                 &mut events,
@@ -376,7 +385,7 @@ fn presence_test_reset_events(
                 &name,
             );
         }
-        for fact in checker.facts().presence_test_names(&name) {
+        for fact in checker.facts().assignments().presence_test_names(&name) {
             push_reset_event(
                 checker,
                 &mut events,
@@ -625,6 +634,7 @@ fn binding_command<'checker, 'ast>(
 ) -> Option<crate::facts::commands::CommandFactRef<'checker, 'ast>> {
     checker
         .facts()
+        .command_facts()
         .innermost_command_at_binding_offset(binding.span.start.offset)
         .or_else(|| {
             checker

--- a/crates/shuck-linter/src/rules/correctness/assignment_looks_like_comparison.rs
+++ b/crates/shuck-linter/src/rules/correctness/assignment_looks_like_comparison.rs
@@ -91,7 +91,7 @@ fn assignment_value_looks_like_comparison(
         return None;
     };
 
-    let fact = checker.facts().word_fact(word.span, context)?;
+    let fact = checker.facts().words().word_fact(word.span, context)?;
     if fact.classification().quote != WordQuote::Unquoted {
         return None;
     }

--- a/crates/shuck-linter/src/rules/correctness/backslash_before_closing_backtick.rs
+++ b/crates/shuck-linter/src/rules/correctness/backslash_before_closing_backtick.rs
@@ -23,6 +23,7 @@ impl Violation for BackslashBeforeClosingBacktick {
 pub fn backslash_before_closing_backtick(checker: &mut Checker) {
     let spans = checker
         .facts()
+        .words()
         .backtick_fragments()
         .iter()
         .filter_map(|fragment| {

--- a/crates/shuck-linter/src/rules/correctness/backtick_in_command_position.rs
+++ b/crates/shuck-linter/src/rules/correctness/backtick_in_command_position.rs
@@ -20,7 +20,11 @@ impl Violation for BacktickInCommandPosition {
 
 pub fn backtick_in_command_position(checker: &mut Checker) {
     let source = checker.source();
-    let spans = checker.facts().backtick_command_name_spans().to_vec();
+    let spans = checker
+        .facts()
+        .command_facts()
+        .backtick_command_name_spans()
+        .to_vec();
 
     for span in spans {
         checker.report_diagnostic_dedup(Diagnostic::new(BacktickInCommandPosition, span).with_fix(

--- a/crates/shuck-linter/src/rules/correctness/bare_slash_marker.rs
+++ b/crates/shuck-linter/src/rules/correctness/bare_slash_marker.rs
@@ -16,6 +16,7 @@ pub fn bare_slash_marker(checker: &mut Checker) {
     let source = checker.source();
     let spans = checker
         .facts()
+        .command_facts()
         .structural_commands()
         .filter(|fact| fact.wrappers().is_empty())
         .filter(|fact| fact.body_args().is_empty())

--- a/crates/shuck-linter/src/rules/correctness/broken_assoc_key.rs
+++ b/crates/shuck-linter/src/rules/correctness/broken_assoc_key.rs
@@ -13,7 +13,10 @@ impl Violation for BrokenAssocKey {
 }
 
 pub fn broken_assoc_key(checker: &mut Checker) {
-    checker.report_fact_slice_dedup(|facts| facts.broken_assoc_key_spans(), || BrokenAssocKey);
+    checker.report_fact_slice_dedup(
+        |facts| facts.assignments().broken_assoc_key_spans(),
+        || BrokenAssocKey,
+    );
 }
 
 #[cfg(test)]

--- a/crates/shuck-linter/src/rules/correctness/case_arm_not_in_getopts.rs
+++ b/crates/shuck-linter/src/rules/correctness/case_arm_not_in_getopts.rs
@@ -34,6 +34,7 @@ pub fn case_arm_not_in_getopts(checker: &mut Checker) {
     let source = checker.source();
     let unexpected = checker
         .facts()
+        .command_facts()
         .getopts_cases()
         .iter()
         .flat_map(|fact| {
@@ -65,12 +66,17 @@ fn case_pattern_deletion_fix(
     source: &str,
     delete_item: bool,
 ) -> Option<Fix> {
-    let item = checker.facts().case_items().iter().find(|item| {
-        item.item().patterns.iter().any(|pattern| {
-            pattern.span.start.offset == pattern_span.start.offset
-                && pattern.span.end.offset == pattern_span.end.offset
-        })
-    })?;
+    let item = checker
+        .facts()
+        .command_facts()
+        .case_items()
+        .iter()
+        .find(|item| {
+            item.item().patterns.iter().any(|pattern| {
+                pattern.span.start.offset == pattern_span.start.offset
+                    && pattern.span.end.offset == pattern_span.end.offset
+            })
+        })?;
 
     if delete_item || item.item().patterns.len() == 1 || all_item_patterns_reported(checker, item) {
         return case_item_deletion_span(item.item(), source)
@@ -84,6 +90,7 @@ fn case_pattern_deletion_fix(
 fn all_item_patterns_reported(checker: &Checker<'_>, item: &CaseItemFact<'_>) -> bool {
     let reported_spans = checker
         .facts()
+        .command_facts()
         .getopts_cases()
         .iter()
         .flat_map(|fact| {

--- a/crates/shuck-linter/src/rules/correctness/case_default_before_glob.rs
+++ b/crates/shuck-linter/src/rules/correctness/case_default_before_glob.rs
@@ -25,6 +25,7 @@ pub fn case_default_before_glob(checker: &mut Checker) {
     let source = checker.source();
     let diagnostics = checker
         .facts()
+        .command_facts()
         .case_pattern_shadows()
         .iter()
         .map(|shadow| {
@@ -48,15 +49,21 @@ fn case_pattern_deletion_fix(
     pattern_span: Span,
     source: &str,
 ) -> Option<Fix> {
-    let item = checker.facts().case_items().iter().find(|item| {
-        item.item().patterns.iter().any(|pattern| {
-            pattern.span.start.offset == pattern_span.start.offset
-                && pattern.span.end.offset == pattern_span.end.offset
-        })
-    })?;
+    let item = checker
+        .facts()
+        .command_facts()
+        .case_items()
+        .iter()
+        .find(|item| {
+            item.item().patterns.iter().any(|pattern| {
+                pattern.span.start.offset == pattern_span.start.offset
+                    && pattern.span.end.offset == pattern_span.end.offset
+            })
+        })?;
 
     let shadowed_spans = checker
         .facts()
+        .command_facts()
         .case_pattern_shadows()
         .iter()
         .map(|shadow| shadow.shadowed_pattern_span())

--- a/crates/shuck-linter/src/rules/correctness/case_glob_reachability.rs
+++ b/crates/shuck-linter/src/rules/correctness/case_glob_reachability.rs
@@ -25,6 +25,7 @@ pub fn case_glob_reachability(checker: &mut Checker) {
     let source = checker.source();
     let diagnostics = checker
         .facts()
+        .command_facts()
         .case_pattern_shadows()
         .iter()
         .map(|shadow| {
@@ -48,15 +49,21 @@ fn case_pattern_deletion_fix(
     pattern_span: Span,
     source: &str,
 ) -> Option<Fix> {
-    let item = checker.facts().case_items().iter().find(|item| {
-        item.item().patterns.iter().any(|pattern| {
-            pattern.span.start.offset == pattern_span.start.offset
-                && pattern.span.end.offset == pattern_span.end.offset
-        })
-    })?;
+    let item = checker
+        .facts()
+        .command_facts()
+        .case_items()
+        .iter()
+        .find(|item| {
+            item.item().patterns.iter().any(|pattern| {
+                pattern.span.start.offset == pattern_span.start.offset
+                    && pattern.span.end.offset == pattern_span.end.offset
+            })
+        })?;
 
     let shadowing_spans = checker
         .facts()
+        .command_facts()
         .case_pattern_shadows()
         .iter()
         .map(|shadow| shadow.shadowing_pattern_span())

--- a/crates/shuck-linter/src/rules/correctness/case_pattern_var.rs
+++ b/crates/shuck-linter/src/rules/correctness/case_pattern_var.rs
@@ -21,6 +21,7 @@ impl Violation for CasePatternVar {
 pub fn case_pattern_var(checker: &mut Checker) {
     let diagnostics = checker
         .facts()
+        .command_facts()
         .case_pattern_expansions()
         .iter()
         .map(|fact| {

--- a/crates/shuck-linter/src/rules/correctness/chained_test_branches.rs
+++ b/crates/shuck-linter/src/rules/correctness/chained_test_branches.rs
@@ -18,6 +18,7 @@ impl Violation for ChainedTestBranches {
 pub fn chained_test_branches(checker: &mut Checker) {
     let mut lists = checker
         .facts()
+        .command_facts()
         .lists()
         .iter()
         .filter(|list| matches_mixed_short_circuit(checker, list))
@@ -87,9 +88,11 @@ fn list_runs_as_if_or_elif_condition(checker: &Checker<'_>, list: &ListFact<'_>)
     list.segments().iter().all(|segment| {
         checker
             .facts()
+            .command_facts()
             .is_if_condition_command(segment.command_id())
             || checker
                 .facts()
+                .command_facts()
                 .is_elif_condition_command(segment.command_id())
     })
 }
@@ -98,6 +101,7 @@ fn list_exempts_warning(checker: &Checker<'_>, list: &ListFact<'_>) -> bool {
     if list.segments().iter().all(|segment| {
         checker
             .facts()
+            .command_facts()
             .command_is_in_completion_registered_function(segment.command_id())
     }) {
         return true;
@@ -153,6 +157,7 @@ fn matches_exempt_fallback_branch(checker: &Checker<'_>, list: &ListFact<'_>) ->
     matches!(
         checker
             .facts()
+            .command_facts()
             .command(last_segment.command_id())
             .effective_or_literal_name()
             .map(command_basename),

--- a/crates/shuck-linter/src/rules/correctness/comma_array_elements.rs
+++ b/crates/shuck-linter/src/rules/correctness/comma_array_elements.rs
@@ -14,7 +14,7 @@ impl Violation for CommaArrayElements {
 
 pub fn comma_array_elements(checker: &mut Checker) {
     checker.report_fact_slice_dedup(
-        |facts| facts.comma_array_assignment_spans(),
+        |facts| facts.assignments().comma_array_assignment_spans(),
         || CommaArrayElements,
     );
 }

--- a/crates/shuck-linter/src/rules/correctness/commented_continuation_line.rs
+++ b/crates/shuck-linter/src/rules/correctness/commented_continuation_line.rs
@@ -20,7 +20,12 @@ impl Violation for CommentedContinuationLine {
 
 pub fn commented_continuation_line(checker: &mut Checker) {
     checker.report_fact_diagnostics_dedup(|facts, report| {
-        for span in facts.commented_continuation_comment_spans().iter().copied() {
+        for span in facts
+            .source_facts()
+            .commented_continuation_comment_spans()
+            .iter()
+            .copied()
+        {
             let backslash_offset = span
                 .start
                 .offset

--- a/crates/shuck-linter/src/rules/correctness/constant_case_subject.rs
+++ b/crates/shuck-linter/src/rules/correctness/constant_case_subject.rs
@@ -15,6 +15,7 @@ impl Violation for ConstantCaseSubject {
 pub fn constant_case_subject(checker: &mut Checker) {
     let spans = checker
         .facts()
+        .words()
         .case_subject_facts()
         .filter(|fact| fact.classification().is_fixed_literal())
         .map(|fact| fact.span())

--- a/crates/shuck-linter/src/rules/correctness/dollar_question_after_command.rs
+++ b/crates/shuck-linter/src/rules/correctness/dollar_question_after_command.rs
@@ -14,7 +14,7 @@ impl Violation for DollarQuestionAfterCommand {
 
 pub fn dollar_question_after_command(checker: &mut Checker) {
     checker.report_fact_slice(
-        |facts| facts.dollar_question_after_command_spans(),
+        |facts| facts.source_facts().dollar_question_after_command_spans(),
         || DollarQuestionAfterCommand,
     );
 }

--- a/crates/shuck-linter/src/rules/correctness/double_paren_grouping.rs
+++ b/crates/shuck-linter/src/rules/correctness/double_paren_grouping.rs
@@ -20,7 +20,7 @@ impl Violation for DoubleParenGrouping {
 
 pub fn double_paren_grouping(checker: &mut Checker) {
     checker.report_fact_diagnostics_dedup(|facts, report| {
-        for span in facts.double_paren_grouping_spans().iter().copied() {
+        for span in facts.words().double_paren_grouping_spans().iter().copied() {
             report(
                 Diagnostic::new(DoubleParenGrouping, span).with_fix(Fix::unsafe_edit(
                     Edit::insertion(span.start.offset + 1, " "),

--- a/crates/shuck-linter/src/rules/correctness/env_prefix_expansion_only.rs
+++ b/crates/shuck-linter/src/rules/correctness/env_prefix_expansion_only.rs
@@ -23,6 +23,7 @@ pub fn env_prefix_expansion_only(checker: &mut Checker) {
     let source = checker.source();
     let facts = checker
         .facts()
+        .assignments()
         .env_prefix_expansion_fix_facts()
         .iter()
         .filter_map(|fact| {
@@ -36,7 +37,7 @@ pub fn env_prefix_expansion_only(checker: &mut Checker) {
     }
 
     checker.report_fact_slice_dedup(
-        |facts| facts.env_prefix_expansion_scope_spans(),
+        |facts| facts.assignments().env_prefix_expansion_scope_spans(),
         || EnvPrefixExpansionOnly,
     );
 }

--- a/crates/shuck-linter/src/rules/correctness/export_with_positional_params.rs
+++ b/crates/shuck-linter/src/rules/correctness/export_with_positional_params.rs
@@ -17,6 +17,7 @@ impl Violation for ExportWithPositionalParams {
 pub fn export_with_positional_params(checker: &mut Checker) {
     let export_ids = checker
         .facts()
+        .command_facts()
         .structural_commands()
         .filter(|fact| fact.effective_name_is("export"))
         .map(|fact| fact.id())
@@ -24,6 +25,7 @@ pub fn export_with_positional_params(checker: &mut Checker) {
 
     let spans = checker
         .facts()
+        .words()
         .expansion_word_facts(ExpansionContext::CommandArgument)
         .filter(|fact| export_ids.contains(&fact.command_id()))
         .filter(|fact| fact.is_plain_parameter_reference())

--- a/crates/shuck-linter/src/rules/correctness/find_output_loop.rs
+++ b/crates/shuck-linter/src/rules/correctness/find_output_loop.rs
@@ -15,6 +15,7 @@ impl Violation for FindOutputLoop {
 pub fn find_output_loop(checker: &mut Checker) {
     let spans = checker
         .facts()
+        .command_facts()
         .for_headers()
         .iter()
         .flat_map(|header| header.words().iter())

--- a/crates/shuck-linter/src/rules/correctness/find_output_to_xargs.rs
+++ b/crates/shuck-linter/src/rules/correctness/find_output_to_xargs.rs
@@ -26,6 +26,7 @@ impl Violation for FindOutputToXargs {
 pub fn find_output_to_xargs(checker: &mut Checker) {
     let diagnostics = checker
         .facts()
+        .command_facts()
         .pipelines()
         .iter()
         .flat_map(|pipeline| unsafe_find_to_xargs_diagnostics(checker, pipeline))
@@ -46,8 +47,14 @@ fn unsafe_find_to_xargs_diagnostics(
         .filter_map(|pair| {
             let left_segment = &pair[0];
             let right_segment = &pair[1];
-            let left = checker.facts().command(left_segment.command_id());
-            let right = checker.facts().command(right_segment.command_id());
+            let left = checker
+                .facts()
+                .command_facts()
+                .command(left_segment.command_id());
+            let right = checker
+                .facts()
+                .command_facts()
+                .command(right_segment.command_id());
 
             if !left_segment.effective_name_is("find") || !right_segment.effective_name_is("xargs")
             {

--- a/crates/shuck-linter/src/rules/correctness/function_arity.rs
+++ b/crates/shuck-linter/src/rules/correctness/function_arity.rs
@@ -12,9 +12,11 @@ pub(crate) fn zsh_function_arity_is_externally_defined(
     checker.shell() == ShellDialect::Zsh
         && (checker
             .facts()
+            .command_facts()
             .function_is_external_entrypoint(function_scope)
             || checker
                 .facts()
+                .command_facts()
                 .function_positional_parameter_facts(function_scope)
                 .required_arg_count()
                 == 0
@@ -27,6 +29,7 @@ fn zsh_function_has_optional_first_positional_parameter(
 ) -> bool {
     let positional = checker
         .facts()
+        .command_facts()
         .function_positional_parameter_facts(function_scope);
     if positional.required_arg_count() != 1 {
         return false;

--- a/crates/shuck-linter/src/rules/correctness/function_called_without_args.rs
+++ b/crates/shuck-linter/src/rules/correctness/function_called_without_args.rs
@@ -24,7 +24,7 @@ pub fn function_called_without_args(checker: &mut Checker) {
     let mut reported = FxHashSet::<BindingId>::default();
     let mut violations = Vec::<(Span, CompactString)>::new();
 
-    for header in checker.facts().function_headers() {
+    for header in checker.facts().command_facts().function_headers() {
         let Some((name, _)) = header.static_name_entry() else {
             continue;
         };
@@ -41,6 +41,7 @@ pub fn function_called_without_args(checker: &mut Checker) {
 
         let positional = checker
             .facts()
+            .command_facts()
             .function_positional_parameter_facts(function_scope);
 
         if !positional.uses_positional_parameters() {

--- a/crates/shuck-linter/src/rules/correctness/function_references_unset_param.rs
+++ b/crates/shuck-linter/src/rules/correctness/function_references_unset_param.rs
@@ -24,7 +24,7 @@ pub fn function_references_unset_param(checker: &mut Checker) {
     let mut reported = FxHashSet::<BindingId>::default();
     let mut violations = Vec::<(Span, CompactString)>::new();
 
-    for header in checker.facts().function_headers() {
+    for header in checker.facts().command_facts().function_headers() {
         let Some((name, _)) = header.static_name_entry() else {
             continue;
         };
@@ -47,6 +47,7 @@ pub fn function_references_unset_param(checker: &mut Checker) {
 
         let positional = checker
             .facts()
+            .command_facts()
             .function_positional_parameter_facts(function_scope);
         if !positional.uses_positional_parameters() || positional.resets_positional_parameters() {
             continue;

--- a/crates/shuck-linter/src/rules/correctness/getopts_option_not_in_case.rs
+++ b/crates/shuck-linter/src/rules/correctness/getopts_option_not_in_case.rs
@@ -20,6 +20,7 @@ impl Violation for GetoptsOptionNotInCase {
 pub fn getopts_option_not_in_case(checker: &mut Checker) {
     let missing = checker
         .facts()
+        .command_facts()
         .getopts_cases()
         .iter()
         .flat_map(|fact| {

--- a/crates/shuck-linter/src/rules/correctness/glob_in_find_substitution.rs
+++ b/crates/shuck-linter/src/rules/correctness/glob_in_find_substitution.rs
@@ -34,6 +34,7 @@ pub fn glob_in_find_substitution(checker: &mut Checker) {
         .flat_map(|find| find.glob_pattern_operand_spans().iter().copied())
         .map(|span| {
             let replacement = facts
+                .words()
                 .any_word_fact(span)
                 .expect("find pattern operand span should map to a word fact")
                 .single_double_quoted_replacement(source);

--- a/crates/shuck-linter/src/rules/correctness/glob_in_test_comparison.rs
+++ b/crates/shuck-linter/src/rules/correctness/glob_in_test_comparison.rs
@@ -61,6 +61,7 @@ fn diagnostic_fix(
 
     if rhs_class.is_fixed_literal()
         || facts
+            .words()
             .any_word_fact(rhs.span)
             .is_none_or(|fact| fact.active_literal_glob_spans(source).is_empty())
     {

--- a/crates/shuck-linter/src/rules/correctness/glob_in_test_directory.rs
+++ b/crates/shuck-linter/src/rules/correctness/glob_in_test_directory.rs
@@ -189,6 +189,7 @@ fn simple_test_unary_file_test_span(
 
 fn reportable_glob_span(word: &Word, facts: &LinterFacts<'_>, source: &str) -> Option<Span> {
     facts
+        .words()
         .any_word_fact(word.span)
         .is_some_and(|fact| !fact.active_literal_glob_spans(source).is_empty())
         .then_some(word.span)

--- a/crates/shuck-linter/src/rules/correctness/glob_with_expansion_in_loop.rs
+++ b/crates/shuck-linter/src/rules/correctness/glob_with_expansion_in_loop.rs
@@ -26,6 +26,7 @@ pub fn glob_with_expansion_in_loop(checker: &mut Checker) {
     let source = checker.source();
     let spans = checker
         .facts()
+        .words()
         .expansion_word_facts(ExpansionContext::ForList)
         .filter(|fact| {
             !fact

--- a/crates/shuck-linter/src/rules/correctness/greater_than_in_test.rs
+++ b/crates/shuck-linter/src/rules/correctness/greater_than_in_test.rs
@@ -278,6 +278,7 @@ fn operand_is_numeric_literal(
     static_word_text(word, source).is_some_and(|text| looks_like_decimal_integer(&text))
         || checker
             .facts()
+            .words()
             .any_word_fact(word.span)
             .is_some_and(|word_fact| {
                 word_fact.is_direct_numeric_expansion()
@@ -318,6 +319,7 @@ fn binding_is_numeric_literal(checker: &Checker<'_>, binding_id: BindingId) -> b
 
     checker
         .facts()
+        .assignments()
         .binding_value(binding_id)
         .and_then(|value| value.scalar_word())
         .and_then(|word| static_word_text(word, checker.source()))

--- a/crates/shuck-linter/src/rules/correctness/heredoc_closer_not_alone.rs
+++ b/crates/shuck-linter/src/rules/correctness/heredoc_closer_not_alone.rs
@@ -22,6 +22,7 @@ pub fn heredoc_closer_not_alone(checker: &mut Checker) {
     let source = checker.source();
     let diagnostics = checker
         .facts()
+        .source_facts()
         .heredoc_closer_not_alone_spans()
         .iter()
         .copied()

--- a/crates/shuck-linter/src/rules/correctness/heredoc_missing_end.rs
+++ b/crates/shuck-linter/src/rules/correctness/heredoc_missing_end.rs
@@ -24,6 +24,7 @@ pub fn heredoc_missing_end(checker: &mut Checker) {
     let source = checker.source();
     let diagnostics = checker
         .facts()
+        .source_facts()
         .heredoc_missing_end_spans()
         .iter()
         .copied()

--- a/crates/shuck-linter/src/rules/correctness/if_dollar_command.rs
+++ b/crates/shuck-linter/src/rules/correctness/if_dollar_command.rs
@@ -25,6 +25,7 @@ pub fn if_dollar_command(checker: &mut Checker) {
     let source = checker.source();
     let diagnostics = checker
         .facts()
+        .command_facts()
         .command_substitution_command_spans()
         .iter()
         .copied()

--- a/crates/shuck-linter/src/rules/correctness/ifs_set_to_literal_backslash_n.rs
+++ b/crates/shuck-linter/src/rules/correctness/ifs_set_to_literal_backslash_n.rs
@@ -14,7 +14,11 @@ impl Violation for IfsSetToLiteralBackslashN {
 
 pub fn ifs_set_to_literal_backslash_n(checker: &mut Checker) {
     checker.report_fact_slice_dedup(
-        |facts| facts.ifs_literal_backslash_assignment_value_spans(),
+        |facts| {
+            facts
+                .assignments()
+                .ifs_literal_backslash_assignment_value_spans()
+        },
         || IfsSetToLiteralBackslashN,
     );
 }

--- a/crates/shuck-linter/src/rules/correctness/indented_shebang.rs
+++ b/crates/shuck-linter/src/rules/correctness/indented_shebang.rs
@@ -19,11 +19,12 @@ impl Violation for IndentedShebang {
 }
 
 pub fn indented_shebang(checker: &mut Checker) {
-    if let Some((span, indent_span)) = checker
-        .facts()
-        .indented_shebang_span()
-        .zip(checker.facts().indented_shebang_indent_span())
-    {
+    if let Some((span, indent_span)) = checker.facts().source_facts().indented_shebang_span().zip(
+        checker
+            .facts()
+            .source_facts()
+            .indented_shebang_indent_span(),
+    ) {
         checker.report_diagnostic_dedup(
             crate::Diagnostic::new(IndentedShebang, span)
                 .with_fix(Fix::unsafe_edit(Edit::deletion(indent_span))),

--- a/crates/shuck-linter/src/rules/correctness/leading_glob_argument.rs
+++ b/crates/shuck-linter/src/rules/correctness/leading_glob_argument.rs
@@ -23,6 +23,7 @@ impl Violation for LeadingGlobArgument {
 pub fn leading_glob_argument(checker: &mut Checker) {
     let diagnostics = checker
         .facts()
+        .words()
         .expansion_word_facts(ExpansionContext::CommandArgument)
         .filter(|fact| fact.host_kind() == WordFactHostKind::Direct)
         .filter_map(|fact| reportable_glob_diagnostic(checker, fact))
@@ -37,7 +38,7 @@ fn reportable_glob_diagnostic(
     checker: &Checker<'_>,
     fact: crate::facts::words::WordOccurrenceRef<'_, '_>,
 ) -> Option<crate::Diagnostic> {
-    let command = checker.facts().command(fact.command_id());
+    let command = checker.facts().command_facts().command(fact.command_id());
     if command_exempts_glob_warning(command.effective_name()) {
         return None;
     }

--- a/crates/shuck-linter/src/rules/correctness/line_oriented_input.rs
+++ b/crates/shuck-linter/src/rules/correctness/line_oriented_input.rs
@@ -15,6 +15,7 @@ impl Violation for LineOrientedInput {
 pub fn line_oriented_input(checker: &mut Checker) {
     let spans = checker
         .facts()
+        .command_facts()
         .for_headers()
         .iter()
         .filter(|header| header.words().len() == 1)

--- a/crates/shuck-linter/src/rules/correctness/malformed_arithmetic_in_condition.rs
+++ b/crates/shuck-linter/src/rules/correctness/malformed_arithmetic_in_condition.rs
@@ -121,7 +121,7 @@ fn simple_test_word_is_bare_operator(
     word: &shuck_ast::Word,
     predicate: fn(&str) -> bool,
 ) -> bool {
-    let Some(fact) = checker.facts().word_fact(
+    let Some(fact) = checker.facts().words().word_fact(
         word.span,
         WordFactContext::Expansion(ExpansionContext::CommandArgument),
     ) else {

--- a/crates/shuck-linter/src/rules/correctness/misquoted_heredoc_close.rs
+++ b/crates/shuck-linter/src/rules/correctness/misquoted_heredoc_close.rs
@@ -24,6 +24,7 @@ pub fn misquoted_heredoc_close(checker: &mut Checker) {
     let source = checker.source();
     let diagnostics = checker
         .facts()
+        .source_facts()
         .misquoted_heredoc_close_spans()
         .iter()
         .copied()

--- a/crates/shuck-linter/src/rules/correctness/nested_parameter_expansion.rs
+++ b/crates/shuck-linter/src/rules/correctness/nested_parameter_expansion.rs
@@ -15,6 +15,7 @@ impl Violation for NestedParameterExpansion {
 pub fn nested_parameter_expansion(checker: &mut Checker) {
     let spans = checker
         .facts()
+        .words()
         .nested_parameter_expansion_fragments()
         .iter()
         .map(|fragment| fragment.span())

--- a/crates/shuck-linter/src/rules/correctness/non_absolute_shebang.rs
+++ b/crates/shuck-linter/src/rules/correctness/non_absolute_shebang.rs
@@ -22,7 +22,7 @@ impl Violation for NonAbsoluteShebang {
 
 pub fn non_absolute_shebang(checker: &mut Checker) {
     let source = checker.source();
-    if let Some(span) = checker.facts().non_absolute_shebang_span() {
+    if let Some(span) = checker.facts().source_facts().non_absolute_shebang_span() {
         let replacement = rewrite_shebang(span.slice(source));
         checker.report_diagnostic_dedup(
             crate::Diagnostic::new(NonAbsoluteShebang, span)

--- a/crates/shuck-linter/src/rules/correctness/open_double_quote.rs
+++ b/crates/shuck-linter/src/rules/correctness/open_double_quote.rs
@@ -21,6 +21,7 @@ impl Violation for OpenDoubleQuote {
 pub fn open_double_quote(checker: &mut Checker) {
     let diagnostics = checker
         .facts()
+        .words()
         .open_double_quote_fragments()
         .iter()
         .map(|fragment| {

--- a/crates/shuck-linter/src/rules/correctness/overwritten_function.rs
+++ b/crates/shuck-linter/src/rules/correctness/overwritten_function.rs
@@ -201,7 +201,7 @@ fn build_compat_structural_facts(checker: &Checker<'_>) -> CompatStructuralFacts
     let mut top_level_loop_candidates = Vec::new();
     let mut break_offsets = Vec::new();
 
-    for fact in checker.facts().structural_commands() {
+    for fact in checker.facts().command_facts().structural_commands() {
         let offset = fact.body_span().start.offset;
         scopes_by_offset.entry(offset).or_insert(fact.scope());
         let is_function = matches!(fact.command(), shuck_ast::Command::Function(_));
@@ -243,6 +243,7 @@ fn build_compat_structural_facts(checker: &Checker<'_>) -> CompatStructuralFacts
 
         for fact in checker
             .facts()
+            .assignments()
             .function_unset_commands_for_name(&binding.name)
         {
             let offset = fact.body_span().start.offset;
@@ -289,6 +290,7 @@ fn supplemental_function_call_candidates(checker: &Checker<'_>) -> Vec<FunctionC
 
     for fact in checker
         .facts()
+        .command_facts()
         .structural_commands()
         .filter(|fact| !matches!(fact.command(), shuck_ast::Command::Function(_)))
     {
@@ -331,6 +333,7 @@ fn first_argument_forwarding_wrappers(checker: &Checker<'_>) -> FxHashMap<Name, 
         function_scopes_invoking_positional_arguments(checker);
     checker
         .facts()
+        .command_facts()
         .function_headers()
         .iter()
         .filter_map(|header| {
@@ -373,6 +376,7 @@ fn wrapper_call_resolves_to_forwarding_binding(
 fn function_scopes_invoking_positional_arguments(checker: &Checker<'_>) -> FxHashSet<ScopeId> {
     checker
         .facts()
+        .command_facts()
         .structural_commands()
         .filter_map(|fact| {
             fact.body_word_span()
@@ -567,7 +571,7 @@ fn report_transient_shadowed_file_scope_definitions(
 
 fn transient_function_shadow_offsets_by_name(checker: &Checker<'_>) -> FxHashMap<Name, Vec<usize>> {
     let mut offsets_by_name = FxHashMap::<Name, Vec<usize>>::default();
-    for header in checker.facts().function_headers() {
+    for header in checker.facts().command_facts().function_headers() {
         let Some(scope) = header.function_scope() else {
             continue;
         };
@@ -697,15 +701,27 @@ fn unset_function_cutoff_offsets(
 }
 
 fn command_offset_is_under_dominance_barrier(checker: &Checker<'_>, offset: usize) -> bool {
-    let Some(mut command_id) = checker.facts().innermost_command_id_at(offset) else {
+    let Some(mut command_id) = checker
+        .facts()
+        .command_facts()
+        .innermost_command_id_at(offset)
+    else {
         return false;
     };
 
     loop {
-        if checker.facts().command_is_dominance_barrier(command_id) {
+        if checker
+            .facts()
+            .command_facts()
+            .command_is_dominance_barrier(command_id)
+        {
             return true;
         }
-        let Some(parent_id) = checker.facts().command_parent_id(command_id) else {
+        let Some(parent_id) = checker
+            .facts()
+            .command_facts()
+            .command_parent_id(command_id)
+        else {
             return false;
         };
         command_id = parent_id;
@@ -965,6 +981,7 @@ fn has_file_scope_script_terminator_before(checker: &Checker<'_>, before_offset:
             offset < before_offset
                 && checker
                     .facts()
+                    .command_facts()
                     .innermost_command_at(offset)
                     .map(|fact| scope_is_file_scope(checker, fact.scope()))
                     .unwrap_or_else(|| {
@@ -979,25 +996,33 @@ fn has_file_scope_termination_barrier_before(checker: &Checker<'_>, before_offse
 }
 
 fn has_file_scope_return_before(checker: &Checker<'_>, before_offset: usize) -> bool {
-    checker.facts().structural_commands().any(|fact| {
-        let offset = fact.body_span().start.offset;
-        offset < before_offset
-            && fact.effective_name_is("return")
-            && scope_is_file_scope(checker, fact.scope())
-            && !command_offset_is_under_dominance_barrier(checker, offset)
-            && !command_offset_is_unreachable(checker, offset)
-    })
+    checker
+        .facts()
+        .command_facts()
+        .structural_commands()
+        .any(|fact| {
+            let offset = fact.body_span().start.offset;
+            offset < before_offset
+                && fact.effective_name_is("return")
+                && scope_is_file_scope(checker, fact.scope())
+                && !command_offset_is_under_dominance_barrier(checker, offset)
+                && !command_offset_is_unreachable(checker, offset)
+        })
 }
 
 fn has_top_level_return_after(checker: &Checker<'_>, after_offset: usize) -> bool {
-    checker.facts().structural_commands().any(|fact| {
-        fact.body_span().start.offset > after_offset
-            && scope_is_file_scope(
-                checker,
-                checker.semantic().scope_at(fact.body_span().start.offset),
-            )
-            && fact.effective_name_is("return")
-    })
+    checker
+        .facts()
+        .command_facts()
+        .structural_commands()
+        .any(|fact| {
+            fact.body_span().start.offset > after_offset
+                && scope_is_file_scope(
+                    checker,
+                    checker.semantic().scope_at(fact.body_span().start.offset),
+                )
+                && fact.effective_name_is("return")
+        })
 }
 
 fn enclosing_function_scope_can_run_persistently(
@@ -1030,14 +1055,18 @@ fn has_direct_call_inside_enclosing_function(
 }
 
 fn has_apparent_infinite_loop_after(checker: &Checker<'_>, offset: usize) -> bool {
-    checker.facts().structural_commands().any(|fact| {
-        fact.body_span().start.offset > offset
-            && scope_is_file_scope(
-                checker,
-                checker.semantic().scope_at(fact.body_span().start.offset),
-            )
-            && command_is_apparent_infinite_loop(checker, fact.command())
-    })
+    checker
+        .facts()
+        .command_facts()
+        .structural_commands()
+        .any(|fact| {
+            fact.body_span().start.offset > offset
+                && scope_is_file_scope(
+                    checker,
+                    checker.semantic().scope_at(fact.body_span().start.offset),
+                )
+                && command_is_apparent_infinite_loop(checker, fact.command())
+        })
 }
 
 fn command_is_apparent_infinite_loop(checker: &Checker<'_>, command: &shuck_ast::Command) -> bool {
@@ -1075,14 +1104,18 @@ fn condition_text_is(source: &str, span: shuck_ast::Span, values: &[&str]) -> bo
 }
 
 fn loop_body_contains_break(checker: &Checker<'_>, body_span: shuck_ast::Span) -> bool {
-    checker.facts().structural_commands().any(|fact| {
-        fact.body_span().start.offset >= body_span.start.offset
-            && fact.body_span().end.offset <= body_span.end.offset
-            && matches!(
-                fact.command(),
-                shuck_ast::Command::Builtin(shuck_ast::BuiltinCommand::Break(_))
-            )
-    })
+    checker
+        .facts()
+        .command_facts()
+        .structural_commands()
+        .any(|fact| {
+            fact.body_span().start.offset >= body_span.start.offset
+                && fact.body_span().end.offset <= body_span.end.offset
+                && matches!(
+                    fact.command(),
+                    shuck_ast::Command::Builtin(shuck_ast::BuiltinCommand::Break(_))
+                )
+        })
 }
 
 fn enclosing_function_has_reportable_c063_diagnostic(
@@ -1095,6 +1128,7 @@ fn enclosing_function_has_reportable_c063_diagnostic(
     };
     let enclosing_bindings = checker
         .facts()
+        .command_facts()
         .function_headers()
         .iter()
         .filter(|header| header.function_scope() == Some(enclosing_scope))

--- a/crates/shuck-linter/src/rules/correctness/pattern_policy.rs
+++ b/crates/shuck-linter/src/rules/correctness/pattern_policy.rs
@@ -78,6 +78,7 @@ fn binding_expands_to_static_pattern_safe_literal(
 ) -> bool {
     checker
         .facts()
+        .assignments()
         .binding_value(binding_id)
         .and_then(|value| value.scalar_word())
         .and_then(|word| static_word_text(word, checker.source()))

--- a/crates/shuck-linter/src/rules/correctness/pattern_with_variable.rs
+++ b/crates/shuck-linter/src/rules/correctness/pattern_with_variable.rs
@@ -26,12 +26,14 @@ pub fn pattern_with_variable(checker: &mut Checker) {
     let shell = checker.shell();
     let replacement_expansion_spans = checker
         .facts()
+        .words()
         .replacement_expansion_fragments()
         .iter()
         .map(|fragment| fragment.span())
         .collect::<Vec<_>>();
     let special_target_operand_spans = checker
         .facts()
+        .words()
         .parameter_pattern_special_target_fragments()
         .iter()
         .map(|fragment| fragment.span())
@@ -39,6 +41,7 @@ pub fn pattern_with_variable(checker: &mut Checker) {
 
     let diagnostics = checker
         .facts()
+        .words()
         .expansion_word_facts(ExpansionContext::ParameterPattern)
         .flat_map(|fact| {
             if span_is_within_any(fact.span(), &replacement_expansion_spans)

--- a/crates/shuck-linter/src/rules/correctness/pipe_to_kill.rs
+++ b/crates/shuck-linter/src/rules/correctness/pipe_to_kill.rs
@@ -15,6 +15,7 @@ impl Violation for PipeToKill {
 pub fn pipe_to_kill(checker: &mut Checker) {
     let spans = checker
         .facts()
+        .command_facts()
         .pipelines()
         .iter()
         .filter(|pipeline| {

--- a/crates/shuck-linter/src/rules/correctness/plus_prefix_in_assignment.rs
+++ b/crates/shuck-linter/src/rules/correctness/plus_prefix_in_assignment.rs
@@ -14,7 +14,7 @@ impl Violation for PlusPrefixInAssignment {
 
 pub fn plus_prefix_in_assignment(checker: &mut Checker) {
     checker.report_fact_slice_dedup(
-        |facts| facts.assignment_like_command_name_spans(),
+        |facts| facts.command_facts().assignment_like_command_name_spans(),
         || PlusPrefixInAssignment,
     );
 }

--- a/crates/shuck-linter/src/rules/correctness/positional_param_as_operator.rs
+++ b/crates/shuck-linter/src/rules/correctness/positional_param_as_operator.rs
@@ -14,7 +14,7 @@ impl Violation for PositionalParamAsOperator {
 
 pub fn positional_param_as_operator(checker: &mut Checker) {
     checker.report_fact_slice_dedup(
-        |facts| facts.positional_parameter_operator_spans(),
+        |facts| facts.words().positional_parameter_operator_spans(),
         || PositionalParamAsOperator,
     );
 }

--- a/crates/shuck-linter/src/rules/correctness/positional_ten_braces.rs
+++ b/crates/shuck-linter/src/rules/correctness/positional_ten_braces.rs
@@ -24,6 +24,7 @@ pub fn positional_ten_braces(checker: &mut Checker) {
     let source = checker.source();
     let diagnostics = checker
         .facts()
+        .words()
         .positional_parameter_fragments()
         .iter()
         .filter(|fragment| fragment.is_above_nine())

--- a/crates/shuck-linter/src/rules/correctness/possible_variable_misspelling.rs
+++ b/crates/shuck-linter/src/rules/correctness/possible_variable_misspelling.rs
@@ -408,6 +408,7 @@ fn add_scope_compat_binding_candidates(index: &mut ScopeCompatIndex, checker: &C
 fn add_scope_compat_presence_test_candidates(index: &mut ScopeCompatIndex, checker: &Checker<'_>) {
     for (name, span) in checker
         .facts()
+        .assignments()
         .presence_test_candidate_spans(checker.semantic())
     {
         let name = name.as_str();
@@ -423,6 +424,7 @@ fn add_scope_compat_presence_test_candidates(index: &mut ScopeCompatIndex, check
 fn add_scope_compat_name_uses(index: &mut ScopeCompatIndex, checker: &Checker<'_>) {
     for name_use in checker
         .facts()
+        .compat()
         .possible_variable_misspelling_scope_compat_name_uses()
     {
         let name = name_use.key().as_str();
@@ -537,6 +539,7 @@ fn is_presence_tested_reference_name(
 ) -> bool {
     checker
         .facts()
+        .assignments()
         .is_presence_tested_name(&Name::from(reference_name), reference_span)
 }
 
@@ -562,6 +565,7 @@ fn looks_like_case_mismatch_reference(name: &str) -> bool {
 fn preferred_candidate_name(checker: &Checker<'_>, target_name: &str) -> Option<String> {
     checker
         .facts()
+        .assignments()
         .possible_variable_misspelling_candidate(checker.semantic(), target_name)
 }
 
@@ -587,6 +591,7 @@ fn is_assignment_target_variant_reference(
 ) -> bool {
     let Some(target_name) = checker
         .facts()
+        .assignments()
         .assignment_value_target_name_for_span(reference_span)
         .map(|name| name.as_str())
     else {
@@ -611,6 +616,7 @@ fn is_build_flag_alias_assignment_value(
 
     checker
         .facts()
+        .assignments()
         .assignment_value_target_name_for_span(reference_span)
         .map(|name| name.as_str())
         .is_some_and(|target_name| {

--- a/crates/shuck-linter/src/rules/correctness/quoted_array_slice.rs
+++ b/crates/shuck-linter/src/rules/correctness/quoted_array_slice.rs
@@ -30,9 +30,9 @@ pub fn quoted_array_slice(checker: &mut Checker) {
         ExpansionContext::DeclarationAssignmentValue,
     ]
     .into_iter()
-    .flat_map(|context| facts.expansion_word_facts(context))
+    .flat_map(|context| facts.words().expansion_word_facts(context))
     .filter(|fact| fact.host_kind() == WordFactHostKind::Direct)
-    .filter(|fact| !facts.is_compound_assignment_value_word(*fact))
+    .filter(|fact| !facts.words().is_compound_assignment_value_word(*fact))
     .filter(|fact| fact.has_direct_all_elements_array_expansion_in_source(locator))
     .map(|fact| {
         (

--- a/crates/shuck-linter/src/rules/correctness/quoted_bash_source.rs
+++ b/crates/shuck-linter/src/rules/correctness/quoted_bash_source.rs
@@ -15,6 +15,7 @@ impl Violation for QuotedBashSource {
 pub fn quoted_bash_source(checker: &mut Checker) {
     let spans = checker
         .facts()
+        .words()
         .plain_unindexed_array_references()
         .filter_map(|fact| match fact {
             PlainUnindexedArrayReferenceFact::SelectorRequired(reference) => {

--- a/crates/shuck-linter/src/rules/correctness/quoted_command_in_test.rs
+++ b/crates/shuck-linter/src/rules/correctness/quoted_command_in_test.rs
@@ -195,6 +195,7 @@ fn simple_test_quoted_pipeline_replacement(
 ) -> Option<String> {
     checker
         .facts()
+        .words()
         .word_fact(
             span,
             WordFactContext::Expansion(ExpansionContext::CommandArgument),

--- a/crates/shuck-linter/src/rules/correctness/redirect_before_pipe.rs
+++ b/crates/shuck-linter/src/rules/correctness/redirect_before_pipe.rs
@@ -23,6 +23,7 @@ impl Violation for RedirectBeforePipe {
 pub fn redirect_before_pipe(checker: &mut Checker) {
     let diagnostics = checker
         .facts()
+        .command_facts()
         .pipelines()
         .iter()
         .flat_map(|pipeline| redirect_diagnostics_for_pipeline(checker, pipeline))
@@ -44,7 +45,10 @@ fn redirect_diagnostics_for_pipeline(
         .zip(pipeline.operators().iter())
         .filter(|(_, operator)| operator.op() == BinaryOp::Pipe)
         .flat_map(|(segment, _)| {
-            let fact = checker.facts().command(segment.command_id());
+            let fact = checker
+                .facts()
+                .command_facts()
+                .command(segment.command_id());
             fact.redirect_facts()
                 .iter()
                 .filter_map(|redirect| {

--- a/crates/shuck-linter/src/rules/correctness/redirect_clobbers_input.rs
+++ b/crates/shuck-linter/src/rules/correctness/redirect_clobbers_input.rs
@@ -21,6 +21,7 @@ impl Violation for RedirectClobbersInput {
 pub fn redirect_clobbers_input(checker: &mut Checker) {
     let spans = checker
         .facts()
+        .command_facts()
         .structural_commands()
         .flat_map(clobber_spans_for_command)
         .collect::<Vec<_>>();

--- a/crates/shuck-linter/src/rules/correctness/shebang_not_on_first_line.rs
+++ b/crates/shuck-linter/src/rules/correctness/shebang_not_on_first_line.rs
@@ -22,11 +22,18 @@ pub fn shebang_not_on_first_line(checker: &mut Checker) {
     let source = checker.source();
     if let Some((span, fix_span)) = checker
         .facts()
+        .source_facts()
         .shebang_not_on_first_line_span()
-        .zip(checker.facts().shebang_not_on_first_line_fix_span())
+        .zip(
+            checker
+                .facts()
+                .source_facts()
+                .shebang_not_on_first_line_fix_span(),
+        )
     {
         let preferred_newline = checker
             .facts()
+            .source_facts()
             .shebang_not_on_first_line_preferred_newline()
             .unwrap_or("\n");
         let moved_line = moved_shebang_line(fix_span.slice(source), preferred_newline);

--- a/crates/shuck-linter/src/rules/correctness/shell_quoting_reuse.rs
+++ b/crates/shuck-linter/src/rules/correctness/shell_quoting_reuse.rs
@@ -19,7 +19,11 @@ pub(crate) fn analyze_shell_quoting_reuse(checker: &Checker<'_>) -> ShellQuoting
         .iter()
         .filter_map(|binding| {
             let context = binding_assignment_context(binding.kind)?;
-            let word = checker.facts().binding_value(binding.id)?.scalar_word()?;
+            let word = checker
+                .facts()
+                .assignments()
+                .binding_value(binding.id)?
+                .scalar_word()?;
             Some(ScalarBinding {
                 id: binding.id,
                 word,
@@ -38,6 +42,7 @@ pub(crate) fn analyze_shell_quoting_reuse(checker: &Checker<'_>) -> ShellQuoting
         .filter_map(|binding| {
             let fact = checker
                 .facts()
+                .words()
                 .word_fact(binding.word.span, binding.context)?;
             fact.contains_shell_quoting_literals().then_some(binding.id)
         })
@@ -62,7 +67,7 @@ pub(crate) fn analyze_shell_quoting_reuse(checker: &Checker<'_>) -> ShellQuoting
     let mut root_cache = FxHashMap::<BindingId, FxHashSet<BindingId>>::default();
     let mut used_root_bindings = FxHashSet::default();
     let mut use_spans = Vec::new();
-    for fact in checker.facts().word_facts() {
+    for fact in checker.facts().words().word_facts() {
         let Some(context) = fact.expansion_context() else {
             continue;
         };
@@ -169,13 +174,14 @@ fn matches_sc2090_context(context: ExpansionContext) -> bool {
 fn command_is_eval(checker: &Checker<'_>, command_id: CommandId) -> bool {
     checker
         .facts()
+        .command_facts()
         .command(command_id)
         .effective_or_literal_name()
         == Some("eval")
 }
 
 fn plain_scalar_reference_bindings(word_span: Span, checker: &Checker<'_>) -> Vec<BindingId> {
-    let Some(fact) = checker.facts().any_word_fact(word_span) else {
+    let Some(fact) = checker.facts().words().any_word_fact(word_span) else {
         return Vec::new();
     };
 

--- a/crates/shuck-linter/src/rules/correctness/single_quoted_literal.rs
+++ b/crates/shuck-linter/src/rules/correctness/single_quoted_literal.rs
@@ -31,6 +31,7 @@ pub fn single_quoted_literal(checker: &mut Checker) {
     let source = checker.source();
     let diagnostics = checker
         .facts()
+        .words()
         .single_quoted_fragments()
         .iter()
         .filter_map(|fragment| {

--- a/crates/shuck-linter/src/rules/correctness/space_after_hash_bang.rs
+++ b/crates/shuck-linter/src/rules/correctness/space_after_hash_bang.rs
@@ -21,8 +21,14 @@ impl Violation for SpaceAfterHashBang {
 pub fn space_after_hash_bang(checker: &mut Checker) {
     if let Some((span, whitespace_span)) = checker
         .facts()
+        .source_facts()
         .space_after_hash_bang_span()
-        .zip(checker.facts().space_after_hash_bang_whitespace_span())
+        .zip(
+            checker
+                .facts()
+                .source_facts()
+                .space_after_hash_bang_whitespace_span(),
+        )
     {
         checker.report_diagnostic_dedup(
             crate::Diagnostic::new(SpaceAfterHashBang, span)

--- a/crates/shuck-linter/src/rules/correctness/spaced_assignment.rs
+++ b/crates/shuck-linter/src/rules/correctness/spaced_assignment.rs
@@ -24,6 +24,7 @@ pub fn spaced_assignment(checker: &mut Checker) {
     let source = checker.source();
     let diagnostics = checker
         .facts()
+        .command_facts()
         .structural_commands()
         .filter_map(|fact| fact.declaration())
         .flat_map(|declaration| spaced_assignment_diagnostics(declaration.operands, source))

--- a/crates/shuck-linter/src/rules/correctness/status_capture_after_branch_test.rs
+++ b/crates/shuck-linter/src/rules/correctness/status_capture_after_branch_test.rs
@@ -14,7 +14,7 @@ impl Violation for StatusCaptureAfterBranchTest {
 
 pub fn status_capture_after_branch_test(checker: &mut Checker) {
     checker.report_fact_slice(
-        |facts| facts.condition_status_capture_spans(),
+        |facts| facts.command_facts().condition_status_capture_spans(),
         || StatusCaptureAfterBranchTest,
     );
 }

--- a/crates/shuck-linter/src/rules/correctness/stderr_before_stdout_redirect.rs
+++ b/crates/shuck-linter/src/rules/correctness/stderr_before_stdout_redirect.rs
@@ -25,6 +25,7 @@ pub fn stderr_before_stdout_redirect(checker: &mut Checker) {
     let source = checker.source();
     let pipeline_producer_command_ids = checker
         .facts()
+        .command_facts()
         .pipelines()
         .iter()
         .flat_map(|pipeline| {
@@ -38,6 +39,7 @@ pub fn stderr_before_stdout_redirect(checker: &mut Checker) {
 
     let diagnostics = checker
         .facts()
+        .command_facts()
         .structural_commands()
         .filter(|fact| !pipeline_producer_command_ids.contains(&fact.id()))
         .flat_map(|fact| {

--- a/crates/shuck-linter/src/rules/correctness/subshell_local_assignment.rs
+++ b/crates/shuck-linter/src/rules/correctness/subshell_local_assignment.rs
@@ -21,7 +21,7 @@ impl Violation for SubshellLocalAssignment {
 
 pub fn subshell_local_assignment(checker: &mut Checker) {
     checker.report_fact_diagnostics(|facts, report| {
-        for site in facts.subshell_assignment_sites() {
+        for site in facts.assignments().subshell_assignment_sites() {
             report(Diagnostic::new(
                 SubshellLocalAssignment {
                     name: site.name.as_str().into(),

--- a/crates/shuck-linter/src/rules/correctness/subshell_side_effect.rs
+++ b/crates/shuck-linter/src/rules/correctness/subshell_side_effect.rs
@@ -21,7 +21,7 @@ impl Violation for SubshellSideEffect {
 
 pub fn subshell_side_effect(checker: &mut Checker) {
     checker.report_fact_diagnostics(|facts, report| {
-        for site in facts.subshell_later_use_sites() {
+        for site in facts.assignments().subshell_later_use_sites() {
             report(Diagnostic::new(
                 SubshellSideEffect {
                     name: site.name.as_str().into(),

--- a/crates/shuck-linter/src/rules/correctness/suspicious_bracket_glob.rs
+++ b/crates/shuck-linter/src/rules/correctness/suspicious_bracket_glob.rs
@@ -35,9 +35,16 @@ pub fn suspicious_bracket_glob(checker: &mut Checker) {
                 .is_none_or(|word| !bare_bracket_test_name(word.span.slice(source)))
         })
         .flat_map(|fact| fact.suspicious_body_name_bracket_glob_spans(source))
-        .chain(checker.facts().case_items().iter().flat_map(|item| {
-            word_spans::case_item_suspicious_bracket_glob_spans(item.item(), source)
-        }))
+        .chain(
+            checker
+                .facts()
+                .command_facts()
+                .case_items()
+                .iter()
+                .flat_map(|item| {
+                    word_spans::case_item_suspicious_bracket_glob_spans(item.item(), source)
+                }),
+        )
         .chain(
             checker
                 .facts()
@@ -54,6 +61,7 @@ pub fn suspicious_bracket_glob(checker: &mut Checker) {
         .chain(
             checker
                 .facts()
+                .words()
                 .word_facts()
                 .iter()
                 .filter(|fact| fact.host_kind() == WordFactHostKind::Direct)

--- a/crates/shuck-linter/src/rules/correctness/template_brace_in_command.rs
+++ b/crates/shuck-linter/src/rules/correctness/template_brace_in_command.rs
@@ -23,6 +23,7 @@ pub fn template_brace_in_command(checker: &mut Checker) {
         .filter_map(|command| {
             let span = command.body_word_span()?;
             let trailing_literal_char = facts
+                .words()
                 .any_word_fact(span)
                 .and_then(|word| word.trailing_literal_char());
             let suspicious_word_shape = command.body_word_contains_template_placeholder(source)

--- a/crates/shuck-linter/src/rules/correctness/tilde_in_string_comparison.rs
+++ b/crates/shuck-linter/src/rules/correctness/tilde_in_string_comparison.rs
@@ -26,6 +26,7 @@ pub fn tilde_in_string_comparison(checker: &mut Checker) {
     let source = checker.source();
     let diagnostics = checker
         .facts()
+        .words()
         .word_facts()
         .filter(|fact| fact.host_kind() == WordFactHostKind::Direct)
         .filter_map(|fact| word_fact_tilde_span(fact, source))

--- a/crates/shuck-linter/src/rules/correctness/trap_string_expansion.rs
+++ b/crates/shuck-linter/src/rules/correctness/trap_string_expansion.rs
@@ -25,6 +25,7 @@ pub fn trap_string_expansion(checker: &mut Checker) {
     let source = checker.source();
     let diagnostics = checker
         .facts()
+        .words()
         .expansion_word_facts(ExpansionContext::TrapAction)
         .filter(|fact| fact.classification().quote == WordQuote::FullyQuoted)
         .flat_map(|fact| trap_string_expansion_diagnostics(fact, source))

--- a/crates/shuck-linter/src/rules/correctness/unchecked_directory_change.rs
+++ b/crates/shuck-linter/src/rules/correctness/unchecked_directory_change.rs
@@ -32,7 +32,7 @@ pub fn unchecked_directory_change(checker: &mut Checker) {
 pub(crate) fn unchecked_directory_change_spans(checker: &mut Checker) -> Vec<(&'static str, Span)> {
     let semantic = checker.semantic();
     let source = checker.source();
-    let errexit_enabled_somewhere = checker.facts().errexit_enabled_anywhere();
+    let errexit_enabled_somewhere = checker.facts().source_facts().errexit_enabled_anywhere();
     checker
         .facts()
         .commands()

--- a/crates/shuck-linter/src/rules/correctness/unchecked_directory_change_in_function.rs
+++ b/crates/shuck-linter/src/rules/correctness/unchecked_directory_change_in_function.rs
@@ -27,7 +27,7 @@ impl Violation for UncheckedDirectoryChangeInFunction {
 
 pub fn unchecked_directory_change_in_function(checker: &mut Checker) {
     if !supports_directory_change_rules(checker.shell())
-        || checker.facts().errexit_enabled_anywhere()
+        || checker.facts().source_facts().errexit_enabled_anywhere()
     {
         return;
     }
@@ -83,12 +83,15 @@ pub fn unchecked_directory_change_in_function(checker: &mut Checker) {
 }
 
 fn nearest_dominance_barrier(facts: &LinterFacts<'_>, id: CommandId) -> Option<CommandId> {
-    let mut parent = facts.command_parent_id(id);
+    let mut parent = facts.command_facts().command_parent_id(id);
     while let Some(parent_id) = parent {
-        if facts.command_is_dominance_barrier(parent_id) {
+        if facts
+            .command_facts()
+            .command_is_dominance_barrier(parent_id)
+        {
             return Some(parent_id);
         }
-        parent = facts.command_parent_id(parent_id);
+        parent = facts.command_facts().command_parent_id(parent_id);
     }
     None
 }

--- a/crates/shuck-linter/src/rules/correctness/undefined_variable.rs
+++ b/crates/shuck-linter/src/rules/correctness/undefined_variable.rs
@@ -53,12 +53,14 @@ pub fn undefined_variable(checker: &mut Checker) {
         }
         if checker
             .facts()
+            .words()
             .is_suppressed_subscript_reference(reference.span)
         {
             continue;
         }
         if checker
             .facts()
+            .source_facts()
             .is_backtick_double_escaped_parameter_reference(reference.span)
         {
             continue;
@@ -99,7 +101,12 @@ fn is_zsh_completion_context_reference(checker: &Checker<'_>, reference: &Refere
         && checker
             .semantic_analysis()
             .enclosing_function_scope_at(reference.span.start.offset)
-            .is_some_and(|scope| checker.facts().function_is_completion_registered(scope))
+            .is_some_and(|scope| {
+                checker
+                    .facts()
+                    .command_facts()
+                    .function_is_completion_registered(scope)
+            })
 }
 
 fn is_zsh_completion_context_name(name: &str) -> bool {

--- a/crates/shuck-linter/src/rules/correctness/unicode_quote_in_string.rs
+++ b/crates/shuck-linter/src/rules/correctness/unicode_quote_in_string.rs
@@ -21,7 +21,7 @@ impl Violation for UnicodeQuoteInString {
 pub fn unicode_quote_in_string(checker: &mut Checker) {
     let source = checker.source();
     checker.report_fact_diagnostics_dedup(|facts, report| {
-        for span in facts.unicode_smart_quote_spans().iter().copied() {
+        for span in facts.words().unicode_smart_quote_spans().iter().copied() {
             report(
                 Diagnostic::new(UnicodeQuoteInString, span).with_fix(Fix::unsafe_edit(
                     Edit::replacement(ascii_quote_replacement(span.slice(source)), span),

--- a/crates/shuck-linter/src/rules/correctness/unicode_single_quote_in_single_quotes.rs
+++ b/crates/shuck-linter/src/rules/correctness/unicode_single_quote_in_single_quotes.rs
@@ -22,6 +22,7 @@ pub fn unicode_single_quote_in_single_quotes(checker: &mut Checker) {
     let source = checker.source();
     let diagnostics = checker
         .facts()
+        .words()
         .single_quoted_fragments()
         .iter()
         .flat_map(|fragment| {

--- a/crates/shuck-linter/src/rules/correctness/unquoted_globs_in_find.rs
+++ b/crates/shuck-linter/src/rules/correctness/unquoted_globs_in_find.rs
@@ -40,6 +40,7 @@ pub fn unquoted_globs_in_find(checker: &mut Checker) {
 
     let diagnostics = checker
         .facts()
+        .words()
         .expansion_word_facts(ExpansionContext::CommandArgument)
         .filter(|fact| find_exec_argument_words.contains(&(fact.command_id(), fact.key())))
         .flat_map(|fact| diagnostics_for_find_exec_argument(source, fact))

--- a/crates/shuck-linter/src/rules/correctness/unquoted_grep_regex.rs
+++ b/crates/shuck-linter/src/rules/correctness/unquoted_grep_regex.rs
@@ -29,12 +29,14 @@ pub fn unquoted_grep_regex(checker: &mut Checker) {
         .flat_map(|grep| grep.patterns().iter())
         .filter(|pattern| {
             facts
+                .words()
                 .any_word_fact(pattern.word().span)
                 .is_some_and(|fact| !fact.active_literal_glob_spans(source).is_empty())
         })
         .map(|pattern| {
             let span = pattern.span();
             let replacement = facts
+                .words()
                 .any_word_fact(span)
                 .expect("grep pattern span should map to a word fact")
                 .single_double_quoted_replacement(source);

--- a/crates/shuck-linter/src/rules/correctness/unreachable_after_exit.rs
+++ b/crates/shuck-linter/src/rules/correctness/unreachable_after_exit.rs
@@ -28,7 +28,7 @@ impl Violation for UnreachableAfterExit {
 
 pub fn unreachable_after_exit(checker: &mut Checker) {
     let source = checker.source();
-    let short_circuit_lists = checker.facts().lists();
+    let short_circuit_lists = checker.facts().command_facts().lists();
     let commands = checker.facts().commands();
     let semantic_analysis = checker.semantic_analysis();
     let unreached_function_spans = unreached_function_definition_spans(checker);
@@ -88,6 +88,7 @@ fn statically_unreached_function_definition_spans(checker: &Checker<'_>) -> Vec<
 
     checker
         .facts()
+        .command_facts()
         .function_headers()
         .iter()
         .filter_map(|header| {
@@ -191,6 +192,7 @@ fn static_call_can_resolve_at_entry(
 fn function_bindings_by_scope(checker: &Checker<'_>) -> FxHashMap<ScopeId, BindingId> {
     checker
         .facts()
+        .command_facts()
         .function_headers()
         .iter()
         .filter_map(|header| Some((header.function_scope()?, header.binding_id()?)))
@@ -248,7 +250,11 @@ fn file_has_file_scope_exit(checker: &Checker<'_>) -> bool {
 fn file_has_top_level_exit_command(checker: &Checker<'_>) -> bool {
     checker.facts().commands().iter().any(|command| {
         command.effective_or_literal_name() == Some("exit")
-            && checker.facts().command_parent_id(command.id()).is_none()
+            && checker
+                .facts()
+                .command_facts()
+                .command_parent_id(command.id())
+                .is_none()
             && checker
                 .semantic()
                 .flow_context_at(&command.stmt().span)

--- a/crates/shuck-linter/src/rules/correctness/unset_associative_array_element.rs
+++ b/crates/shuck-linter/src/rules/correctness/unset_associative_array_element.rs
@@ -25,6 +25,7 @@ pub fn unset_associative_array_element(checker: &mut Checker) {
 
     for fact in checker
         .facts()
+        .command_facts()
         .structural_commands()
         .filter(|fact| fact.effective_name_is("unset"))
     {

--- a/crates/shuck-linter/src/rules/correctness/unused_assignment.rs
+++ b/crates/shuck-linter/src/rules/correctness/unused_assignment.rs
@@ -338,18 +338,25 @@ fn loop_keyword_report_span(
     checker: &Checker<'_>,
     definition_span: shuck_ast::Span,
 ) -> Option<shuck_ast::Span> {
-    if let Some(header) = checker.facts().for_headers().iter().find(|header| {
-        header
-            .command()
-            .targets
-            .iter()
-            .any(|target| target.span == definition_span)
-    }) {
+    if let Some(header) = checker
+        .facts()
+        .command_facts()
+        .for_headers()
+        .iter()
+        .find(|header| {
+            header
+                .command()
+                .targets
+                .iter()
+                .any(|target| target.span == definition_span)
+        })
+    {
         return Some(keyword_span(header.command().span, "for"));
     }
 
     checker
         .facts()
+        .command_facts()
         .select_headers()
         .iter()
         .find(|header| header.command().variable_span == definition_span)

--- a/crates/shuck-linter/src/rules/correctness/unused_heredoc.rs
+++ b/crates/shuck-linter/src/rules/correctness/unused_heredoc.rs
@@ -22,7 +22,11 @@ impl Violation for UnusedHeredoc {
 
 pub fn unused_heredoc(checker: &mut Checker) {
     let locator = checker.locator();
-    let spans = checker.facts().unused_heredoc_spans().to_vec();
+    let spans = checker
+        .facts()
+        .source_facts()
+        .unused_heredoc_spans()
+        .to_vec();
     for span in spans {
         let mut diagnostic = Diagnostic::new(UnusedHeredoc, span);
         if let Some(fix) = unused_heredoc_fix(locator, span) {

--- a/crates/shuck-linter/src/rules/correctness/variable_reference_common.rs
+++ b/crates/shuck-linter/src/rules/correctness/variable_reference_common.rs
@@ -29,12 +29,14 @@ pub(super) fn is_reportable_variable_reference(
     }
     if checker
         .facts()
+        .assignments()
         .is_c006_presence_tested_name(&reference.name, reference.span)
     {
         return false;
     }
     if checker
         .facts()
+        .words()
         .is_suppressed_subscript_reference(reference.span)
     {
         return false;
@@ -47,6 +49,7 @@ pub(super) fn is_reportable_variable_reference(
             .is_defaulting_parameter_operand_reference(reference.id)
         || checker
             .facts()
+            .assignments()
             .has_prior_c006_suppressing_reference(&reference.name, reference.span)
     {
         return false;

--- a/crates/shuck-linter/src/rules/performance/grep_count_pipeline.rs
+++ b/crates/shuck-linter/src/rules/performance/grep_count_pipeline.rs
@@ -25,6 +25,7 @@ impl Violation for GrepCountPipeline {
 pub fn grep_count_pipeline(checker: &mut Checker) {
     let reports = checker
         .facts()
+        .command_facts()
         .pipelines()
         .iter()
         .flat_map(|pipeline| unsafe_grep_count_pipeline_reports(checker, pipeline))
@@ -55,8 +56,14 @@ fn unsafe_grep_count_pipeline_reports(
         .filter_map(|(pair, operator)| {
             let left_segment = &pair[0];
             let right_segment = &pair[1];
-            let left = checker.facts().command(left_segment.command_id());
-            let right = checker.facts().command(right_segment.command_id());
+            let left = checker
+                .facts()
+                .command_facts()
+                .command(left_segment.command_id());
+            let right = checker
+                .facts()
+                .command_facts()
+                .command(right_segment.command_id());
 
             if !is_raw_utility_named(left, "grep") || !is_raw_utility_named(right, "wc") {
                 return None;

--- a/crates/shuck-linter/src/rules/performance/single_test_subshell.rs
+++ b/crates/shuck-linter/src/rules/performance/single_test_subshell.rs
@@ -22,7 +22,11 @@ impl Violation for SingleTestSubshell {
 
 pub fn single_test_subshell(checker: &mut Checker) {
     let source = checker.source();
-    let spans = checker.facts().single_test_subshell_spans().to_vec();
+    let spans = checker
+        .facts()
+        .command_facts()
+        .single_test_subshell_spans()
+        .to_vec();
     for span in spans {
         checker.report_diagnostic_dedup(
             Diagnostic::new(SingleTestSubshell, span)

--- a/crates/shuck-linter/src/rules/performance/subshell_test_group.rs
+++ b/crates/shuck-linter/src/rules/performance/subshell_test_group.rs
@@ -22,9 +22,10 @@ impl Violation for SubshellTestGroup {
 
 pub fn subshell_test_group(checker: &mut Checker) {
     let source = checker.source();
-    let single_test_spans = checker.facts().single_test_subshell_spans();
+    let single_test_spans = checker.facts().command_facts().single_test_subshell_spans();
     let spans = checker
         .facts()
+        .command_facts()
         .subshell_test_group_spans()
         .iter()
         .copied()

--- a/crates/shuck-linter/src/rules/portability/ansi_c_quoting.rs
+++ b/crates/shuck-linter/src/rules/portability/ansi_c_quoting.rs
@@ -28,6 +28,7 @@ pub fn ansi_c_quoting(checker: &mut Checker) {
 
     let spans = checker
         .facts()
+        .words()
         .single_quoted_fragments()
         .iter()
         .filter(|fragment| fragment.dollar_quoted())

--- a/crates/shuck-linter/src/rules/portability/array_keys_in_sh.rs
+++ b/crates/shuck-linter/src/rules/portability/array_keys_in_sh.rs
@@ -19,6 +19,7 @@ pub fn array_keys_in_sh(checker: &mut Checker) {
 
     let spans = checker
         .facts()
+        .words()
         .indirect_expansion_fragments()
         .iter()
         .filter(|fragment| fragment.array_keys())

--- a/crates/shuck-linter/src/rules/portability/array_reference.rs
+++ b/crates/shuck-linter/src/rules/portability/array_reference.rs
@@ -19,6 +19,7 @@ pub fn array_reference(checker: &mut Checker) {
 
     let spans = checker
         .facts()
+        .words()
         .indexed_array_reference_fragments()
         .iter()
         .filter_map(|fragment| match fragment {

--- a/crates/shuck-linter/src/rules/portability/base_prefix_in_arithmetic.rs
+++ b/crates/shuck-linter/src/rules/portability/base_prefix_in_arithmetic.rs
@@ -31,6 +31,7 @@ pub fn base_prefix_in_arithmetic(checker: &mut Checker) {
     let source = checker.source();
     let diagnostics = checker
         .facts()
+        .words()
         .arithmetic_literal_facts()
         .iter()
         .filter_map(|fact| {

--- a/crates/shuck-linter/src/rules/portability/bash_case_fallthrough.rs
+++ b/crates/shuck-linter/src/rules/portability/bash_case_fallthrough.rs
@@ -24,6 +24,7 @@ pub fn bash_case_fallthrough(checker: &mut Checker) {
 
     let spans = checker
         .facts()
+        .command_facts()
         .case_items()
         .iter()
         .filter(|item| {

--- a/crates/shuck-linter/src/rules/portability/brace_expansion.rs
+++ b/crates/shuck-linter/src/rules/portability/brace_expansion.rs
@@ -19,6 +19,7 @@ pub fn brace_expansion(checker: &mut Checker) {
 
     let spans = checker
         .facts()
+        .words()
         .word_facts()
         .iter()
         .filter(|fact| {

--- a/crates/shuck-linter/src/rules/portability/c_style_for_arithmetic_in_sh.rs
+++ b/crates/shuck-linter/src/rules/portability/c_style_for_arithmetic_in_sh.rs
@@ -26,10 +26,16 @@ pub fn c_style_for_arithmetic_in_sh(checker: &mut Checker) {
     let source = checker.source();
     checker.report_fact_diagnostics(|facts, report| {
         let mut fix_facts = facts
+            .words()
             .arithmetic_update_operator_fix_facts()
             .iter()
             .peekable();
-        for span in facts.arithmetic_update_operator_spans().iter().copied() {
+        for span in facts
+            .words()
+            .arithmetic_update_operator_spans()
+            .iter()
+            .copied()
+        {
             let diagnostic = Diagnostic::new(CStyleForArithmeticInSh, span);
             let diagnostic = if fix_facts
                 .peek()

--- a/crates/shuck-linter/src/rules/portability/conditional_portability.rs
+++ b/crates/shuck-linter/src/rules/portability/conditional_portability.rs
@@ -199,7 +199,13 @@ macro_rules! cached_portability_rule {
 
             checker.report_fact_spans_dedup(
                 |facts, report| {
-                    for span in facts.conditional_portability().$accessor().iter().copied() {
+                    for span in facts
+                        .compat()
+                        .conditional_portability()
+                        .$accessor()
+                        .iter()
+                        .copied()
+                    {
                         report(span);
                     }
                 },
@@ -234,6 +240,7 @@ pub fn extglob_in_test(checker: &mut Checker) {
     checker.report_fact_spans_dedup(
         |facts, report| {
             for span in facts
+                .compat()
                 .conditional_portability()
                 .extglob_in_test()
                 .iter()
@@ -272,6 +279,7 @@ pub fn test_equality_operator(checker: &mut Checker) {
     let source = checker.source();
     let diagnostics = checker
         .facts()
+        .compat()
         .conditional_portability()
         .test_equality_operator()
         .iter()
@@ -298,6 +306,7 @@ pub fn caret_negation_in_bracket(checker: &mut Checker) {
 
     let diagnostics = checker
         .facts()
+        .compat()
         .conditional_portability()
         .caret_negation_in_bracket()
         .iter()
@@ -324,6 +333,7 @@ pub fn a_test_in_sh(checker: &mut Checker) {
 
     let diagnostics = checker
         .facts()
+        .compat()
         .conditional_portability()
         .a_test_in_sh()
         .iter()

--- a/crates/shuck-linter/src/rules/portability/csh_syntax_in_sh.rs
+++ b/crates/shuck-linter/src/rules/portability/csh_syntax_in_sh.rs
@@ -22,6 +22,7 @@ pub fn csh_syntax_in_sh(checker: &mut Checker) {
 
     let spans = checker
         .facts()
+        .command_facts()
         .structural_commands()
         .filter(|fact| fact.effective_name_is("set"))
         .filter_map(|fact| {

--- a/crates/shuck-linter/src/rules/portability/dollar_string_in_sh.rs
+++ b/crates/shuck-linter/src/rules/portability/dollar_string_in_sh.rs
@@ -29,6 +29,7 @@ pub fn dollar_string_in_sh(checker: &mut Checker) {
 
     let spans = checker
         .facts()
+        .words()
         .dollar_double_quoted_fragments()
         .iter()
         .map(|fragment| fragment.span())

--- a/crates/shuck-linter/src/rules/portability/echo_backslash_escapes.rs
+++ b/crates/shuck-linter/src/rules/portability/echo_backslash_escapes.rs
@@ -21,7 +21,7 @@ pub fn echo_backslash_escapes(checker: &mut Checker) {
     }
 
     checker.report_fact_slice_dedup(
-        |facts| facts.echo_backslash_escape_word_spans(),
+        |facts| facts.words().echo_backslash_escape_word_spans(),
         || EchoBackslashEscapes,
     );
 }

--- a/crates/shuck-linter/src/rules/portability/function_keyword.rs
+++ b/crates/shuck-linter/src/rules/portability/function_keyword.rs
@@ -19,6 +19,7 @@ pub fn function_keyword(checker: &mut Checker) {
 
     let spans = checker
         .facts()
+        .command_facts()
         .function_headers()
         .iter()
         .filter(|header| header.uses_function_keyword() && !header.has_trailing_parens())

--- a/crates/shuck-linter/src/rules/portability/function_keyword_in_sh.rs
+++ b/crates/shuck-linter/src/rules/portability/function_keyword_in_sh.rs
@@ -27,6 +27,7 @@ pub fn function_keyword_in_sh(checker: &mut Checker) {
 
     let diagnostics = checker
         .facts()
+        .command_facts()
         .function_headers()
         .iter()
         .filter(|header| header.uses_function_keyword() && header.has_trailing_parens())

--- a/crates/shuck-linter/src/rules/portability/function_params_in_sh.rs
+++ b/crates/shuck-linter/src/rules/portability/function_params_in_sh.rs
@@ -21,7 +21,7 @@ pub fn function_params_in_sh(checker: &mut Checker) {
     }
 
     checker.report_fact_slice_dedup(
-        |facts| facts.function_parameter_fallback_spans(),
+        |facts| facts.command_facts().function_parameter_fallback_spans(),
         || FunctionParamsInSh,
     );
 }

--- a/crates/shuck-linter/src/rules/portability/hyphenated_function_name.rs
+++ b/crates/shuck-linter/src/rules/portability/hyphenated_function_name.rs
@@ -28,6 +28,7 @@ pub fn hyphenated_function_name(checker: &mut Checker) {
     let source = checker.source();
     let diagnostics = checker
         .facts()
+        .command_facts()
         .function_headers()
         .iter()
         .flat_map(|header| {

--- a/crates/shuck-linter/src/rules/portability/indirect_expansion.rs
+++ b/crates/shuck-linter/src/rules/portability/indirect_expansion.rs
@@ -19,6 +19,7 @@ pub fn indirect_expansion(checker: &mut Checker) {
 
     let spans = checker
         .facts()
+        .words()
         .indirect_expansion_fragments()
         .iter()
         .map(|fragment| fragment.span())

--- a/crates/shuck-linter/src/rules/portability/legacy_arithmetic_in_sh.rs
+++ b/crates/shuck-linter/src/rules/portability/legacy_arithmetic_in_sh.rs
@@ -28,6 +28,7 @@ pub fn legacy_arithmetic_in_sh(checker: &mut Checker) {
     let source = checker.source();
     let diagnostics = checker
         .facts()
+        .words()
         .legacy_arithmetic_fragments()
         .iter()
         .filter_map(|fragment| legacy_arithmetic_fix(fragment.span(), source))

--- a/crates/shuck-linter/src/rules/portability/multi_var_for_loop.rs
+++ b/crates/shuck-linter/src/rules/portability/multi_var_for_loop.rs
@@ -20,6 +20,7 @@ pub fn multi_var_for_loop(checker: &mut Checker) {
 
     let spans = checker
         .facts()
+        .command_facts()
         .for_headers()
         .iter()
         .filter_map(|fact| fact.command().targets.get(1).map(|target| target.span))

--- a/crates/shuck-linter/src/rules/portability/nested_zsh_substitution.rs
+++ b/crates/shuck-linter/src/rules/portability/nested_zsh_substitution.rs
@@ -20,6 +20,7 @@ pub fn nested_zsh_substitution(checker: &mut Checker) {
 
     let spans = checker
         .facts()
+        .words()
         .word_facts()
         .iter()
         .flat_map(|fact| fact.nested_zsh_substitution_spans())

--- a/crates/shuck-linter/src/rules/portability/pipe_stderr_in_sh.rs
+++ b/crates/shuck-linter/src/rules/portability/pipe_stderr_in_sh.rs
@@ -25,6 +25,7 @@ pub fn pipe_stderr_in_sh(checker: &mut Checker) {
 
     let diagnostics = checker
         .facts()
+        .command_facts()
         .pipelines()
         .iter()
         .flat_map(|pipeline| pipeline.operators().iter())

--- a/crates/shuck-linter/src/rules/portability/plus_equals_append.rs
+++ b/crates/shuck-linter/src/rules/portability/plus_equals_append.rs
@@ -21,7 +21,7 @@ pub fn plus_equals_append(checker: &mut Checker) {
     }
 
     checker.report_fact_slice_dedup(
-        |facts| facts.plus_equals_assignment_spans(),
+        |facts| facts.assignments().plus_equals_assignment_spans(),
         || PlusEqualsAppend,
     );
 }

--- a/crates/shuck-linter/src/rules/portability/replacement_expansion.rs
+++ b/crates/shuck-linter/src/rules/portability/replacement_expansion.rs
@@ -19,6 +19,7 @@ pub fn replacement_expansion(checker: &mut Checker) {
 
     let spans = checker
         .facts()
+        .words()
         .replacement_expansion_fragments()
         .iter()
         .map(|fragment| fragment.span())

--- a/crates/shuck-linter/src/rules/portability/select_loop.rs
+++ b/crates/shuck-linter/src/rules/portability/select_loop.rs
@@ -21,6 +21,7 @@ pub fn select_loop(checker: &mut Checker) {
 
     let spans = checker
         .facts()
+        .command_facts()
         .select_headers()
         .iter()
         .map(|header| keyword_span(header.span(), "select"))

--- a/crates/shuck-linter/src/rules/portability/star_glob_removal_in_sh.rs
+++ b/crates/shuck-linter/src/rules/portability/star_glob_removal_in_sh.rs
@@ -19,6 +19,7 @@ pub fn star_glob_removal_in_sh(checker: &mut Checker) {
 
     let spans = checker
         .facts()
+        .words()
         .positional_parameter_trim_fragments()
         .iter()
         .map(|fragment| fragment.span())

--- a/crates/shuck-linter/src/rules/portability/substring_expansion.rs
+++ b/crates/shuck-linter/src/rules/portability/substring_expansion.rs
@@ -19,6 +19,7 @@ pub fn substring_expansion(checker: &mut Checker) {
 
     let spans = checker
         .facts()
+        .words()
         .substring_expansion_fragments()
         .iter()
         .map(|fragment| fragment.span())

--- a/crates/shuck-linter/src/rules/portability/unset_pattern_in_sh.rs
+++ b/crates/shuck-linter/src/rules/portability/unset_pattern_in_sh.rs
@@ -24,6 +24,7 @@ pub fn unset_pattern_in_sh(checker: &mut Checker) {
 
     let spans = checker
         .facts()
+        .command_facts()
         .structural_commands()
         .filter(|fact| fact.effective_name_is("unset"))
         .filter_map(|fact| fact.options().unset())

--- a/crates/shuck-linter/src/rules/portability/uppercase_expansion.rs
+++ b/crates/shuck-linter/src/rules/portability/uppercase_expansion.rs
@@ -19,6 +19,7 @@ pub fn uppercase_expansion(checker: &mut Checker) {
 
     let spans = checker
         .facts()
+        .words()
         .case_modification_fragments()
         .iter()
         .map(|fragment| fragment.span())

--- a/crates/shuck-linter/src/rules/portability/zsh_array_subscript_in_case.rs
+++ b/crates/shuck-linter/src/rules/portability/zsh_array_subscript_in_case.rs
@@ -19,7 +19,7 @@ pub fn zsh_array_subscript_in_case(checker: &mut Checker) {
     }
 
     checker.report_fact_slice_dedup(
-        |facts| facts.case_pattern_impossible_spans(),
+        |facts| facts.command_facts().case_pattern_impossible_spans(),
         || ZshArraySubscriptInCase,
     );
 }

--- a/crates/shuck-linter/src/rules/portability/zsh_flag_expansion.rs
+++ b/crates/shuck-linter/src/rules/portability/zsh_flag_expansion.rs
@@ -20,6 +20,7 @@ pub fn zsh_flag_expansion(checker: &mut Checker) {
 
     let spans = checker
         .facts()
+        .words()
         .word_facts()
         .iter()
         .flat_map(|fact| fact.zsh_flag_modifier_spans())

--- a/crates/shuck-linter/src/rules/portability/zsh_nested_expansion.rs
+++ b/crates/shuck-linter/src/rules/portability/zsh_nested_expansion.rs
@@ -20,6 +20,7 @@ pub fn zsh_nested_expansion(checker: &mut Checker) {
 
     let spans = checker
         .facts()
+        .words()
         .word_facts()
         .iter()
         .flat_map(|fact| fact.zsh_nested_expansion_spans())

--- a/crates/shuck-linter/src/rules/portability/zsh_parameter_flag.rs
+++ b/crates/shuck-linter/src/rules/portability/zsh_parameter_flag.rs
@@ -22,6 +22,7 @@ pub fn zsh_parameter_flag(checker: &mut Checker) {
 
     let spans = checker
         .facts()
+        .words()
         .word_facts()
         .iter()
         .flat_map(|fact| parameter_flag_spans(fact.span().slice(checker.source()), fact.span()))

--- a/crates/shuck-linter/src/rules/portability/zsh_parameter_index_flag.rs
+++ b/crates/shuck-linter/src/rules/portability/zsh_parameter_index_flag.rs
@@ -20,6 +20,7 @@ pub fn zsh_parameter_index_flag(checker: &mut Checker) {
 
     let spans = checker
         .facts()
+        .words()
         .zsh_parameter_index_flag_fragments()
         .iter()
         .map(|fragment| fragment.span())

--- a/crates/shuck-linter/src/rules/portability/zsh_prompt_bracket.rs
+++ b/crates/shuck-linter/src/rules/portability/zsh_prompt_bracket.rs
@@ -22,6 +22,7 @@ pub fn zsh_prompt_bracket(checker: &mut Checker) {
 
     let spans = checker
         .facts()
+        .words()
         .word_facts()
         .iter()
         .flat_map(|fact| prompt_bracket_spans(fact.span().slice(checker.source()), fact.span()))

--- a/crates/shuck-linter/src/rules/security/eval_on_array.rs
+++ b/crates/shuck-linter/src/rules/security/eval_on_array.rs
@@ -16,11 +16,13 @@ pub fn eval_on_array(checker: &mut Checker) {
     let locator = checker.locator();
     let command_arg_facts = checker
         .facts()
+        .words()
         .expansion_word_facts(ExpansionContext::CommandArgument)
         .collect::<Vec<_>>();
 
     let spans = checker
         .facts()
+        .command_facts()
         .structural_commands()
         .filter(|fact| fact.effective_name_is("eval"))
         .flat_map(|command| command.body_args())

--- a/crates/shuck-linter/src/rules/security/find_execdir_with_shell.rs
+++ b/crates/shuck-linter/src/rules/security/find_execdir_with_shell.rs
@@ -16,6 +16,7 @@ impl Violation for FindExecDirWithShell {
 pub fn find_execdir_with_shell(checker: &mut Checker) {
     let spans = checker
         .facts()
+        .command_facts()
         .structural_commands()
         .filter_map(|fact| fact.options().find_exec_shell())
         .flat_map(|fact| fact.shell_command_spans().iter().copied())

--- a/crates/shuck-linter/src/rules/security/rm_glob_on_variable_path.rs
+++ b/crates/shuck-linter/src/rules/security/rm_glob_on_variable_path.rs
@@ -18,6 +18,7 @@ pub fn rm_glob_on_variable_path(checker: &mut Checker) {
     let source = checker.source();
     let reportable_word_spans = checker
         .facts()
+        .words()
         .expansion_word_facts(ExpansionContext::CommandArgument)
         .filter(|fact| fact.host_kind() == WordFactHostKind::Direct)
         .filter(|fact| {
@@ -30,6 +31,7 @@ pub fn rm_glob_on_variable_path(checker: &mut Checker) {
 
     let spans = checker
         .facts()
+        .command_facts()
         .structural_commands()
         .filter(|fact| fact.effective_name_is("rm"))
         .filter_map(|fact| fact.options().rm().map(|rm| (fact.id(), rm)))

--- a/crates/shuck-linter/src/rules/style/ampersand_semicolon.rs
+++ b/crates/shuck-linter/src/rules/style/ampersand_semicolon.rs
@@ -20,7 +20,12 @@ impl Violation for AmpersandSemicolon {
 
 pub fn ampersand_semicolon(checker: &mut Checker) {
     checker.report_fact_diagnostics_dedup(|facts, report| {
-        for span in facts.background_semicolon_spans().iter().copied() {
+        for span in facts
+            .command_facts()
+            .background_semicolon_spans()
+            .iter()
+            .copied()
+        {
             report(
                 Diagnostic::new(AmpersandSemicolon, span)
                     .with_fix(Fix::safe_edit(Edit::deletion(span))),

--- a/crates/shuck-linter/src/rules/style/arithmetic_score_line.rs
+++ b/crates/shuck-linter/src/rules/style/arithmetic_score_line.rs
@@ -24,6 +24,7 @@ pub fn arithmetic_score_line(checker: &mut Checker) {
     let source = checker.source();
     let diagnostics = checker
         .facts()
+        .words()
         .arithmetic_score_line_spans()
         .iter()
         .copied()

--- a/crates/shuck-linter/src/rules/style/array_index_arithmetic.rs
+++ b/crates/shuck-linter/src/rules/style/array_index_arithmetic.rs
@@ -23,7 +23,7 @@ impl Violation for ArrayIndexArithmetic {
 pub fn array_index_arithmetic(checker: &mut Checker) {
     let source = checker.source();
     checker.report_fact_diagnostics_dedup(|facts, report| {
-        for span in facts.array_index_arithmetic_spans().iter().copied() {
+        for span in facts.words().array_index_arithmetic_spans().iter().copied() {
             if let Some(fix) = array_index_arithmetic_fix(span, source) {
                 report(Diagnostic::new(ArrayIndexArithmetic, span).with_fix(fix));
             }

--- a/crates/shuck-linter/src/rules/style/bare_command_name_assignment.rs
+++ b/crates/shuck-linter/src/rules/style/bare_command_name_assignment.rs
@@ -24,7 +24,12 @@ impl Violation for BareCommandNameAssignment {
 pub fn bare_command_name_assignment(checker: &mut Checker) {
     let source = checker.source();
     checker.report_fact_diagnostics_dedup(|facts, report| {
-        for span in facts.bare_command_name_assignment_spans().iter().copied() {
+        for span in facts
+            .command_facts()
+            .bare_command_name_assignment_spans()
+            .iter()
+            .copied()
+        {
             let diagnostic = Diagnostic::new(BareCommandNameAssignment, span);
             report(match quote_assignment_value_fix(span, source) {
                 Some(fix) => diagnostic.with_fix(fix),

--- a/crates/shuck-linter/src/rules/style/bare_read.rs
+++ b/crates/shuck-linter/src/rules/style/bare_read.rs
@@ -19,6 +19,7 @@ pub fn bare_read(checker: &mut Checker) {
 
     let spans = checker
         .facts()
+        .command_facts()
         .structural_commands()
         .filter(|fact| fact.effective_name_is("read"))
         .filter(|fact| fact.wrappers().is_empty())

--- a/crates/shuck-linter/src/rules/style/brace_variable_before_bracket.rs
+++ b/crates/shuck-linter/src/rules/style/brace_variable_before_bracket.rs
@@ -28,6 +28,7 @@ pub fn brace_variable_before_bracket(checker: &mut Checker) {
     let source = checker.source();
     let diagnostics = checker
         .facts()
+        .words()
         .brace_variable_before_bracket_spans()
         .iter()
         .copied()

--- a/crates/shuck-linter/src/rules/style/combine_appends.rs
+++ b/crates/shuck-linter/src/rules/style/combine_appends.rs
@@ -19,12 +19,13 @@ pub fn combine_appends(checker: &mut Checker) {
     let mut bodies: FxHashMap<FactSpan, Vec<StatementFact>> = FxHashMap::default();
     let case_item_body_spans = checker
         .facts()
+        .command_facts()
         .case_items()
         .iter()
         .map(|item| FactSpan::new(item.item().body.span))
         .collect::<FxHashSet<_>>();
 
-    for fact in checker.facts().statement_facts() {
+    for fact in checker.facts().command_facts().statement_facts() {
         if case_item_body_spans.contains(&FactSpan::new(fact.body_span())) {
             continue;
         }
@@ -158,7 +159,10 @@ fn commands_for_statement<'checker, 'ast>(
     checker: &'checker Checker<'ast>,
     statement: &StatementFact,
 ) -> Vec<crate::CommandFactRef<'checker, 'ast>> {
-    let command = checker.facts().command(statement.command_id());
+    let command = checker
+        .facts()
+        .command_facts()
+        .command(statement.command_id());
     let mut command_ids = FxHashSet::default();
     let mut commands = Vec::new();
 
@@ -167,13 +171,19 @@ fn commands_for_statement<'checker, 'ast>(
 
     if let Some(pipeline) = checker
         .facts()
+        .command_facts()
         .pipelines()
         .iter()
         .find(|pipeline| pipeline.span() == command.span())
     {
         for segment in pipeline.segments() {
             if command_ids.insert(segment.command_id()) {
-                commands.push(checker.facts().command(segment.command_id()));
+                commands.push(
+                    checker
+                        .facts()
+                        .command_facts()
+                        .command(segment.command_id()),
+                );
             }
         }
     }

--- a/crates/shuck-linter/src/rules/style/command_output_array_split.rs
+++ b/crates/shuck-linter/src/rules/style/command_output_array_split.rs
@@ -24,6 +24,7 @@ pub fn command_output_array_split(checker: &mut Checker) {
     let source = checker.source();
     let diagnostics = checker
         .facts()
+        .words()
         .array_assignment_split_word_facts()
         .flat_map(|fact| {
             fact.split_sensitive_unquoted_command_substitution_spans()

--- a/crates/shuck-linter/src/rules/style/command_substitution_in_alias.rs
+++ b/crates/shuck-linter/src/rules/style/command_substitution_in_alias.rs
@@ -14,7 +14,7 @@ impl Violation for CommandSubstitutionInAlias {
 
 pub fn command_substitution_in_alias(checker: &mut Checker) {
     checker.report_fact_slice_dedup(
-        |facts| facts.alias_definition_expansion_spans(),
+        |facts| facts.command_facts().alias_definition_expansion_spans(),
         || CommandSubstitutionInAlias,
     );
 }

--- a/crates/shuck-linter/src/rules/style/default_value_in_colon_assign.rs
+++ b/crates/shuck-linter/src/rules/style/default_value_in_colon_assign.rs
@@ -34,6 +34,7 @@ pub fn default_value_in_colon_assign(checker: &mut Checker) {
     let source = checker.source();
     let diagnostics = checker
         .facts()
+        .words()
         .expansion_word_facts(ExpansionContext::CommandArgument)
         .filter(|fact| colon_command_ids.contains(&fact.command_id()))
         .flat_map(|fact| fact.unquoted_assign_default_spans())

--- a/crates/shuck-linter/src/rules/style/dollar_in_arithmetic.rs
+++ b/crates/shuck-linter/src/rules/style/dollar_in_arithmetic.rs
@@ -24,6 +24,7 @@ pub fn dollar_in_arithmetic(checker: &mut Checker) {
     let source = checker.source();
     let diagnostics = checker
         .facts()
+        .words()
         .dollar_in_arithmetic_spans()
         .iter()
         .copied()

--- a/crates/shuck-linter/src/rules/style/double_quote_nesting.rs
+++ b/crates/shuck-linter/src/rules/style/double_quote_nesting.rs
@@ -29,20 +29,24 @@ pub fn double_quote_nesting(checker: &mut Checker) {
     let source = checker.source();
     let diagnostics = checker
         .facts()
+        .words()
         .expansion_word_facts(ExpansionContext::CommandName)
         .chain(
             checker
                 .facts()
+                .words()
                 .expansion_word_facts(ExpansionContext::CommandArgument),
         )
         .chain(
             checker
                 .facts()
+                .words()
                 .expansion_word_facts(ExpansionContext::AssignmentValue),
         )
         .chain(
             checker
                 .facts()
+                .words()
                 .expansion_word_facts(ExpansionContext::DeclarationAssignmentValue),
         )
         .flat_map(|fact| {
@@ -80,6 +84,7 @@ pub fn double_quote_nesting(checker: &mut Checker) {
         .chain(
             checker
                 .facts()
+                .source_facts()
                 .comment_double_quote_nesting_spans()
                 .iter()
                 .copied()

--- a/crates/shuck-linter/src/rules/style/duplicate_shebang_flag.rs
+++ b/crates/shuck-linter/src/rules/style/duplicate_shebang_flag.rs
@@ -13,7 +13,7 @@ impl Violation for DuplicateShebangFlag {
 }
 
 pub fn duplicate_shebang_flag(checker: &mut Checker) {
-    if let Some(span) = checker.facts().duplicate_shebang_flag_span() {
+    if let Some(span) = checker.facts().source_facts().duplicate_shebang_flag_span() {
         checker.report(DuplicateShebangFlag, span);
     }
 }

--- a/crates/shuck-linter/src/rules/style/echo_here_doc.rs
+++ b/crates/shuck-linter/src/rules/style/echo_here_doc.rs
@@ -22,7 +22,11 @@ impl Violation for EchoHereDoc {
 
 pub fn echo_here_doc(checker: &mut Checker) {
     let locator = checker.locator();
-    let spans = checker.facts().echo_here_doc_spans().to_vec();
+    let spans = checker
+        .facts()
+        .source_facts()
+        .echo_here_doc_spans()
+        .to_vec();
     for span in spans {
         let mut diagnostic = Diagnostic::new(EchoHereDoc, span);
         if let Some(fix) = echo_here_doc_fix(locator, span) {

--- a/crates/shuck-linter/src/rules/style/echo_to_sed_substitution.rs
+++ b/crates/shuck-linter/src/rules/style/echo_to_sed_substitution.rs
@@ -18,7 +18,7 @@ pub fn echo_to_sed_substitution(checker: &mut Checker) {
     }
 
     checker.report_fact_slice_dedup(
-        |facts| facts.echo_to_sed_substitution_spans(),
+        |facts| facts.words().echo_to_sed_substitution_spans(),
         || EchoToSedSubstitution,
     );
 }

--- a/crates/shuck-linter/src/rules/style/echoed_command_substitution.rs
+++ b/crates/shuck-linter/src/rules/style/echoed_command_substitution.rs
@@ -38,6 +38,7 @@ pub fn echoed_command_substitution(checker: &mut Checker) {
 
             checker
                 .facts()
+                .words()
                 .word_fact(
                     word.span,
                     WordFactContext::Expansion(ExpansionContext::CommandArgument),

--- a/crates/shuck-linter/src/rules/style/env_prefix_command_only.rs
+++ b/crates/shuck-linter/src/rules/style/env_prefix_command_only.rs
@@ -15,7 +15,7 @@ impl Violation for EnvPrefixCommandOnly {
 
 pub fn env_prefix_command_only(checker: &mut Checker) {
     checker.report_fact_slice_dedup(
-        |facts| facts.env_prefix_assignment_scope_spans(),
+        |facts| facts.assignments().env_prefix_assignment_scope_spans(),
         || EnvPrefixCommandOnly,
     );
 }

--- a/crates/shuck-linter/src/rules/style/escaped_underscore.rs
+++ b/crates/shuck-linter/src/rules/style/escaped_underscore.rs
@@ -25,6 +25,7 @@ impl Violation for EscapedUnderscore {
 pub fn escaped_underscore(checker: &mut Checker) {
     let escapes = checker
         .facts()
+        .words()
         .escape_scan_matches()
         .iter()
         .copied()

--- a/crates/shuck-linter/src/rules/style/export_command_substitution.rs
+++ b/crates/shuck-linter/src/rules/style/export_command_substitution.rs
@@ -19,7 +19,7 @@ impl Violation for ExportCommandSubstitution {
 pub fn export_command_substitution(checker: &mut Checker) {
     let mut findings = Vec::new();
 
-    for fact in checker.facts().structural_commands() {
+    for fact in checker.facts().command_facts().structural_commands() {
         for probe in fact.declaration_assignment_probes() {
             if !should_report_s010_declaration(
                 checker,

--- a/crates/shuck-linter/src/rules/style/function_body_without_braces.rs
+++ b/crates/shuck-linter/src/rules/style/function_body_without_braces.rs
@@ -31,6 +31,7 @@ pub fn function_body_without_braces(checker: &mut Checker) {
     let source = checker.source();
     let diagnostics = checker
         .facts()
+        .command_facts()
         .function_body_without_braces_spans()
         .iter()
         .copied()

--- a/crates/shuck-linter/src/rules/style/function_in_alias.rs
+++ b/crates/shuck-linter/src/rules/style/function_in_alias.rs
@@ -13,7 +13,10 @@ impl Violation for FunctionInAlias {
 }
 
 pub fn function_in_alias(checker: &mut Checker) {
-    checker.report_fact_slice_dedup(|facts| facts.function_in_alias_spans(), || FunctionInAlias);
+    checker.report_fact_slice_dedup(
+        |facts| facts.command_facts().function_in_alias_spans(),
+        || FunctionInAlias,
+    );
 }
 
 #[cfg(test)]

--- a/crates/shuck-linter/src/rules/style/getopts_invalid_flag_handler.rs
+++ b/crates/shuck-linter/src/rules/style/getopts_invalid_flag_handler.rs
@@ -16,6 +16,7 @@ impl Violation for GetoptsInvalidFlagHandler {
 pub fn getopts_invalid_flag_handler(checker: &mut Checker) {
     let spans = checker
         .facts()
+        .command_facts()
         .getopts_cases()
         .iter()
         .filter(|fact| fact.missing_invalid_flag_handler())

--- a/crates/shuck-linter/src/rules/style/glob_assigned_to_variable.rs
+++ b/crates/shuck-linter/src/rules/style/glob_assigned_to_variable.rs
@@ -25,14 +25,21 @@ pub fn glob_assigned_to_variable(checker: &mut Checker) {
     let source = checker.source();
     let diagnostics = checker
         .facts()
+        .words()
         .expansion_word_facts(ExpansionContext::AssignmentValue)
         .chain(
             checker
                 .facts()
+                .words()
                 .expansion_word_facts(ExpansionContext::DeclarationAssignmentValue),
         )
         .filter(|fact| fact.host_kind() == WordFactHostKind::Direct)
-        .filter(|fact| !checker.facts().is_compound_assignment_value_word(*fact))
+        .filter(|fact| {
+            !checker
+                .facts()
+                .words()
+                .is_compound_assignment_value_word(*fact)
+        })
         .filter(|fact| fact.classification().quote != WordQuote::FullyQuoted)
         .filter_map(|fact| {
             let glob_spans = fact.active_literal_glob_spans(source);

--- a/crates/shuck-linter/src/rules/style/grep_output_in_test.rs
+++ b/crates/shuck-linter/src/rules/style/grep_output_in_test.rs
@@ -232,6 +232,7 @@ fn word_fact_has_plain_command_substitution(
 ) -> bool {
     checker
         .facts()
+        .words()
         .word_fact(
             word_span,
             WordFactContext::Expansion(ExpansionContext::CommandArgument),

--- a/crates/shuck-linter/src/rules/style/heredoc_end_space.rs
+++ b/crates/shuck-linter/src/rules/style/heredoc_end_space.rs
@@ -24,6 +24,7 @@ pub fn heredoc_end_space(checker: &mut Checker) {
     let source = checker.source();
     let diagnostics = checker
         .facts()
+        .source_facts()
         .heredoc_end_space_spans()
         .iter()
         .copied()

--- a/crates/shuck-linter/src/rules/style/legacy_arithmetic_expansion.rs
+++ b/crates/shuck-linter/src/rules/style/legacy_arithmetic_expansion.rs
@@ -24,6 +24,7 @@ pub fn legacy_arithmetic_expansion(checker: &mut Checker) {
     let source = checker.source();
     let diagnostics = checker
         .facts()
+        .words()
         .legacy_arithmetic_fragments()
         .iter()
         .filter_map(|fragment| legacy_arithmetic_fix(fragment.span(), source))

--- a/crates/shuck-linter/src/rules/style/legacy_backticks.rs
+++ b/crates/shuck-linter/src/rules/style/legacy_backticks.rs
@@ -15,6 +15,7 @@ impl Violation for LegacyBackticks {
 pub fn legacy_backticks(checker: &mut Checker) {
     let spans = checker
         .facts()
+        .words()
         .backtick_fragments()
         .iter()
         .filter(|fragment| !fragment.is_empty())

--- a/crates/shuck-linter/src/rules/style/literal_backslash.rs
+++ b/crates/shuck-linter/src/rules/style/literal_backslash.rs
@@ -23,6 +23,7 @@ pub fn literal_backslash(checker: &mut Checker) {
     let facts = checker.facts();
     let diagnostics = checker
         .facts()
+        .words()
         .word_facts()
         .iter()
         .filter(|fact| is_relevant_word_context(fact.expansion_context()))
@@ -59,6 +60,7 @@ fn is_command_name_word<'a>(
     fact: crate::facts::words::WordOccurrenceRef<'_, 'a>,
 ) -> bool {
     facts
+        .command_facts()
         .command(fact.command_id())
         .body_name_word()
         .is_some_and(|word| word.span == fact.span())
@@ -70,6 +72,7 @@ fn is_unalias_argument<'a>(
 ) -> bool {
     fact.expansion_context() == Some(ExpansionContext::CommandArgument)
         && facts
+            .command_facts()
             .command(fact.command_id())
             .effective_name_is("unalias")
 }

--- a/crates/shuck-linter/src/rules/style/literal_backslash_in_single_quotes.rs
+++ b/crates/shuck-linter/src/rules/style/literal_backslash_in_single_quotes.rs
@@ -24,6 +24,7 @@ pub fn literal_backslash_in_single_quotes(checker: &mut Checker) {
     let source = checker.source();
     let diagnostics = checker
         .facts()
+        .words()
         .single_quoted_fragments()
         .iter()
         .filter_map(|fragment| {

--- a/crates/shuck-linter/src/rules/style/literal_braces.rs
+++ b/crates/shuck-linter/src/rules/style/literal_braces.rs
@@ -20,7 +20,7 @@ impl Violation for LiteralBraces {
 
 pub fn literal_braces(checker: &mut Checker) {
     checker.report_fact_diagnostics_dedup(|facts, report| {
-        for span in facts.literal_brace_spans().iter().copied() {
+        for span in facts.words().literal_brace_spans().iter().copied() {
             report(
                 Diagnostic::new(LiteralBraces, span)
                     .with_fix(Fix::safe_edit(Edit::insertion(span.start.offset, "\\"))),

--- a/crates/shuck-linter/src/rules/style/literal_control_escape.rs
+++ b/crates/shuck-linter/src/rules/style/literal_control_escape.rs
@@ -16,6 +16,7 @@ impl Violation for LiteralControlEscape {
 pub fn literal_control_escape(checker: &mut Checker) {
     let spans = checker
         .facts()
+        .words()
         .escape_scan_matches()
         .iter()
         .copied()

--- a/crates/shuck-linter/src/rules/style/loop_from_command_output.rs
+++ b/crates/shuck-linter/src/rules/style/loop_from_command_output.rs
@@ -16,6 +16,7 @@ impl Violation for LoopFromCommandOutput {
 pub fn loop_from_command_output(checker: &mut Checker) {
     let spans = checker
         .facts()
+        .command_facts()
         .for_headers()
         .iter()
         .filter(|header| !header.is_nested_word_command())

--- a/crates/shuck-linter/src/rules/style/ls_grep_pipeline.rs
+++ b/crates/shuck-linter/src/rules/style/ls_grep_pipeline.rs
@@ -15,12 +15,19 @@ impl Violation for LsGrepPipeline {
 pub fn ls_grep_pipeline(checker: &mut Checker) {
     let spans = checker
         .facts()
+        .command_facts()
         .pipelines()
         .iter()
         .flat_map(|pipeline| {
             pipeline.segments().windows(2).filter_map(|pair| {
-                let left = checker.facts().command(pair[0].command_id());
-                let right = checker.facts().command(pair[1].command_id());
+                let left = checker
+                    .facts()
+                    .command_facts()
+                    .command(pair[0].command_id());
+                let right = checker
+                    .facts()
+                    .command_facts()
+                    .command(pair[1].command_id());
 
                 if !is_raw_utility_named(left, "ls") || !is_raw_utility_named(right, "grep") {
                     return None;

--- a/crates/shuck-linter/src/rules/style/ls_in_substitution.rs
+++ b/crates/shuck-linter/src/rules/style/ls_in_substitution.rs
@@ -30,6 +30,7 @@ pub fn ls_in_substitution(checker: &mut Checker) {
 fn processed_ls_pipeline_spans(checker: &Checker) -> Vec<Span> {
     let mut spans = checker
         .facts()
+        .command_facts()
         .pipelines()
         .iter()
         .flat_map(|pipeline| {
@@ -54,6 +55,7 @@ fn processed_ls_pipeline_spans(checker: &Checker) -> Vec<Span> {
             .filter(|substitution| {
                 !checker
                     .facts()
+                    .command_facts()
                     .pipelines()
                     .iter()
                     .any(|pipeline| span_contains(substitution.span(), pipeline.span()))
@@ -69,7 +71,7 @@ fn left_segment_is_s047_ls_candidate(
     checker: &Checker,
     command_id: crate::facts::CommandId,
 ) -> bool {
-    let command = checker.facts().command(command_id);
+    let command = checker.facts().command_facts().command(command_id);
 
     command.literal_name() == Some("ls") && command.wrappers().is_empty()
 }
@@ -81,6 +83,7 @@ fn pipeline_ls_command_span(
 ) -> Span {
     let command = checker
         .facts()
+        .command_facts()
         .command(pipeline.segments()[segment_index].command_id());
     let span = Span {
         start: command.span_in_source(checker.source()).start,

--- a/crates/shuck-linter/src/rules/style/ls_piped_to_xargs.rs
+++ b/crates/shuck-linter/src/rules/style/ls_piped_to_xargs.rs
@@ -15,12 +15,19 @@ impl Violation for LsPipedToXargs {
 pub fn ls_piped_to_xargs(checker: &mut Checker) {
     let spans = checker
         .facts()
+        .command_facts()
         .pipelines()
         .iter()
         .flat_map(|pipeline| {
             pipeline.segments().windows(2).filter_map(|pair| {
-                let left = checker.facts().command(pair[0].command_id());
-                let right = checker.facts().command(pair[1].command_id());
+                let left = checker
+                    .facts()
+                    .command_facts()
+                    .command(pair[0].command_id());
+                let right = checker
+                    .facts()
+                    .command_facts()
+                    .command(pair[1].command_id());
 
                 if !is_raw_command_named(left, "ls") || !is_raw_command_named(right, "xargs") {
                     return None;

--- a/crates/shuck-linter/src/rules/style/missing_shebang_line.rs
+++ b/crates/shuck-linter/src/rules/style/missing_shebang_line.rs
@@ -17,7 +17,7 @@ pub fn missing_shebang_line(checker: &mut Checker) {
         return;
     }
 
-    if let Some(span) = checker.facts().missing_shebang_line_span() {
+    if let Some(span) = checker.facts().source_facts().missing_shebang_line_span() {
         checker.report(MissingShebangLine, span);
     }
 }

--- a/crates/shuck-linter/src/rules/style/mixed_quote_word.rs
+++ b/crates/shuck-linter/src/rules/style/mixed_quote_word.rs
@@ -35,8 +35,8 @@ pub fn mixed_quote_word(checker: &mut Checker) {
         ExpansionContext::CasePattern,
     ]
     .into_iter()
-    .flat_map(|context| facts.expansion_word_facts(context))
-    .chain(facts.case_subject_facts())
+    .flat_map(|context| facts.words().expansion_word_facts(context))
+    .chain(facts.words().case_subject_facts())
     .filter(|fact| fact.host_kind() == WordFactHostKind::Direct)
     .flat_map(|fact| {
         let replacement_span = fact.span();

--- a/crates/shuck-linter/src/rules/style/positional_args_in_string.rs
+++ b/crates/shuck-linter/src/rules/style/positional_args_in_string.rs
@@ -19,7 +19,7 @@ pub fn positional_args_in_string(checker: &mut Checker) {
         ExpansionContext::CommandArgument,
     ]
     .into_iter()
-    .flat_map(|context| checker.facts().expansion_word_facts(context))
+    .flat_map(|context| checker.facts().words().expansion_word_facts(context))
     .filter_map(|fact| fact.folded_all_elements_array_span_in_source(locator))
     .collect::<Vec<_>>();
 

--- a/crates/shuck-linter/src/rules/style/printf_format_variable.rs
+++ b/crates/shuck-linter/src/rules/style/printf_format_variable.rs
@@ -27,6 +27,7 @@ pub fn printf_format_variable(checker: &mut Checker) {
         .filter_map(|word| {
             checker
                 .facts()
+                .words()
                 .word_fact(
                     word.span,
                     WordFactContext::Expansion(ExpansionContext::CommandArgument),

--- a/crates/shuck-linter/src/rules/style/ps_grep_pipeline.rs
+++ b/crates/shuck-linter/src/rules/style/ps_grep_pipeline.rs
@@ -17,6 +17,7 @@ impl Violation for PsGrepPipeline {
 pub fn ps_grep_pipeline(checker: &mut Checker) {
     let spans = checker
         .facts()
+        .command_facts()
         .pipelines()
         .iter()
         .flat_map(|pipeline| unsafe_ps_grep_pipeline_spans(checker, pipeline))
@@ -30,8 +31,14 @@ fn unsafe_ps_grep_pipeline_spans(checker: &Checker<'_>, pipeline: &PipelineFact<
         .segments()
         .windows(2)
         .filter_map(|pair| {
-            let left = checker.facts().command(pair[0].command_id());
-            let right = checker.facts().command(pair[1].command_id());
+            let left = checker
+                .facts()
+                .command_facts()
+                .command(pair[0].command_id());
+            let right = checker
+                .facts()
+                .command_facts()
+                .command(pair[1].command_id());
 
             if !is_raw_utility_named(left, "ps") || !is_raw_utility_named(right, "grep") {
                 return None;

--- a/crates/shuck-linter/src/rules/style/quoted_dollar_star_loop.rs
+++ b/crates/shuck-linter/src/rules/style/quoted_dollar_star_loop.rs
@@ -24,6 +24,7 @@ impl Violation for QuotedDollarStarLoop {
 pub fn quoted_dollar_star_loop(checker: &mut Checker) {
     let diagnostics = checker
         .facts()
+        .command_facts()
         .for_headers()
         .iter()
         .filter_map(|header| {

--- a/crates/shuck-linter/src/rules/style/redundant_return_status.rs
+++ b/crates/shuck-linter/src/rules/style/redundant_return_status.rs
@@ -14,7 +14,7 @@ impl Violation for RedundantReturnStatus {
 
 pub fn redundant_return_status(checker: &mut Checker) {
     checker.report_fact_slice_dedup(
-        |facts| facts.redundant_return_status_spans(),
+        |facts| facts.command_facts().redundant_return_status_spans(),
         || RedundantReturnStatus,
     );
 }

--- a/crates/shuck-linter/src/rules/style/redundant_spaces_in_echo.rs
+++ b/crates/shuck-linter/src/rules/style/redundant_spaces_in_echo.rs
@@ -21,6 +21,7 @@ impl Violation for RedundantSpacesInEcho {
 pub fn redundant_spaces_in_echo(checker: &mut Checker) {
     let diagnostics = checker
         .facts()
+        .command_facts()
         .redundant_echo_space_facts()
         .iter()
         .map(|fact| {

--- a/crates/shuck-linter/src/rules/style/single_iteration_loop.rs
+++ b/crates/shuck-linter/src/rules/style/single_iteration_loop.rs
@@ -16,6 +16,7 @@ pub fn single_iteration_loop(checker: &mut Checker) {
     let locator = checker.locator();
     let spans = checker
         .facts()
+        .command_facts()
         .for_headers()
         .iter()
         .filter(|header| !header.is_nested_word_command())
@@ -24,7 +25,7 @@ pub fn single_iteration_loop(checker: &mut Checker) {
                 return None;
             };
 
-            let fact = checker.facts().word_fact(
+            let fact = checker.facts().words().word_fact(
                 word.span(),
                 WordFactContext::Expansion(ExpansionContext::ForList),
             )?;

--- a/crates/shuck-linter/src/rules/style/single_quote_backslash.rs
+++ b/crates/shuck-linter/src/rules/style/single_quote_backslash.rs
@@ -24,6 +24,7 @@ pub fn single_quote_backslash(checker: &mut Checker) {
     let source = checker.source();
     let diagnostics = checker
         .facts()
+        .words()
         .single_quoted_fragments()
         .iter()
         .filter_map(|fragment| single_quoted_fragment_backslash_span(fragment.span(), source))

--- a/crates/shuck-linter/src/rules/style/spaced_tabstrip_close.rs
+++ b/crates/shuck-linter/src/rules/style/spaced_tabstrip_close.rs
@@ -24,6 +24,7 @@ pub fn spaced_tabstrip_close(checker: &mut Checker) {
     let source = checker.source();
     let diagnostics = checker
         .facts()
+        .source_facts()
         .spaced_tabstrip_close_spans()
         .iter()
         .copied()

--- a/crates/shuck-linter/src/rules/style/su_without_flag.rs
+++ b/crates/shuck-linter/src/rules/style/su_without_flag.rs
@@ -16,6 +16,7 @@ impl Violation for SuWithoutFlag {
 pub fn su_without_flag(checker: &mut Checker) {
     let piped_command_ids = checker
         .facts()
+        .command_facts()
         .pipelines()
         .iter()
         .flat_map(|pipeline| {

--- a/crates/shuck-linter/src/rules/style/suspect_closing_quote.rs
+++ b/crates/shuck-linter/src/rules/style/suspect_closing_quote.rs
@@ -15,6 +15,7 @@ impl Violation for SuspectClosingQuote {
 pub fn suspect_closing_quote(checker: &mut Checker) {
     let spans = checker
         .facts()
+        .words()
         .suspect_closing_quote_fragments()
         .iter()
         .map(|fragment| fragment.span())

--- a/crates/shuck-linter/src/rules/style/trailing_directive.rs
+++ b/crates/shuck-linter/src/rules/style/trailing_directive.rs
@@ -20,7 +20,11 @@ impl Violation for TrailingDirective {
 
 pub fn trailing_directive(checker: &mut Checker) {
     let locator = checker.locator();
-    let spans = checker.facts().trailing_directive_comment_spans().to_vec();
+    let spans = checker
+        .facts()
+        .source_facts()
+        .trailing_directive_comment_spans()
+        .to_vec();
     for span in spans {
         let mut diagnostic = Diagnostic::new(TrailingDirective, span);
         if let Some(fix) = trailing_directive_fix(locator, span) {

--- a/crates/shuck-linter/src/rules/style/unquoted_array_expansion.rs
+++ b/crates/shuck-linter/src/rules/style/unquoted_array_expansion.rs
@@ -33,7 +33,7 @@ pub fn unquoted_array_expansion(checker: &mut Checker) {
         ExpansionContext::SelectList,
     ]
     .into_iter()
-    .flat_map(|context| checker.facts().expansion_word_facts(context))
+    .flat_map(|context| checker.facts().words().expansion_word_facts(context))
     .flat_map(|fact| {
         fact.unquoted_all_elements_array_expansion_spans()
             .iter()
@@ -45,6 +45,7 @@ pub fn unquoted_array_expansion(checker: &mut Checker) {
         spans.extend(
             checker
                 .facts()
+                .words()
                 .expansion_word_facts(ExpansionContext::DeclarationAssignmentValue)
                 .flat_map(|fact| {
                     fact.unquoted_all_elements_array_expansion_spans()

--- a/crates/shuck-linter/src/rules/style/unquoted_array_split.rs
+++ b/crates/shuck-linter/src/rules/style/unquoted_array_split.rs
@@ -24,6 +24,7 @@ pub fn unquoted_array_split(checker: &mut Checker) {
     let source = checker.source();
     let diagnostics = checker
         .facts()
+        .words()
         .array_assignment_split_word_facts()
         .flat_map(|fact| {
             let candidate_spans = fact

--- a/crates/shuck-linter/src/rules/style/unquoted_command_substitution.rs
+++ b/crates/shuck-linter/src/rules/style/unquoted_command_substitution.rs
@@ -22,7 +22,10 @@ impl Violation for UnquotedCommandSubstitution {
 }
 
 pub fn unquoted_command_substitution(checker: &mut Checker) {
-    let arithmetic_spans = checker.facts().arithmetic_command_substitution_spans();
+    let arithmetic_spans = checker
+        .facts()
+        .words()
+        .arithmetic_command_substitution_spans();
     let pgrep_spans = checker
         .facts()
         .commands()
@@ -50,6 +53,7 @@ pub fn unquoted_command_substitution(checker: &mut Checker) {
     let source = checker.source();
     let diagnostics = checker
         .facts()
+        .words()
         .word_facts()
         .iter()
         .flat_map(|fact| {

--- a/crates/shuck-linter/src/rules/style/unquoted_dollar_star.rs
+++ b/crates/shuck-linter/src/rules/style/unquoted_dollar_star.rs
@@ -32,7 +32,7 @@ pub fn unquoted_dollar_star(checker: &mut Checker) {
         ExpansionContext::SelectList,
     ]
     .into_iter()
-    .flat_map(|context| checker.facts().expansion_word_facts(context))
+    .flat_map(|context| checker.facts().words().expansion_word_facts(context))
     .filter(|fact| !fact.has_literal_affixes())
     .flat_map(unquoted_star_splat_spans)
     .map(|span| {

--- a/crates/shuck-linter/src/rules/style/unquoted_expansion.rs
+++ b/crates/shuck-linter/src/rules/style/unquoted_expansion.rs
@@ -45,8 +45,10 @@ pub fn unquoted_expansion(checker: &mut Checker) {
     let array_assignment_split_spans = collect_array_assignment_split_candidate_spans(checker);
     let numeric_test_operand_spans = collect_numeric_test_operand_spans(checker, source);
     let plain_run_first_arg_spans = collect_plain_run_first_arg_spans(checker);
-    let backtick_escaped_parameter_spans =
-        checker.facts().backtick_escaped_parameter_reference_spans();
+    let backtick_escaped_parameter_spans = checker
+        .facts()
+        .source_facts()
+        .backtick_escaped_parameter_reference_spans();
 
     let mut spans = Vec::new();
     let locator = checker.locator();
@@ -59,7 +61,7 @@ pub fn unquoted_expansion(checker: &mut Checker) {
         plain_run_first_arg_spans: &plain_run_first_arg_spans,
         backtick_escaped_parameter_spans,
     };
-    for fact in checker.facts().word_facts() {
+    for fact in checker.facts().words().word_facts() {
         collect_word_fact_reports(&report_context, &mut safe_values, &mut spans, fact);
         collect_array_assignment_split_reports(
             &mut safe_values,
@@ -69,9 +71,11 @@ pub fn unquoted_expansion(checker: &mut Checker) {
             &array_assignment_split_spans,
         );
     }
-    let arithmetic_command_substitution_spans =
-        checker.facts().arithmetic_command_substitution_spans();
-    for fact in checker.facts().arithmetic_command_word_facts() {
+    let arithmetic_command_substitution_spans = checker
+        .facts()
+        .words()
+        .arithmetic_command_substitution_spans();
+    for fact in checker.facts().words().arithmetic_command_word_facts() {
         collect_arithmetic_word_fact_reports(
             &report_context,
             &mut safe_values,
@@ -80,7 +84,7 @@ pub fn unquoted_expansion(checker: &mut Checker) {
             arithmetic_command_substitution_spans,
         );
     }
-    for escaped in checker.facts().backtick_escaped_parameters() {
+    for escaped in checker.facts().source_facts().backtick_escaped_parameters() {
         if escaped.standalone_command_name {
             continue;
         }
@@ -214,6 +218,7 @@ fn collect_plain_run_first_arg_spans(checker: &Checker) -> FxHashSet<FactSpan> {
 fn collect_array_assignment_split_candidate_spans(checker: &Checker) -> Vec<Span> {
     let mut spans = checker
         .facts()
+        .words()
         .array_assignment_split_word_facts()
         .flat_map(|fact| {
             let command_substitution_spans = fact.command_substitution_spans();

--- a/crates/shuck-linter/src/rules/style/unquoted_expansion/safe_value.rs
+++ b/crates/shuck-linter/src/rules/style/unquoted_expansion/safe_value.rs
@@ -202,7 +202,7 @@ impl<'a> SafeValueIndex<'a> {
         if self.span_is_after_unconditional_inline_terminator(word.span) {
             return false;
         }
-        let Some(fact) = self.facts.any_word_fact(word.span) else {
+        let Some(fact) = self.facts.words().any_word_fact(word.span) else {
             return false;
         };
         let analysis = fact.analysis();
@@ -266,7 +266,7 @@ impl<'a> SafeValueIndex<'a> {
     }
 
     fn word_fact(&self, word: &Word) -> Option<crate::WordOccurrenceRef<'_, 'a>> {
-        self.facts.any_word_fact(word.span)
+        self.facts.words().any_word_fact(word.span)
     }
 
     fn word_plain_scalar_reference_name(&self, word: &Word) -> Option<Name> {
@@ -421,6 +421,7 @@ impl<'a> SafeValueIndex<'a> {
                 }
                 let Some(word) = self
                     .facts
+                    .assignments()
                     .binding_value(binding_id)
                     .and_then(|value| value.scalar_word())
                 else {
@@ -430,12 +431,16 @@ impl<'a> SafeValueIndex<'a> {
                     return false;
                 }
 
-                self.facts.any_word_fact(word.span).is_some_and(|fact| {
-                    fact.command_substitution_spans()
-                        .iter()
-                        .copied()
-                        .any(|command_substitution| span_contains(command_substitution, span))
-                }) && !self.span_is_inside_loop_context(span)
+                self.facts
+                    .words()
+                    .any_word_fact(word.span)
+                    .is_some_and(|fact| {
+                        fact.command_substitution_spans()
+                            .iter()
+                            .copied()
+                            .any(|command_substitution| span_contains(command_substitution, span))
+                    })
+                    && !self.span_is_inside_loop_context(span)
                     && !self.span_is_inside_if_condition(span)
                     && {
                         self.binding_value_stack.push(binding_id);
@@ -483,6 +488,7 @@ impl<'a> SafeValueIndex<'a> {
             }
             let setup_atom = self
                 .facts
+                .assignments()
                 .binding_value(binding_id)
                 .and_then(|value| value.scalar_word())
                 .and_then(|word| static_word_text(word, self.source))
@@ -506,32 +512,39 @@ impl<'a> SafeValueIndex<'a> {
         self.semantic.bindings().iter().any(|binding| {
             let Some(word) = self
                 .facts
+                .assignments()
                 .binding_value(binding.id)
                 .and_then(|value| value.scalar_word())
             else {
                 return false;
             };
             span_contains(word.span, span)
-                && self.facts.any_word_fact(word.span).is_some_and(|fact| {
-                    fact.command_substitution_spans()
-                        .iter()
-                        .copied()
-                        .any(|command_substitution| span_contains(command_substitution, span))
-                })
+                && self
+                    .facts
+                    .words()
+                    .any_word_fact(word.span)
+                    .is_some_and(|fact| {
+                        fact.command_substitution_spans()
+                            .iter()
+                            .copied()
+                            .any(|command_substitution| span_contains(command_substitution, span))
+                    })
         })
     }
 
     fn span_is_inside_loop_context(&self, span: Span) -> bool {
         let mut current = self
             .facts
+            .command_facts()
             .innermost_command_id_at(span.start.offset)
             .or_else(|| {
                 self.facts
+                    .command_facts()
                     .innermost_command_id_containing_offset(span.start.offset)
             });
         while let Some(command_id) = current {
             if matches!(
-                self.facts.command(command_id).command(),
+                self.facts.command_facts().command(command_id).command(),
                 Command::Compound(
                     CompoundCommand::For(_)
                         | CompoundCommand::Repeat(_)
@@ -544,7 +557,7 @@ impl<'a> SafeValueIndex<'a> {
             ) {
                 return true;
             }
-            current = self.facts.command_parent_id(command_id);
+            current = self.facts.command_facts().command_parent_id(command_id);
         }
 
         false
@@ -553,14 +566,16 @@ impl<'a> SafeValueIndex<'a> {
     fn span_is_inside_if_condition(&self, span: Span) -> bool {
         let mut current = self
             .facts
+            .command_facts()
             .innermost_command_id_at(span.start.offset)
             .or_else(|| {
                 self.facts
+                    .command_facts()
                     .innermost_command_id_containing_offset(span.start.offset)
             });
         while let Some(command_id) = current {
             if let Command::Compound(CompoundCommand::If(command)) =
-                self.facts.command(command_id).command()
+                self.facts.command_facts().command(command_id).command()
                 && (span_contains(command.condition.span, span)
                     || command
                         .elif_branches
@@ -569,7 +584,7 @@ impl<'a> SafeValueIndex<'a> {
             {
                 return true;
             }
-            current = self.facts.command_parent_id(command_id);
+            current = self.facts.command_facts().command_parent_id(command_id);
         }
 
         false
@@ -623,7 +638,10 @@ impl<'a> SafeValueIndex<'a> {
         word: &Word,
         context: ExpansionContext,
     ) -> bool {
-        let behavior = self.facts.expansion_behavior_at(word.span.start.offset);
+        let behavior = self
+            .facts
+            .command_facts()
+            .expansion_behavior_at(word.span.start.offset);
         let runtime = analyze_literal_runtime(word, self.source, context, Some(&behavior));
         if !runtime.is_runtime_sensitive() {
             return false;
@@ -927,6 +945,7 @@ impl<'a> SafeValueIndex<'a> {
             .ancestor_scopes(self.semantic.scope_at(offset))
             .find(|scope| {
                 self.facts
+                    .command_facts()
                     .function_cli_dispatch_facts(*scope)
                     .exported_from_case_cli()
             })
@@ -935,6 +954,7 @@ impl<'a> SafeValueIndex<'a> {
     fn case_cli_reachable_function_scope_at(&self, offset: usize) -> Option<ScopeId> {
         let scope = self.analysis.enclosing_function_scope_at(offset)?;
         self.facts
+            .command_facts()
             .is_case_cli_reachable_function_scope(scope)
             .then_some(scope)
     }
@@ -952,6 +972,7 @@ impl<'a> SafeValueIndex<'a> {
         };
 
         self.facts
+            .command_facts()
             .function_cli_dispatch_facts(scope)
             .exported_from_case_cli()
             || self.static_caller_is_case_cli_exported(scope, &mut FxHashSet::default())
@@ -971,6 +992,7 @@ impl<'a> SafeValueIndex<'a> {
             .into_iter()
             .any(|(caller_scope, _)| {
                 self.facts
+                    .command_facts()
                     .function_cli_dispatch_facts(caller_scope)
                     .exported_from_case_cli()
                     || self.static_caller_is_case_cli_exported(caller_scope, seen)
@@ -1013,13 +1035,15 @@ impl<'a> SafeValueIndex<'a> {
 
     fn span_is_exit_or_return_argument(&self, at: Span) -> bool {
         self.facts
+            .command_facts()
             .innermost_command_id_at(at.start.offset)
             .or_else(|| {
                 self.facts
+                    .command_facts()
                     .innermost_command_id_containing_offset(at.start.offset)
             })
             .is_some_and(|command_id| {
-                let command = self.facts.command(command_id);
+                let command = self.facts.command_facts().command(command_id);
                 match command.command() {
                     Command::Builtin(BuiltinCommand::Exit(command)) => {
                         command
@@ -1054,13 +1078,15 @@ impl<'a> SafeValueIndex<'a> {
 
     fn span_is_return_argument(&self, at: Span) -> bool {
         self.facts
+            .command_facts()
             .innermost_command_id_at(at.start.offset)
             .or_else(|| {
                 self.facts
+                    .command_facts()
                     .innermost_command_id_containing_offset(at.start.offset)
             })
             .is_some_and(|command_id| {
-                let command = self.facts.command(command_id);
+                let command = self.facts.command_facts().command(command_id);
                 match command.command() {
                     Command::Builtin(BuiltinCommand::Return(command)) => {
                         command
@@ -1097,28 +1123,32 @@ impl<'a> SafeValueIndex<'a> {
         at: Span,
     ) -> bool {
         let binding = self.semantic.binding(binding_id);
-        self.facts.function_headers().iter().any(|header| {
-            function_has_terminal_exit(header.function())
-                && header
-                    .call_arity()
-                    .zero_arg_call_spans()
-                    .iter()
-                    .filter_map(|call_span| self.command_for_name_word_span(*call_span))
-                    .any(|command| {
-                        !command.is_nested_word_command()
-                            && command.body_args().is_empty()
-                            && self.command_runs_in_unconditional_flow(command.id(), at)
-                            && {
-                                let call_span = command.span_in_source(self.source);
-                                self.definition_command_resolves_at_call(
-                                    header.command_id(),
-                                    call_span,
-                                ) && call_span.end.offset <= at.start.offset
-                                    && (call_span.start.offset >= binding.span.end.offset
-                                        || call_span.end.offset <= binding.span.start.offset)
-                            }
-                    })
-        })
+        self.facts
+            .command_facts()
+            .function_headers()
+            .iter()
+            .any(|header| {
+                function_has_terminal_exit(header.function())
+                    && header
+                        .call_arity()
+                        .zero_arg_call_spans()
+                        .iter()
+                        .filter_map(|call_span| self.command_for_name_word_span(*call_span))
+                        .any(|command| {
+                            !command.is_nested_word_command()
+                                && command.body_args().is_empty()
+                                && self.command_runs_in_unconditional_flow(command.id(), at)
+                                && {
+                                    let call_span = command.span_in_source(self.source);
+                                    self.definition_command_resolves_at_call(
+                                        header.command_id(),
+                                        call_span,
+                                    ) && call_span.end.offset <= at.start.offset
+                                        && (call_span.start.offset >= binding.span.end.offset
+                                            || call_span.end.offset <= binding.span.start.offset)
+                                }
+                        })
+            })
     }
 
     fn span_is_after_unconditional_inline_terminator(&self, at: Span) -> bool {
@@ -1138,7 +1168,7 @@ impl<'a> SafeValueIndex<'a> {
         command_id: crate::facts::CommandId,
         call_span: Span,
     ) -> bool {
-        let command = self.facts.command(command_id);
+        let command = self.facts.command_facts().command(command_id);
         let command_scope = self.enclosing_function_scope_at(command.span().start.offset);
         let call_scope = self.enclosing_function_scope_at(call_span.start.offset);
         if command_scope.is_some() && command_scope != call_scope {
@@ -1148,12 +1178,12 @@ impl<'a> SafeValueIndex<'a> {
             return false;
         }
 
-        let mut parent_id = self.facts.command_parent_id(command_id);
+        let mut parent_id = self.facts.command_facts().command_parent_id(command_id);
         while let Some(id) = parent_id {
-            if self.facts.command_is_dominance_barrier(id) {
+            if self.facts.command_facts().command_is_dominance_barrier(id) {
                 return false;
             }
-            parent_id = self.facts.command_parent_id(id);
+            parent_id = self.facts.command_facts().command_parent_id(id);
         }
         true
     }
@@ -1167,7 +1197,7 @@ impl<'a> SafeValueIndex<'a> {
             return false;
         }
 
-        let command = self.facts.command(command_id);
+        let command = self.facts.command_facts().command(command_id);
         let definition_scope = self.enclosing_function_scope_at(command.span().start.offset);
         let call_scope = self.enclosing_function_scope_at(call_span.start.offset);
 
@@ -1182,14 +1212,16 @@ impl<'a> SafeValueIndex<'a> {
         &self,
         span: Span,
     ) -> Option<crate::facts::CommandFactRef<'a, 'a>> {
-        self.facts.command_for_name_word_span(span)
+        self.facts.command_facts().command_for_name_word_span(span)
     }
 
     fn function_definition_command_for_scope(
         &self,
         scope: ScopeId,
     ) -> Option<crate::facts::CommandFactRef<'a, 'a>> {
-        self.facts.function_definition_command(scope)
+        self.facts
+            .command_facts()
+            .function_definition_command(scope)
     }
 
     fn function_scope_resolves_at_call_site(&self, callee_scope: ScopeId, site: &CallSite) -> bool {
@@ -1309,7 +1341,7 @@ impl<'a> SafeValueIndex<'a> {
         let target_function = self.named_function_kind(target_scope)?;
         let mut first_key: Option<S001FunctionEventKey> = None;
 
-        for command in self.facts.structural_commands() {
+        for command in self.facts.command_facts().structural_commands() {
             if !command.options().unset().is_some_and(|unset| {
                 target_function
                     .static_names()
@@ -1354,12 +1386,12 @@ impl<'a> SafeValueIndex<'a> {
     }
 
     fn command_has_dominance_barrier_ancestor(&self, command_id: crate::facts::CommandId) -> bool {
-        let mut current = self.facts.command_parent_id(command_id);
+        let mut current = self.facts.command_facts().command_parent_id(command_id);
         while let Some(id) = current {
-            if self.facts.command_is_dominance_barrier(id) {
+            if self.facts.command_facts().command_is_dominance_barrier(id) {
                 return true;
             }
-            current = self.facts.command_parent_id(id);
+            current = self.facts.command_facts().command_parent_id(id);
         }
         false
     }
@@ -1369,7 +1401,7 @@ impl<'a> SafeValueIndex<'a> {
         command_id: crate::facts::CommandId,
         reference_at: Span,
     ) -> bool {
-        let command = self.facts.command(command_id);
+        let command = self.facts.command_facts().command(command_id);
         if self.enclosing_function_scope_at(command.span().start.offset)
             != self.enclosing_function_scope_at(reference_at.start.offset)
         {
@@ -1379,12 +1411,12 @@ impl<'a> SafeValueIndex<'a> {
             return false;
         }
 
-        let mut parent_id = self.facts.command_parent_id(command_id);
+        let mut parent_id = self.facts.command_facts().command_parent_id(command_id);
         while let Some(id) = parent_id {
-            if self.facts.command_is_dominance_barrier(id) {
+            if self.facts.command_facts().command_is_dominance_barrier(id) {
                 return false;
             }
-            parent_id = self.facts.command_parent_id(id);
+            parent_id = self.facts.command_facts().command_parent_id(id);
         }
         true
     }
@@ -1393,12 +1425,12 @@ impl<'a> SafeValueIndex<'a> {
         let mut current = Some(command_id);
         while let Some(id) = current {
             if matches!(
-                self.facts.command(id).stmt().terminator,
+                self.facts.command_facts().command(id).stmt().terminator,
                 Some(StmtTerminator::Background(_))
             ) {
                 return true;
             }
-            current = self.facts.command_parent_id(id);
+            current = self.facts.command_facts().command_parent_id(id);
         }
         false
     }
@@ -1409,6 +1441,7 @@ impl<'a> SafeValueIndex<'a> {
 
     fn binding_is_quoted_static_literal(&self, binding_id: BindingId) -> bool {
         self.facts
+            .assignments()
             .binding_value(binding_id)
             .and_then(|value| value.scalar_word())
             .is_some_and(|word| {
@@ -1429,6 +1462,7 @@ impl<'a> SafeValueIndex<'a> {
             }
         ) && self
             .facts
+            .assignments()
             .binding_value(binding_id)
             .and_then(|value| value.scalar_word())
             .and_then(|word| static_word_text(word, self.source))
@@ -1481,6 +1515,7 @@ impl<'a> SafeValueIndex<'a> {
             }
             let Some(text) = self
                 .facts
+                .assignments()
                 .binding_value(binding_id)
                 .and_then(|value| value.scalar_word())
                 .and_then(|word| static_word_text(word, self.source))
@@ -1566,7 +1601,7 @@ impl<'a> SafeValueIndex<'a> {
             }
             first_binding_start = first_binding_start.min(binding.span.start.offset);
 
-            let Some(value) = self.facts.binding_value(binding_id) else {
+            let Some(value) = self.facts.assignments().binding_value(binding_id) else {
                 return false;
             };
             if !value.conditional_assignment_shortcut() {
@@ -1650,9 +1685,15 @@ impl<'a> SafeValueIndex<'a> {
         if !matches!(
             binding.kind,
             BindingKind::Assignment | BindingKind::Declaration(_)
-        ) || self.facts.binding_value(binding_id).is_some_and(|value| {
-            value.one_sided_short_circuit_assignment() || value.conditional_assignment_shortcut()
-        }) {
+        ) || self
+            .facts
+            .assignments()
+            .binding_value(binding_id)
+            .is_some_and(|value| {
+                value.one_sided_short_circuit_assignment()
+                    || value.conditional_assignment_shortcut()
+            })
+        {
             return None;
         }
 
@@ -1739,6 +1780,7 @@ impl<'a> SafeValueIndex<'a> {
         }
         if self
             .facts
+            .assignments()
             .binding_value(binding_id)
             .and_then(|value| value.scalar_word())
             .and_then(|word| static_word_text(word, self.source))
@@ -1789,6 +1831,7 @@ impl<'a> SafeValueIndex<'a> {
     ) -> Option<FieldSafeBindingClass> {
         let text = self
             .facts
+            .assignments()
             .binding_value(binding_id)
             .and_then(|value| value.scalar_word())
             .and_then(|word| static_word_text(word, self.source))?;
@@ -1813,6 +1856,7 @@ impl<'a> SafeValueIndex<'a> {
 
         let word = self
             .facts
+            .assignments()
             .binding_value(binding_id)
             .and_then(|value| value.scalar_word())?;
         let target_name = self.word_plain_scalar_reference_name(word)?;
@@ -1880,7 +1924,7 @@ impl<'a> SafeValueIndex<'a> {
                 } else if self.binding_is_name_only_declaration(binding_id) {
                     true
                 } else {
-                    let binding_value = self.facts.binding_value(binding_id);
+                    let binding_value = self.facts.assignments().binding_value(binding_id);
                     let scalar_word = binding_value.and_then(|value| value.scalar_word());
                     let case_cli_status_capture_stays_unsafe = case_cli_scope
                         == Some(binding.scope)
@@ -1912,6 +1956,7 @@ impl<'a> SafeValueIndex<'a> {
             } => {
                 let words = self
                     .facts
+                    .assignments()
                     .binding_value(binding_id)
                     .and_then(|value| value.loop_words())
                     .map(|words| words.to_vec());
@@ -2006,6 +2051,7 @@ impl<'a> SafeValueIndex<'a> {
         };
         let Some(word) = self
             .facts
+            .assignments()
             .binding_value(binding_id)
             .and_then(|value| value.scalar_word())
         else {
@@ -2197,6 +2243,7 @@ impl<'a> SafeValueIndex<'a> {
 
     fn binding_value_is_standalone_status_capture(&self, binding_id: BindingId) -> bool {
         self.facts
+            .assignments()
             .binding_value(binding_id)
             .is_some_and(|value| value.standalone_status_or_pid_capture())
     }
@@ -2254,7 +2301,7 @@ impl<'a> SafeValueIndex<'a> {
     }
 
     fn status_capture_binding_is_in_short_circuit_branch(&self, span: Span) -> bool {
-        self.facts.lists().iter().any(|list| {
+        self.facts.command_facts().lists().iter().any(|list| {
             list.segments()
                 .iter()
                 .skip(1)
@@ -2273,17 +2320,20 @@ impl<'a> SafeValueIndex<'a> {
             return false;
         }
 
-        self.facts.structural_commands().any(|command| {
-            command.span().end.offset <= at.start.offset
-                && self.command_blocks_cover_all_paths_to_reference(command, name, at)
-                && !case_cli_scope.is_some_and(|scope| {
-                    self.offset_is_in_scope_or_descendant(command.span().start.offset, scope)
-                })
-                && command
-                    .declaration_assignment_probes()
-                    .iter()
-                    .any(|probe| probe.status_capture() && probe.target_name() == name.as_str())
-        })
+        self.facts
+            .command_facts()
+            .structural_commands()
+            .any(|command| {
+                command.span().end.offset <= at.start.offset
+                    && self.command_blocks_cover_all_paths_to_reference(command, name, at)
+                    && !case_cli_scope.is_some_and(|scope| {
+                        self.offset_is_in_scope_or_descendant(command.span().start.offset, scope)
+                    })
+                    && command
+                        .declaration_assignment_probes()
+                        .iter()
+                        .any(|probe| probe.status_capture() && probe.target_name() == name.as_str())
+            })
     }
 
     fn offset_is_in_scope_or_descendant(&self, offset: usize, ancestor_scope: ScopeId) -> bool {
@@ -2348,12 +2398,15 @@ impl<'a> SafeValueIndex<'a> {
     }
 
     fn unset_command_covers_reference(&self, name: &Name, at: Span) -> bool {
-        self.facts.unset_commands_for_name(name).any(|command| {
-            command.span().end.offset <= at.start.offset
-                && self.command_runs_in_persistent_shell_context(command.id())
-                && self.command_runs_in_unconditional_flow(command.id(), at)
-                && self.command_blocks_cover_all_paths_to_reference(command, name, at)
-        })
+        self.facts
+            .assignments()
+            .unset_commands_for_name(name)
+            .any(|command| {
+                command.span().end.offset <= at.start.offset
+                    && self.command_runs_in_persistent_shell_context(command.id())
+                    && self.command_runs_in_unconditional_flow(command.id(), at)
+                    && self.command_blocks_cover_all_paths_to_reference(command, name, at)
+            })
     }
 
     fn binding_is_cleared_by_dominating_unset(
@@ -2363,20 +2416,23 @@ impl<'a> SafeValueIndex<'a> {
         at: Span,
     ) -> bool {
         let binding = self.semantic.binding(binding_id);
-        self.facts.unset_commands_for_name(name).any(|command| {
-            command.span().start.offset >= binding.span.end.offset
-                && command.span().end.offset <= at.start.offset
-                && self.command_runs_in_persistent_shell_context(command.id())
-                && !self.command_is_in_background_context(command.id())
-                && self.command_blocks_cover_all_paths_to_reference(command, name, at)
-        })
+        self.facts
+            .assignments()
+            .unset_commands_for_name(name)
+            .any(|command| {
+                command.span().start.offset >= binding.span.end.offset
+                    && command.span().end.offset <= at.start.offset
+                    && self.command_runs_in_persistent_shell_context(command.id())
+                    && !self.command_is_in_background_context(command.id())
+                    && self.command_blocks_cover_all_paths_to_reference(command, name, at)
+            })
     }
 
     fn command_runs_in_persistent_shell_context(
         &self,
         command_id: crate::facts::CommandId,
     ) -> bool {
-        let command = self.facts.command(command_id);
+        let command = self.facts.command_facts().command(command_id);
 
         self.semantic
             .ancestor_scopes(command.scope())
@@ -2453,17 +2509,27 @@ impl<'a> SafeValueIndex<'a> {
     }
 
     fn loop_variable_reference_stays_within_body(&self, definition_span: Span, at: Span) -> bool {
-        self.facts.for_headers().iter().any(|header| {
-            header
-                .command()
-                .targets
+        self.facts
+            .command_facts()
+            .for_headers()
+            .iter()
+            .any(|header| {
+                header
+                    .command()
+                    .targets
+                    .iter()
+                    .any(|target| target.span == definition_span)
+                    && span_contains(header.command().body.span, at)
+            })
+            || self
+                .facts
+                .command_facts()
+                .select_headers()
                 .iter()
-                .any(|target| target.span == definition_span)
-                && span_contains(header.command().body.span, at)
-        }) || self.facts.select_headers().iter().any(|header| {
-            header.command().variable_span == definition_span
-                && span_contains(header.command().body.span, at)
-        })
+                .any(|header| {
+                    header.command().variable_span == definition_span
+                        && span_contains(header.command().body.span, at)
+                })
     }
 
     fn loop_variable_reference_stays_within_static_callers(
@@ -2622,6 +2688,7 @@ impl<'a> SafeValueIndex<'a> {
         };
         if self
             .facts
+            .command_facts()
             .is_case_cli_reachable_function_scope(helper_scope)
             || !self.named_function_call_sites(helper_scope).is_empty()
         {
@@ -3157,27 +3224,33 @@ impl<'a> SafeValueIndex<'a> {
         let call_span = self
             .command_for_name_word_span(at)
             .map_or(at, |command| command.span());
-        let Some(mut command_id) = self.facts.innermost_command_id_at(call_span.start.offset)
+        let Some(mut command_id) = self
+            .facts
+            .command_facts()
+            .innermost_command_id_at(call_span.start.offset)
         else {
             return false;
         };
-        while self.facts.command(command_id).span() != call_span {
-            let Some(parent_id) = self.facts.command_parent_id(command_id) else {
+        while self.facts.command_facts().command(command_id).span() != call_span {
+            let Some(parent_id) = self.facts.command_facts().command_parent_id(command_id) else {
                 return false;
             };
             command_id = parent_id;
         }
 
-        let mut current = self.facts.command_parent_id(command_id);
+        let mut current = self.facts.command_facts().command_parent_id(command_id);
         while let Some(command_id) = current {
-            let command = self.facts.command(command_id);
+            let command = self.facts.command_facts().command(command_id);
             if command.span().start.offset < call_span.start.offset
                 && call_span.end.offset <= command.span().end.offset
-                && self.facts.command_is_dominance_barrier(command_id)
+                && self
+                    .facts
+                    .command_facts()
+                    .command_is_dominance_barrier(command_id)
             {
                 return true;
             }
-            current = self.facts.command_parent_id(command_id);
+            current = self.facts.command_facts().command_parent_id(command_id);
         }
 
         false
@@ -3326,6 +3399,7 @@ impl<'a> SafeValueIndex<'a> {
 
     fn function_scope_end_span(&self, scope: ScopeId) -> Option<Span> {
         self.facts
+            .command_facts()
             .function_headers()
             .iter()
             .find(|header| header.function_scope() == Some(scope))
@@ -3372,29 +3446,35 @@ impl<'a> SafeValueIndex<'a> {
             return false;
         }
 
-        let Some(mut command_id) = self.facts.innermost_command_id_at(call_span.start.offset)
+        let Some(mut command_id) = self
+            .facts
+            .command_facts()
+            .innermost_command_id_at(call_span.start.offset)
         else {
             return true;
         };
-        while self.facts.command(command_id).span() != call_span {
-            let Some(parent_id) = self.facts.command_parent_id(command_id) else {
+        while self.facts.command_facts().command(command_id).span() != call_span {
+            let Some(parent_id) = self.facts.command_facts().command_parent_id(command_id) else {
                 return true;
             };
             command_id = parent_id;
         }
 
-        let mut current = self.facts.command_parent_id(command_id);
+        let mut current = self.facts.command_facts().command_parent_id(command_id);
         while let Some(command_id) = current {
-            let command = self.facts.command(command_id);
+            let command = self.facts.command_facts().command(command_id);
             if command.span().end.offset > limit_offset {
                 break;
             }
             if command.span().start.offset < call_span.start.offset
-                && self.facts.command_is_dominance_barrier(command_id)
+                && self
+                    .facts
+                    .command_facts()
+                    .command_is_dominance_barrier(command_id)
             {
                 return false;
             }
-            current = self.facts.command_parent_id(command_id);
+            current = self.facts.command_facts().command_parent_id(command_id);
         }
 
         true
@@ -3404,21 +3484,25 @@ impl<'a> SafeValueIndex<'a> {
         let binding = self.semantic.binding(binding_id);
         let Some(mut current) = self
             .facts
+            .command_facts()
             .innermost_command_id_at(binding.span.start.offset)
-            .and_then(|id| self.facts.command_parent_id(id))
+            .and_then(|id| self.facts.command_facts().command_parent_id(id))
         else {
             return false;
         };
 
         loop {
-            let command = self.facts.command(current);
-            if self.facts.command_is_dominance_barrier(current)
+            let command = self.facts.command_facts().command(current);
+            if self
+                .facts
+                .command_facts()
+                .command_is_dominance_barrier(current)
                 && command.span().end.offset <= at.start.offset
             {
                 return true;
             }
 
-            let Some(parent_id) = self.facts.command_parent_id(current) else {
+            let Some(parent_id) = self.facts.command_facts().command_parent_id(current) else {
                 return false;
             };
             current = parent_id;
@@ -3427,6 +3511,7 @@ impl<'a> SafeValueIndex<'a> {
 
     fn binding_is_one_sided_short_circuit_assignment(&self, binding_id: BindingId) -> bool {
         self.facts
+            .assignments()
             .binding_value(binding_id)
             .is_some_and(|value| value.one_sided_short_circuit_assignment())
     }
@@ -3577,6 +3662,7 @@ impl<'a> SafeValueIndex<'a> {
         at: Span,
     ) -> FxHashSet<BlockId> {
         self.facts
+            .assignments()
             .unset_commands_for_name(name)
             .filter(|command| {
                 command.span().end.offset <= at.start.offset
@@ -3596,14 +3682,14 @@ impl<'a> SafeValueIndex<'a> {
     }
 
     fn command_is_in_boolean_list(&self, command_id: crate::facts::CommandId) -> bool {
-        let mut current = self.facts.command_parent_id(command_id);
+        let mut current = self.facts.command_facts().command_parent_id(command_id);
         while let Some(id) = current {
-            if let Command::Binary(binary) = self.facts.command(id).command()
+            if let Command::Binary(binary) = self.facts.command_facts().command(id).command()
                 && matches!(binary.op, BinaryOp::And | BinaryOp::Or)
             {
                 return true;
             }
-            current = self.facts.command_parent_id(id);
+            current = self.facts.command_facts().command_parent_id(id);
         }
         false
     }
@@ -3649,13 +3735,15 @@ impl<'a> SafeValueIndex<'a> {
 
         let command_id = self
             .facts
+            .command_facts()
             .innermost_command_id_at(at.start.offset)
             .or_else(|| {
                 self.facts
+                    .command_facts()
                     .innermost_command_id_containing_offset(at.start.offset)
             })?;
         self.analysis
-            .block_ids_for_span(self.facts.command(command_id).span())
+            .block_ids_for_span(self.facts.command_facts().command(command_id).span())
             .first()
             .copied()
     }
@@ -3894,6 +3982,7 @@ impl<'a> SafeValueIndex<'a> {
         bindings.into_iter().all(|binding_id| {
             let Some(word) = self
                 .facts
+                .assignments()
                 .binding_value(binding_id)
                 .and_then(|value| value.scalar_word())
             else {
@@ -4023,13 +4112,18 @@ impl<'a> SafeValueIndex<'a> {
         if bindings.iter().copied().any(|binding_id| {
             (self.binding_is_one_sided_short_circuit_assignment(binding_id)
                 && !self.binding_assigns_static_integer_literal(binding_id))
-                || self.facts.binding_value(binding_id).is_some_and(|value| {
-                    value.conditional_assignment_shortcut()
-                        && !self.binding_assigns_static_integer_literal(binding_id)
-                        || value.scalar_word().is_some_and(|word| {
-                            static_word_text(word, self.source).is_some_and(|text| text.is_empty())
-                        })
-                })
+                || self
+                    .facts
+                    .assignments()
+                    .binding_value(binding_id)
+                    .is_some_and(|value| {
+                        value.conditional_assignment_shortcut()
+                            && !self.binding_assigns_static_integer_literal(binding_id)
+                            || value.scalar_word().is_some_and(|word| {
+                                static_word_text(word, self.source)
+                                    .is_some_and(|text| text.is_empty())
+                            })
+                    })
         }) {
             return false;
         }
@@ -4056,6 +4150,7 @@ impl<'a> SafeValueIndex<'a> {
 
         let Some(word) = self
             .facts
+            .assignments()
             .binding_value(binding_id)
             .and_then(|value| value.scalar_word())
         else {
@@ -4067,6 +4162,7 @@ impl<'a> SafeValueIndex<'a> {
 
     fn binding_assigns_static_integer_literal(&self, binding_id: BindingId) -> bool {
         self.facts
+            .assignments()
             .binding_value(binding_id)
             .and_then(|value| value.scalar_word())
             .is_some_and(|word| word_static_text_is_shell_integer(word, self.source))
@@ -4080,13 +4176,17 @@ impl<'a> SafeValueIndex<'a> {
         if bindings.is_empty()
             || bindings.iter().copied().any(|binding_id| {
                 self.binding_is_one_sided_short_circuit_assignment(binding_id)
-                    || self.facts.binding_value(binding_id).is_some_and(|value| {
-                        value.conditional_assignment_shortcut()
-                            || value.scalar_word().is_some_and(|word| {
-                                static_word_text(word, self.source)
-                                    .is_some_and(|text| text.is_empty())
-                            })
-                    })
+                    || self
+                        .facts
+                        .assignments()
+                        .binding_value(binding_id)
+                        .is_some_and(|value| {
+                            value.conditional_assignment_shortcut()
+                                || value.scalar_word().is_some_and(|word| {
+                                    static_word_text(word, self.source)
+                                        .is_some_and(|text| text.is_empty())
+                                })
+                        })
             })
         {
             return false;
@@ -4113,6 +4213,7 @@ impl<'a> SafeValueIndex<'a> {
         }
 
         self.facts
+            .assignments()
             .binding_value(binding_id)
             .and_then(|value| value.scalar_word())
             .is_some_and(word_is_arithmetic_expansion)
@@ -4149,6 +4250,7 @@ impl<'a> SafeValueIndex<'a> {
 
         let Some(word) = self
             .facts
+            .assignments()
             .binding_value(binding_id)
             .and_then(|value| value.scalar_word())
         else {
@@ -4734,6 +4836,7 @@ f() {
         let mut safe_values = SafeValueIndex::build(semantic.semantic(), &analysis, &facts, source);
 
         let word_fact = facts
+            .words()
             .word_facts()
             .iter()
             .find(|fact| {
@@ -4761,6 +4864,7 @@ f() {
         let mut safe_values = SafeValueIndex::build(semantic.semantic(), &analysis, &facts, source);
 
         let word_fact = facts
+            .words()
             .word_facts()
             .iter()
             .find(|fact| {
@@ -4822,6 +4926,7 @@ done
         let mut safe_values = SafeValueIndex::build(semantic.semantic(), &analysis, &facts, source);
 
         let unsafe_words = facts
+            .words()
             .word_facts()
             .iter()
             .filter(|fact| {
@@ -4837,6 +4942,7 @@ done
         );
 
         let safe_words = facts
+            .words()
             .word_facts()
             .iter()
             .filter(|fact| {
@@ -4873,6 +4979,7 @@ iptables $flag -t nat -N chain
         let mut safe_values = SafeValueIndex::build(semantic.semantic(), &analysis, &facts, source);
 
         let short_circuit_word = facts
+            .words()
             .word_facts()
             .iter()
             .find(|fact| {
@@ -4881,6 +4988,7 @@ iptables $flag -t nat -N chain
             })
             .expect("expected short-circuit command argument");
         let if_else_word = facts
+            .words()
             .word_facts()
             .iter()
             .find(|fact| {
@@ -4914,6 +5022,7 @@ done
         let mut safe_values = SafeValueIndex::build(semantic.semantic(), &analysis, &facts, source);
 
         let loop_words = facts
+            .words()
             .word_facts()
             .iter()
             .filter(|fact| {
@@ -4951,6 +5060,7 @@ f() {
         let mut safe_values = SafeValueIndex::build(semantic.semantic(), &analysis, &facts, source);
 
         let word_fact = facts
+            .words()
             .word_facts()
             .iter()
             .find(|fact| {
@@ -4983,6 +5093,7 @@ done
         let mut safe_values = SafeValueIndex::build(semantic.semantic(), &analysis, &facts, source);
 
         let word_fact = facts
+            .words()
             .word_facts()
             .iter()
             .find(|fact| {
@@ -5018,6 +5129,7 @@ fi
         let mut safe_values = SafeValueIndex::build(semantic.semantic(), &analysis, &facts, source);
 
         let validate_uses = facts
+            .words()
             .word_facts()
             .iter()
             .filter(|fact| {
@@ -5053,6 +5165,7 @@ f() {
         let mut safe_values = SafeValueIndex::build(semantic.semantic(), &analysis, &facts, source);
 
         let word_fact = facts
+            .words()
             .word_facts()
             .iter()
             .find(|fact| {
@@ -5094,6 +5207,7 @@ f() {
         let mut safe_values = SafeValueIndex::build(semantic.semantic(), &analysis, &facts, source);
 
         let validate_uses = facts
+            .words()
             .word_facts()
             .iter()
             .filter(|fact| {
@@ -5149,6 +5263,7 @@ printf '%s\\n' vm-${disk_ext_with_default:-}
         let mut safe_values = SafeValueIndex::build(semantic.semantic(), &analysis, &facts, source);
 
         let maybe_uninitialized = facts
+            .words()
             .word_facts()
             .iter()
             .find(|fact| {
@@ -5157,6 +5272,7 @@ printf '%s\\n' vm-${disk_ext_with_default:-}
             })
             .expect("expected maybe-uninitialized command argument");
         let explicit_default = facts
+            .words()
             .word_facts()
             .iter()
             .find(|fact| {
@@ -5266,6 +5382,7 @@ value=\"$(free ${humanreadable} | awk '{print $2}')\"
         let mut safe_values = SafeValueIndex::build(semantic.semantic(), &analysis, &facts, source);
 
         let word_fact = facts
+            .words()
             .word_facts()
             .iter()
             .find(|fact| {
@@ -5293,6 +5410,7 @@ done
         let mut safe_values = SafeValueIndex::build(semantic.semantic(), &analysis, &facts, source);
 
         let after_loop_use = facts
+            .words()
             .word_facts()
             .iter()
             .find(|fact| {
@@ -5352,6 +5470,7 @@ echo \"MD5SUM=\\\"$( md5sum $PRGNAM-$VERSION.tar.xz | cut -d' ' -f1 )\\\"\"
         let mut safe_values = SafeValueIndex::build(semantic.semantic(), &analysis, &facts, source);
 
         let version_use = facts
+            .words()
             .word_facts()
             .iter()
             .find(|fact| {
@@ -5386,6 +5505,7 @@ config() {
         let mut safe_values = SafeValueIndex::build(semantic.semantic(), &analysis, &facts, source);
 
         let word_fact = facts
+            .words()
             .word_facts()
             .iter()
             .find(|fact| {
@@ -5442,6 +5562,7 @@ printf '%s\\n' $opt hi
         let mut safe_values = SafeValueIndex::build(semantic.semantic(), &analysis, &facts, source);
 
         let unsafe_words = facts
+            .words()
             .word_facts()
             .iter()
             .filter(|fact| {
@@ -5454,6 +5575,7 @@ printf '%s\\n' $opt hi
             })
             .collect::<Vec<_>>();
         let safe_words = facts
+            .words()
             .word_facts()
             .iter()
             .filter(|fact| {
@@ -5505,6 +5627,7 @@ GetAMI
         let mut safe_values = SafeValueIndex::build(semantic.semantic(), &analysis, &facts, source);
 
         let word_fact = facts
+            .words()
             .word_facts()
             .iter()
             .find(|fact| {
@@ -5543,6 +5666,7 @@ GetAMI
         let mut safe_values = SafeValueIndex::build(semantic.semantic(), &analysis, &facts, source);
 
         let word_fact = facts
+            .words()
             .word_facts()
             .iter()
             .find(|fact| {
@@ -5600,6 +5724,7 @@ fn_backup_compression
         let mut safe_values = SafeValueIndex::build(semantic.semantic(), &analysis, &facts, source);
 
         let word_fact = facts
+            .words()
             .word_facts()
             .iter()
             .find(|fact| {
@@ -5637,6 +5762,7 @@ exit $?
         let mut safe_values = SafeValueIndex::build(semantic.semantic(), &analysis, &facts, source);
 
         let command_name = facts
+            .words()
             .word_facts()
             .iter()
             .find(|fact| {
@@ -5645,6 +5771,7 @@ exit $?
             })
             .expect("expected dynamic command-name fact");
         let command_arg = facts
+            .words()
             .word_facts()
             .iter()
             .find(|fact| {
@@ -5682,6 +5809,7 @@ esac
         let mut safe_values = SafeValueIndex::build(semantic.semantic(), &analysis, &facts, source);
 
         let command_name = facts
+            .words()
             .word_facts()
             .iter()
             .find(|fact| {
@@ -5690,6 +5818,7 @@ esac
             })
             .expect("expected dynamic command-name fact");
         let command_arg = facts
+            .words()
             .word_facts()
             .iter()
             .find(|fact| {
@@ -5724,6 +5853,7 @@ exit $?
         let mut safe_values = SafeValueIndex::build(semantic.semantic(), &analysis, &facts, source);
 
         let dispatched_use = facts
+            .words()
             .word_facts()
             .iter()
             .find(|fact| {
@@ -5781,6 +5911,7 @@ exit $?
         let mut safe_values = SafeValueIndex::build(semantic.semantic(), &analysis, &facts, source);
 
         let command_arg = facts
+            .words()
             .word_facts()
             .iter()
             .find(|fact| {
@@ -5814,6 +5945,7 @@ exit 0
         let mut safe_values = SafeValueIndex::build(semantic.semantic(), &analysis, &facts, source);
 
         let command_arg = facts
+            .words()
             .word_facts()
             .iter()
             .find(|fact| {
@@ -5851,6 +5983,7 @@ exit $?
         let mut safe_values = SafeValueIndex::build(semantic.semantic(), &analysis, &facts, source);
 
         let command_arg = facts
+            .words()
             .word_facts()
             .iter()
             .find(|fact| {
@@ -5886,6 +6019,7 @@ exit $?
         let mut safe_values = SafeValueIndex::build(semantic.semantic(), &analysis, &facts, source);
 
         let command_arg = facts
+            .words()
             .word_facts()
             .iter()
             .find(|fact| {
@@ -5922,6 +6056,7 @@ exit $?
         let mut safe_values = SafeValueIndex::build(semantic.semantic(), &analysis, &facts, source);
 
         let command_name = facts
+            .words()
             .word_facts()
             .iter()
             .find(|fact| {
@@ -5930,6 +6065,7 @@ exit $?
             })
             .expect("expected nested command-substitution command name");
         let command_arg = facts
+            .words()
             .word_facts()
             .iter()
             .find(|fact| {
@@ -5961,6 +6097,7 @@ exit 0
         let mut safe_values = SafeValueIndex::build(semantic.semantic(), &analysis, &facts, source);
 
         let command_arg = facts
+            .words()
             .word_facts()
             .iter()
             .find(|fact| {
@@ -5991,6 +6128,7 @@ outer() {
         let mut safe_values = SafeValueIndex::build(semantic.semantic(), &analysis, &facts, source);
 
         let command_arg = facts
+            .words()
             .word_facts()
             .iter()
             .find(|fact| {
@@ -6029,6 +6167,7 @@ fi
         let mut safe_values = SafeValueIndex::build(semantic.semantic(), &analysis, &facts, source);
 
         let command_arg = facts
+            .words()
             .word_facts()
             .iter()
             .find(|fact| {
@@ -6063,6 +6202,7 @@ exit $?
         let mut safe_values = SafeValueIndex::build(semantic.semantic(), &analysis, &facts, source);
 
         let indirect_use = facts
+            .words()
             .word_facts()
             .iter()
             .find(|fact| {
@@ -6106,6 +6246,7 @@ unsafe_path
         let mut safe_values = SafeValueIndex::build(semantic.semantic(), &analysis, &facts, source);
 
         let word_fact = facts
+            .words()
             .word_facts()
             .iter()
             .find(|fact| {
@@ -6148,6 +6289,7 @@ done
         let mut safe_values = SafeValueIndex::build(semantic.semantic(), &analysis, &facts, source);
 
         let unsafe_words = facts
+            .words()
             .word_facts()
             .iter()
             .filter(|fact| {
@@ -6185,6 +6327,7 @@ do_start
         let mut safe_values = SafeValueIndex::build(semantic.semantic(), &analysis, &facts, source);
 
         let word_fact = facts
+            .words()
             .word_facts()
             .iter()
             .find(|fact| {
@@ -6227,6 +6370,7 @@ run_make
         let mut safe_values = SafeValueIndex::build(semantic.semantic(), &analysis, &facts, source);
 
         let word_fact = facts
+            .words()
             .word_facts()
             .iter()
             .find(|fact| {
@@ -6261,6 +6405,7 @@ render() {
         let mut safe_values = SafeValueIndex::build(semantic.semantic(), &analysis, &facts, source);
 
         let word_fact = facts
+            .words()
             .word_facts()
             .iter()
             .find(|fact| {
@@ -6292,6 +6437,7 @@ move_up $count
         let mut safe_values = SafeValueIndex::build(semantic.semantic(), &analysis, &facts, source);
 
         let word_fact = facts
+            .words()
             .word_facts()
             .iter()
             .find(|fact| {
@@ -6329,6 +6475,7 @@ render() {
         let mut safe_values = SafeValueIndex::build(semantic.semantic(), &analysis, &facts, source);
 
         let word_fact = facts
+            .words()
             .word_facts()
             .iter()
             .find(|fact| {
@@ -6379,6 +6526,7 @@ main() {
         let mut safe_values = SafeValueIndex::build(semantic.semantic(), &analysis, &facts, source);
 
         let word_fact = facts
+            .words()
             .word_facts()
             .iter()
             .find(|fact| {
@@ -6415,6 +6563,7 @@ render() {
         let mut safe_values = SafeValueIndex::build(semantic.semantic(), &analysis, &facts, source);
 
         let word_fact = facts
+            .words()
             .word_facts()
             .iter()
             .find(|fact| {
@@ -6451,6 +6600,7 @@ render() {
         let safe_values = SafeValueIndex::build(semantic.semantic(), &analysis, &facts, source);
 
         let word_fact = facts
+            .words()
             .word_facts()
             .iter()
             .find(|fact| {
@@ -6501,6 +6651,7 @@ render() {
         let mut safe_values = SafeValueIndex::build(semantic.semantic(), &analysis, &facts, source);
 
         let word_fact = facts
+            .words()
             .word_facts()
             .iter()
             .find(|fact| {
@@ -6538,6 +6689,7 @@ clean_caller() {
         let safe_values = SafeValueIndex::build(semantic.semantic(), &analysis, &facts, source);
 
         let word_fact = facts
+            .words()
             .word_facts()
             .iter()
             .find(|fact| {
@@ -6576,6 +6728,7 @@ openssl dgst -sha${sig:2} file
         let mut safe_values = SafeValueIndex::build(semantic.semantic(), &analysis, &facts, source);
 
         let word_fact = facts
+            .words()
             .word_facts()
             .iter()
             .find(|fact| {
@@ -6608,6 +6761,7 @@ run() {
         let mut safe_values = SafeValueIndex::build(semantic.semantic(), &analysis, &facts, source);
 
         let word_fact = facts
+            .words()
             .word_facts()
             .iter()
             .find(|fact| {
@@ -6656,6 +6810,7 @@ safe_path_b
         let mut safe_values = SafeValueIndex::build(semantic.semantic(), &analysis, &facts, source);
 
         let word_fact = facts
+            .words()
             .word_facts()
             .iter()
             .find(|fact| {
@@ -6697,6 +6852,7 @@ fi
         let mut safe_values = SafeValueIndex::build(semantic.semantic(), &analysis, &facts, source);
 
         let word_fact = facts
+            .words()
             .word_facts()
             .iter()
             .find(|fact| {
@@ -6736,6 +6892,7 @@ read_disc
         let mut safe_values = SafeValueIndex::build(semantic.semantic(), &analysis, &facts, source);
 
         let word_fact = facts
+            .words()
             .word_facts()
             .iter()
             .find(|fact| {
@@ -6780,6 +6937,7 @@ printf '%s\\n' $pkgname
         let mut safe_values = SafeValueIndex::build(semantic.semantic(), &analysis, &facts, source);
 
         let word_fact = facts
+            .words()
             .word_facts()
             .iter()
             .find(|fact| {
@@ -6805,6 +6963,7 @@ bash ${debug:+\"-x\"} script
         let mut safe_values = SafeValueIndex::build(semantic.semantic(), &analysis, &facts, source);
 
         let word_fact = facts
+            .words()
             .word_facts()
             .iter()
             .find(|fact| {
@@ -6830,6 +6989,7 @@ printf '%s\\n' ${debug:+\"a b\"}
         let mut safe_values = SafeValueIndex::build(semantic.semantic(), &analysis, &facts, source);
 
         let word_fact = facts
+            .words()
             .word_facts()
             .iter()
             .find(|fact| {
@@ -6860,6 +7020,7 @@ openssl dgst -sha${sig:2} payload
         let mut safe_values = SafeValueIndex::build(semantic.semantic(), &analysis, &facts, source);
 
         let word_fact = facts
+            .words()
             .word_facts()
             .iter()
             .find(|fact| {
@@ -6896,6 +7057,7 @@ openssl dgst -sha${sig:2} payload
         let mut safe_values = SafeValueIndex::build(semantic.semantic(), &analysis, &facts, source);
 
         let word_fact = facts
+            .words()
             .word_facts()
             .iter()
             .find(|fact| {
@@ -6924,6 +7086,7 @@ echo /tmp/$SAFE
         let mut safe_values = SafeValueIndex::build(semantic.semantic(), &analysis, &facts, source);
 
         let word_fact = facts
+            .words()
             .word_facts()
             .iter()
             .find(|fact| {
@@ -6961,6 +7124,7 @@ fi
         let mut safe_values = SafeValueIndex::build(semantic.semantic(), &analysis, &facts, source);
 
         let word_fact = facts
+            .words()
             .word_facts()
             .iter()
             .find(|fact| {
@@ -7007,6 +7171,7 @@ echo x >> ${OPENBSD_CONTENTS}
         let facts = LinterFacts::build(&output.file, source, &semantic, &indexer);
         let mut safe_values = SafeValueIndex::build(semantic.semantic(), &analysis, &facts, source);
         let exit_header = facts
+            .command_facts()
             .function_headers()
             .iter()
             .find(|header| {
@@ -7017,6 +7182,7 @@ echo x >> ${OPENBSD_CONTENTS}
             .expect("expected Exit function header");
 
         let nested_argument = facts
+            .words()
             .word_facts()
             .iter()
             .find(|fact| {
@@ -7026,6 +7192,7 @@ echo x >> ${OPENBSD_CONTENTS}
             })
             .expect("expected nested command argument fact");
         let redirect_target = facts
+            .words()
             .word_facts()
             .iter()
             .find(|fact| {
@@ -7062,6 +7229,7 @@ helper() {
         let mut safe_values = SafeValueIndex::build(semantic.semantic(), &analysis, &facts, source);
 
         let word_fact = facts
+            .words()
             .word_facts()
             .iter()
             .find(|fact| {
@@ -7086,6 +7254,7 @@ helper() (
         let semantic = LinterSemanticArtifacts::build(&output.file, source, &indexer);
         let facts = LinterFacts::build(&output.file, source, &semantic, &indexer);
         let helper_header = facts
+            .command_facts()
             .function_headers()
             .iter()
             .find(|header| {
@@ -7112,6 +7281,7 @@ helper() {
         let semantic = LinterSemanticArtifacts::build(&output.file, source, &indexer);
         let facts = LinterFacts::build(&output.file, source, &semantic, &indexer);
         let helper_header = facts
+            .command_facts()
             .function_headers()
             .iter()
             .find(|header| {
@@ -7137,6 +7307,7 @@ helper() {
         let semantic = LinterSemanticArtifacts::build(&output.file, source, &indexer);
         let facts = LinterFacts::build(&output.file, source, &semantic, &indexer);
         let helper_header = facts
+            .command_facts()
             .function_headers()
             .iter()
             .find(|header| {
@@ -7162,6 +7333,7 @@ helper() {
         let semantic = LinterSemanticArtifacts::build(&output.file, source, &indexer);
         let facts = LinterFacts::build(&output.file, source, &semantic, &indexer);
         let helper_header = facts
+            .command_facts()
             .function_headers()
             .iter()
             .find(|header| {
@@ -7187,6 +7359,7 @@ helper() {
         let semantic = LinterSemanticArtifacts::build(&output.file, source, &indexer);
         let facts = LinterFacts::build(&output.file, source, &semantic, &indexer);
         let helper_header = facts
+            .command_facts()
             .function_headers()
             .iter()
             .find(|header| {
@@ -7216,6 +7389,7 @@ helper() {
         let semantic = LinterSemanticArtifacts::build(&output.file, source, &indexer);
         let facts = LinterFacts::build(&output.file, source, &semantic, &indexer);
         let helper_header = facts
+            .command_facts()
             .function_headers()
             .iter()
             .find(|header| {
@@ -7244,6 +7418,7 @@ helper() {
         let semantic = LinterSemanticArtifacts::build(&output.file, source, &indexer);
         let facts = LinterFacts::build(&output.file, source, &semantic, &indexer);
         let helper_header = facts
+            .command_facts()
             .function_headers()
             .iter()
             .find(|header| {
@@ -7272,6 +7447,7 @@ helper() {
         let semantic = LinterSemanticArtifacts::build(&output.file, source, &indexer);
         let facts = LinterFacts::build(&output.file, source, &semantic, &indexer);
         let helper_header = facts
+            .command_facts()
             .function_headers()
             .iter()
             .find(|header| {
@@ -7298,6 +7474,7 @@ helper() {
         let semantic = LinterSemanticArtifacts::build(&output.file, source, &indexer);
         let facts = LinterFacts::build(&output.file, source, &semantic, &indexer);
         let helper_header = facts
+            .command_facts()
             .function_headers()
             .iter()
             .find(|header| {
@@ -7328,6 +7505,7 @@ helper() {
         let semantic = LinterSemanticArtifacts::build(&output.file, source, &indexer);
         let facts = LinterFacts::build(&output.file, source, &semantic, &indexer);
         let helper_header = facts
+            .command_facts()
             .function_headers()
             .iter()
             .find(|header| {
@@ -7358,6 +7536,7 @@ Exit() { exit 0; }
         let facts = LinterFacts::build(&output.file, source, &semantic, &indexer);
         let mut safe_values = SafeValueIndex::build(semantic.semantic(), &analysis, &facts, source);
         let target = facts
+            .words()
             .word_facts()
             .iter()
             .find(|fact| {

--- a/crates/shuck-linter/src/rules/style/unquoted_path_in_mkdir.rs
+++ b/crates/shuck-linter/src/rules/style/unquoted_path_in_mkdir.rs
@@ -34,7 +34,7 @@ pub fn unquoted_path_in_mkdir(checker: &mut Checker) {
         .filter(|fact| fact.effective_name_is("mkdir"))
         .flat_map(|fact| mkdir_path_operand_spans(fact, source))
         .filter_map(|span| {
-            checker.facts().word_fact(
+            checker.facts().words().word_fact(
                 span,
                 WordFactContext::Expansion(ExpansionContext::CommandArgument),
             )

--- a/crates/shuck-linter/src/rules/style/unquoted_tr_class.rs
+++ b/crates/shuck-linter/src/rules/style/unquoted_tr_class.rs
@@ -33,7 +33,7 @@ pub fn unquoted_tr_class(checker: &mut Checker) {
         .filter(|fact| fact.effective_name_is("tr") && fact.wrappers().is_empty())
         .flat_map(|fact| {
             fact.body_args().iter().filter_map(|word| {
-                let word_fact = checker.facts().word_fact(
+                let word_fact = checker.facts().words().word_fact(
                     word.span,
                     WordFactContext::Expansion(ExpansionContext::CommandArgument),
                 )?;

--- a/crates/shuck-linter/src/rules/style/unquoted_variable_in_test.rs
+++ b/crates/shuck-linter/src/rules/style/unquoted_variable_in_test.rs
@@ -44,7 +44,7 @@ pub fn unquoted_variable_in_test(checker: &mut Checker) {
             }
 
             let operand = simple_test.operands()[1];
-            let Some(word_fact) = facts.word_fact(
+            let Some(word_fact) = facts.words().word_fact(
                 operand.span,
                 WordFactContext::Expansion(ExpansionContext::CommandArgument),
             ) else {

--- a/crates/shuck-linter/src/rules/style/unquoted_word_between_quotes.rs
+++ b/crates/shuck-linter/src/rules/style/unquoted_word_between_quotes.rs
@@ -24,6 +24,7 @@ pub fn unquoted_word_between_quotes(checker: &mut Checker) {
     let source = checker.source();
     let diagnostics = checker
         .facts()
+        .words()
         .word_facts()
         .iter()
         .flat_map(|fact| fact.unquoted_word_after_single_quoted_segment_spans(source))


### PR DESCRIPTION
## Summary
- remove the legacy flat `LinterFacts` accessor surface
- route linter rules, fact tests, benchmarks, and CLI tests through `command_facts()`, `words()`, `assignments()`, `source_facts()`, and `compat()`
- keep the new fact store façade types nameable from the crate root

## Validation
- cargo fmt -- --check
- cargo test -p shuck-linter --no-default-features
- cargo test -p shuck-linter
- cargo test -p shuck-cli --test zsh_option_state
- cargo clippy --all-targets -- -D warnings
- make test-large-corpus SHUCK_LARGE_CORPUS_SAMPLE_PERCENT=10
- make test-large-corpus
