### PR TITLE
feat(linter): add C016 stray control keyword rule

### DIFF
--- a/crates/shuck-linter/src/parse_diagnostics.rs
+++ b/crates/shuck-linter/src/parse_diagnostics.rs
@@ -700,7 +700,9 @@ fn stray_closing_keyword_spans(
 
 fn is_more_specific_parse_diagnostic(locator: Locator<'_>, diagnostic: &ParseDiagnostic) -> bool {
     let diagnostic = std::slice::from_ref(diagnostic);
-    if_missing_then_span(locator, diagnostic).is_some()
+    let keyword = diagnostic[0].span.slice(locator.source());
+    (matches!(keyword, "fi" | "else" | "elif")
+        && if_missing_then_span(locator, diagnostic).is_some())
         || until_missing_do_span(locator, diagnostic).is_some()
 }
 
@@ -2068,6 +2070,24 @@ esac
         );
 
         assert!(diagnostics.is_empty());
+    }
+
+    #[test]
+    fn reports_later_stray_closing_keyword_with_missing_then_recovery() {
+        let source = "#!/bin/sh\nif true\n  echo hi\nfi\ndone\n";
+        let recovered = Parser::new(source).parse();
+        let settings = LinterSettings::for_rule(Rule::StrayClosingKeyword);
+        let diagnostics = collect_parse_rule_diagnostics(
+            &recovered.file,
+            source,
+            Some(&recovered),
+            &settings.rules,
+            ShellDialect::Sh,
+        );
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].rule, Rule::StrayClosingKeyword);
+        assert_eq!(diagnostics[0].span.slice(source), "done");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Add C016 for parse diagnostics caused by stray shell control keywords such as `fi`, `done`, `esac`, `else`, `then`, `elif`, and `do`.
- Scope the mapping to sh/bash/dash/ksh so zsh diagnostic baselines remain unchanged.
- Wire the rule into registry aliases, ShellCheck mapping generation, correctness fixtures, and snapshots.
- Keep the packaging smoke script self-lint green without changing the generated test file contents.

## Validation
- `cargo test -p shuck-linter stray_control_keyword -- --nocapture`
- `cargo test -p shuck-linter c016 -- --nocapture`
- `cargo test -p shuck-linter does_not_map_stray_control_keyword_in_zsh_mode -- --nocapture`
- `make test-large-corpus SHUCK_LARGE_CORPUS_RULES=C016`
- `make test`
- `make check`