### PR TITLE
ci: run make check in lint job

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -21,7 +21,7 @@ Before opening this PR, please confirm:
 ## Test plan
 
 <!-- How did you verify this works? Tick what applies; add commands you ran. -->
-- [ ] `make check` (fmt + clippy + udeps)
+- [ ] `make check` (fmt + clippy + cargo-shear)
 - [ ] `make test`
 - [ ] `make test-large-corpus` (for rule changes that affect conformance)
 - [ ] Added or updated unit / integration / insta snapshot tests

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -57,22 +57,13 @@ jobs:
       - name: "Check release-please crate version coverage"
         run: python3 scripts/check-release-please-config.py
 
-  cargo-fmt:
-    name: "cargo fmt"
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-        with:
-          persist-credentials: false
-      - name: "Install Rust toolchain"
-        run: rustup component add rustfmt
-      - run: cargo fmt --all --check
-
-  cargo-clippy:
-    name: "cargo clippy"
+  lint:
+    name: "lint"
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    permissions:
+      id-token: write
+      contents: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
@@ -80,12 +71,15 @@ jobs:
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           save-if: ${{ github.ref == 'refs/heads/main' }}
+      - name: "Install Nix"
+        uses: DeterminateSystems/determinate-nix-action@32cb6a5ae30bb0dfc996fa7baf8bf1ed28442fa4 # v3.17.3
+      - uses: DeterminateSystems/flakehub-cache-action@77fe95416299b8d1351b57bf10a1042a0ed75708 # v3.17.3
       - name: "Install Rust toolchain"
-        run: rustup component add clippy
+        run: rustup component add rustfmt clippy
       - name: "Fetch dependencies"
         run: cargo fetch
-      - name: "Clippy"
-        run: cargo clippy --workspace --all-targets --all-features --offline -- -D warnings
+      - name: "Run lint checks"
+        run: make check
 
   cargo-deny:
     name: "cargo deny"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1795,7 +1795,6 @@ dependencies = [
  "colored",
  "etcetera",
  "globset",
- "ignore",
  "insta",
  "notify",
  "predicates",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,9 @@
 resolver = "2"
 members = ["crates/*"]
 
+[workspace.metadata.cargo-shear]
+ignored = ["shuck-benchmark", "shuck-format"]
+
 [workspace.package]
 version = "0.0.40"
 edition = "2024"

--- a/Makefile
+++ b/Makefile
@@ -297,6 +297,6 @@ check-scripts:
 	cargo run -q -p shuck-cli -- check --no-cache scripts
 check:
 	cargo fmt -- --check
-	cargo clippy --all-targets -- -D warnings
+	cargo clippy --workspace --all-targets --all-features -- -D warnings
 	$(NIX_DEVELOP) cargo shear
 	$(MAKE) --no-print-directory check-scripts

--- a/Makefile
+++ b/Makefile
@@ -298,5 +298,5 @@ check-scripts:
 check:
 	cargo fmt -- --check
 	cargo clippy --all-targets -- -D warnings
-	$(NIX_DEVELOP) env RUSTC_BOOTSTRAP=1 cargo udeps --all-targets
+	$(NIX_DEVELOP) cargo shear
 	$(MAKE) --no-print-directory check-scripts

--- a/crates/shuck-benchmark/Cargo.toml
+++ b/crates/shuck-benchmark/Cargo.toml
@@ -18,11 +18,8 @@ dhat-heap = ["dep:dhat"]
 
 [dependencies]
 shuck-formatter = { workspace = true, features = ["benchmarking"] }
-shuck-indexer = { workspace = true }
 shuck-linter = { workspace = true, features = ["benchmarking"] }
 shuck-parser = { workspace = true }
-shuck-semantic = { workspace = true }
-walkdir = "2"
 dhat = { version = "0.3", optional = true }
 
 [target.'cfg(not(target_os = "windows"))'.dependencies]
@@ -33,7 +30,10 @@ criterion = { version = "0.5", features = ["html_reports"] }
 serde = { workspace = true }
 serde_json = { workspace = true }
 shuck-cli = { workspace = true }
+shuck-indexer = { workspace = true }
+shuck-semantic = { workspace = true }
 tempfile = { workspace = true }
+walkdir = "2"
 
 [[example]]
 name = "parser_counts"

--- a/crates/shuck-cli/Cargo.toml
+++ b/crates/shuck-cli/Cargo.toml
@@ -28,7 +28,6 @@ clap = { workspace = true }
 colored = { workspace = true }
 etcetera = { workspace = true }
 globset = { workspace = true }
-ignore = { workspace = true }
 notify = { workspace = true }
 rayon = { workspace = true }
 serde = { workspace = true }

--- a/flake.nix
+++ b/flake.nix
@@ -23,7 +23,7 @@
             pkgs.shfmt
             pkgs.zsh
             pkgs.cargo-fuzz
-            pkgs.cargo-udeps
+            pkgs.cargo-shear
             pkgs.yq
           ];
         };


### PR DESCRIPTION
## Summary

- Replace the `cargo udeps` leg of `make check` with `cargo shear`.
- Update the Nix dev shell and PR checklist to use cargo-shear.
- Collapse the separate CI fmt/clippy jobs into one `lint` job that runs `make check`.
- Clean up dependency metadata so cargo-shear passes on the current workspace.

## Test plan

- `make check`
