### PR TITLE
feat(linter): add S084 function doc content rule

### DIFF
--- a/crates/shuck-cli/src/commands/check/settings.rs
+++ b/crates/shuck-cli/src/commands/check/settings.rs
@@ -55,6 +55,10 @@ struct EffectivePerFileShell {
 struct EffectiveRuleOptions {
     c001_treat_indirect_expansion_targets_as_used: bool,
     c063_report_unreached_nested_definitions: bool,
+    s084_require_globals: bool,
+    s084_require_arguments: bool,
+    s084_require_outputs: bool,
+    s084_require_returns: bool,
     s085_non_trivial_line_threshold: usize,
     s085_non_trivial_function_count: usize,
     s085_main_name: String,
@@ -177,6 +181,10 @@ impl EffectiveRuleOptions {
             c063_report_unreached_nested_definitions: rule_options
                 .c063
                 .report_unreached_nested_definitions,
+            s084_require_globals: rule_options.s084.require_globals,
+            s084_require_arguments: rule_options.s084.require_arguments,
+            s084_require_outputs: rule_options.s084.require_outputs,
+            s084_require_returns: rule_options.s084.require_returns,
             s085_non_trivial_line_threshold: rule_options.s085.non_trivial_line_threshold,
             s085_non_trivial_function_count: rule_options.s085.non_trivial_function_count,
             s085_main_name: rule_options.s085.main_name.clone(),
@@ -191,6 +199,10 @@ impl CacheKey for EffectiveRuleOptions {
             .cache_key(state);
         self.c063_report_unreached_nested_definitions
             .cache_key(state);
+        self.s084_require_globals.cache_key(state);
+        self.s084_require_arguments.cache_key(state);
+        self.s084_require_outputs.cache_key(state);
+        self.s084_require_returns.cache_key(state);
         self.s085_non_trivial_line_threshold.cache_key(state);
         self.s085_non_trivial_function_count.cache_key(state);
         self.s085_main_name.cache_key(state);
@@ -941,6 +953,38 @@ fn linter_rule_options_for_lint_config(lint: &LintConfig) -> shuck_linter::Linte
         .and_then(|c063| c063.report_unreached_nested_definitions)
     {
         rule_options.c063.report_unreached_nested_definitions = value;
+    }
+    if let Some(value) = lint
+        .rule_options
+        .as_ref()
+        .and_then(|options| options.s084.as_ref())
+        .and_then(|s084| s084.require_globals)
+    {
+        rule_options.s084.require_globals = value;
+    }
+    if let Some(value) = lint
+        .rule_options
+        .as_ref()
+        .and_then(|options| options.s084.as_ref())
+        .and_then(|s084| s084.require_arguments)
+    {
+        rule_options.s084.require_arguments = value;
+    }
+    if let Some(value) = lint
+        .rule_options
+        .as_ref()
+        .and_then(|options| options.s084.as_ref())
+        .and_then(|s084| s084.require_outputs)
+    {
+        rule_options.s084.require_outputs = value;
+    }
+    if let Some(value) = lint
+        .rule_options
+        .as_ref()
+        .and_then(|options| options.s084.as_ref())
+        .and_then(|s084| s084.require_returns)
+    {
+        rule_options.s084.require_returns = value;
     }
     if let Some(value) = lint
         .rule_options

--- a/crates/shuck-config/src/lib.rs
+++ b/crates/shuck-config/src/lib.rs
@@ -60,10 +60,16 @@ const CONFIG_OVERRIDE_LINT_ZSH_PLUGIN_KEYS: &[&str] = &[
     "theme-loads",
     "entrypoints",
 ];
-const CONFIG_OVERRIDE_LINT_RULE_OPTION_KEYS: &[&str] = &["c001", "c063", "s085"];
+const CONFIG_OVERRIDE_LINT_RULE_OPTION_KEYS: &[&str] = &["c001", "c063", "s084", "s085"];
 const CONFIG_OVERRIDE_C001_RULE_OPTION_KEYS: &[&str] =
     &["treat-indirect-expansion-targets-as-used"];
 const CONFIG_OVERRIDE_C063_RULE_OPTION_KEYS: &[&str] = &["report-unreached-nested-definitions"];
+const CONFIG_OVERRIDE_S084_RULE_OPTION_KEYS: &[&str] = &[
+    "require-globals",
+    "require-arguments",
+    "require-outputs",
+    "require-returns",
+];
 const CONFIG_OVERRIDE_S085_RULE_OPTION_KEYS: &[&str] = &[
     "non-trivial-line-threshold",
     "non-trivial-function-count",
@@ -321,6 +327,8 @@ pub struct LintRuleOptionsConfig {
     pub c001: Option<C001RuleOptionsConfig>,
     /// Options for rule C063.
     pub c063: Option<C063RuleOptionsConfig>,
+    /// Options for rule S084.
+    pub s084: Option<S084RuleOptionsConfig>,
     /// Options for rule S085.
     pub s085: Option<S085RuleOptionsConfig>,
 }
@@ -332,6 +340,9 @@ impl LintRuleOptionsConfig {
         }
         if let Some(c063) = overrides.c063 {
             self.c063.get_or_insert_default().apply_overrides(c063);
+        }
+        if let Some(s084) = overrides.s084 {
+            self.s084.get_or_insert_default().apply_overrides(s084);
         }
         if let Some(s085) = overrides.s085 {
             self.s085.get_or_insert_default().apply_overrides(s085);
@@ -373,6 +384,37 @@ impl C063RuleOptionsConfig {
     }
 }
 
+/// Options for rule S084.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Deserialize)]
+#[serde(default, rename_all = "kebab-case", deny_unknown_fields)]
+pub struct S084RuleOptionsConfig {
+    /// Whether comments should document global variables used by a function body.
+    pub require_globals: Option<bool>,
+    /// Whether comments should document positional parameters used by a function body.
+    pub require_arguments: Option<bool>,
+    /// Whether comments should document stdout output produced by a function body.
+    pub require_outputs: Option<bool>,
+    /// Whether comments should document explicit return statuses from a function body.
+    pub require_returns: Option<bool>,
+}
+
+impl S084RuleOptionsConfig {
+    fn apply_overrides(&mut self, overrides: Self) {
+        if overrides.require_globals.is_some() {
+            self.require_globals = overrides.require_globals;
+        }
+        if overrides.require_arguments.is_some() {
+            self.require_arguments = overrides.require_arguments;
+        }
+        if overrides.require_outputs.is_some() {
+            self.require_outputs = overrides.require_outputs;
+        }
+        if overrides.require_returns.is_some() {
+            self.require_returns = overrides.require_returns;
+        }
+    }
+}
+
 /// Options for rule S085.
 #[derive(Debug, Clone, Default, PartialEq, Eq, Deserialize)]
 #[serde(default, rename_all = "kebab-case", deny_unknown_fields)]
@@ -398,7 +440,6 @@ impl S085RuleOptionsConfig {
         }
     }
 }
-
 /// Partial formatter settings supplied by CLI flags or config files.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub struct FormatSettingsPatch {
@@ -680,6 +721,41 @@ const CONFIGURATION_METADATA: [ConfigSectionMetadata; 3] = [
                             value_type: "bool",
                             example: "report-unreached-nested-definitions = true",
                         }],
+                        sections: &[],
+                    },
+                    ConfigSectionMetadata {
+                        key: "s084",
+                        docs: "Behavior overrides for `S084` function documentation content.",
+                        fields: &[
+                            ConfigFieldMetadata {
+                                key: "require-globals",
+                                docs: "Require a Globals section when a documented function reads or writes non-local variables.",
+                                default: "true",
+                                value_type: "bool",
+                                example: "require-globals = false",
+                            },
+                            ConfigFieldMetadata {
+                                key: "require-arguments",
+                                docs: "Require an Arguments section when a documented function uses positional parameters.",
+                                default: "true",
+                                value_type: "bool",
+                                example: "require-arguments = false",
+                            },
+                            ConfigFieldMetadata {
+                                key: "require-outputs",
+                                docs: "Require an Outputs section when a documented function writes with echo or printf.",
+                                default: "true",
+                                value_type: "bool",
+                                example: "require-outputs = false",
+                            },
+                            ConfigFieldMetadata {
+                                key: "require-returns",
+                                docs: "Require a Returns section when a documented function has an explicit return code.",
+                                default: "true",
+                                value_type: "bool",
+                                example: "require-returns = false",
+                            },
+                        ],
                         sections: &[],
                     },
                     ConfigSectionMetadata {
@@ -1384,6 +1460,9 @@ fn validate_lint_rule_options_override(value: &toml::Value) -> std::result::Resu
     if let Some(c063_value) = rule_options.get("c063") {
         validate_c063_rule_options_override(c063_value)?;
     }
+    if let Some(s084_value) = rule_options.get("s084") {
+        validate_s084_rule_options_override(s084_value)?;
+    }
     if let Some(s085_value) = rule_options.get("s085") {
         validate_s085_rule_options_override(s085_value)?;
     }
@@ -1423,6 +1502,22 @@ fn validate_c063_rule_options_override(value: &toml::Value) -> std::result::Resu
     Ok(())
 }
 
+fn validate_s084_rule_options_override(value: &toml::Value) -> std::result::Result<(), String> {
+    let s084 = value
+        .as_table()
+        .ok_or_else(|| "`[lint.rule-options.s084]` must be a TOML table".to_owned())?;
+    for key in s084.keys() {
+        if !CONFIG_OVERRIDE_S084_RULE_OPTION_KEYS.contains(&key.as_str()) {
+            return Err(format!(
+                "unsupported `[lint.rule-options.s084]` option `{key}`; expected one of: {}",
+                CONFIG_OVERRIDE_S084_RULE_OPTION_KEYS.join(", ")
+            ));
+        }
+    }
+
+    Ok(())
+}
+
 fn validate_s085_rule_options_override(value: &toml::Value) -> std::result::Result<(), String> {
     let s085 = value
         .as_table()
@@ -1438,7 +1533,6 @@ fn validate_s085_rule_options_override(value: &toml::Value) -> std::result::Resu
 
     Ok(())
 }
-
 fn invalid_config_argument(
     cmd: &clap::Command,
     arg: Option<&clap::Arg>,
@@ -1680,6 +1774,27 @@ mod tests {
     }
 
     #[test]
+    fn inline_config_overrides_validate_supported_s084_rule_option_keys() {
+        let config = parse_config_override(
+            "lint.rule-options.s084.require-globals = false\n\
+             lint.rule-options.s084.require-arguments = false\n\
+             lint.rule-options.s084.require-outputs = true\n\
+             lint.rule-options.s084.require-returns = true",
+        )
+        .unwrap();
+        let s084 = config
+            .lint
+            .rule_options
+            .as_ref()
+            .and_then(|options| options.s084.as_ref())
+            .expect("missing s084 options");
+        assert_eq!(s084.require_globals, Some(false));
+        assert_eq!(s084.require_arguments, Some(false));
+        assert_eq!(s084.require_outputs, Some(true));
+        assert_eq!(s084.require_returns, Some(true));
+    }
+
+    #[test]
     fn inline_config_overrides_validate_supported_s085_rule_option_keys() {
         let config = parse_config_override(
             "lint.rule-options.s085.non-trivial-line-threshold = 20\n\
@@ -1795,6 +1910,12 @@ mod tests {
     }
 
     #[test]
+    fn inline_config_overrides_reject_unknown_s084_rule_option_keys() {
+        let err = parse_config_override("lint.rule-options.s084.preview = true").unwrap_err();
+        assert!(err.contains("unsupported `[lint.rule-options.s084]` option `preview`"));
+    }
+
+    #[test]
     fn inline_config_overrides_reject_unknown_s085_rule_option_keys() {
         let err = parse_config_override("lint.rule-options.s085.preview = true").unwrap_err();
         assert!(err.contains("unsupported `[lint.rule-options.s085]` option `preview`"));
@@ -1904,6 +2025,35 @@ mod tests {
                 .as_ref()
                 .and_then(|options| options.c063.as_ref())
                 .and_then(|c063| c063.report_unreached_nested_definitions),
+            Some(false)
+        );
+    }
+
+    #[test]
+    fn s084_rule_option_config_arguments_allow_last_override_to_win() {
+        let tempdir = tempdir().unwrap();
+        let config = ConfigArguments::from_cli(
+            vec![
+                SingleConfigArgument::SettingsOverride(Box::new(
+                    parse_config_override("lint.rule-options.s084.require-returns = true").unwrap(),
+                )),
+                SingleConfigArgument::SettingsOverride(Box::new(
+                    parse_config_override("lint.rule-options.s084.require-returns = false")
+                        .unwrap(),
+                )),
+            ],
+            false,
+        )
+        .unwrap();
+
+        let loaded = load_project_config(tempdir.path(), &config).unwrap();
+        assert_eq!(
+            loaded
+                .lint
+                .rule_options
+                .as_ref()
+                .and_then(|options| options.s084.as_ref())
+                .and_then(|s084| s084.require_returns),
             Some(false)
         );
     }

--- a/crates/shuck-linter/resources/test/fixtures/style/S084.sh
+++ b/crates/shuck-linter/resources/test/fixtures/style/S084.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+# Builds an absolute output path.
+build_path() {
+  local suffix=$1
+  echo "${BASE_DIR}/${suffix}"
+  return 0
+}
+
+# Builds an absolute output path by joining BASE_DIR with a suffix.
+#
+# Globals:
+#   BASE_DIR
+# Arguments:
+#   $1 - The path suffix to append.
+# Outputs:
+#   Writes the constructed path to stdout.
+# Returns:
+#   0 always.
+build_more_path() {
+  local suffix=$1
+  echo "${BASE_DIR}/${suffix}"
+  return 0
+}

--- a/crates/shuck-linter/src/checker.rs
+++ b/crates/shuck-linter/src/checker.rs
@@ -380,6 +380,9 @@ impl<'a> Checker<'a> {
         if self.is_rule_enabled(Rule::FunctionBodyWithoutBraces) {
             rules::style::function_body_without_braces::function_body_without_braces(self);
         }
+        if self.is_rule_enabled(Rule::FunctionDocContent) {
+            rules::style::function_doc_content::function_doc_content(self);
+        }
         if self.is_rule_enabled(Rule::RedundantReturnStatus) {
             rules::style::redundant_return_status::redundant_return_status(self);
         }

--- a/crates/shuck-linter/src/facts/builder.rs
+++ b/crates/shuck-linter/src/facts/builder.rs
@@ -952,6 +952,7 @@ impl<'a, 'analysis> LinterFactsBuilder<'a, 'analysis> {
                 completion_registered_function_scopes,
                 external_entrypoint_function_scopes,
                 function_headers,
+                function_doc_content: OnceLock::new(),
                 function_definition_command_ids_by_scope,
                 case_cli_reachable_function_scopes,
                 function_in_alias_spans,
@@ -1060,6 +1061,7 @@ impl<'a, 'analysis> LinterFactsBuilder<'a, 'analysis> {
             source_facts: SourceFactStore {
                 source,
                 line_index: self._indexer.line_index(),
+                comment_index: self._indexer.comment_index(),
                 shell: self.shell,
                 indented_shebang_span: shebang_header_facts.indented_shebang_span,
                 indented_shebang_indent_span: shebang_header_facts.indented_shebang_indent_span,

--- a/crates/shuck-linter/src/facts/functions.rs
+++ b/crates/shuck-linter/src/facts/functions.rs
@@ -180,6 +180,348 @@ pub(crate) fn build_function_header_facts<'a>(
         .collect()
 }
 
+pub(crate) fn build_function_doc_content_facts<'a>(
+    semantic: &SemanticModel,
+    headers: &[FunctionHeaderFact<'a>],
+    commands: &[CommandFact<'a>],
+    positional_parameter_facts: &FxHashMap<ScopeId, FunctionPositionalParameterFacts>,
+    source: &str,
+    line_index: &LineIndex,
+    comment_index: &CommentIndex,
+) -> Vec<FunctionDocContentFact> {
+    let mut summaries = build_function_doc_body_summaries(semantic, commands, source);
+
+    headers
+        .iter()
+        .filter_map(|header| {
+            let (name, name_span) = header.static_name_entry()?;
+            let function_scope = header.function_scope()?;
+            let function_span = header.function_span_in_source(source);
+            let comment_block = leading_function_doc_block(
+                source,
+                line_index,
+                comment_index,
+                function_span.start.line,
+            );
+            let summary = summaries.remove(&function_scope).unwrap_or_default();
+            let uses_positional_parameters = positional_parameter_facts
+                .get(&function_scope)
+                .is_some_and(|facts| facts.uses_positional_parameters());
+
+            Some(FunctionDocContentFact::new(
+                name,
+                name_span,
+                comment_block.map(|block| block.span),
+                comment_block
+                    .map(|block| block.sections)
+                    .unwrap_or_default(),
+                FunctionDocBodyBehavior::new(
+                    summary.uses_global_variables,
+                    uses_positional_parameters,
+                    summary.writes_stdout,
+                    summary.has_explicit_return,
+                ),
+            ))
+        })
+        .collect()
+}
+
+#[derive(Debug, Clone, Copy, Default)]
+struct FunctionDocBodySummary {
+    uses_global_variables: bool,
+    writes_stdout: bool,
+    has_explicit_return: bool,
+}
+
+fn build_function_doc_body_summaries(
+    semantic: &SemanticModel,
+    commands: &[CommandFact<'_>],
+    source: &str,
+) -> FxHashMap<ScopeId, FunctionDocBodySummary> {
+    let mut summaries = FxHashMap::<ScopeId, FunctionDocBodySummary>::default();
+    let reference_bindings = reference_binding_index(semantic);
+    let global_reference_skip_spans = function_doc_global_reference_skip_spans(commands, source);
+
+    for reference in semantic.references() {
+        if !reference_can_represent_global(reference, &global_reference_skip_spans) {
+            continue;
+        }
+        let Some(function_scope) = semantic.enclosing_function_scope(reference.scope) else {
+            continue;
+        };
+        if reference_is_global_variable_use(
+            semantic,
+            reference,
+            function_scope,
+            &reference_bindings,
+        ) {
+            summaries
+                .entry(function_scope)
+                .or_default()
+                .uses_global_variables = true;
+        }
+    }
+
+    for binding in semantic.bindings() {
+        let Some(function_scope) = semantic.enclosing_function_scope(binding.scope) else {
+            continue;
+        };
+        if !binding_can_represent_global_write(semantic, binding, function_scope) {
+            continue;
+        }
+        summaries
+            .entry(function_scope)
+            .or_default()
+            .uses_global_variables = true;
+    }
+
+    for command in commands {
+        let Some(function_scope) = command.enclosing_function_scope() else {
+            continue;
+        };
+        let summary = summaries.entry(function_scope).or_default();
+        summary.writes_stdout |= function_body_command_writes_stdout(command, source);
+        summary.has_explicit_return |=
+            !command.is_nested_word_command() && command_has_explicit_return(command);
+    }
+
+    summaries
+}
+
+fn reference_binding_index(semantic: &SemanticModel) -> FxHashMap<ReferenceId, BindingId> {
+    let mut index = FxHashMap::default();
+    for binding in semantic.bindings() {
+        for reference in &binding.references {
+            index.insert(*reference, binding.id);
+        }
+    }
+    index
+}
+
+fn reference_can_represent_global(reference: &Reference, skip_spans: &FxHashSet<FactSpan>) -> bool {
+    !matches!(reference.kind, ReferenceKind::DeclarationName)
+        && !is_special_or_positional_parameter_name(reference.name.as_str())
+        && !skip_spans.contains(&FactSpan::new(reference.span))
+}
+
+fn reference_is_global_variable_use(
+    semantic: &SemanticModel,
+    reference: &Reference,
+    function_scope: ScopeId,
+    reference_bindings: &FxHashMap<ReferenceId, BindingId>,
+) -> bool {
+    let Some(binding_id) = reference_bindings.get(&reference.id).copied() else {
+        return true;
+    };
+    let binding = semantic.binding(binding_id);
+    if matches!(binding.kind, BindingKind::FunctionDefinition) {
+        return false;
+    }
+
+    !binding.attributes.contains(BindingAttributes::LOCAL)
+        || semantic.enclosing_function_scope(binding.scope) != Some(function_scope)
+}
+
+fn binding_can_represent_global_write(
+    semantic: &SemanticModel,
+    binding: &Binding,
+    function_scope: ScopeId,
+) -> bool {
+    !binding.attributes.contains(BindingAttributes::LOCAL)
+        && !matches!(
+            binding.kind,
+            BindingKind::FunctionDefinition | BindingKind::Imported
+        )
+        && !is_special_or_positional_parameter_name(binding.name.as_str())
+        && !binding_targets_prior_local(semantic, binding, function_scope)
+}
+
+fn binding_targets_prior_local(
+    semantic: &SemanticModel,
+    binding: &Binding,
+    function_scope: ScopeId,
+) -> bool {
+    semantic
+        .bindings_for(&binding.name)
+        .iter()
+        .any(|candidate| {
+            let candidate = semantic.binding(*candidate);
+            candidate.id != binding.id
+                && candidate.span.start.offset < binding.span.start.offset
+                && candidate.attributes.contains(BindingAttributes::LOCAL)
+                && semantic.enclosing_function_scope(candidate.scope) == Some(function_scope)
+        })
+}
+
+fn is_special_or_positional_parameter_name(name: &str) -> bool {
+    name.bytes().all(|byte| byte.is_ascii_digit())
+        || matches!(name, "@" | "*" | "#" | "?" | "-" | "$" | "!")
+}
+
+fn function_body_command_writes_stdout(command: &CommandFact<'_>, source: &str) -> bool {
+    if command.is_nested_word_command() || command_stdout_is_redirected(command) {
+        return false;
+    }
+
+    command.normalized().effective_basename_is("echo")
+        || (command.normalized().effective_basename_is("printf")
+            && (!command.effective_name_is("printf")
+                || !printf_assigns_to_variable(command, source)))
+}
+
+fn printf_assigns_to_variable(command: &CommandFact<'_>, source: &str) -> bool {
+    match command
+        .body_args()
+        .first()
+        .and_then(|word| static_word_text(word, source))
+    {
+        Some(text) if text == "-v" => command.body_args().len() >= 2,
+        Some(text) if text.starts_with("-v") && text.len() > 2 => true,
+        _ => false,
+    }
+}
+
+fn command_stdout_is_redirected(command: &CommandFact<'_>) -> bool {
+    command.redirects().iter().any(redirect_redirects_stdout)
+}
+
+fn redirect_redirects_stdout(redirect: &Redirect) -> bool {
+    if redirect.fd_var.is_some() {
+        return false;
+    }
+
+    match redirect.kind {
+        RedirectKind::Output
+        | RedirectKind::Clobber
+        | RedirectKind::Append
+        | RedirectKind::DupOutput => redirect.fd.unwrap_or(1) == 1,
+        RedirectKind::ReadWrite => redirect.fd == Some(1),
+        RedirectKind::OutputBoth => true,
+        RedirectKind::Input
+        | RedirectKind::HereDoc
+        | RedirectKind::HereDocStrip
+        | RedirectKind::HereString
+        | RedirectKind::DupInput => false,
+    }
+}
+
+fn command_has_explicit_return(command: &CommandFact<'_>) -> bool {
+    matches!(
+        command.command(),
+        Command::Builtin(BuiltinCommand::Return(command)) if command.code.is_some()
+    )
+}
+
+fn function_doc_global_reference_skip_spans(
+    commands: &[CommandFact<'_>],
+    source: &str,
+) -> FxHashSet<FactSpan> {
+    commands
+        .iter()
+        .filter_map(|command| printf_assignment_target_span(command, source))
+        .map(FactSpan::new)
+        .collect()
+}
+
+fn printf_assignment_target_span(command: &CommandFact<'_>, source: &str) -> Option<Span> {
+    if !command.effective_name_is("printf") {
+        return None;
+    }
+
+    let args = command.body_args();
+    match args.first().and_then(|word| static_word_text(word, source)) {
+        Some(text) if text == "-v" => args.get(1).map(|word| word.span),
+        Some(text) if text.starts_with("-v") && text.len() > 2 => Some(args[0].span),
+        _ => None,
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+struct LeadingFunctionDocBlock {
+    span: Span,
+    sections: FunctionDocSections,
+}
+
+fn leading_function_doc_block(
+    source: &str,
+    line_index: &LineIndex,
+    comment_index: &CommentIndex,
+    function_start_line: usize,
+) -> Option<LeadingFunctionDocBlock> {
+    let mut line = function_start_line.checked_sub(1)?;
+    let mut block_start: Option<Position> = None;
+    let mut block_end: Option<Position> = None;
+    let mut sections = FunctionDocSections::default();
+    let mut has_doc_comment = false;
+
+    loop {
+        let Some(comment) = comment_index
+            .comments_on_line(line)
+            .iter()
+            .find(|comment| comment.is_own_line)
+        else {
+            break;
+        };
+        let line_start = usize::from(line_index.line_start(line)?);
+        let line_end = usize::from(line_index.line_range(line, source)?.end()).min(source.len());
+        let comment_start = usize::from(comment.range.start());
+        let comment_end = usize::from(comment.range.end()).min(line_end);
+        if comment_start < line_start || comment_start >= comment_end {
+            break;
+        }
+
+        let comment_text = &source[comment_start..comment_end];
+        let Some(comment_body) = function_doc_comment_body(comment_text) else {
+            break;
+        };
+
+        let line_start_position = Position {
+            line,
+            column: 1,
+            offset: line_start,
+        };
+        let comment_start_position =
+            line_start_position.advanced_by(&source[line_start..comment_start]);
+        let comment_end_position =
+            line_start_position.advanced_by(&source[line_start..comment_end]);
+        block_start = Some(comment_start_position);
+        block_end.get_or_insert(comment_end_position);
+
+        if is_function_doc_comment_body(comment_body) {
+            has_doc_comment = true;
+            sections.record_comment_body(comment_body);
+        }
+
+        let Some(previous_line) = line.checked_sub(1) else {
+            break;
+        };
+        line = previous_line;
+    }
+
+    if !has_doc_comment {
+        return None;
+    }
+
+    Some(LeadingFunctionDocBlock {
+        span: Span::from_positions(block_start?, block_end?),
+        sections,
+    })
+}
+
+fn function_doc_comment_body(comment_text: &str) -> Option<&str> {
+    let body = comment_text.strip_prefix('#')?.trim();
+    (!body.starts_with('!')).then_some(body)
+}
+
+fn is_function_doc_comment_body(body: &str) -> bool {
+    if body.is_empty() {
+        return false;
+    }
+
+    let lower = body.to_ascii_lowercase();
+    !lower.starts_with("shellcheck ") && !lower.starts_with("shuck:")
+}
+
 #[cfg_attr(shuck_profiling, inline(never))]
 pub(crate) fn build_function_cli_dispatch_facts(
     dispatches: &[CaseCliDispatch],

--- a/crates/shuck-linter/src/facts/mod.rs
+++ b/crates/shuck-linter/src/facts/mod.rs
@@ -85,7 +85,7 @@ use shuck_ast::{
     is_shell_variable_name, static_command_name_text, static_command_wrapper_target_index,
     static_word_text, word_is_standalone_status_capture,
 };
-use shuck_indexer::{Indexer, LineIndex, RegionIndex};
+use shuck_indexer::{CommentIndex, Indexer, LineIndex, RegionIndex};
 #[cfg(test)]
 use shuck_parser::parser::Parser;
 use shuck_semantic::{

--- a/crates/shuck-linter/src/facts/model.rs
+++ b/crates/shuck-linter/src/facts/model.rs
@@ -18,6 +18,7 @@ pub(crate) struct CommandFactStore<'a> {
     pub(in crate::facts) completion_registered_function_scopes: FxHashSet<ScopeId>,
     pub(in crate::facts) external_entrypoint_function_scopes: FxHashSet<ScopeId>,
     pub(in crate::facts) function_headers: Vec<FunctionHeaderFact<'a>>,
+    pub(in crate::facts) function_doc_content: OnceLock<Vec<FunctionDocContentFact>>,
     pub(in crate::facts) function_definition_command_ids_by_scope: FxHashMap<ScopeId, CommandId>,
     pub(in crate::facts) case_cli_reachable_function_scopes: FxHashSet<ScopeId>,
     pub(in crate::facts) function_in_alias_spans: Vec<Span>,
@@ -133,6 +134,7 @@ pub(crate) struct AssignmentFactStore<'a> {
 pub(crate) struct SourceFactStore<'a> {
     pub(in crate::facts) source: &'a str,
     pub(in crate::facts) line_index: &'a LineIndex,
+    pub(in crate::facts) comment_index: &'a CommentIndex,
     pub(in crate::facts) shell: ShellDialect,
     pub(in crate::facts) indented_shebang_span: Option<Span>,
     pub(in crate::facts) indented_shebang_indent_span: Option<Span>,
@@ -515,6 +517,20 @@ impl<'facts, 'a> CommandFactQueries<'facts, 'a> {
 
     pub(crate) fn function_headers(self) -> &'facts [FunctionHeaderFact<'a>] {
         &self.facts.command.function_headers
+    }
+
+    pub(crate) fn function_doc_content(self) -> &'facts [FunctionDocContentFact] {
+        self.facts.command.function_doc_content.get_or_init(|| {
+            build_function_doc_content_facts(
+                self.facts.semantic,
+                &self.facts.command.function_headers,
+                &self.facts.command.commands,
+                &self.facts.command.function_positional_parameter_facts,
+                self.facts.source_facts.source,
+                self.facts.source_facts.line_index,
+                self.facts.source_facts.comment_index,
+            )
+        })
     }
 
     pub(crate) fn function_in_alias_spans(self) -> &'facts [Span] {
@@ -1280,6 +1296,144 @@ impl<'facts, 'a> CompatFacts<'facts, 'a> {
             .compat
             .possible_variable_misspelling_scope_compat_name_uses
             .get_or_init(|| build_possible_variable_misspelling_scope_compat_name_uses(self.facts))
+    }
+}
+
+#[derive(Debug, Clone, Copy, Default)]
+pub(crate) struct FunctionDocSections {
+    globals: bool,
+    arguments: bool,
+    outputs: bool,
+    returns: bool,
+}
+
+impl FunctionDocSections {
+    pub(crate) fn record_comment_body(&mut self, body: &str) {
+        let lower = body.trim().to_ascii_lowercase();
+        if lower.starts_with("globals:") {
+            self.globals = true;
+        } else if lower.starts_with("arguments:") {
+            self.arguments = true;
+        } else if lower.starts_with("outputs:") {
+            self.outputs = true;
+        } else if lower.starts_with("returns:") {
+            self.returns = true;
+        }
+    }
+
+    pub(crate) fn has_globals(self) -> bool {
+        self.globals
+    }
+
+    pub(crate) fn has_arguments(self) -> bool {
+        self.arguments
+    }
+
+    pub(crate) fn has_outputs(self) -> bool {
+        self.outputs
+    }
+
+    pub(crate) fn has_returns(self) -> bool {
+        self.returns
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct FunctionDocContentFact {
+    name: Name,
+    name_span: Span,
+    leading_comment_span: Option<Span>,
+    documented_sections: FunctionDocSections,
+    body_behavior: FunctionDocBodyBehavior,
+}
+
+impl FunctionDocContentFact {
+    pub(crate) fn new(
+        name: &Name,
+        name_span: Span,
+        leading_comment_span: Option<Span>,
+        documented_sections: FunctionDocSections,
+        body_behavior: FunctionDocBodyBehavior,
+    ) -> Self {
+        Self {
+            name: name.clone(),
+            name_span,
+            leading_comment_span,
+            documented_sections,
+            body_behavior,
+        }
+    }
+
+    pub(crate) fn name(&self) -> &Name {
+        &self.name
+    }
+
+    pub(crate) fn name_span(&self) -> Span {
+        self.name_span
+    }
+
+    pub(crate) fn has_leading_comment(&self) -> bool {
+        self.leading_comment_span.is_some()
+    }
+
+    pub(crate) fn documented_sections(&self) -> FunctionDocSections {
+        self.documented_sections
+    }
+
+    pub(crate) fn uses_global_variables(&self) -> bool {
+        self.body_behavior.uses_global_variables()
+    }
+
+    pub(crate) fn uses_positional_parameters(&self) -> bool {
+        self.body_behavior.uses_positional_parameters()
+    }
+
+    pub(crate) fn writes_stdout(&self) -> bool {
+        self.body_behavior.writes_stdout()
+    }
+
+    pub(crate) fn has_explicit_return(&self) -> bool {
+        self.body_behavior.has_explicit_return()
+    }
+}
+
+#[derive(Debug, Clone, Copy, Default)]
+pub(crate) struct FunctionDocBodyBehavior {
+    uses_global_variables: bool,
+    uses_positional_parameters: bool,
+    writes_stdout: bool,
+    has_explicit_return: bool,
+}
+
+impl FunctionDocBodyBehavior {
+    pub(crate) fn new(
+        uses_global_variables: bool,
+        uses_positional_parameters: bool,
+        writes_stdout: bool,
+        has_explicit_return: bool,
+    ) -> Self {
+        Self {
+            uses_global_variables,
+            uses_positional_parameters,
+            writes_stdout,
+            has_explicit_return,
+        }
+    }
+
+    pub(crate) fn uses_global_variables(self) -> bool {
+        self.uses_global_variables
+    }
+
+    pub(crate) fn uses_positional_parameters(self) -> bool {
+        self.uses_positional_parameters
+    }
+
+    pub(crate) fn writes_stdout(self) -> bool {
+        self.writes_stdout
+    }
+
+    pub(crate) fn has_explicit_return(self) -> bool {
+        self.has_explicit_return
     }
 }
 

--- a/crates/shuck-linter/src/lib.rs
+++ b/crates/shuck-linter/src/lib.rs
@@ -107,7 +107,7 @@ pub(crate) use rules::common::word::conditional_binary_op_is_string_match;
 /// Linter configuration and per-file ignore types.
 pub use settings::{
     AmbientShellOptions, C001RuleOptions, C063RuleOptions, CompiledPerFileIgnoreList,
-    LinterRuleOptions, LinterSettings, PerFileIgnore, S085RuleOptions,
+    LinterRuleOptions, LinterSettings, PerFileIgnore, S084RuleOptions, S085RuleOptions,
 };
 /// Shell dialect selection used by the linter.
 pub use shell::ShellDialect;

--- a/crates/shuck-linter/src/registry.rs
+++ b/crates/shuck-linter/src/registry.rs
@@ -673,6 +673,7 @@ declare_rules! {
     ("S073", Category::Style, Severity::Warning, SpacedTabstripClose),
     ("S074", Category::Style, Severity::Warning, AmpersandSemicolon),
     ("S075", Category::Style, Severity::Warning, CombineAppends),
+    ("S084", Category::Style, Severity::Warning, FunctionDocContent),
     ("S085", Category::Style, Severity::Warning, MissingMainEntrypoint),
 }
 

--- a/crates/shuck-linter/src/rules/style/function_doc_content.rs
+++ b/crates/shuck-linter/src/rules/style/function_doc_content.rs
@@ -1,0 +1,279 @@
+use crate::{Checker, Rule, Violation};
+
+pub struct FunctionDocContent {
+    name: String,
+    missing_sections: Vec<DocSection>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum DocSection {
+    Globals,
+    Arguments,
+    Outputs,
+    Returns,
+}
+
+impl DocSection {
+    fn label(self) -> &'static str {
+        match self {
+            Self::Globals => "Globals",
+            Self::Arguments => "Arguments",
+            Self::Outputs => "Outputs",
+            Self::Returns => "Returns",
+        }
+    }
+}
+
+impl Violation for FunctionDocContent {
+    fn rule() -> Rule {
+        Rule::FunctionDocContent
+    }
+
+    fn message(&self) -> String {
+        format!(
+            "document function `{}` with missing sections: {}",
+            self.name,
+            self.missing_sections
+                .iter()
+                .map(|section| section.label())
+                .collect::<Vec<_>>()
+                .join(", ")
+        )
+    }
+}
+
+pub fn function_doc_content(checker: &mut Checker) {
+    let options = checker.rule_options().s084.clone();
+    let violations = checker
+        .facts()
+        .command_facts()
+        .function_doc_content()
+        .iter()
+        .filter(|fact| fact.has_leading_comment())
+        .filter_map(|fact| {
+            let missing_sections = missing_doc_sections(fact, &options);
+            (!missing_sections.is_empty()).then(|| {
+                (
+                    fact.name_span(),
+                    FunctionDocContent {
+                        name: fact.name().as_str().to_owned(),
+                        missing_sections,
+                    },
+                )
+            })
+        })
+        .collect::<Vec<_>>();
+
+    for (span, violation) in violations {
+        checker.report(violation, span);
+    }
+}
+
+fn missing_doc_sections(
+    fact: &crate::facts::FunctionDocContentFact,
+    options: &crate::S084RuleOptions,
+) -> Vec<DocSection> {
+    let documented = fact.documented_sections();
+    let mut missing = Vec::new();
+
+    if options.require_globals && fact.uses_global_variables() && !documented.has_globals() {
+        missing.push(DocSection::Globals);
+    }
+    if options.require_arguments && fact.uses_positional_parameters() && !documented.has_arguments()
+    {
+        missing.push(DocSection::Arguments);
+    }
+    if options.require_outputs && fact.writes_stdout() && !documented.has_outputs() {
+        missing.push(DocSection::Outputs);
+    }
+    if options.require_returns && fact.has_explicit_return() && !documented.has_returns() {
+        missing.push(DocSection::Returns);
+    }
+
+    missing
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::test::test_snippet;
+    use crate::{LinterSettings, Rule};
+
+    fn diagnostics(source: &str) -> Vec<crate::Diagnostic> {
+        test_snippet(source, &LinterSettings::for_rule(Rule::FunctionDocContent))
+    }
+
+    #[test]
+    fn reports_missing_sections_for_observed_body_behavior() {
+        let source = "\
+#!/bin/bash
+# Builds an absolute output path.
+build_path() {
+  local suffix=$1
+  echo \"${BASE_DIR}/${suffix}\"
+  return 0
+}
+";
+        let diagnostics = diagnostics(source);
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].span.slice(source), "build_path");
+        assert!(diagnostics[0].message.contains("Globals"));
+        assert!(diagnostics[0].message.contains("Arguments"));
+        assert!(diagnostics[0].message.contains("Outputs"));
+        assert!(diagnostics[0].message.contains("Returns"));
+    }
+
+    #[test]
+    fn accepts_complete_function_comment_sections() {
+        let source = "\
+#!/bin/bash
+# Builds an absolute output path by joining BASE_DIR with a suffix.
+#
+# Globals:
+#   BASE_DIR
+# Arguments:
+#   $1 - The path suffix to append.
+# Outputs:
+#   Writes the constructed path to stdout.
+# Returns:
+#   0 always.
+build_path() {
+  local suffix=$1
+  echo \"${BASE_DIR}/${suffix}\"
+  return 0
+}
+";
+        assert!(diagnostics(source).is_empty());
+    }
+
+    #[test]
+    fn skips_functions_without_leading_doc_comment() {
+        let source = "\
+#!/bin/bash
+build_path() {
+  echo \"${BASE_DIR}/$1\"
+  return 0
+}
+";
+        assert!(diagnostics(source).is_empty());
+    }
+
+    #[test]
+    fn ignores_local_variables_and_non_stdout_prints() {
+        let source = "\
+#!/bin/bash
+# Prepares local state.
+prepare() {
+  local target
+  printf -v target '%s' ok
+  echo hidden >out.txt
+}
+";
+        assert!(diagnostics(source).is_empty());
+    }
+
+    #[test]
+    fn attached_printf_v_option_assigns_without_stdout_output() {
+        let source = "\
+#!/bin/bash
+# Updates shared state.
+set_state() {
+  printf -vSTATE '%s' ok
+}
+";
+        let diagnostics = diagnostics(source);
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].span.slice(source), "set_state");
+        assert!(diagnostics[0].message.contains("Globals"));
+        assert!(!diagnostics[0].message.contains("Outputs"));
+    }
+
+    #[test]
+    fn printf_option_end_keeps_later_v_text_as_stdout_output() {
+        let source = "\
+#!/bin/bash
+# Prints the state marker.
+emit_state() {
+  printf -- -vSTATE
+}
+";
+        let diagnostics = diagnostics(source);
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].span.slice(source), "emit_state");
+        assert!(!diagnostics[0].message.contains("Globals"));
+        assert!(diagnostics[0].message.contains("Outputs"));
+    }
+
+    #[test]
+    fn path_qualified_printf_counts_as_stdout_output() {
+        let source = "\
+#!/bin/bash
+# Prints a status line.
+emit_status() {
+  /usr/bin/printf '%s\\n' ready
+}
+";
+        let diagnostics = diagnostics(source);
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].span.slice(source), "emit_status");
+        assert!(diagnostics[0].message.contains("Outputs"));
+    }
+
+    #[test]
+    fn reports_global_writes_without_globals_section() {
+        let source = "\
+#!/bin/bash
+# Updates the shared state.
+set_state() {
+  STATE=ready
+}
+";
+        let diagnostics = diagnostics(source);
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].span.slice(source), "set_state");
+        assert!(diagnostics[0].message.contains("Globals"));
+    }
+
+    #[test]
+    fn ignores_returns_nested_in_command_substitutions() {
+        let source = "\
+#!/bin/bash
+# Prepares local state.
+prepare() {
+  local value
+  value=$(return 7)
+}
+";
+        assert!(diagnostics(source).is_empty());
+    }
+
+    #[test]
+    fn section_options_can_be_disabled_independently() {
+        let source = "\
+#!/bin/bash
+# Builds an absolute output path.
+#
+# Globals:
+#   BASE_DIR
+# Arguments:
+#   $1 - The path suffix.
+build_path() {
+  local suffix=$1
+  echo \"${BASE_DIR}/${suffix}\"
+  return 0
+}
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::FunctionDocContent)
+                .with_s084_require_outputs(false)
+                .with_s084_require_returns(false),
+        );
+
+        assert!(diagnostics.is_empty());
+    }
+}

--- a/crates/shuck-linter/src/rules/style/mod.rs
+++ b/crates/shuck-linter/src/rules/style/mod.rs
@@ -27,6 +27,7 @@ pub mod escaped_underscore;
 pub mod export_command_substitution;
 pub mod fgrep_deprecated;
 pub mod function_body_without_braces;
+pub mod function_doc_content;
 pub mod function_in_alias;
 pub mod getopts_invalid_flag_handler;
 pub mod glob_assigned_to_variable;
@@ -167,6 +168,7 @@ mod tests {
     #[test_case(Rule::SpacedTabstripClose, Path::new("S073.sh"))]
     #[test_case(Rule::AmpersandSemicolon, Path::new("S074.sh"))]
     #[test_case(Rule::CombineAppends, Path::new("S075.sh"))]
+    #[test_case(Rule::FunctionDocContent, Path::new("S084.sh"))]
     #[test_case(Rule::MissingMainEntrypoint, Path::new("S085.sh"))]
     fn rules(rule: Rule, path: &Path) -> anyhow::Result<()> {
         let snapshot = format!("{}_{}", rule.code(), path.display());

--- a/crates/shuck-linter/src/rules/style/snapshots/shuck_linter__rules__style__tests__S084_S084.sh.snap
+++ b/crates/shuck-linter/src/rules/style/snapshots/shuck_linter__rules__style__tests__S084_S084.sh.snap
@@ -1,0 +1,8 @@
+---
+source: crates/shuck-linter/src/rules/style/mod.rs
+---
+S084 document function `build_path` with missing sections: Globals, Arguments, Outputs, Returns
+ --> <source>:3:1
+  |
+3 | build_path() {
+  |

--- a/crates/shuck-linter/src/settings.rs
+++ b/crates/shuck-linter/src/settings.rs
@@ -22,6 +22,8 @@ pub struct LinterRuleOptions {
     pub c001: C001RuleOptions,
     /// Behavior overrides for `C063`.
     pub c063: C063RuleOptions,
+    /// Behavior overrides for `S084`.
+    pub s084: S084RuleOptions,
     /// Behavior overrides for `S085`.
     pub s085: S085RuleOptions,
 }
@@ -59,6 +61,25 @@ impl C063RuleOptions {
         }
     }
 }
+/// Behavior overrides for `S084` function documentation content.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct S084RuleOptions {
+    pub require_globals: bool,
+    pub require_arguments: bool,
+    pub require_outputs: bool,
+    pub require_returns: bool,
+}
+
+impl Default for S084RuleOptions {
+    fn default() -> Self {
+        Self {
+            require_globals: true,
+            require_arguments: true,
+            require_outputs: true,
+            require_returns: true,
+        }
+    }
+}
 
 /// Behavior overrides for `S085` main entrypoint analysis.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -80,7 +101,6 @@ impl Default for S085RuleOptions {
         }
     }
 }
