### PR TITLE
feat(server): add document symbols

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1943,6 +1943,7 @@ dependencies = [
  "shuck-indexer",
  "shuck-linter",
  "shuck-parser",
+ "shuck-semantic",
  "tempfile",
  "tracing",
  "tracing-subscriber",

--- a/crates/shuck-benchmark/Cargo.toml
+++ b/crates/shuck-benchmark/Cargo.toml
@@ -68,6 +68,10 @@ name = "semantic"
 harness = false
 
 [[bench]]
+name = "editor"
+harness = false
+
+[[bench]]
 name = "unused_assignment"
 harness = false
 

--- a/crates/shuck-benchmark/benches/editor.rs
+++ b/crates/shuck-benchmark/benches/editor.rs
@@ -1,0 +1,68 @@
+use criterion::{BenchmarkId, Criterion, Throughput, black_box, criterion_group, criterion_main};
+use shuck_benchmark::{benchmark_cases, configure_benchmark_allocator, parse_fixture};
+use shuck_indexer::Indexer;
+use shuck_semantic::{EditorDocumentSymbol, SemanticModel};
+
+configure_benchmark_allocator!();
+
+struct PreparedEditorInput {
+    semantic: SemanticModel,
+    binding_count: u64,
+}
+
+fn prepare_editor_input(source: &'static str) -> PreparedEditorInput {
+    let output = parse_fixture(source);
+    let indexer = Indexer::new(source, &output);
+    let semantic = SemanticModel::build(&output.file, source, &indexer);
+    let binding_count = semantic.bindings().len() as u64;
+
+    PreparedEditorInput {
+        semantic,
+        binding_count,
+    }
+}
+
+fn count_document_symbols(symbols: &[EditorDocumentSymbol]) -> usize {
+    symbols
+        .iter()
+        .map(|symbol| 1 + count_document_symbols(&symbol.children))
+        .sum()
+}
+
+fn build_document_symbols(input: &PreparedEditorInput) -> usize {
+    // Keep parse/index/semantic construction out of the timed loop so this
+    // benchmark isolates the editor query projection itself.
+    let symbols = input.semantic.editor_query().document_symbols();
+    black_box(count_document_symbols(&symbols))
+}
+
+fn bench_editor_document_symbols(c: &mut Criterion) {
+    let mut group = c.benchmark_group("editor_document_symbols");
+
+    for case in benchmark_cases() {
+        let inputs = case
+            .files
+            .iter()
+            .map(|file| prepare_editor_input(file.source))
+            .collect::<Vec<_>>();
+        let total_bindings = inputs
+            .iter()
+            .map(|input| input.binding_count)
+            .sum::<u64>()
+            .max(1);
+
+        group.sample_size(case.speed.sample_size());
+        group.throughput(Throughput::Elements(total_bindings));
+        group.bench_function(BenchmarkId::from_parameter(case.name), move |b| {
+            b.iter(|| {
+                let symbol_count: usize = inputs.iter().map(build_document_symbols).sum();
+                black_box(symbol_count);
+            });
+        });
+    }
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_editor_document_symbols);
+criterion_main!(benches);

--- a/crates/shuck-semantic/src/editor.rs
+++ b/crates/shuck-semantic/src/editor.rs
@@ -1,0 +1,410 @@
+//! Editor-facing semantic query shapes.
+
+use std::ops::Deref;
+
+use rustc_hash::FxHashMap;
+use shuck_ast::{Name, Span};
+
+use crate::{
+    Binding, BindingAttributes, BindingId, BindingKind, DeclarationOperand, ScopeId, ScopeKind,
+    SemanticModel, SpanKey,
+};
+
+/// LSP-agnostic query object for editor features.
+pub struct EditorQuery<'model> {
+    model: &'model SemanticModel,
+}
+
+/// One semantic symbol suitable for editor presentation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EditorSymbol {
+    /// User-visible symbol name.
+    pub name: Name,
+    /// Editor-facing symbol category.
+    pub kind: EditorSymbolKind,
+    /// Span that introduces the symbol.
+    pub definition_span: Span,
+    /// Span to select when navigating to the symbol.
+    pub selection_span: Span,
+    /// Semantic scope that owns the symbol.
+    pub scope: ScopeId,
+    /// Underlying semantic binding, when the symbol has one.
+    pub binding: Option<BindingId>,
+}
+
+/// Hierarchical document-symbol item.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EditorDocumentSymbol {
+    /// Reusable semantic symbol payload.
+    pub symbol: EditorSymbol,
+    /// Span covering the item in the source document.
+    pub range: Span,
+    /// Child symbols nested inside this symbol.
+    pub children: Vec<EditorDocumentSymbol>,
+}
+
+impl Deref for EditorDocumentSymbol {
+    type Target = EditorSymbol;
+
+    fn deref(&self) -> &Self::Target {
+        &self.symbol
+    }
+}
+
+/// Coarse editor-facing symbol kind.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EditorSymbolKind {
+    /// A shell function definition.
+    Function,
+    /// A scalar-like shell variable.
+    Variable,
+    /// An array-like shell variable.
+    Array,
+    /// An associative-array-like shell variable.
+    AssociativeArray,
+    /// A declaration operand such as `local name` or `declare name`.
+    Declaration,
+    /// A runtime-provided name.
+    RuntimeName,
+}
+
+#[derive(Debug, Clone)]
+struct PendingDocumentSymbol {
+    symbol: EditorDocumentSymbol,
+    parent: Option<usize>,
+    sort_offset: usize,
+}
+
+type DocumentSymbolRangesByBinding = Vec<Option<Span>>;
+type DeclarationOperandRanges = FxHashMap<SpanKey, Span>;
+
+impl SemanticModel {
+    /// Returns an editor-facing query object over this semantic model.
+    pub fn editor_query(&self) -> EditorQuery<'_> {
+        EditorQuery { model: self }
+    }
+}
+
+impl<'model> EditorQuery<'model> {
+    /// Creates an editor query over `model`.
+    pub fn new(model: &'model SemanticModel) -> Self {
+        Self { model }
+    }
+
+    /// Builds a hierarchical document-symbol tree for the analyzed document.
+    pub fn document_symbols(&self) -> Vec<EditorDocumentSymbol> {
+        let analysis = self.model.analysis();
+        let mut pending = Vec::new();
+        let mut function_symbols_by_scope = FxHashMap::default();
+        let document_symbol_ranges_by_binding = self
+            .model
+            .editor_document_symbol_ranges_by_binding
+            .get_or_init(|| document_symbol_ranges_by_binding(self.model));
+
+        for binding in self.model.function_definition_bindings() {
+            let Some(symbol) = document_symbol_for_function(binding) else {
+                continue;
+            };
+            let index = pending.len();
+            let function_scope = analysis.function_scope_for_binding(binding.id);
+            pending.push(PendingDocumentSymbol {
+                sort_offset: binding.span.start.offset,
+                symbol,
+                parent: None,
+            });
+            if let Some(function_scope) = function_scope {
+                function_symbols_by_scope
+                    .entry(function_scope)
+                    .or_insert(index);
+            }
+        }
+
+        let function_count = pending.len();
+        for symbol in pending.iter_mut().take(function_count) {
+            let scope = symbol.symbol.symbol.scope;
+            symbol.parent =
+                enclosing_function_symbol(self.model, scope, &function_symbols_by_scope);
+        }
+
+        for binding in self.model.bindings() {
+            if matches!(binding.kind, BindingKind::FunctionDefinition) {
+                continue;
+            }
+            let Some(parent) =
+                document_symbol_parent_for_binding(self.model, binding, &function_symbols_by_scope)
+            else {
+                continue;
+            };
+            let Some(symbol) =
+                document_symbol_for_binding(binding, document_symbol_ranges_by_binding)
+            else {
+                continue;
+            };
+            pending.push(PendingDocumentSymbol {
+                sort_offset: binding.span.start.offset,
+                symbol,
+                parent,
+            });
+        }
+
+        build_document_symbol_tree(pending)
+    }
+}
+
+fn document_symbol_parent_for_binding(
+    model: &SemanticModel,
+    binding: &Binding,
+    function_symbols_by_scope: &FxHashMap<ScopeId, usize>,
+) -> Option<Option<usize>> {
+    if file_scope_binding_is_document_symbol(model, binding) {
+        return Some(None);
+    }
+
+    if function_child_binding_is_document_symbol(binding) {
+        return enclosing_function_symbol(model, binding.scope, function_symbols_by_scope)
+            .map(Some);
+    }
+
+    None
+}
+
+fn file_scope_binding_is_document_symbol(model: &SemanticModel, binding: &Binding) -> bool {
+    matches!(model.scope_kind(binding.scope), ScopeKind::File)
+        && matches!(
+            binding.kind,
+            BindingKind::Assignment
+                | BindingKind::AppendAssignment
+                | BindingKind::ArrayAssignment
+                | BindingKind::Declaration(_)
+                | BindingKind::Nameref
+        )
+}
+
+fn function_child_binding_is_document_symbol(binding: &Binding) -> bool {
+    matches!(
+        binding.kind,
+        BindingKind::Declaration(_) | BindingKind::LoopVariable | BindingKind::Nameref
+    )
+}
+
+fn document_symbol_for_function(binding: &Binding) -> Option<EditorDocumentSymbol> {
+    let BindingKind::FunctionDefinition = binding.kind else {
+        return None;
+    };
+    let definition_span = binding_definition_span(binding);
+    Some(EditorDocumentSymbol {
+        range: definition_span,
+        symbol: EditorSymbol {
+            name: binding.name.clone(),
+            kind: EditorSymbolKind::Function,
+            definition_span,
+            selection_span: binding.span,
+            scope: binding.scope,
+            binding: Some(binding.id),
+        },
+        children: Vec::new(),
+    })
+}
+
+fn document_symbol_for_binding(
+    binding: &Binding,
+    document_symbol_ranges_by_binding: &DocumentSymbolRangesByBinding,
+) -> Option<EditorDocumentSymbol> {
+    let definition_span = binding_definition_span(binding);
+    Some(EditorDocumentSymbol {
+        range: document_symbol_range_for_binding(binding, document_symbol_ranges_by_binding)
+            .unwrap_or(definition_span),
+        symbol: EditorSymbol {
+            name: binding.name.clone(),
+            kind: editor_symbol_kind_for_binding(binding)?,
+            definition_span,
+            selection_span: binding.span,
+            scope: binding.scope,
+            binding: Some(binding.id),
+        },
+        children: Vec::new(),
+    })
+}
+
+fn editor_symbol_kind_for_binding(binding: &Binding) -> Option<EditorSymbolKind> {
+    if binding.attributes.contains(BindingAttributes::ASSOC) {
+        return Some(EditorSymbolKind::AssociativeArray);
+    }
+    if binding.attributes.contains(BindingAttributes::ARRAY)
+        || matches!(
+            binding.kind,
+            BindingKind::ArrayAssignment
+                | BindingKind::MapfileTarget
+                | BindingKind::ZparseoptsTarget
+        )
+    {
+        return Some(EditorSymbolKind::Array);
+    }
+
+    match binding.kind {
+        BindingKind::Declaration(_) | BindingKind::Nameref => Some(EditorSymbolKind::Declaration),
+        BindingKind::Assignment
+        | BindingKind::AppendAssignment
+        | BindingKind::LoopVariable
+        | BindingKind::ReadTarget
+        | BindingKind::PrintfTarget
+        | BindingKind::GetoptsTarget
+        | BindingKind::ArithmeticAssignment => Some(EditorSymbolKind::Variable),
+        BindingKind::ArrayAssignment
+        | BindingKind::MapfileTarget
+        | BindingKind::ZparseoptsTarget => Some(EditorSymbolKind::Array),
+        BindingKind::FunctionDefinition
+        | BindingKind::Imported
+        | BindingKind::ParameterDefaultAssignment => None,
+    }
+}
+
+fn document_symbol_range_for_binding(
+    binding: &Binding,
+    document_symbol_ranges_by_binding: &DocumentSymbolRangesByBinding,
+) -> Option<Span> {
+    if !matches!(
+        binding.kind,
+        BindingKind::Declaration(_) | BindingKind::Nameref
+    ) {
+        return None;
+    }
+
+    document_symbol_ranges_by_binding
+        .get(binding.id.index())
+        .copied()
+        .flatten()
+}
+
+fn document_symbol_ranges_by_binding(model: &SemanticModel) -> DocumentSymbolRangesByBinding {
+    let declaration_operand_ranges = declaration_operand_ranges_by_definition_span(model);
+    let mut ranges = vec![None; model.bindings().len()];
+    for binding in model.bindings() {
+        ranges[binding.id.index()] =
+            declaration_operand_range_for_binding(binding, &declaration_operand_ranges);
+    }
+    ranges
+}
+
+fn declaration_operand_range_for_binding(
+    binding: &Binding,
+    declaration_operand_ranges: &DeclarationOperandRanges,
+) -> Option<Span> {
+    if matches!(
+        binding.kind,
+        BindingKind::Declaration(_) | BindingKind::Nameref
+    ) {
+        if let Some(range) = declaration_operand_ranges.get(&SpanKey::new(binding.span)) {
+            return Some(*range);
+        }
+
+        if let Some(range) =
+            declaration_operand_ranges.get(&SpanKey::new(binding_definition_span(binding)))
+        {
+            return Some(*range);
+        }
+    }
+
+    None
+}
+
+fn declaration_operand_ranges_by_definition_span(
+    model: &SemanticModel,
+) -> DeclarationOperandRanges {
+    let mut ranges = DeclarationOperandRanges::default();
+    for declaration in model.declarations() {
+        for operand in &declaration.operands {
+            match operand {
+                DeclarationOperand::Name { span, .. } => {
+                    ranges.insert(SpanKey::new(*span), *span);
+                }
+                DeclarationOperand::Assignment {
+                    operand_span,
+                    target_span,
+                    name_span,
+                    ..
+                } => {
+                    ranges.insert(SpanKey::new(*name_span), *operand_span);
+                    ranges.insert(SpanKey::new(*target_span), *operand_span);
+                }
+                DeclarationOperand::Flag { .. } | DeclarationOperand::DynamicWord { .. } => {}
+            }
+        }
+    }
+    ranges
+}
+
+fn binding_definition_span(binding: &Binding) -> Span {
+    match binding.origin {
+        crate::BindingOrigin::Assignment {
+            definition_span, ..
+        }
+        | crate::BindingOrigin::LoopVariable {
+            definition_span, ..
+        }
+        | crate::BindingOrigin::ParameterDefaultAssignment { definition_span }
+        | crate::BindingOrigin::Imported { definition_span }
+        | crate::BindingOrigin::FunctionDefinition { definition_span }
+        | crate::BindingOrigin::BuiltinTarget {
+            definition_span, ..
+        }
+        | crate::BindingOrigin::ArithmeticAssignment {
+            definition_span, ..
+        }
+        | crate::BindingOrigin::Declaration { definition_span }
+        | crate::BindingOrigin::Nameref { definition_span } => definition_span,
+    }
+}
+
+fn enclosing_function_symbol(
+    model: &SemanticModel,
+    scope: ScopeId,
+    function_symbols_by_scope: &FxHashMap<ScopeId, usize>,
+) -> Option<usize> {
+    model
+        .ancestor_scopes(scope)
+        .find_map(|scope| function_symbols_by_scope.get(&scope).copied())
+}
+
+fn build_document_symbol_tree(
+    mut pending: Vec<PendingDocumentSymbol>,
+) -> Vec<EditorDocumentSymbol> {
+    let mut child_ids = vec![Vec::new(); pending.len()];
+    let mut root_ids = Vec::new();
+
+    for (index, symbol) in pending.iter().enumerate() {
+        if let Some(parent) = symbol.parent {
+            child_ids[parent].push(index);
+        } else {
+            root_ids.push(index);
+        }
+    }
+
+    let sort_offsets = pending
+        .iter()
+        .map(|symbol| symbol.sort_offset)
+        .collect::<Vec<_>>();
+    root_ids.sort_by_key(|index| sort_offsets[*index]);
+    for children in &mut child_ids {
+        children.sort_by_key(|index| sort_offsets[*index]);
+    }
+
+    root_ids
+        .into_iter()
+        .map(|index| take_document_symbol(index, &mut pending, &child_ids))
+        .collect()
+}
+
+fn take_document_symbol(
+    index: usize,
+    pending: &mut [PendingDocumentSymbol],
+    child_ids: &[Vec<usize>],
+) -> EditorDocumentSymbol {
+    let mut symbol = pending[index].symbol.clone();
+    symbol.children = child_ids[index]
+        .iter()
+        .copied()
+        .map(|child| take_document_symbol(child, pending, child_ids))
+        .collect();
+    symbol
+}

