### PR TITLE
feat(server): add semantic symbol hover

### DIFF
--- a/crates/shuck-benchmark/benches/editor.rs
+++ b/crates/shuck-benchmark/benches/editor.rs
@@ -1,5 +1,7 @@
-use criterion::{BenchmarkId, Criterion, Throughput, black_box, criterion_group, criterion_main};
-use shuck_benchmark::{benchmark_cases, configure_benchmark_allocator, parse_fixture};
+use criterion::{
+    BatchSize, BenchmarkId, Criterion, Throughput, black_box, criterion_group, criterion_main,
+};
+use shuck_benchmark::{TestFile, benchmark_cases, configure_benchmark_allocator, parse_fixture};
 use shuck_indexer::Indexer;
 use shuck_semantic::{EditorDocumentSymbol, SemanticModel};
 
@@ -8,6 +10,7 @@ configure_benchmark_allocator!();
 struct PreparedEditorInput {
     semantic: SemanticModel,
     binding_count: u64,
+    hover_probes: Vec<usize>,
 }
 
 fn prepare_editor_input(source: &'static str) -> PreparedEditorInput {
@@ -15,11 +18,20 @@ fn prepare_editor_input(source: &'static str) -> PreparedEditorInput {
     let indexer = Indexer::new(source, &output);
     let semantic = SemanticModel::build(&output.file, source, &indexer);
     let binding_count = semantic.bindings().len() as u64;
+    let hover_probes = hover_probes(source, &semantic);
 
     PreparedEditorInput {
         semantic,
         binding_count,
+        hover_probes,
     }
+}
+
+fn prepare_editor_inputs(files: &'static [TestFile]) -> Vec<PreparedEditorInput> {
+    files
+        .iter()
+        .map(|file| prepare_editor_input(file.source))
+        .collect()
 }
 
 fn count_document_symbols(symbols: &[EditorDocumentSymbol]) -> usize {
@@ -34,6 +46,69 @@ fn build_document_symbols(input: &PreparedEditorInput) -> usize {
     // benchmark isolates the editor query projection itself.
     let symbols = input.semantic.editor_query().document_symbols();
     black_box(count_document_symbols(&symbols))
+}
+
+fn hover_probes(source: &str, semantic: &SemanticModel) -> Vec<usize> {
+    let mut probes = Vec::new();
+    probes.extend(
+        semantic
+            .bindings()
+            .iter()
+            .filter(|binding| binding.span.start.offset < binding.span.end.offset)
+            .take(64)
+            .map(|binding| binding.span.start.offset),
+    );
+    probes.extend(
+        semantic
+            .references()
+            .iter()
+            .filter(|reference| reference.span.start.offset < reference.span.end.offset)
+            .take(64)
+            .map(|reference| reference.span.start.offset),
+    );
+    for binding in semantic.function_definition_bindings().take(32) {
+        probes.extend(
+            semantic
+                .call_sites_for(&binding.name)
+                .iter()
+                .filter(|site| site.name_span.start.offset < site.name_span.end.offset)
+                .take(2)
+                .map(|site| site.name_span.start.offset),
+        );
+    }
+    probes.extend(miss_probes(source).take(16));
+    probes.sort_unstable();
+    probes.dedup();
+    if probes.is_empty() {
+        probes.push(0);
+    }
+    probes
+}
+
+fn miss_probes(source: &str) -> impl Iterator<Item = usize> + '_ {
+    std::iter::once(0).chain(source.match_indices('\n').map(|(offset, _)| offset))
+}
+
+fn run_hover_queries(input: &PreparedEditorInput) -> usize {
+    let query = input.semantic.editor_query();
+    let hit_count = input
+        .hover_probes
+        .iter()
+        .filter(|offset| query.hover_at_offset(**offset).is_some())
+        .count();
+    black_box(hit_count)
+}
+
+fn run_hover_queries_for_inputs(inputs: &[PreparedEditorInput]) -> usize {
+    inputs.iter().map(run_hover_queries).sum()
+}
+
+fn hover_probe_count(inputs: &[PreparedEditorInput]) -> u64 {
+    inputs
+        .iter()
+        .map(|input| input.hover_probes.len() as u64)
+        .sum::<u64>()
+        .max(1)
 }
 
 fn bench_editor_document_symbols(c: &mut Criterion) {
@@ -64,5 +139,38 @@ fn bench_editor_document_symbols(c: &mut Criterion) {
     group.finish();
 }
 
-criterion_group!(benches, bench_editor_document_symbols);
+fn bench_editor_hover(c: &mut Criterion) {
+    let mut cold_group = c.benchmark_group("editor_hover_cold");
+    for case in benchmark_cases() {
+        let probe_count = hover_probe_count(&prepare_editor_inputs(case.files));
+        cold_group.sample_size(case.speed.sample_size());
+        cold_group.throughput(Throughput::Elements(probe_count));
+        cold_group.bench_function(BenchmarkId::from_parameter(case.name), move |b| {
+            b.iter_batched(
+                || prepare_editor_inputs(case.files),
+                |inputs| run_hover_queries_for_inputs(&inputs),
+                BatchSize::SmallInput,
+            );
+        });
+    }
+    cold_group.finish();
+
+    let mut warm_group = c.benchmark_group("editor_hover_warm");
+    for case in benchmark_cases() {
+        let inputs = prepare_editor_inputs(case.files);
+        let probe_count = hover_probe_count(&inputs);
+        for input in &inputs {
+            let _ = run_hover_queries(input);
+        }
+
+        warm_group.sample_size(case.speed.sample_size());
+        warm_group.throughput(Throughput::Elements(probe_count));
+        warm_group.bench_function(BenchmarkId::from_parameter(case.name), move |b| {
+            b.iter(|| run_hover_queries_for_inputs(&inputs));
+        });
+    }
+    warm_group.finish();
+}
+
+criterion_group!(benches, bench_editor_document_symbols, bench_editor_hover);
 criterion_main!(benches);

--- a/crates/shuck-linter/src/rules/correctness/mutable_global.rs
+++ b/crates/shuck-linter/src/rules/correctness/mutable_global.rs
@@ -251,7 +251,9 @@ fn report_span_for_binding(binding: &Binding) -> Span {
         | BindingOrigin::Assignment {
             definition_span, ..
         }
-        | BindingOrigin::ParameterDefaultAssignment { definition_span }
+        | BindingOrigin::ParameterDefaultAssignment {
+            definition_span, ..
+        }
         | BindingOrigin::Imported { definition_span }
         | BindingOrigin::FunctionDefinition { definition_span }
         | BindingOrigin::BuiltinTarget {

--- a/crates/shuck-linter/src/rules/correctness/unused_assignment.rs
+++ b/crates/shuck-linter/src/rules/correctness/unused_assignment.rs
@@ -322,7 +322,9 @@ fn report_span_for_binding(checker: &Checker<'_>, binding: &Binding) -> shuck_as
         BindingOrigin::Assignment {
             definition_span, ..
         }
-        | BindingOrigin::ParameterDefaultAssignment { definition_span }
+        | BindingOrigin::ParameterDefaultAssignment {
+            definition_span, ..
+        }
         | BindingOrigin::Imported { definition_span }
         | BindingOrigin::FunctionDefinition { definition_span }
         | BindingOrigin::BuiltinTarget {

--- a/crates/shuck-semantic/src/binding.rs
+++ b/crates/shuck-semantic/src/binding.rs
@@ -55,6 +55,8 @@ pub enum BindingOrigin {
     ParameterDefaultAssignment {
         /// Span of the operator site that introduces the binding.
         definition_span: Span,
+        /// Span of the parameter name assigned by the operator.
+        target_span: Span,
     },
     /// A binding imported from a sourced file or ambient contract.
     Imported {

--- a/crates/shuck-semantic/src/builder/references.rs
+++ b/crates/shuck-semantic/src/builder/references.rs
@@ -7,7 +7,22 @@ impl<'a, 'idx, 'observer> SemanticModelBuilder<'a, 'idx, 'observer> {
         kind: ReferenceKind,
         span: Span,
     ) -> ReferenceId {
+        self.add_reference_with_name_span(name, kind, span, Span::new())
+    }
+
+    pub(super) fn add_reference_with_name_span(
+        &mut self,
+        name: &Name,
+        kind: ReferenceKind,
+        span: Span,
+        name_span: Span,
+    ) -> ReferenceId {
         let span = self.normalize_reference_span(name, kind, span);
+        let name_span = if name_span.to_range().is_empty() {
+            self.reference_name_span(name, span).unwrap_or(span)
+        } else {
+            name_span
+        };
         let id = ReferenceId(self.references.len() as u32);
         let scope = self.current_scope();
         let resolved = self.resolve_reference(name, scope, span.start.offset);
@@ -19,6 +34,7 @@ impl<'a, 'idx, 'observer> SemanticModelBuilder<'a, 'idx, 'observer> {
             kind,
             scope,
             span,
+            name_span,
         });
         self.reference_index
             .entry(name.clone())
@@ -106,6 +122,21 @@ impl<'a, 'idx, 'observer> SemanticModelBuilder<'a, 'idx, 'observer> {
         } else {
             span
         }
+    }
+
+    fn reference_name_span(&self, name: &Name, span: Span) -> Option<Span> {
+        let syntax = span.slice(self.source);
+        let (relative_start, name_len) = if let Some(start) = syntax.find(name.as_str()) {
+            (start, name.as_str().len())
+        } else if let Some(stripped) = name.as_str().strip_prefix('+') {
+            (syntax.find(stripped)?, stripped.len())
+        } else {
+            return None;
+        };
+        let start_offset = span.start.offset + relative_start;
+        let end_offset = start_offset + name_len;
+        let (start, end) = self.source_positions_for_offsets(start_offset, end_offset)?;
+        (start.offset < end.offset).then(|| Span::from_positions(start, end))
     }
 
     pub(super) fn recover_braced_reference_span(&self, name: &Name, span: Span) -> Option<Span> {
@@ -249,6 +280,7 @@ impl<'a, 'idx, 'observer> SemanticModelBuilder<'a, 'idx, 'observer> {
             reference.span,
             BindingOrigin::ParameterDefaultAssignment {
                 definition_span: reference.span,
+                target_span: reference.name_span,
             },
             attributes,
         );

--- a/crates/shuck-semantic/src/builder/words.rs
+++ b/crates/shuck-semantic/src/builder/words.rs
@@ -253,7 +253,12 @@ impl<'a, 'idx, 'observer> SemanticModelBuilder<'a, 'idx, 'observer> {
         span: Span,
     ) -> ReferenceId {
         let reference_kind = self.word_reference_kind_override.unwrap_or(reference_kind);
-        let id = self.add_reference(&reference.name, reference_kind, span);
+        let id = self.add_reference_with_name_span(
+            &reference.name,
+            reference_kind,
+            span,
+            reference.name_span,
+        );
         self.visit_var_ref_subscript_words(
             Some(&reference.name),
             reference.subscript.as_deref(),

--- a/crates/shuck-semantic/src/editor.rs
+++ b/crates/shuck-semantic/src/editor.rs
@@ -6,8 +6,8 @@ use rustc_hash::FxHashMap;
 use shuck_ast::{Name, Span};
 
 use crate::{
-    Binding, BindingAttributes, BindingId, BindingKind, DeclarationOperand, ScopeId, ScopeKind,
-    SemanticModel, SpanKey,
+    Binding, BindingAttributes, BindingId, BindingKind, DeclarationOperand, ReferenceId, ScopeId,
+    ScopeKind, SemanticModel, SpanKey,
 };
 
 /// LSP-agnostic query object for editor features.
@@ -41,6 +41,23 @@ pub struct EditorDocumentSymbol {
     pub range: Span,
     /// Child symbols nested inside this symbol.
     pub children: Vec<EditorDocumentSymbol>,
+}
+
+/// Semantic hover information for one source symbol.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EditorHover {
+    /// Reusable semantic symbol payload.
+    pub symbol: EditorSymbol,
+    /// Span that should be highlighted by the hover response.
+    pub target_span: Span,
+    /// Attributes attached to the underlying binding, if any.
+    pub attributes: BindingAttributes,
+    /// Whether the symbol came from an imported contract or sourced file.
+    pub imported: bool,
+    /// Whether the symbol is provided by the active shell runtime.
+    pub runtime: bool,
+    /// Number of file-local call sites resolved to this function, when applicable.
+    pub function_call_count: Option<usize>,
 }
 
 impl Deref for EditorDocumentSymbol {
@@ -77,6 +94,20 @@ struct PendingDocumentSymbol {
 
 type DocumentSymbolRangesByBinding = Vec<Option<Span>>;
 type DeclarationOperandRanges = FxHashMap<SpanKey, Span>;
+pub(crate) type EditorHoverTargets = Vec<EditorHoverTarget>;
+
+#[derive(Debug, Clone)]
+pub(crate) struct EditorHoverTarget {
+    span: Span,
+    kind: EditorHoverTargetKind,
+}
+
+#[derive(Debug, Clone)]
+enum EditorHoverTargetKind {
+    Binding(BindingId),
+    Reference(ReferenceId),
+    FunctionCall { name: Name, name_span: Span },
+}
 
 impl SemanticModel {
     /// Returns an editor-facing query object over this semantic model.
@@ -149,6 +180,203 @@ impl<'model> EditorQuery<'model> {
 
         build_document_symbol_tree(pending)
     }
+
+    /// Returns semantic hover information for the symbol at `offset`.
+    pub fn hover_at_offset(&self, offset: usize) -> Option<EditorHover> {
+        let targets = self
+            .model
+            .editor_hover_targets
+            .get_or_init(|| build_editor_hover_targets(self.model));
+        let upper = targets.partition_point(|target| target.span.start.offset <= offset);
+
+        let mut best: Option<(&EditorHoverTarget, HoverTargetRank)> = None;
+        for target in targets[..upper].iter().rev() {
+            if target.span.end.offset <= offset {
+                break;
+            }
+            if !span_contains_offset(target.span, offset) {
+                continue;
+            }
+            let rank = hover_target_rank(target);
+            if best.is_none_or(|(_, best_rank)| rank < best_rank) {
+                best = Some((target, rank));
+            }
+        }
+
+        best.and_then(|(target, _)| hover_for_target(self.model, target))
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+struct HoverTargetRank {
+    priority: u8,
+    width: usize,
+}
+
+fn span_contains_offset(span: Span, offset: usize) -> bool {
+    span.start.offset <= offset && offset < span.end.offset
+}
+
+fn hover_target_rank(target: &EditorHoverTarget) -> HoverTargetRank {
+    let priority = match target.kind {
+        EditorHoverTargetKind::Binding(_) => 0,
+        EditorHoverTargetKind::FunctionCall { .. } => 1,
+        EditorHoverTargetKind::Reference(_) => 2,
+    };
+    HoverTargetRank {
+        priority,
+        width: target
+            .span
+            .end
+            .offset
+            .saturating_sub(target.span.start.offset),
+    }
+}
+
+fn build_editor_hover_targets(model: &SemanticModel) -> EditorHoverTargets {
+    let mut targets = Vec::new();
+    for binding in model.bindings() {
+        if hover_symbol_kind_for_binding(binding).is_some() && !binding.span.to_range().is_empty() {
+            targets.push(EditorHoverTarget {
+                span: binding.span,
+                kind: EditorHoverTargetKind::Binding(binding.id),
+            });
+        }
+    }
+    for reference in model.references() {
+        if !reference.span.to_range().is_empty() {
+            targets.push(EditorHoverTarget {
+                span: reference.span,
+                kind: EditorHoverTargetKind::Reference(reference.id),
+            });
+        }
+    }
+    for (name, sites) in &model.call_sites {
+        for site in sites {
+            if !site.name_span.to_range().is_empty() {
+                targets.push(EditorHoverTarget {
+                    span: site.name_span,
+                    kind: EditorHoverTargetKind::FunctionCall {
+                        name: name.clone(),
+                        name_span: site.name_span,
+                    },
+                });
+            }
+        }
+    }
+    targets.sort_by_key(|target| (target.span.start.offset, target.span.end.offset));
+    targets
+}
+
+fn hover_for_target(model: &SemanticModel, target: &EditorHoverTarget) -> Option<EditorHover> {
+    match &target.kind {
+        EditorHoverTargetKind::Binding(binding_id) => {
+            hover_for_binding(model, model.binding(*binding_id), target.span)
+        }
+        EditorHoverTargetKind::Reference(reference_id) => {
+            let reference = model.reference(*reference_id);
+            if let Some(binding) = model.resolved_binding(*reference_id) {
+                return hover_for_binding(model, binding, reference.span);
+            }
+            if model.predefined_runtime_refs.contains(reference_id)
+                || model.name_is_known_runtime(reference.name.as_str())
+            {
+                return Some(runtime_hover(model, reference.name.clone(), reference.span));
+            }
+            None
+        }
+        EditorHoverTargetKind::FunctionCall { name, name_span } => {
+            let binding_id = model
+                .analysis()
+                .visible_function_binding_at_call(name, *name_span)?;
+            hover_for_binding(model, model.binding(binding_id), *name_span)
+        }
+    }
+}
+
+fn hover_for_binding(
+    model: &SemanticModel,
+    binding: &Binding,
+    target_span: Span,
+) -> Option<EditorHover> {
+    let kind = hover_symbol_kind_for_binding(binding)?;
+    let definition_span = binding_definition_span(binding);
+    Some(EditorHover {
+        symbol: EditorSymbol {
+            name: binding.name.clone(),
+            kind,
+            definition_span,
+            selection_span: binding.span,
+            scope: binding.scope,
+            binding: Some(binding.id),
+        },
+        target_span,
+        attributes: binding.attributes,
+        imported: binding_is_imported(binding),
+        runtime: false,
+        function_call_count: (kind == EditorSymbolKind::Function)
+            .then(|| function_call_count_for_binding(model, binding)),
+    })
+}
+
+fn runtime_hover(model: &SemanticModel, name: Name, target_span: Span) -> EditorHover {
+    let kind = if model.runtime.is_preinitialized_associative_array(&name) {
+        EditorSymbolKind::AssociativeArray
+    } else if model.runtime.is_preinitialized_array(&name) {
+        EditorSymbolKind::Array
+    } else {
+        EditorSymbolKind::RuntimeName
+    };
+    EditorHover {
+        symbol: EditorSymbol {
+            name,
+            kind,
+            definition_span: target_span,
+            selection_span: target_span,
+            scope: model.scope_at(target_span.start.offset),
+            binding: None,
+        },
+        target_span,
+        attributes: BindingAttributes::empty(),
+        imported: false,
+        runtime: true,
+        function_call_count: None,
+    }
+}
+
+fn hover_symbol_kind_for_binding(binding: &Binding) -> Option<EditorSymbolKind> {
+    if matches!(binding.kind, BindingKind::FunctionDefinition)
+        || binding
+            .attributes
+            .contains(BindingAttributes::IMPORTED_FUNCTION)
+    {
+        return Some(EditorSymbolKind::Function);
+    }
+    if matches!(
+        binding.kind,
+        BindingKind::Imported | BindingKind::ParameterDefaultAssignment
+    ) {
+        return Some(EditorSymbolKind::Variable);
+    }
+    editor_symbol_kind_for_binding(binding)
+}
+
+fn binding_is_imported(binding: &Binding) -> bool {
+    matches!(binding.kind, BindingKind::Imported)
+        || binding.attributes.intersects(
+            BindingAttributes::IMPORTED_POSSIBLE
+                | BindingAttributes::IMPORTED_FUNCTION
+                | BindingAttributes::IMPORTED_FILE_ENTRY
+                | BindingAttributes::IMPORTED_FILE_ENTRY_INITIALIZED,
+        )
+}
+
+fn function_call_count_for_binding(model: &SemanticModel, binding: &Binding) -> usize {
+    model
+        .analysis()
+        .resolved_function_call_sites(&binding.name)
+        .filter(|(_, binding_id)| *binding_id == binding.id)
+        .count()
 }
 
 fn document_symbol_parent_for_binding(

--- a/crates/shuck-semantic/src/editor.rs
+++ b/crates/shuck-semantic/src/editor.rs
@@ -236,17 +236,18 @@ fn hover_target_rank(target: &EditorHoverTarget) -> HoverTargetRank {
 fn build_editor_hover_targets(model: &SemanticModel) -> EditorHoverTargets {
     let mut targets = Vec::new();
     for binding in model.bindings() {
-        if hover_symbol_kind_for_binding(binding).is_some() && !binding.span.to_range().is_empty() {
+        let span = binding_hover_span(binding);
+        if hover_symbol_kind_for_binding(binding).is_some() && !span.to_range().is_empty() {
             targets.push(EditorHoverTarget {
-                span: binding.span,
+                span,
                 kind: EditorHoverTargetKind::Binding(binding.id),
             });
         }
     }
     for reference in model.references() {
-        if !reference.span.to_range().is_empty() {
+        if !reference.name_span.to_range().is_empty() {
             targets.push(EditorHoverTarget {
-                span: reference.span,
+                span: reference.name_span,
                 kind: EditorHoverTargetKind::Reference(reference.id),
             });
         }
@@ -276,12 +277,16 @@ fn hover_for_target(model: &SemanticModel, target: &EditorHoverTarget) -> Option
         EditorHoverTargetKind::Reference(reference_id) => {
             let reference = model.reference(*reference_id);
             if let Some(binding) = model.resolved_binding(*reference_id) {
-                return hover_for_binding(model, binding, reference.span);
+                return hover_for_binding(model, binding, reference.name_span);
             }
             if model.predefined_runtime_refs.contains(reference_id)
-                || model.name_is_known_runtime(reference.name.as_str())
+                || model.name_is_predefined_runtime(reference.name.as_str())
             {
-                return Some(runtime_hover(model, reference.name.clone(), reference.span));
+                return Some(runtime_hover(
+                    model,
+                    reference.name.clone(),
+                    reference.name_span,
+                ));
             }
             None
         }
@@ -377,6 +382,13 @@ fn function_call_count_for_binding(model: &SemanticModel, binding: &Binding) -> 
         .resolved_function_call_sites(&binding.name)
         .filter(|(_, binding_id)| *binding_id == binding.id)
         .count()
+}
+
+fn binding_hover_span(binding: &Binding) -> Span {
+    match binding.origin {
+        crate::BindingOrigin::ParameterDefaultAssignment { target_span, .. } => target_span,
+        _ => binding.span,
+    }
 }
 
 fn document_symbol_parent_for_binding(
@@ -570,7 +582,9 @@ fn binding_definition_span(binding: &Binding) -> Span {
         | crate::BindingOrigin::LoopVariable {
             definition_span, ..
         }
-        | crate::BindingOrigin::ParameterDefaultAssignment { definition_span }
+        | crate::BindingOrigin::ParameterDefaultAssignment {
+            definition_span, ..
+        }
         | crate::BindingOrigin::Imported { definition_span }
         | crate::BindingOrigin::FunctionDefinition { definition_span }
         | crate::BindingOrigin::BuiltinTarget {

--- a/crates/shuck-semantic/src/lib.rs
+++ b/crates/shuck-semantic/src/lib.rs
@@ -68,7 +68,7 @@ pub use dataflow::{
 /// Declaration records discovered while building the semantic model.
 pub use declaration::{Declaration, DeclarationBuiltin, DeclarationOperand};
 /// Editor-facing semantic query types.
-pub use editor::{EditorDocumentSymbol, EditorQuery, EditorSymbol, EditorSymbolKind};
+pub use editor::{EditorDocumentSymbol, EditorHover, EditorQuery, EditorSymbol, EditorSymbolKind};
 /// Direct function-call reachability query types.
 pub use function_call_reachability::{
     DirectFunctionCallReachability, DirectFunctionCallWindow, FunctionCallCandidate,
@@ -792,6 +792,7 @@ pub struct SemanticModel {
     guarded_or_defaulting_reference_offsets_by_name: OnceLock<FxHashMap<Name, Box<[usize]>>>,
     declarations_by_command_span: OnceLock<FxHashMap<SpanKey, usize>>,
     editor_document_symbol_ranges_by_binding: OnceLock<Vec<Option<Span>>>,
+    editor_hover_targets: OnceLock<editor::EditorHoverTargets>,
     unconditional_function_bindings: OnceLock<FxHashSet<BindingId>>,
     function_bindings_by_scope: OnceLock<FxHashMap<ScopeId, SmallVec<[BindingId; 2]>>>,
     visible_function_call_bindings: OnceLock<FxHashMap<SpanKey, BindingId>>,
@@ -907,6 +908,7 @@ impl SemanticModel {
             guarded_or_defaulting_reference_offsets_by_name: OnceLock::new(),
             declarations_by_command_span: OnceLock::new(),
             editor_document_symbol_ranges_by_binding: OnceLock::new(),
+            editor_hover_targets: OnceLock::new(),
             unconditional_function_bindings: OnceLock::new(),
             function_bindings_by_scope: OnceLock::new(),
             visible_function_call_bindings: OnceLock::new(),

--- a/crates/shuck-semantic/src/reference.rs
+++ b/crates/shuck-semantic/src/reference.rs
@@ -25,6 +25,8 @@ pub struct Reference {
     pub scope: ScopeId,
     /// Source span of the use.
     pub span: Span,
+    /// Source span of the referenced name token.
+    pub name_span: Span,
 }
 
 /// Semantic category for a shell name use.

--- a/crates/shuck-semantic/src/tests.rs
+++ b/crates/shuck-semantic/src/tests.rs
@@ -148,7 +148,7 @@ echo \"$foo\"
     assert_eq!(definition.target_span.slice(source), "foo");
     assert!(!definition.runtime);
 
-    let reference_span = span_for_nth(source, "$foo", 0);
+    let reference_span = span_for_nth(source, "foo", 1);
     let reference = model
         .editor_query()
         .hover_at_offset(reference_span.start.offset)
@@ -204,7 +204,7 @@ build
 fn editor_hover_reports_runtime_names_without_definitions() {
     let source = "printf '%s\\n' \"$HOME\"\n";
     let model = model(source);
-    let name = span_for_nth(source, "$HOME", 0);
+    let name = span_for_nth(source, "HOME", 0);
     let hover = model
         .editor_query()
         .hover_at_offset(name.start.offset)
@@ -214,6 +214,53 @@ fn editor_hover_reports_runtime_names_without_definitions() {
     assert_eq!(hover.target_span, name);
     assert!(hover.runtime);
     assert!(hover.symbol.binding.is_none());
+}
+
+#[test]
+fn editor_hover_uses_name_span_inside_parameter_expansions() {
+    let source = "\
+foo=1
+printf '%s\\n' \"${foo:-fallback}\"
+printf '%s\\n' \"${created:=fallback}\"
+";
+    let model = model(source);
+    let query = model.editor_query();
+
+    let braced_reference = span_for_nth(source, "foo", 1);
+    let hover = query
+        .hover_at_offset(braced_reference.start.offset)
+        .expect("braced reference name should have hover");
+    assert_eq!(hover.symbol.name.as_str(), "foo");
+    assert_eq!(hover.target_span, braced_reference);
+
+    let default_assignment = span_for_nth(source, "created", 0);
+    let hover = query
+        .hover_at_offset(default_assignment.start.offset)
+        .expect("default assignment name should have hover");
+    assert_eq!(hover.symbol.name.as_str(), "created");
+    assert_eq!(hover.target_span, default_assignment);
+
+    for offset in [
+        source.find(":-").unwrap(),
+        source.find(":=").unwrap(),
+        span_for_nth(source, "fallback", 0).start.offset,
+        span_for_nth(source, "fallback", 1).start.offset,
+    ] {
+        assert!(query.hover_at_offset(offset).is_none(), "{offset}");
+    }
+}
+
+#[test]
+fn editor_hover_skips_known_runtime_names_that_are_not_active_for_shell() {
+    let source = "#!/bin/sh\nprintf '%s\\n' \"$BASH_VERSION\"\n";
+    let model = model_with_profile(source, ShellProfile::native(ShellDialect::Posix));
+    let name = span_for_nth(source, "BASH_VERSION", 0);
+    assert!(
+        model
+            .editor_query()
+            .hover_at_offset(name.start.offset)
+            .is_none()
+    );
 }
 
 #[test]

--- a/crates/shuck-semantic/src/tests.rs
+++ b/crates/shuck-semantic/src/tests.rs
@@ -132,6 +132,102 @@ build() {
     );
 }
 
+#[test]
+fn editor_hover_returns_binding_and_reference_symbols() {
+    let source = "\
+foo=1
+echo \"$foo\"
+";
+    let model = model(source);
+    let definition = model
+        .editor_query()
+        .hover_at_offset(source.find("foo").unwrap())
+        .expect("definition should have hover");
+    assert_eq!(definition.symbol.name.as_str(), "foo");
+    assert_eq!(definition.symbol.kind, EditorSymbolKind::Variable);
+    assert_eq!(definition.target_span.slice(source), "foo");
+    assert!(!definition.runtime);
+
+    let reference_span = span_for_nth(source, "$foo", 0);
+    let reference = model
+        .editor_query()
+        .hover_at_offset(reference_span.start.offset)
+        .expect("reference should have hover");
+    assert_eq!(reference.symbol.name.as_str(), "foo");
+    assert_eq!(reference.symbol.definition_span.slice(source), "foo");
+    assert_eq!(reference.target_span, reference_span);
+}
+
+#[test]
+fn editor_hover_reports_declaration_attributes() {
+    let source = "\
+build() {
+  local -a items
+  printf '%s\\n' \"${items[@]}\"
+}
+";
+    let model = model(source);
+    let declaration = span_for_nth(source, "items", 0);
+    let hover = model
+        .editor_query()
+        .hover_at_offset(declaration.start.offset)
+        .expect("declaration should have hover");
+    assert_eq!(hover.symbol.name.as_str(), "items");
+    assert_eq!(hover.symbol.kind, EditorSymbolKind::Array);
+    assert!(hover.attributes.contains(BindingAttributes::LOCAL));
+    assert!(hover.attributes.contains(BindingAttributes::ARRAY));
+}
+
+#[test]
+fn editor_hover_resolves_function_calls() {
+    let source = "\
+build() { :; }
+build
+";
+    let model = model(source);
+    let call = span_for_nth(source, "build", 1);
+    let hover = model
+        .editor_query()
+        .hover_at_offset(call.start.offset)
+        .expect("function call should have hover");
+    assert_eq!(hover.symbol.name.as_str(), "build");
+    assert_eq!(hover.symbol.kind, EditorSymbolKind::Function);
+    assert_eq!(
+        hover.symbol.definition_span.slice(source),
+        "build() { :; }\n"
+    );
+    assert_eq!(hover.target_span, call);
+    assert_eq!(hover.function_call_count, Some(1));
+}
+
+#[test]
+fn editor_hover_reports_runtime_names_without_definitions() {
+    let source = "printf '%s\\n' \"$HOME\"\n";
+    let model = model(source);
+    let name = span_for_nth(source, "$HOME", 0);
+    let hover = model
+        .editor_query()
+        .hover_at_offset(name.start.offset)
+        .expect("runtime name should have hover");
+    assert_eq!(hover.symbol.name.as_str(), "HOME");
+    assert_eq!(hover.symbol.kind, EditorSymbolKind::RuntimeName);
+    assert_eq!(hover.target_span, name);
+    assert!(hover.runtime);
+    assert!(hover.symbol.binding.is_none());
+}
+
+#[test]
+fn editor_hover_ignores_comments_and_single_quoted_text() {
+    let source = "\
+# foo in a comment
+printf '%s\\n' '$foo'
+";
+    let model = model(source);
+    for offset in [source.find("foo").unwrap(), source.rfind("foo").unwrap()] {
+        assert!(model.editor_query().hover_at_offset(offset).is_none());
+    }
+}
+
 fn span_for_nth(source: &str, needle: &str, index: usize) -> Span {
     let start_offset = source
         .match_indices(needle)

--- a/crates/shuck-server/src/editor.rs
+++ b/crates/shuck-server/src/editor.rs
@@ -1,0 +1,53 @@
+use std::path::Path;
+
+use shuck_indexer::Indexer;
+use shuck_linter::ShellDialect;
+use shuck_parser::{
+    ShellProfile,
+    parser::{ParseResult, Parser},
+};
+use shuck_semantic::{SemanticBuildOptions, SemanticModel};
+
+pub(crate) struct ParsedEditorDocument {
+    parse_result: ParseResult,
+    shell_profile: ShellProfile,
+    pub(crate) indexer: Indexer,
+}
+
+pub(crate) fn analyze_editor_document(
+    source: &str,
+    path: Option<&Path>,
+    shell: ShellDialect,
+) -> SemanticModel {
+    let parsed = parse_editor_document(source, shell);
+    semantic_for_parsed_document(&parsed, source, path)
+}
+
+pub(crate) fn parse_editor_document(source: &str, shell: ShellDialect) -> ParsedEditorDocument {
+    let shell_profile = shell.shell_profile();
+    let parse_result = Parser::with_profile(source, shell_profile.clone()).parse();
+    let indexer = Indexer::new(source, &parse_result);
+    ParsedEditorDocument {
+        parse_result,
+        shell_profile,
+        indexer,
+    }
+}
+
+pub(crate) fn semantic_for_parsed_document(
+    parsed: &ParsedEditorDocument,
+    source: &str,
+    path: Option<&Path>,
+) -> SemanticModel {
+    SemanticModel::build_with_options(
+        &parsed.parse_result.file,
+        source,
+        &parsed.indexer,
+        SemanticBuildOptions {
+            source_path: path,
+            shell_profile: Some(parsed.shell_profile.clone()),
+            resolve_source_closure: false,
+            ..SemanticBuildOptions::default()
+        },
+    )
+}

--- a/crates/shuck-server/src/lib.rs
+++ b/crates/shuck-server/src/lib.rs
@@ -17,6 +17,7 @@ pub use session::{Client, ClientOptions, DocumentQuery, DocumentSnapshot, Global
 pub use workspace::{Workspace, Workspaces};
 
 mod edit;
+mod editor;
 mod fix;
 mod format;
 mod lint;

--- a/crates/shuck-server/src/resolve.rs
+++ b/crates/shuck-server/src/resolve.rs
@@ -2,7 +2,7 @@ use lsp_types as types;
 use shuck_linter::{
     ShellCheckCodeMap, SuppressionAction, SuppressionSource, rule_metadata_by_code,
 };
-use shuck_parser::parser::Parser;
+use shuck_semantic::{BindingAttributes, EditorHover, EditorSymbolKind, ScopeKind, SemanticModel};
 
 use crate::edit::RangeExt;
 use crate::session::{Client, DocumentSnapshot};
@@ -12,17 +12,15 @@ pub(crate) fn hover(
     _client: &Client,
     params: types::HoverParams,
 ) -> crate::server::Result<Option<types::Hover>> {
-    if crate::lint::document_shell(&snapshot).is_none() {
+    let Some(shell) = crate::lint::document_shell(&snapshot) else {
         return Ok(None);
-    }
+    };
 
     let query = snapshot.query();
     let source = query.document().contents();
-    let parse_result = Parser::new(source).parse();
-    let indexer = shuck_indexer::Indexer::new(source, &parse_result);
+    let path = query.file_path();
+    let parsed = crate::editor::parse_editor_document(source, shell);
     let shellcheck_map = ShellCheckCodeMap::default();
-    let directives =
-        shuck_linter::parse_directives(source, indexer.comment_index(), &shellcheck_map);
     let position = params.text_document_position_params.position;
     let offset = usize::from(
         types::Range {
@@ -32,9 +30,44 @@ pub(crate) fn hover(
         .to_text_range(source, query.document().index(), snapshot.encoding())
         .start(),
     );
-    let line =
-        usize::try_from(params.text_document_position_params.position.line).unwrap_or_default() + 1;
-    let Some(directive) = directives.iter().find(|directive| {
+
+    if let Some(hover) = directive_hover(
+        &snapshot,
+        source,
+        query.document().index(),
+        parsed.indexer.comment_index(),
+        &shellcheck_map,
+        params.text_document_position_params.position,
+        offset,
+    ) {
+        return Ok(Some(hover));
+    }
+
+    let semantic = crate::editor::semantic_for_parsed_document(&parsed, source, path.as_deref());
+    let Some(semantic_hover) = semantic.editor_query().hover_at_offset(offset) else {
+        return Ok(None);
+    };
+    Ok(Some(render_semantic_hover(
+        &snapshot,
+        source,
+        query.document().index(),
+        &semantic,
+        &semantic_hover,
+    )))
+}
+
+fn directive_hover(
+    snapshot: &DocumentSnapshot,
+    source: &str,
+    line_index: &shuck_indexer::LineIndex,
+    comment_index: &shuck_indexer::CommentIndex,
+    shellcheck_map: &ShellCheckCodeMap,
+    position: types::Position,
+    offset: usize,
+) -> Option<types::Hover> {
+    let directives = shuck_linter::parse_directives(source, comment_index, shellcheck_map);
+    let line = usize::try_from(position.line).unwrap_or_default() + 1;
+    let directive = directives.iter().find(|directive| {
         usize::try_from(directive.line).ok() == Some(line)
             && offset >= usize::from(directive.range.start())
             && offset <= usize::from(directive.range.end())
@@ -47,20 +80,14 @@ pub(crate) fn hover(
                         | SuppressionAction::DisableFile
                 ) | (SuppressionSource::ShellCheck, SuppressionAction::Disable)
             )
-    }) else {
-        return Ok(None);
-    };
+    })?;
 
-    let Some((display_code, canonical_code, start_offset, end_offset)) = code_at_offset(
+    let (display_code, canonical_code, start_offset, end_offset) = code_at_offset(
         directive.range.slice(source),
         usize::from(directive.range.start()),
         offset,
-    ) else {
-        return Ok(None);
-    };
-    let Some(metadata) = rule_metadata_by_code(&canonical_code) else {
-        return Ok(None);
-    };
+    )?;
+    let metadata = rule_metadata_by_code(&canonical_code)?;
 
     let rule_name = humanize_rule_name(&canonical_code);
     let fix_marker = if metadata.fix_description.is_some() {
@@ -80,7 +107,7 @@ pub(crate) fn hover(
         markdown.push_str(&format!("\n\nSee also: SC{shellcheck_code:04}"));
     }
 
-    Ok(Some(types::Hover {
+    Some(types::Hover {
         contents: types::HoverContents::Markup(types::MarkupContent {
             kind: types::MarkupKind::Markdown,
             value: markdown,
@@ -91,10 +118,113 @@ pub(crate) fn hover(
                 shuck_ast::TextSize::new(end_offset as u32),
             ),
             source,
-            query.document().index(),
+            line_index,
             snapshot.encoding(),
         )),
-    }))
+    })
+}
+
+fn render_semantic_hover(
+    snapshot: &DocumentSnapshot,
+    source: &str,
+    line_index: &shuck_indexer::LineIndex,
+    semantic: &SemanticModel,
+    hover: &EditorHover,
+) -> types::Hover {
+    let mut markdown = format!(
+        "### {}\n\n{}",
+        markdown_code(hover.symbol.name.as_str()),
+        symbol_kind_label(hover.symbol.kind)
+    );
+
+    if hover.runtime {
+        markdown.push_str("\n\nProvided by the active shell runtime.");
+    } else {
+        markdown.push_str(&format!(
+            "\n\nDefined at line {}, column {}.",
+            hover.symbol.definition_span.start.line, hover.symbol.definition_span.start.column
+        ));
+    }
+
+    markdown.push_str(&format!(
+        "\n\nScope: {}.",
+        scope_summary(semantic, hover.symbol.scope)
+    ));
+
+    let attributes = attribute_labels(hover.attributes);
+    if !attributes.is_empty() {
+        markdown.push_str(&format!("\n\nAttributes: {}.", attributes.join(", ")));
+    }
+    if hover.imported {
+        markdown.push_str("\n\nImported into this analysis.");
+    }
+    if let Some(count) = hover.function_call_count {
+        let noun = if count == 1 { "site" } else { "sites" };
+        markdown.push_str(&format!("\n\nFile-local call sites: {count} {noun}."));
+    }
+
+    types::Hover {
+        contents: types::HoverContents::Markup(types::MarkupContent {
+            kind: types::MarkupKind::Markdown,
+            value: markdown,
+        }),
+        range: Some(crate::edit::to_lsp_range(
+            hover.target_span.to_range(),
+            source,
+            line_index,
+            snapshot.encoding(),
+        )),
+    }
+}
+
+fn markdown_code(text: &str) -> String {
+    format!("`{}`", text.replace('`', "\\`"))
+}
+
+fn symbol_kind_label(kind: EditorSymbolKind) -> &'static str {
+    match kind {
+        EditorSymbolKind::Function => "Function",
+        EditorSymbolKind::Variable => "Variable",
+        EditorSymbolKind::Array => "Array variable",
+        EditorSymbolKind::AssociativeArray => "Associative array variable",
+        EditorSymbolKind::Declaration => "Declaration",
+        EditorSymbolKind::RuntimeName => "Runtime name",
+    }
+}
+
+fn scope_summary(semantic: &SemanticModel, scope: shuck_semantic::ScopeId) -> String {
+    match semantic.scope_kind(scope) {
+        ScopeKind::File => "top-level".to_owned(),
+        ScopeKind::Function(function) => function
+            .static_names()
+            .first()
+            .map(|name| format!("function {}", markdown_code(name.as_str())))
+            .unwrap_or_else(|| "function-local".to_owned()),
+        ScopeKind::Subshell => "subshell".to_owned(),
+        ScopeKind::CommandSubstitution => "command substitution".to_owned(),
+        ScopeKind::Pipeline => "pipeline".to_owned(),
+    }
+}
+
+fn attribute_labels(attributes: BindingAttributes) -> Vec<&'static str> {
+    [
+        (BindingAttributes::EXPORTED, "exported"),
+        (BindingAttributes::READONLY, "readonly"),
+        (BindingAttributes::LOCAL, "local"),
+        (BindingAttributes::INTEGER, "integer"),
+        (BindingAttributes::ARRAY, "array"),
+        (BindingAttributes::ASSOC, "associative array"),
+        (BindingAttributes::NAMEREF, "nameref"),
+        (BindingAttributes::LOWERCASE, "lowercase"),
+        (BindingAttributes::UPPERCASE, "uppercase"),
+        (
+            BindingAttributes::DECLARATION_INITIALIZED,
+            "initialized by declaration",
+        ),
+    ]
+    .into_iter()
+    .filter_map(|(flag, label)| attributes.contains(flag).then_some(label))
+    .collect()
 }
 
 fn code_at_offset(
@@ -158,6 +288,8 @@ mod tests {
         ClientCapabilities, HoverParams, Position, TextDocumentIdentifier,
         TextDocumentPositionParams, Url, WorkDoneProgressParams,
     };
+    use shuck_ast::{TextRange, TextSize};
+    use shuck_indexer::LineIndex;
 
     use super::*;
     use crate::{
@@ -165,6 +297,13 @@ mod tests {
     };
 
     fn make_snapshot(source: &str) -> (DocumentSnapshot, Client) {
+        make_snapshot_with_encoding(source, PositionEncoding::UTF16)
+    }
+
+    fn make_snapshot_with_encoding(
+        source: &str,
+        encoding: PositionEncoding,
+    ) -> (DocumentSnapshot, Client) {
         let (main_loop_sender, _main_loop_receiver) = channel::unbounded();
         let (client_sender, _client_receiver) = channel::unbounded();
         let client = Client::new(main_loop_sender, client_sender);
@@ -175,15 +314,14 @@ mod tests {
         let global = GlobalOptions::default().into_settings(client.clone());
         let mut session = Session::new(
             &ClientCapabilities::default(),
-            PositionEncoding::UTF16,
+            encoding,
             global,
             &workspaces,
             &client,
         )
         .expect("test session should initialize");
 
-        let uri = Url::from_file_path(workspace_root.join("script.sh"))
-            .expect("script path should convert to a URL");
+        let uri = script_uri();
         session.open_text_document(
             uri.clone(),
             TextDocument::new(source.to_owned(), 1).with_language_id("shellscript"),
@@ -195,6 +333,40 @@ mod tests {
                 .expect("test document should produce a snapshot"),
             client,
         )
+    }
+
+    fn script_uri() -> Url {
+        Url::from_file_path(std::env::temp_dir().join("shuck-server-hover-tests/script.sh"))
+            .expect("script path should convert to a URL")
+    }
+
+    fn hover_params(source: &str, needle: &str, encoding: PositionEncoding) -> HoverParams {
+        let offset = source.find(needle).expect("needle should exist") + needle.len() / 2;
+        HoverParams {
+            text_document_position_params: TextDocumentPositionParams {
+                text_document: TextDocumentIdentifier { uri: script_uri() },
+                position: position_for_offset(source, offset, encoding),
+            },
+            work_done_progress_params: WorkDoneProgressParams::default(),
+        }
+    }
+
+    fn position_for_offset(source: &str, offset: usize, encoding: PositionEncoding) -> Position {
+        let index = LineIndex::new(source);
+        crate::edit::to_lsp_range(
+            TextRange::new(TextSize::new(offset as u32), TextSize::new(offset as u32)),
+            source,
+            &index,
+            encoding,
+        )
+        .start
+    }
+
+    fn hover_markdown(hover: types::Hover) -> String {
+        let types::HoverContents::Markup(markup) = hover.contents else {
+            panic!("expected markdown hover content");
+        };
+        markup.value
     }
 
     #[test]
@@ -261,6 +433,92 @@ mod tests {
         assert!(markup.value.contains("SC2154"));
         assert!(markup.value.contains("See also: C006"));
         assert!(markup.value.contains("Fix available") || markup.value.contains("No auto-fix"));
+    }
+
+    #[test]
+    fn hover_falls_back_to_semantic_symbols() {
+        let source = "#!/bin/bash\nname=world\nprintf '%s\\n' \"$name\"\n";
+        let (snapshot, client) = make_snapshot(source);
+        let hover = hover(
+            snapshot,
+            &client,
+            hover_params(source, "name\"", PositionEncoding::UTF16),
+        )
+        .expect("hover request should succeed")
+        .expect("semantic hover should be present");
+
+        let markdown = hover_markdown(hover.clone());
+        assert!(markdown.contains("`name`"));
+        assert!(markdown.contains("Variable"));
+        assert!(markdown.contains("Defined at line 2, column 1"));
+        assert!(markdown.contains("Scope: top-level"));
+        let range = hover.range.expect("semantic hover should have a range");
+        assert_eq!(range.start.line, 2);
+    }
+
+    #[test]
+    fn hover_reports_semantic_function_call_details() {
+        let source = "#!/bin/bash\nbuild() { :; }\nbuild\n";
+        let (snapshot, client) = make_snapshot(source);
+        let hover = hover(
+            snapshot,
+            &client,
+            hover_params(source, "build\n", PositionEncoding::UTF16),
+        )
+        .expect("hover request should succeed")
+        .expect("function hover should be present");
+
+        let markdown = hover_markdown(hover);
+        assert!(markdown.contains("`build`"));
+        assert!(markdown.contains("Function"));
+        assert!(markdown.contains("File-local call sites: 1 site"));
+    }
+
+    #[test]
+    fn hover_reports_runtime_names() {
+        let source = "#!/bin/bash\nprintf '%s\\n' \"$HOME\"\n";
+        let (snapshot, client) = make_snapshot(source);
+        let hover = hover(
+            snapshot,
+            &client,
+            hover_params(source, "HOME", PositionEncoding::UTF16),
+        )
+        .expect("hover request should succeed")
+        .expect("runtime hover should be present");
+
+        let markdown = hover_markdown(hover);
+        assert!(markdown.contains("`HOME`"));
+        assert!(markdown.contains("Runtime name"));
+        assert!(markdown.contains("Provided by the active shell runtime"));
+    }
+
+    #[test]
+    fn semantic_hover_ranges_use_negotiated_position_encoding() {
+        let source = "#!/bin/bash\nname=world\nprintf 'é' \"$name\"\n";
+        let (utf16_snapshot, utf16_client) =
+            make_snapshot_with_encoding(source, PositionEncoding::UTF16);
+        let utf16_hover = hover(
+            utf16_snapshot,
+            &utf16_client,
+            hover_params(source, "name\"", PositionEncoding::UTF16),
+        )
+        .expect("hover request should succeed")
+        .expect("utf16 hover should be present");
+
+        let (utf8_snapshot, utf8_client) =
+            make_snapshot_with_encoding(source, PositionEncoding::UTF8);
+        let utf8_hover = hover(
+            utf8_snapshot,
+            &utf8_client,
+            hover_params(source, "name\"", PositionEncoding::UTF8),
+        )
+        .expect("hover request should succeed")
+        .expect("utf8 hover should be present");
+
+        let utf16_range = utf16_hover.range.expect("utf16 hover range");
+        let utf8_range = utf8_hover.range.expect("utf8 hover range");
+        assert_eq!(utf16_range.start.line, utf8_range.start.line);
+        assert!(utf8_range.start.character > utf16_range.start.character);
     }
 
     #[test]

--- a/crates/shuck-server/src/symbols.rs
+++ b/crates/shuck-server/src/symbols.rs
@@ -7,8 +7,7 @@ use sha2::{Digest, Sha256};
 use shuck_discover::{DiscoveredFile, DiscoveryOptions, FileKind, discover_files};
 use shuck_indexer::LineIndex;
 use shuck_linter::ShellDialect;
-use shuck_parser::parser::Parser;
-use shuck_semantic::{EditorDocumentSymbol, EditorSymbolKind, SemanticBuildOptions, SemanticModel};
+use shuck_semantic::{EditorDocumentSymbol, EditorSymbolKind};
 
 use crate::PositionEncoding;
 use crate::TextDocument;
@@ -414,21 +413,9 @@ fn editor_document_symbols(
     path: Option<&Path>,
     shell: ShellDialect,
 ) -> Vec<EditorDocumentSymbol> {
-    let shell_profile = shell.shell_profile();
-    let parse_result = Parser::with_profile(source, shell_profile.clone()).parse();
-    let indexer = shuck_indexer::Indexer::new(source, &parse_result);
-    let semantic = SemanticModel::build_with_options(
-        &parse_result.file,
-        source,
-        &indexer,
-        SemanticBuildOptions {
-            source_path: path,
-            shell_profile: Some(shell_profile),
-            resolve_source_closure: false,
-            ..SemanticBuildOptions::default()
-        },
-    );
-    semantic.editor_query().document_symbols()
+    crate::editor::analyze_editor_document(source, path, shell)
+        .editor_query()
+        .document_symbols()
 }
 
 fn workspace_symbol_summary_from_open_document(

--- a/crates/shuck-server/tests/manual/README.md
+++ b/crates/shuck-server/tests/manual/README.md
@@ -35,6 +35,7 @@ Available scenarios:
 
 - `diagnostics/open_edit`
 - `hover/rule_directive`
+- `hover/semantic_symbol`
 - `symbols/document_symbols`
 - `symbols/workspace_symbols`
 - `code_actions/quick_fix`

--- a/crates/shuck-server/tests/manual/fixtures/workspace/hover/semantic_symbol.sh
+++ b/crates/shuck-server/tests/manual/fixtures/workspace/hover/semantic_symbol.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+name=world
+greet() {
+  printf '%s\n' "$name"
+}
+
+greet

--- a/crates/shuck-server/tests/manual/lua/shuck_server_blackbox/hover/semantic_symbol.lua
+++ b/crates/shuck-server/tests/manual/lua/shuck_server_blackbox/hover/semantic_symbol.lua
@@ -1,0 +1,18 @@
+local M = {}
+
+function M.run(t)
+  local bufnr = select(1, t.open_fixture("hover/semantic_symbol.sh"))
+
+  local line = vim.api.nvim_buf_get_lines(bufnr, 4, 5, false)[1]
+  assert(line, "expected the hover fixture to have a variable reference")
+
+  local name_index = assert(string.find(line, "name", 1, true), "failed to find name reference")
+  local hover = t.hover_at(bufnr, 4, name_index - 1)
+  local markdown = t.hover_markdown(hover)
+
+  assert(string.find(markdown, "`name`", 1, true), "expected hover markdown to name the symbol")
+  assert(string.find(markdown, "Variable", 1, true), "expected variable hover")
+  assert(string.find(markdown, "Defined at line 3", 1, true), "expected definition location")
+end
+
+return M

--- a/crates/shuck-server/tests/manual/run_neovim_blackbox.py
+++ b/crates/shuck-server/tests/manual/run_neovim_blackbox.py
@@ -19,6 +19,7 @@ FIXTURE_ROOT = MANUAL_ROOT / "fixtures" / "workspace"
 SCENARIOS = [
     "diagnostics/open_edit",
     "hover/rule_directive",
+    "hover/semantic_symbol",
     "symbols/document_symbols",
     "symbols/workspace_symbols",
     "code_actions/quick_fix",


### PR DESCRIPTION
## Summary
- add lazy semantic-symbol hover queries in shuck-semantic
- preserve directive hover precedence while adding semantic hover rendering in shuck-server
- add editor hover benchmarks and a Neovim black-box hover fixture

## Validation
- cargo fmt --all --check
- cargo test -p shuck-semantic editor_hover
- cargo test -p shuck-server hover
- cargo test -p shuck-server symbols
- cargo test -p shuck-server
- cargo bench -p shuck-benchmark --bench editor
- make test

Note: the Neovim black-box scenario was added but could not be run locally where nvim is unavailable.