-
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct LinterSettings {
     pub rules: RuleSet,
@@ -263,6 +283,26 @@ impl LinterSettings {
         self
     }
 
+    pub fn with_s084_require_globals(mut self, value: bool) -> Self {
+        self.rule_options.s084.require_globals = value;
+        self
+    }
+
+    pub fn with_s084_require_arguments(mut self, value: bool) -> Self {
+        self.rule_options.s084.require_arguments = value;
+        self
+    }
+
+    pub fn with_s084_require_outputs(mut self, value: bool) -> Self {
+        self.rule_options.s084.require_outputs = value;
+        self
+    }
+
+    pub fn with_s084_require_returns(mut self, value: bool) -> Self {
+        self.rule_options.s084.require_returns = value;
+        self
+    }
+
     pub fn with_s085_non_trivial_line_threshold(mut self, value: usize) -> Self {
         self.rule_options.s085.non_trivial_line_threshold = value;
         self
@@ -277,7 +317,6 @@ impl LinterSettings {
         self.rule_options.s085.main_name = value.into();
         self
     }
-
     pub fn per_file_ignored_rules(&self, path: Option<&Path>) -> RuleSet {
         path.map_or(RuleSet::EMPTY, |path| {
             self.per_file_ignores.ignored_rules(path)

--- a/crates/shuck-semantic/src/builder/mod.rs
+++ b/crates/shuck-semantic/src/builder/mod.rs
@@ -838,11 +838,19 @@ fn mapfile_flag_takes_value(flag: char) -> bool {
 }
 
 fn printf_v_target(args: &[&Word], source: &str) -> Option<(Name, Span)> {
-    args.windows(2).find_map(|window| {
-        (static_word_text(window[0], source).as_deref() == Some("-v"))
-            .then_some(window[1])
-            .and_then(|word| named_target_word(word, source))
-    })
+    let word = args.first()?;
+    let text = static_word_text(word, source)?;
+
+    match text.as_ref() {
+        "--" => None,
+        "-v" => args.get(1).and_then(|word| named_target_word(word, source)),
+        text => {
+            let target = text
+                .strip_prefix("-v")
+                .filter(|target| !target.is_empty())?;
+            printf_attached_v_target(word, source, target)
+        }
+    }
 }
 
 fn getopts_target(args: &[&Word], source: &str) -> Option<(Name, Span)> {
@@ -1810,6 +1818,23 @@ fn read_attached_array_target(
     source: &str,
     target_text: &str,
 ) -> Option<(Name, Span)> {
+    if !is_name(target_text) {
+        return None;
+    }
+
+    let target_span = word
+        .span
+        .slice(source)
+        .rfind(target_text)
+        .map(|start| {
+            read_option_attached_target_span(word.span, source, start, start + target_text.len())
+        })
+        .unwrap_or(word.span);
+
+    Some((Name::from(target_text), target_span))
+}
+
+fn printf_attached_v_target(word: &Word, source: &str, target_text: &str) -> Option<(Name, Span)> {
     if !is_name(target_text) {
         return None;
     }

--- a/crates/shuck-semantic/src/tests.rs
+++ b/crates/shuck-semantic/src/tests.rs
@@ -4240,6 +4240,9 @@ read -ar
 mapfile mapfile_target
 readarray readarray_target
 printf -v printf_target '%s' value
+printf -vattached_printf_target '%s' value
+printf -- -vnot_a_printf_target
+printf '%s' -vformat_text
 getopts 'ab' getopts_target
 ";
     let model = model(source);
@@ -4319,6 +4322,23 @@ getopts 'ab' getopts_target
         })
         .unwrap();
     assert_eq!(printf_target.span.slice(source), "printf_target");
+
+    let attached_printf_target = model
+        .bindings()
+        .iter()
+        .find(|binding| {
+            binding.name == "attached_printf_target"
+                && matches!(binding.kind, BindingKind::PrintfTarget)
+        })
+        .unwrap();
+    assert_eq!(
+        attached_printf_target.span.slice(source),
+        "attached_printf_target"
+    );
+    assert!(!model.bindings().iter().any(|binding| {
+        matches!(binding.kind, BindingKind::PrintfTarget)
+            && matches!(binding.name.as_str(), "not_a_printf_target" | "format_text")
+    }));
 
     let getopts_target = model
         .bindings()

--- a/website/app/lib/rules-data.generated.json
+++ b/website/app/lib/rules-data.generated.json
@@ -6668,10 +6668,10 @@
       "bash"
     ],
     "shellcheckCode": null,
-    "implemented": false,
-    "status": "planned",
+    "implemented": true,
+    "status": "implemented",
     "hasKnownShellcheckDivergences": false,
-    "severity": null,
+    "severity": "Warning",
     "fixStatus": "none",
     "fixAvailability": "none",
     "fixSafety": null,


### PR DESCRIPTION
## Summary
- add S084 function documentation content style rule
- add reusable function doc content facts for comment sections and function body behavior summaries
- wire S084 config/cache settings, registry dispatch, fixture, and snapshot

## Validation
- `cargo test -p shuck-linter function_doc_content -- --nocapture`
- `cargo test -p shuck-config s084_rule_option -- --nocapture`
- `cargo test -p shuck-cli commands::check::settings::tests -- --nocapture`
- `INSTA_UPDATE=always cargo test -p shuck-linter rules::style::tests::rules::rule_functiondoccontent_path_new_s084_sh_expects -- --nocapture`
- `make test-large-corpus SHUCK_LARGE_CORPUS_RULES=S084`
- `make test`
- `make check`