--- a/crates/shuck-semantic/src/lib.rs
+++ b/crates/shuck-semantic/src/lib.rs
@@ -16,6 +16,7 @@ mod contract;
 mod dataflow;
 mod declaration;
 mod dense_bit_set;
+mod editor;
 mod function_call_reachability;
 mod function_resolution;
 mod glob;
@@ -66,6 +67,8 @@ pub use dataflow::{
 };
 /// Declaration records discovered while building the semantic model.
 pub use declaration::{Declaration, DeclarationBuiltin, DeclarationOperand};
+/// Editor-facing semantic query types.
+pub use editor::{EditorDocumentSymbol, EditorQuery, EditorSymbol, EditorSymbolKind};
 /// Direct function-call reachability query types.
 pub use function_call_reachability::{
     DirectFunctionCallReachability, DirectFunctionCallWindow, FunctionCallCandidate,
@@ -788,6 +791,7 @@ pub struct SemanticModel {
     bindings_by_definition_span: OnceLock<FxHashMap<SpanKey, BindingId>>,
     guarded_or_defaulting_reference_offsets_by_name: OnceLock<FxHashMap<Name, Box<[usize]>>>,
     declarations_by_command_span: OnceLock<FxHashMap<SpanKey, usize>>,
+    editor_document_symbol_ranges_by_binding: OnceLock<Vec<Option<Span>>>,
     unconditional_function_bindings: OnceLock<FxHashSet<BindingId>>,
     function_bindings_by_scope: OnceLock<FxHashMap<ScopeId, SmallVec<[BindingId; 2]>>>,
     visible_function_call_bindings: OnceLock<FxHashMap<SpanKey, BindingId>>,
@@ -902,6 +906,7 @@ impl SemanticModel {
             bindings_by_definition_span: OnceLock::new(),
             guarded_or_defaulting_reference_offsets_by_name: OnceLock::new(),
             declarations_by_command_span: OnceLock::new(),
+            editor_document_symbol_ranges_by_binding: OnceLock::new(),
             unconditional_function_bindings: OnceLock::new(),
             function_bindings_by_scope: OnceLock::new(),
             visible_function_call_bindings: OnceLock::new(),

--- a/crates/shuck-semantic/src/tests.rs
+++ b/crates/shuck-semantic/src/tests.rs
@@ -32,6 +32,106 @@ fn model_with_profile(source: &str, profile: ShellProfile) -> SemanticModel {
     )
 }
 
+#[test]
+fn editor_document_symbols_include_top_level_assignments_and_declarations() {
+    let source = "\
+VERSION=1
+declare -A LOOKUP
+declare -n REF=target
+build() { :; }
+";
+    let model = model(source);
+    let symbols = model.editor_query().document_symbols();
+
+    assert_eq!(
+        symbols
+            .iter()
+            .map(|symbol| symbol.name.as_str())
+            .collect::<Vec<_>>(),
+        ["VERSION", "LOOKUP", "REF", "build"]
+    );
+    assert_eq!(symbols[0].kind, EditorSymbolKind::Variable);
+    assert_eq!(symbols[0].range.slice(source), "VERSION");
+    assert_eq!(symbols[1].kind, EditorSymbolKind::AssociativeArray);
+    assert_eq!(symbols[1].range.slice(source), "LOOKUP");
+    assert_eq!(symbols[2].kind, EditorSymbolKind::Declaration);
+    assert_eq!(symbols[2].range.slice(source), "REF=target");
+    assert_eq!(symbols[3].kind, EditorSymbolKind::Function);
+    assert_eq!(symbols[3].selection_span.slice(source), "build");
+    assert_eq!(symbols[3].range.slice(source), "build() { :; }\n");
+}
+
+#[test]
+fn editor_document_symbols_nest_function_locals_loop_variables_and_nested_functions() {
+    let source = "\
+build() {
+  local artifact
+  local -n alias=artifact
+  for item in \"$@\"; do
+    :
+  done
+  helper() {
+    local nested
+  }
+}
+";
+    let model = model(source);
+    let symbols = model.editor_query().document_symbols();
+
+    assert_eq!(symbols.len(), 1);
+    assert_eq!(symbols[0].name.as_str(), "build");
+    assert_eq!(
+        symbols[0]
+            .children
+            .iter()
+            .map(|symbol| symbol.name.as_str())
+            .collect::<Vec<_>>(),
+        ["artifact", "alias", "item", "helper"]
+    );
+    assert_eq!(symbols[0].children[0].kind, EditorSymbolKind::Declaration);
+    assert_eq!(symbols[0].children[1].kind, EditorSymbolKind::Declaration);
+    assert_eq!(symbols[0].children[1].range.slice(source), "alias=artifact");
+    assert_eq!(symbols[0].children[2].kind, EditorSymbolKind::Variable);
+    assert_eq!(symbols[0].children[3].kind, EditorSymbolKind::Function);
+    assert_eq!(
+        symbols[0].children[3]
+            .children
+            .iter()
+            .map(|symbol| symbol.name.as_str())
+            .collect::<Vec<_>>(),
+        ["nested"]
+    );
+}
+
+#[test]
+fn editor_document_symbols_skip_function_local_plain_assignments() {
+    let source = "\
+top=1
+build() {
+  temp=2
+  local kept
+}
+";
+    let model = model(source);
+    let symbols = model.editor_query().document_symbols();
+
+    assert_eq!(
+        symbols
+            .iter()
+            .map(|symbol| symbol.name.as_str())
+            .collect::<Vec<_>>(),
+        ["top", "build"]
+    );
+    assert_eq!(
+        symbols[1]
+            .children
+            .iter()
+            .map(|symbol| symbol.name.as_str())
+            .collect::<Vec<_>>(),
+        ["kept"]
+    );
+}
+
 fn span_for_nth(source: &str, needle: &str, index: usize) -> Span {
     let start_offset = source
         .match_indices(needle)

--- a/crates/shuck-server/Cargo.toml
+++ b/crates/shuck-server/Cargo.toml
@@ -23,6 +23,7 @@ shuck-formatter = { workspace = true }
 shuck-indexer = { workspace = true }
 shuck-linter = { workspace = true }
 shuck-parser = { workspace = true }
+shuck-semantic = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 

--- a/crates/shuck-server/src/lib.rs
+++ b/crates/shuck-server/src/lib.rs
@@ -24,6 +24,7 @@ mod logging;
 mod resolve;
 mod server;
 mod session;
+mod symbols;
 mod workspace;
 
 pub(crate) const SERVER_NAME: &str = "shuck";

--- a/crates/shuck-server/src/server.rs
+++ b/crates/shuck-server/src/server.rs
@@ -148,6 +148,7 @@ impl Server {
             }),
             document_formatting_provider: None,
             document_range_formatting_provider: None,
+            document_symbol_provider: Some(OneOf::Left(true)),
             diagnostic_provider: Some(types::DiagnosticServerCapabilities::Options(
                 DiagnosticOptions {
                     identifier: Some(crate::DIAGNOSTIC_NAME.into()),
@@ -299,6 +300,15 @@ mod tests {
         let capabilities = Server::server_capabilities(PositionEncoding::UTF16);
         assert!(capabilities.document_formatting_provider.is_none());
         assert!(capabilities.document_range_formatting_provider.is_none());
+    }
+
+    #[test]
+    fn advertises_document_symbol_capability() {
+        let capabilities = Server::server_capabilities(PositionEncoding::UTF16);
+        assert_eq!(
+            capabilities.document_symbol_provider,
+            Some(OneOf::Left(true))
+        );
     }
 
     #[test]

--- a/crates/shuck-server/src/server/api.rs
+++ b/crates/shuck-server/src/server/api.rs
@@ -45,6 +45,9 @@ pub(super) fn request(req: server::Request) -> Task {
         request::DocumentDiagnostic::METHOD => {
             background_request_task::<request::DocumentDiagnostic>(req, BackgroundSchedule::Worker)
         }
+        request::DocumentSymbols::METHOD => {
+            background_request_task::<request::DocumentSymbols>(req, BackgroundSchedule::Worker)
+        }
         request::ExecuteCommand::METHOD => sync_request_task::<request::ExecuteCommand>(req),
         request::Format::METHOD => {
             background_request_task::<request::Format>(req, BackgroundSchedule::Fmt)

--- a/crates/shuck-server/src/server/api/requests.rs
+++ b/crates/shuck-server/src/server/api/requests.rs
@@ -1,6 +1,7 @@
 mod code_action;
 mod code_action_resolve;
 mod diagnostic;
+mod document_symbol;
 mod execute_command;
 mod format;
 mod format_range;
@@ -15,6 +16,7 @@ use super::{
 pub(super) use code_action::CodeActions;
 pub(super) use code_action_resolve::CodeActionResolve;
 pub(super) use diagnostic::DocumentDiagnostic;
+pub(super) use document_symbol::DocumentSymbols;
 pub(super) use execute_command::ExecuteCommand;
 pub(super) use format::Format;
 pub(super) use format_range::FormatRange;

--- a/crates/shuck-server/src/server/api/requests/document_symbol.rs
+++ b/crates/shuck-server/src/server/api/requests/document_symbol.rs
@@ -1,0 +1,29 @@
+use lsp_types::{self as types, request as req};
+
+use crate::session::{Client, DocumentSnapshot};
+use crate::symbols;
+
+pub(crate) struct DocumentSymbols;
+
+impl super::RequestHandler for DocumentSymbols {
+    type RequestType = req::DocumentSymbolRequest;
+}
+
+impl super::BackgroundDocumentRequestHandler for DocumentSymbols {
+    super::define_document_url!(params: &types::DocumentSymbolParams);
+
+    fn run_without_snapshot(
+        _client: &Client,
+        _params: types::DocumentSymbolParams,
+    ) -> crate::server::Result<symbols::DocumentSymbolResponse> {
+        Ok(None)
+    }
+
+    fn run_with_snapshot(
+        snapshot: DocumentSnapshot,
+        client: &Client,
+        params: types::DocumentSymbolParams,
+    ) -> crate::server::Result<symbols::DocumentSymbolResponse> {
+        symbols::document_symbols(snapshot, client, params)
+    }
+}

--- a/crates/shuck-server/src/session/capabilities.rs
+++ b/crates/shuck-server/src/session/capabilities.rs
@@ -7,6 +7,7 @@ pub(crate) struct ResolvedClientCapabilities {
     pub(crate) document_changes: bool,
     pub(crate) workspace_refresh: bool,
     pub(crate) pull_diagnostics: bool,
+    pub(crate) hierarchical_document_symbols: bool,
 }
 
 impl ResolvedClientCapabilities {
@@ -41,6 +42,13 @@ impl ResolvedClientCapabilities {
             .and_then(|text_document| text_document.diagnostic.as_ref())
             .is_some();
 
+        let hierarchical_document_symbols = client_capabilities
+            .text_document
+            .as_ref()
+            .and_then(|text_document| text_document.document_symbol.as_ref())
+            .and_then(|document_symbol| document_symbol.hierarchical_document_symbol_support)
+            .unwrap_or_default();
+
         Self {
             code_action_deferred_edit_resolution: code_action_data_support
                 && code_action_edit_resolution,
@@ -48,6 +56,7 @@ impl ResolvedClientCapabilities {
             document_changes,
             workspace_refresh: false,
             pull_diagnostics,
+            hierarchical_document_symbols,
         }
     }
 }

--- a/crates/shuck-server/src/symbols.rs
+++ b/crates/shuck-server/src/symbols.rs
@@ -1,0 +1,342 @@
+use lsp_types as types;
+use shuck_parser::parser::Parser;
+use shuck_semantic::{EditorDocumentSymbol, EditorSymbolKind, SemanticBuildOptions, SemanticModel};
+
+use crate::session::{Client, DocumentSnapshot};
+
+pub(crate) type DocumentSymbolResponse = Option<types::DocumentSymbolResponse>;
+
+pub(crate) fn document_symbols(
+    snapshot: DocumentSnapshot,
+    _client: &Client,
+    _params: types::DocumentSymbolParams,
+) -> crate::server::Result<DocumentSymbolResponse> {
+    let Some(shell) = crate::lint::document_shell(&snapshot) else {
+        return Ok(None);
+    };
+
+    let query = snapshot.query();
+    let source = query.document().contents();
+    let shell_profile = shell.shell_profile();
+    let parse_result = Parser::with_profile(source, shell_profile.clone()).parse();
+    let indexer = shuck_indexer::Indexer::new(source, &parse_result);
+    let semantic = SemanticModel::build_with_options(
+        &parse_result.file,
+        source,
+        &indexer,
+        SemanticBuildOptions {
+            source_path: query.file_path().as_deref(),
+            shell_profile: Some(shell_profile),
+            resolve_source_closure: false,
+            ..SemanticBuildOptions::default()
+        },
+    );
+    let editor_symbols = semantic.editor_query().document_symbols();
+
+    if snapshot
+        .resolved_client_capabilities()
+        .hierarchical_document_symbols
+    {
+        let symbols = editor_symbols
+            .iter()
+            .map(|symbol| to_lsp_document_symbol(symbol, &snapshot))
+            .collect();
+        Ok(Some(types::DocumentSymbolResponse::Nested(symbols)))
+    } else {
+        let symbols = editor_symbols
+            .iter()
+            .flat_map(|symbol| to_lsp_symbol_information(symbol, &snapshot, None))
+            .collect();
+        Ok(Some(types::DocumentSymbolResponse::Flat(symbols)))
+    }
+}
+
+#[allow(deprecated)]
+fn to_lsp_document_symbol(
+    symbol: &EditorDocumentSymbol,
+    snapshot: &DocumentSnapshot,
+) -> types::DocumentSymbol {
+    let source = snapshot.query().document().contents();
+    let line_index = snapshot.query().document().index();
+    let children = (!symbol.children.is_empty()).then(|| {
+        symbol
+            .children
+            .iter()
+            .map(|child| to_lsp_document_symbol(child, snapshot))
+            .collect()
+    });
+
+    types::DocumentSymbol {
+        name: symbol.name.to_string(),
+        detail: None,
+        kind: to_lsp_symbol_kind(symbol.kind),
+        tags: None,
+        deprecated: None,
+        range: crate::edit::to_lsp_range(
+            symbol.range.to_range(),
+            source,
+            line_index,
+            snapshot.encoding(),
+        ),
+        selection_range: crate::edit::to_lsp_range(
+            symbol.selection_span.to_range(),
+            source,
+            line_index,
+            snapshot.encoding(),
+        ),
+        children,
+    }
+}
+
+#[allow(deprecated)]
+fn to_lsp_symbol_information(
+    symbol: &EditorDocumentSymbol,
+    snapshot: &DocumentSnapshot,
+    container_name: Option<&str>,
+) -> Vec<types::SymbolInformation> {
+    let source = snapshot.query().document().contents();
+    let line_index = snapshot.query().document().index();
+    let mut symbols = vec![types::SymbolInformation {
+        name: symbol.name.to_string(),
+        kind: to_lsp_symbol_kind(symbol.kind),
+        tags: None,
+        deprecated: None,
+        location: types::Location::new(
+            snapshot.query().file_url().clone(),
+            crate::edit::to_lsp_range(
+                symbol.selection_span.to_range(),
+                source,
+                line_index,
+                snapshot.encoding(),
+            ),
+        ),
+        container_name: container_name.map(str::to_owned),
+    }];
+
+    symbols.extend(
+        symbol.children.iter().flat_map(|child| {
+            to_lsp_symbol_information(child, snapshot, Some(symbol.name.as_str()))
+        }),
+    );
+    symbols
+}
+
+fn to_lsp_symbol_kind(kind: EditorSymbolKind) -> types::SymbolKind {
+    match kind {
+        EditorSymbolKind::Function => types::SymbolKind::FUNCTION,
+        EditorSymbolKind::Array | EditorSymbolKind::AssociativeArray => types::SymbolKind::ARRAY,
+        EditorSymbolKind::Variable
+        | EditorSymbolKind::Declaration
+        | EditorSymbolKind::RuntimeName => types::SymbolKind::VARIABLE,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crossbeam::channel;
+    use lsp_types::{
+        ClientCapabilities, DocumentSymbolClientCapabilities, DocumentSymbolParams,
+        DocumentSymbolResponse, PartialResultParams, PositionEncodingKind,
+        TextDocumentClientCapabilities, TextDocumentIdentifier, Url, WorkDoneProgressParams,
+    };
+
+    use super::*;
+    use crate::{
+        Client, GlobalOptions, PositionEncoding, Session, TextDocument, Workspace, Workspaces,
+    };
+
+    fn position_encoding_kind(encoding: PositionEncoding) -> PositionEncodingKind {
+        match encoding {
+            PositionEncoding::UTF8 => PositionEncodingKind::UTF8,
+            PositionEncoding::UTF16 => PositionEncodingKind::UTF16,
+            PositionEncoding::UTF32 => PositionEncodingKind::UTF32,
+        }
+    }
+
+    fn make_snapshot(
+        source: &str,
+        encoding: PositionEncoding,
+        hierarchical_document_symbols: bool,
+    ) -> (DocumentSnapshot, Client, Url) {
+        let (main_loop_sender, _main_loop_receiver) = channel::unbounded();
+        let (client_sender, _client_receiver) = channel::unbounded();
+        let client = Client::new(main_loop_sender, client_sender);
+        let workspace_root = std::env::temp_dir().join("shuck-server-symbol-tests");
+        let workspace_uri =
+            Url::from_file_path(&workspace_root).expect("workspace path should convert to a URL");
+        let workspaces = Workspaces::new(vec![Workspace::default(workspace_uri)]);
+        let global = GlobalOptions::default().into_settings(client.clone());
+        let mut session = Session::new(
+            &ClientCapabilities {
+                general: Some(lsp_types::GeneralClientCapabilities {
+                    position_encodings: Some(vec![position_encoding_kind(encoding)]),
+                    ..Default::default()
+                }),
+                text_document: Some(TextDocumentClientCapabilities {
+                    document_symbol: Some(DocumentSymbolClientCapabilities {
+                        hierarchical_document_symbol_support: Some(hierarchical_document_symbols),
+                        ..Default::default()
+                    }),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            },
+            encoding,
+            global,
+            &workspaces,
+            &client,
+        )
+        .expect("test session should initialize");
+
+        let uri = Url::from_file_path(workspace_root.join("script.sh"))
+            .expect("script path should convert to a URL");
+        session.open_text_document(
+            uri.clone(),
+            TextDocument::new(source.to_owned(), 1).with_language_id("shellscript"),
+        );
+
+        (
+            session
+                .take_snapshot(uri.clone())
+                .expect("test document should produce a snapshot"),
+            client,
+            uri,
+        )
+    }
+
+    #[test]
+    fn document_symbols_return_nested_lsp_symbols() {
+        let source = "\
+#!/bin/bash
+VERSION=1
+build() {
+  local artifact
+}
+";
+        let (snapshot, client, uri) = make_snapshot(source, PositionEncoding::UTF16, true);
+        let response = document_symbols(
+            snapshot,
+            &client,
+            DocumentSymbolParams {
+                text_document: TextDocumentIdentifier { uri },
+                work_done_progress_params: WorkDoneProgressParams::default(),
+                partial_result_params: PartialResultParams::default(),
+            },
+        )
+        .expect("document symbol request should succeed")
+        .expect("document symbol response should be present");
+
+        let DocumentSymbolResponse::Nested(symbols) = response else {
+            panic!("expected nested document symbols");
+        };
+        assert_eq!(symbols.len(), 2);
+        assert_eq!(symbols[0].name, "VERSION");
+        assert_eq!(symbols[0].kind, types::SymbolKind::VARIABLE);
+        assert_eq!(symbols[0].selection_range.start.line, 1);
+        assert_eq!(symbols[0].selection_range.start.character, 0);
+        assert_eq!(symbols[0].selection_range.end.character, 7);
+
+        assert_eq!(symbols[1].name, "build");
+        assert_eq!(symbols[1].kind, types::SymbolKind::FUNCTION);
+        assert_eq!(symbols[1].selection_range.start.line, 2);
+        assert_eq!(symbols[1].selection_range.start.character, 0);
+        assert_eq!(symbols[1].selection_range.end.character, 5);
+
+        let children = symbols[1]
+            .children
+            .as_ref()
+            .expect("function symbol should have children");
+        assert_eq!(children.len(), 1);
+        assert_eq!(children[0].name, "artifact");
+        assert_eq!(children[0].kind, types::SymbolKind::VARIABLE);
+        assert_eq!(children[0].selection_range.start.line, 3);
+        assert_eq!(children[0].selection_range.start.character, 8);
+    }
+
+    #[test]
+    fn document_symbols_fall_back_to_flat_response_without_hierarchical_client_support() {
+        let source = "\
+#!/bin/bash
+VERSION=1
+build() {
+  local artifact
+}
+";
+        let (snapshot, client, uri) = make_snapshot(source, PositionEncoding::UTF16, false);
+        let response = document_symbols(
+            snapshot,
+            &client,
+            DocumentSymbolParams {
+                text_document: TextDocumentIdentifier { uri },
+                work_done_progress_params: WorkDoneProgressParams::default(),
+                partial_result_params: PartialResultParams::default(),
+            },
+        )
+        .expect("document symbol request should succeed")
+        .expect("document symbol response should be present");
+
+        let DocumentSymbolResponse::Flat(symbols) = response else {
+            panic!("expected flat document symbols");
+        };
+        assert_eq!(
+            symbols
+                .iter()
+                .map(|symbol| symbol.name.as_str())
+                .collect::<Vec<_>>(),
+            ["VERSION", "build", "artifact"]
+        );
+        assert_eq!(symbols[0].container_name, None);
+        assert_eq!(symbols[2].container_name.as_deref(), Some("build"));
+    }
+
+    #[test]
+    fn document_symbol_ranges_use_negotiated_position_encoding() {
+        let source = "build() { echo \"é\"; local cafe; }\n";
+
+        let (snapshot, client, uri) = make_snapshot(source, PositionEncoding::UTF16, true);
+        let utf16_response = document_symbols(
+            snapshot,
+            &client,
+            DocumentSymbolParams {
+                text_document: TextDocumentIdentifier { uri },
+                work_done_progress_params: WorkDoneProgressParams::default(),
+                partial_result_params: PartialResultParams::default(),
+            },
+        )
+        .expect("document symbol request should succeed")
+        .expect("document symbol response should be present");
+        let DocumentSymbolResponse::Nested(utf16_symbols) = utf16_response else {
+            panic!("expected nested document symbols");
+        };
+        let utf16_child = &utf16_symbols[0]
+            .children
+            .as_ref()
+            .expect("function should have children")[0];
+        assert_eq!(utf16_child.name, "cafe");
+        assert_eq!(utf16_child.selection_range.start.character, 26);
+        assert_eq!(utf16_child.selection_range.end.character, 30);
+
+        let (snapshot, client, uri) = make_snapshot(source, PositionEncoding::UTF8, true);
+        let utf8_response = document_symbols(
+            snapshot,
+            &client,
+            DocumentSymbolParams {
+                text_document: TextDocumentIdentifier { uri },
+                work_done_progress_params: WorkDoneProgressParams::default(),
+                partial_result_params: PartialResultParams::default(),
+            },
+        )
+        .expect("document symbol request should succeed")
+        .expect("document symbol response should be present");
+        let DocumentSymbolResponse::Nested(utf8_symbols) = utf8_response else {
+            panic!("expected nested document symbols");
+        };
+        let utf8_child = &utf8_symbols[0]
+            .children
+            .as_ref()
+            .expect("function should have children")[0];
+        assert_eq!(utf8_child.name, "cafe");
+        assert_eq!(utf8_child.selection_range.start.character, 27);
+        assert_eq!(utf8_child.selection_range.end.character, 31);
+    }
+}

--- a/crates/shuck-server/tests/manual/README.md
+++ b/crates/shuck-server/tests/manual/README.md
@@ -35,6 +35,7 @@ Available scenarios:
 
 - `diagnostics/open_edit`
 - `hover/rule_directive`
+- `symbols/document_symbols`
 - `code_actions/quick_fix`
 - `code_actions/fix_all`
 - `formatting/request_round_trip`

--- a/crates/shuck-server/tests/manual/fixtures/workspace/symbols/document_symbols.sh
+++ b/crates/shuck-server/tests/manual/fixtures/workspace/symbols/document_symbols.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+VERSION=1
+declare -A LOOKUP
+
+build() {
+  local artifact
+  for item in "$@"; do
+    :
+  done
+  helper() {
+    local nested
+  }
+}

--- a/crates/shuck-server/tests/manual/lua/shuck_server_blackbox/symbols/document_symbols.lua
+++ b/crates/shuck-server/tests/manual/lua/shuck_server_blackbox/symbols/document_symbols.lua
@@ -1,0 +1,41 @@
+local M = {}
+
+local function child_names(symbol)
+  local names = {}
+  for _, child in ipairs(symbol.children or {}) do
+    table.insert(names, child.name)
+  end
+  return names
+end
+
+function M.run(t)
+  local bufnr, client_id = t.open_fixture("symbols/document_symbols.sh")
+  local client = t.client(bufnr, client_id)
+
+  assert(
+    client.server_capabilities.documentSymbolProvider ~= nil,
+    "expected documentSymbolProvider to be advertised"
+  )
+
+  local symbols = t.client_request_sync(client, "textDocument/documentSymbol", {
+    textDocument = { uri = vim.uri_from_bufnr(bufnr) },
+  }, bufnr, 5000)
+
+  assert(symbols ~= nil, "expected document symbols response")
+  assert(#symbols == 3, "expected three top-level symbols: " .. vim.inspect(symbols))
+  assert(symbols[1].name == "VERSION", "expected VERSION as first symbol")
+  assert(symbols[2].name == "LOOKUP", "expected LOOKUP as second symbol")
+  assert(symbols[3].name == "build", "expected build as third symbol")
+
+  local build = symbols[3]
+  local build_children = child_names(build)
+  assert(vim.deep_equal(build_children, { "artifact", "item", "helper" }), vim.inspect(build))
+
+  local helper = build.children[3]
+  assert(
+    vim.deep_equal(child_names(helper), { "nested" }),
+    "expected helper to contain nested local: " .. vim.inspect(helper)
+  )
+end
+
+return M

--- a/crates/shuck-server/tests/manual/run_neovim_blackbox.py
+++ b/crates/shuck-server/tests/manual/run_neovim_blackbox.py
@@ -19,6 +19,7 @@ FIXTURE_ROOT = MANUAL_ROOT / "fixtures" / "workspace"
 SCENARIOS = [
     "diagnostics/open_edit",
     "hover/rule_directive",
+    "symbols/document_symbols",
     "code_actions/quick_fix",
     "code_actions/fix_all",
     "formatting/request_round_trip",


### PR DESCRIPTION
## Summary
- add semantic-owned editor document-symbol query shapes and hierarchy construction
- wire `textDocument/documentSymbol` through the LSP server with nested and flat responses based on client capability
- add semantic, server, Neovim black-box, and Criterion coverage for document symbols

## Validation
- `cargo fmt --all --check`
- `cargo clippy -p shuck-server -p shuck-cli --all-targets -- -D warnings`
- `cargo test -p shuck-semantic`
- `cargo test -p shuck-server`
- `cargo check -p shuck-benchmark --benches`
- `cargo clippy -p shuck-benchmark --benches -- -D warnings`
- `cargo bench -p shuck-benchmark --bench editor -- --warm-up-time 1 --measurement-time 1 --noplot`
- `nix --extra-experimental-features 'nix-command flakes' develop --command python3 crates/shuck-server/tests/manual/run_neovim_blackbox.py --case symbols/document_symbols --skip-build`