### PR TITLE
feat(server): cache document analysis for LSP requests

### DIFF
--- a/crates/shuck-server/src/analysis.rs
+++ b/crates/shuck-server/src/analysis.rs
@@ -1,0 +1,231 @@
+use std::collections::VecDeque;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Mutex, OnceLock};
+
+use lsp_types::Url;
+use shuck_indexer::{Indexer, LineIndex};
+use shuck_parser::{
+    ShellProfile,
+    parser::{ParseResult, Parser},
+};
+use shuck_semantic::{SemanticBuildOptions, SemanticModel};
+
+use crate::TextDocument;
+use crate::edit::{DocumentVersion, PositionEncoding};
+use crate::lint::RawDocumentDiagnostics;
+use crate::session::DocumentSnapshot;
+
+const MAX_ANALYSIS_DOCUMENTS: usize = 64;
+const MAX_ANALYSIS_SOURCE_BYTES: usize = 32 * 1024 * 1024;
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct AnalysisCacheKey {
+    uri: Url,
+    version: DocumentVersion,
+    document_id: usize,
+    settings_epoch: u64,
+    encoding: PositionEncoding,
+}
+
+struct AnalysisCacheEntry {
+    key: AnalysisCacheKey,
+    source_bytes: usize,
+    analysis: Arc<DocumentAnalysis>,
+}
+
+#[derive(Default)]
+struct AnalysisCacheState {
+    entries: VecDeque<AnalysisCacheEntry>,
+    source_bytes: usize,
+}
+
+pub(crate) struct DocumentAnalysisCache {
+    state: Mutex<AnalysisCacheState>,
+    settings_epoch: AtomicU64,
+}
+
+pub(crate) struct DocumentAnalysis {
+    document: Arc<TextDocument>,
+    path: Option<PathBuf>,
+    shell_profile: ShellProfile,
+    parse_result: ParseResult,
+    indexer: Indexer,
+    semantic: OnceLock<SemanticModel>,
+    raw_diagnostics: OnceLock<RawDocumentDiagnostics>,
+}
+
+impl DocumentAnalysisCache {
+    pub(crate) fn new() -> Self {
+        Self {
+            state: Mutex::new(AnalysisCacheState::default()),
+            settings_epoch: AtomicU64::new(0),
+        }
+    }
+
+    pub(crate) fn current_settings_epoch(&self) -> u64 {
+        self.settings_epoch.load(Ordering::Acquire)
+    }
+
+    pub(crate) fn get_or_build(
+        &self,
+        snapshot: &DocumentSnapshot,
+    ) -> Option<Arc<DocumentAnalysis>> {
+        let key = analysis_cache_key(snapshot);
+        if let Some(cached) = self.get(&key) {
+            return Some(cached);
+        }
+
+        let analysis = Arc::new(DocumentAnalysis::new(snapshot)?);
+        self.insert(key, analysis.clone());
+        Some(analysis)
+    }
+
+    pub(crate) fn invalidate_uri(&self, uri: &Url) {
+        let mut state = lock_or_recover(&self.state);
+        let mut retained = VecDeque::with_capacity(state.entries.len());
+        let mut retained_bytes = 0usize;
+        while let Some(entry) = state.entries.pop_front() {
+            if entry.key.uri == *uri {
+                continue;
+            }
+            retained_bytes += entry.source_bytes;
+            retained.push_back(entry);
+        }
+        state.entries = retained;
+        state.source_bytes = retained_bytes;
+    }
+
+    pub(crate) fn clear(&self) {
+        let mut state = lock_or_recover(&self.state);
+        state.entries.clear();
+        state.source_bytes = 0;
+        self.settings_epoch.fetch_add(1, Ordering::AcqRel);
+    }
+
+    fn get(&self, key: &AnalysisCacheKey) -> Option<Arc<DocumentAnalysis>> {
+        let mut state = lock_or_recover(&self.state);
+        let index = state.entries.iter().position(|entry| entry.key == *key)?;
+        let entry = state.entries.remove(index)?;
+        let analysis = entry.analysis.clone();
+        state.entries.push_back(entry);
+        Some(analysis)
+    }
+
+    fn insert(&self, key: AnalysisCacheKey, analysis: Arc<DocumentAnalysis>) {
+        let mut state = lock_or_recover(&self.state);
+        if let Some(index) = state.entries.iter().position(|entry| entry.key == key) {
+            let Some(entry) = state.entries.remove(index) else {
+                return;
+            };
+            state.entries.push_back(entry);
+            return;
+        }
+
+        let source_bytes = analysis.source().len();
+        state.source_bytes += source_bytes;
+        state.entries.push_back(AnalysisCacheEntry {
+            key,
+            source_bytes,
+            analysis,
+        });
+        evict_over_budget(&mut state);
+    }
+}
+
+impl DocumentAnalysis {
+    fn new(snapshot: &DocumentSnapshot) -> Option<Self> {
+        let query = snapshot.query();
+        let document = query.document().clone();
+        let source = document.contents();
+        let path = query.file_path();
+        let shell = crate::lint::infer_document_shell_from_parts(
+            snapshot.shuck_settings(),
+            query.language_id(),
+            source,
+            path.as_deref(),
+        )?;
+        let shell_profile = shell.shell_profile();
+        let parse_result = Parser::with_profile(source, shell_profile.clone()).parse();
+        let indexer = Indexer::new(source, &parse_result);
+
+        Some(Self {
+            document,
+            path,
+            shell_profile,
+            parse_result,
+            indexer,
+            semantic: OnceLock::new(),
+            raw_diagnostics: OnceLock::new(),
+        })
+    }
+
+    pub(crate) fn source(&self) -> &str {
+        self.document.contents()
+    }
+
+    pub(crate) fn line_index(&self) -> &LineIndex {
+        self.document.index()
+    }
+
+    pub(crate) fn path(&self) -> Option<&Path> {
+        self.path.as_deref()
+    }
+
+    pub(crate) fn parse_result(&self) -> &ParseResult {
+        &self.parse_result
+    }
+
+    pub(crate) fn indexer(&self) -> &Indexer {
+        &self.indexer
+    }
+
+    pub(crate) fn semantic(&self) -> &SemanticModel {
+        self.semantic.get_or_init(|| {
+            SemanticModel::build_with_options(
+                &self.parse_result.file,
+                self.source(),
+                &self.indexer,
+                SemanticBuildOptions {
+                    source_path: self.path(),
+                    shell_profile: Some(self.shell_profile.clone()),
+                    resolve_source_closure: false,
+                    ..SemanticBuildOptions::default()
+                },
+            )
+        })
+    }
+
+    pub(crate) fn raw_diagnostics(&self, snapshot: &DocumentSnapshot) -> &RawDocumentDiagnostics {
+        self.raw_diagnostics
+            .get_or_init(|| crate::lint::collect_raw_diagnostics_for_analysis(snapshot, self))
+    }
+}
+
+fn analysis_cache_key(snapshot: &DocumentSnapshot) -> AnalysisCacheKey {
+    let query = snapshot.query();
+    AnalysisCacheKey {
+        uri: query.file_url().clone(),
+        version: query.document().version(),
+        document_id: Arc::as_ptr(query.document()) as usize,
+        settings_epoch: snapshot.analysis_settings_epoch(),
+        encoding: snapshot.encoding(),
+    }
+}
+
+fn evict_over_budget(state: &mut AnalysisCacheState) {
+    while state.entries.len() > MAX_ANALYSIS_DOCUMENTS
+        || (state.source_bytes > MAX_ANALYSIS_SOURCE_BYTES && state.entries.len() > 1)
+    {
+        let Some(entry) = state.entries.pop_front() else {
+            break;
+        };
+        state.source_bytes = state.source_bytes.saturating_sub(entry.source_bytes);
+    }
+}
+
+fn lock_or_recover<T>(mutex: &Mutex<T>) -> std::sync::MutexGuard<'_, T> {
+    mutex
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+}

--- a/crates/shuck-server/src/edit.rs
+++ b/crates/shuck-server/src/edit.rs
@@ -12,7 +12,7 @@ pub(crate) use text_document::LanguageId;
 pub use text_document::TextDocument;
 
 /// Client/server position encoding negotiated for LSP text ranges.
-#[derive(Default, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Default, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum PositionEncoding {
     /// UTF-16 code-unit positions, the LSP default.
     #[default]

--- a/crates/shuck-server/src/lib.rs
+++ b/crates/shuck-server/src/lib.rs
@@ -16,6 +16,7 @@ pub use server::Server;
 pub use session::{Client, ClientOptions, DocumentQuery, DocumentSnapshot, GlobalOptions, Session};
 pub use workspace::{Workspace, Workspaces};
 
+mod analysis;
 mod edit;
 mod editor;
 mod fix;

--- a/crates/shuck-server/src/lint.rs
+++ b/crates/shuck-server/src/lint.rs
@@ -8,7 +8,6 @@ use shuck_linter::{
     AnalysisRequest, Applicability, Diagnostic as ShuckDiagnostic, Edit as ShuckEdit, Fix,
     Severity, ShellCheckCodeMap, ShellDialect,
 };
-use shuck_parser::parser::Parser;
 
 use crate::edit::{LanguageId, RangeExt};
 use crate::session::{DocumentSnapshot, ShuckSettings};
@@ -38,6 +37,7 @@ pub(crate) struct AssociatedDiagnosticData {
     pub(crate) applicability: DiagnosticApplicability,
 }
 
+#[derive(Clone)]
 pub(crate) struct RawDocumentDiagnostics {
     pub(crate) shell_diagnostics: Vec<ShuckDiagnostic>,
     pub(crate) parse_error: Option<ParseErrorDiagnostic>,
@@ -52,24 +52,22 @@ pub(crate) struct ParseErrorDiagnostic {
 
 /// Generate LSP diagnostics for a document snapshot.
 pub fn generate_diagnostics(snapshot: &DocumentSnapshot) -> Vec<types::Diagnostic> {
-    let query = snapshot.query();
-    let source = query.document().contents();
-    let path = query.file_path();
-    let Some(shell) = infer_document_shell(snapshot, source, path.as_deref()) else {
+    let Some(analysis) = snapshot.analysis() else {
         return Vec::new();
     };
 
-    let raw = collect_raw_diagnostics(snapshot, shell, source, path.as_deref());
+    let source = analysis.source();
+    let raw = analysis.raw_diagnostics(snapshot);
     let directive_edits = directive_edits_by_line(
         snapshot,
         source,
-        query.document().index(),
-        path.as_deref(),
+        analysis.line_index(),
+        analysis.path(),
         &raw.shell_diagnostics,
     );
     let mut diagnostics = raw
         .shell_diagnostics
-        .into_iter()
+        .iter()
         .map(|diagnostic| {
             let directive_edit = directive_edits
                 .get(&diagnostic.span.start.line)
@@ -77,20 +75,20 @@ pub fn generate_diagnostics(snapshot: &DocumentSnapshot) -> Vec<types::Diagnosti
                 .flatten();
             to_lsp_diagnostic(
                 snapshot,
-                &diagnostic,
+                diagnostic,
                 source,
-                query.document().index(),
+                analysis.line_index(),
                 directive_edit,
             )
         })
         .collect::<Vec<_>>();
 
     if snapshot.client_settings().show_syntax_errors()
-        && let Some(parse_error) = raw.parse_error
+        && let Some(parse_error) = raw.parse_error.clone()
     {
         diagnostics.insert(
             0,
-            parse_error_to_lsp(snapshot, source, query.document().index(), parse_error),
+            parse_error_to_lsp(snapshot, source, analysis.line_index(), parse_error),
         );
     }
 
@@ -100,18 +98,9 @@ pub fn generate_diagnostics(snapshot: &DocumentSnapshot) -> Vec<types::Diagnosti
 pub(crate) fn collect_raw_diagnostics_for_snapshot(
     snapshot: &DocumentSnapshot,
 ) -> Option<RawDocumentDiagnostics> {
-    let query = snapshot.query();
-    let source = query.document().contents();
-    let path = query.file_path();
-    document_shell(snapshot)
-        .map(|shell| collect_raw_diagnostics(snapshot, shell, source, path.as_deref()))
-}
-
-pub(crate) fn document_shell(snapshot: &DocumentSnapshot) -> Option<ShellDialect> {
-    let query = snapshot.query();
-    let source = query.document().contents();
-    let path = query.file_path();
-    infer_document_shell(snapshot, source, path.as_deref())
+    snapshot
+        .analysis()
+        .map(|analysis| analysis.raw_diagnostics(snapshot).clone())
 }
 
 pub(crate) fn fix_all_document_edits(
@@ -181,28 +170,25 @@ pub(crate) fn associated_diagnostic_data(
         .and_then(|value| serde_json::from_value(value).ok())
 }
 
-fn collect_raw_diagnostics(
+pub(crate) fn collect_raw_diagnostics_for_analysis(
     snapshot: &DocumentSnapshot,
-    shell: ShellDialect,
-    source: &str,
-    path: Option<&Path>,
+    analysis: &crate::analysis::DocumentAnalysis,
 ) -> RawDocumentDiagnostics {
-    let parse_result = Parser::with_profile(source, shell.shell_profile()).parse();
     let shellcheck_map = ShellCheckCodeMap::default();
     let shell_diagnostics = AnalysisRequest::from_parse_result(
-        &parse_result,
-        source,
+        analysis.parse_result(),
+        analysis.source(),
         snapshot.shuck_settings().linter(),
     )
-    .with_optional_source_path(path)
+    .with_optional_source_path(analysis.path())
     .with_shellcheck_map(&shellcheck_map)
     .lint();
-    let parse_error = parse_result.is_err().then(|| {
+    let parse_error = analysis.parse_result().is_err().then(|| {
         let shuck_parser::Error::Parse {
             message,
             line,
             column,
-        } = parse_result.strict_error();
+        } = analysis.parse_result().strict_error();
         ParseErrorDiagnostic {
             line,
             column,
@@ -361,19 +347,6 @@ fn diagnostic_severity(severity: Severity) -> types::DiagnosticSeverity {
         Severity::Warning => types::DiagnosticSeverity::WARNING,
         Severity::Error => types::DiagnosticSeverity::ERROR,
     }
-}
-
-fn infer_document_shell(
-    snapshot: &DocumentSnapshot,
-    query_source: &str,
-    path: Option<&Path>,
-) -> Option<ShellDialect> {
-    infer_document_shell_from_parts(
-        snapshot.shuck_settings(),
-        snapshot.query().language_id(),
-        query_source,
-        path,
-    )
 }
 
 pub(crate) fn infer_document_shell_from_parts(

--- a/crates/shuck-server/src/resolve.rs
+++ b/crates/shuck-server/src/resolve.rs
@@ -12,14 +12,12 @@ pub(crate) fn hover(
     _client: &Client,
     params: types::HoverParams,
 ) -> crate::server::Result<Option<types::Hover>> {
-    let Some(shell) = crate::lint::document_shell(&snapshot) else {
+    let Some(analysis) = snapshot.analysis() else {
         return Ok(None);
     };
 
     let query = snapshot.query();
-    let source = query.document().contents();
-    let path = query.file_path();
-    let parsed = crate::editor::parse_editor_document(source, shell);
+    let source = analysis.source();
     let shellcheck_map = ShellCheckCodeMap::default();
     let position = params.text_document_position_params.position;
     let offset = usize::from(
@@ -34,8 +32,8 @@ pub(crate) fn hover(
     if let Some(hover) = directive_hover(
         &snapshot,
         source,
-        query.document().index(),
-        parsed.indexer.comment_index(),
+        analysis.line_index(),
+        analysis.indexer().comment_index(),
         &shellcheck_map,
         params.text_document_position_params.position,
         offset,
@@ -43,15 +41,15 @@ pub(crate) fn hover(
         return Ok(Some(hover));
     }
 
-    let semantic = crate::editor::semantic_for_parsed_document(&parsed, source, path.as_deref());
+    let semantic = analysis.semantic();
     let Some(semantic_hover) = semantic.editor_query().hover_at_offset(offset) else {
         return Ok(None);
     };
     Ok(Some(render_semantic_hover(
         &snapshot,
         source,
-        query.document().index(),
-        &semantic,
+        analysis.line_index(),
+        semantic,
         &semantic_hover,
     )))
 }

--- a/crates/shuck-server/src/session.rs
+++ b/crates/shuck-server/src/session.rs
@@ -5,6 +5,7 @@ use std::sync::Arc;
 
 use lsp_types::{ClientCapabilities, FileEvent, Url};
 
+use crate::analysis::{DocumentAnalysis, DocumentAnalysisCache};
 use crate::edit::{DocumentKey, DocumentVersion};
 use crate::session::request_queue::RequestQueue;
 use crate::session::settings::{ClientSettings, GlobalClientSettings};
@@ -33,6 +34,7 @@ pub struct Session {
     global_settings: GlobalClientSettings,
     resolved_client_capabilities: Arc<ResolvedClientCapabilities>,
     workspace_symbols: Arc<crate::symbols::WorkspaceSymbolIndex>,
+    analysis_cache: Arc<DocumentAnalysisCache>,
     request_queue: RequestQueue,
     shutdown_requested: bool,
 }
@@ -44,6 +46,8 @@ pub struct DocumentSnapshot {
     client_settings: Arc<ClientSettings>,
     document_ref: index::DocumentQuery,
     position_encoding: PositionEncoding,
+    analysis_cache: Arc<DocumentAnalysisCache>,
+    analysis_settings_epoch: u64,
 }
 
 impl Session {
@@ -63,6 +67,7 @@ impl Session {
                 client_capabilities,
             )),
             workspace_symbols: Arc::new(crate::symbols::WorkspaceSymbolIndex::default()),
+            analysis_cache: Arc::new(DocumentAnalysisCache::new()),
             request_queue: RequestQueue::new(),
             shutdown_requested: false,
         })
@@ -100,6 +105,8 @@ impl Session {
             client_settings,
             document_ref: self.index.make_document_ref(key, settings)?,
             position_encoding: self.position_encoding,
+            analysis_cache: self.analysis_cache.clone(),
+            analysis_settings_epoch: self.analysis_cache.current_settings_epoch(),
         })
     }
 
@@ -109,17 +116,24 @@ impl Session {
         content_changes: Vec<lsp_types::TextDocumentContentChangeEvent>,
         new_version: DocumentVersion,
     ) -> crate::Result<()> {
-        self.index
-            .update_text_document(key, content_changes, new_version, self.encoding())
+        let result =
+            self.index
+                .update_text_document(key, content_changes, new_version, self.encoding());
+        if result.is_ok() {
+            self.analysis_cache.invalidate_uri(&key.clone().into_url());
+        }
+        result
     }
 
     /// Open or replace an in-memory text document.
     pub fn open_text_document(&mut self, url: Url, document: TextDocument) {
+        self.analysis_cache.invalidate_uri(&url);
         self.index.open_text_document(url, document);
     }
 
     pub(crate) fn close_document(&mut self, key: &DocumentKey) -> crate::Result<()> {
         self.index.close_document(key)?;
+        self.analysis_cache.invalidate_uri(&key.clone().into_url());
         self.workspace_symbols
             .invalidate_uri(&key.clone().into_url());
         Ok(())
@@ -127,18 +141,21 @@ impl Session {
 
     pub(crate) fn reload_settings(&mut self, changes: &[FileEvent], client: &Client) {
         self.index.reload_settings(changes, client);
+        self.analysis_cache.clear();
         self.workspace_symbols.invalidate_file_events(changes);
     }
 
     pub(crate) fn open_workspace_folder(&mut self, url: Url, client: &Client) -> crate::Result<()> {
         self.index
             .open_workspace_folder(url, &self.global_settings, client)?;
+        self.analysis_cache.clear();
         self.workspace_symbols.invalidate_all();
         Ok(())
     }
 
     pub(crate) fn close_workspace_folder(&mut self, url: &Url) -> crate::Result<()> {
         self.index.close_workspace_folder(url)?;
+        self.analysis_cache.clear();
         self.workspace_symbols.invalidate_all();
         Ok(())
     }
@@ -160,6 +177,7 @@ impl Session {
     }
 
     pub(crate) fn update_client_options(&mut self, options: ClientOptions) {
+        self.analysis_cache.clear();
         self.workspace_symbols.invalidate_all();
         self.global_settings.update_options(options);
         self.index.clear_project_settings_cache();
@@ -170,6 +188,7 @@ impl Session {
         options: ClientOptions,
         workspace_options: Option<WorkspaceOptionsMap>,
     ) {
+        self.analysis_cache.clear();
         self.workspace_symbols.invalidate_all();
         self.global_settings.update_options(options);
         if let Some(workspace_options) = workspace_options {
@@ -237,14 +256,22 @@ impl DocumentSnapshot {
     pub(crate) fn encoding(&self) -> PositionEncoding {
         self.position_encoding
     }
+
+    pub(crate) fn analysis(&self) -> Option<Arc<DocumentAnalysis>> {
+        self.analysis_cache.get_or_build(self)
+    }
+
+    pub(crate) fn analysis_settings_epoch(&self) -> u64 {
+        self.analysis_settings_epoch
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use crossbeam::channel;
     use lsp_types::{
-        ClientCapabilities, DidChangeWatchedFilesClientCapabilities, Url,
-        WorkspaceClientCapabilities,
+        ClientCapabilities, DidChangeWatchedFilesClientCapabilities,
+        TextDocumentContentChangeEvent, Url, WorkspaceClientCapabilities,
     };
 
     use super::*;
@@ -261,6 +288,113 @@ mod tests {
             }),
             ..ClientCapabilities::default()
         }
+    }
+
+    fn make_test_session() -> (tempfile::TempDir, Session, Url) {
+        let workspace = tempfile::tempdir().expect("workspace should be created");
+        let workspace_uri =
+            Url::from_file_path(workspace.path()).expect("workspace path should convert");
+        let workspaces = Workspaces::new(vec![Workspace::default(workspace_uri)]);
+        let (main_loop_sender, _main_loop_receiver) = channel::unbounded();
+        let (client_sender, _client_receiver) = channel::unbounded();
+        let client = Client::new(main_loop_sender, client_sender);
+        let global = GlobalOptions::default().into_settings(client.clone());
+        let mut session = Session::new(
+            &ClientCapabilities::default(),
+            PositionEncoding::UTF16,
+            global,
+            &workspaces,
+            &client,
+        )
+        .expect("test session should initialize");
+        let uri = Url::from_file_path(workspace.path().join("script.sh"))
+            .expect("script path should convert to a URL");
+        session.open_text_document(
+            uri.clone(),
+            TextDocument::new("#!/bin/bash\nname=value\necho \"$name\"\n".to_owned(), 1)
+                .with_language_id("shellscript"),
+        );
+        (workspace, session, uri)
+    }
+
+    #[test]
+    fn document_analysis_cache_reuses_same_document_version() {
+        let (_workspace, session, uri) = make_test_session();
+        let first = session
+            .take_snapshot(uri.clone())
+            .expect("test document should produce a snapshot")
+            .analysis()
+            .expect("shell document should have analysis");
+        let second = session
+            .take_snapshot(uri)
+            .expect("test document should produce a snapshot")
+            .analysis()
+            .expect("shell document should have analysis");
+
+        assert!(Arc::ptr_eq(&first, &second));
+    }
+
+    #[test]
+    fn document_analysis_cache_invalidates_after_document_change() {
+        let (_workspace, mut session, uri) = make_test_session();
+        let before = session
+            .take_snapshot(uri.clone())
+            .expect("test document should produce a snapshot")
+            .analysis()
+            .expect("shell document should have analysis");
+        let key = session.key_from_url(uri.clone());
+
+        session
+            .update_text_document(
+                &key,
+                vec![TextDocumentContentChangeEvent {
+                    range: None,
+                    range_length: None,
+                    text: "#!/bin/bash\nother=value\necho \"$other\"\n".to_owned(),
+                }],
+                2,
+            )
+            .expect("document change should apply");
+
+        let after = session
+            .take_snapshot(uri)
+            .expect("test document should produce a snapshot")
+            .analysis()
+            .expect("shell document should have analysis");
+
+        assert!(!Arc::ptr_eq(&before, &after));
+        assert!(after.source().contains("other=value"));
+    }
+
+    #[test]
+    fn document_analysis_cache_invalidates_after_configuration_change() {
+        let (_workspace, mut session, uri) = make_test_session();
+        let stale_snapshot = session
+            .take_snapshot(uri.clone())
+            .expect("test document should produce a snapshot");
+        let before = stale_snapshot
+            .analysis()
+            .expect("shell document should have analysis");
+
+        session.update_client_options(ClientOptions {
+            lint: Some(shuck_config::LintConfig {
+                select: Some(vec!["C006".to_owned()]),
+                ..shuck_config::LintConfig::default()
+            }),
+            ..ClientOptions::default()
+        });
+
+        let stale_after_clear = stale_snapshot
+            .analysis()
+            .expect("stale snapshot can still analyze its own settings epoch");
+        let after = session
+            .take_snapshot(uri)
+            .expect("test document should produce a snapshot")
+            .analysis()
+            .expect("shell document should have analysis");
+
+        assert!(!Arc::ptr_eq(&before, &after));
+        assert!(!Arc::ptr_eq(&stale_after_clear, &after));
     }
 
     #[test]

--- a/crates/shuck-server/src/symbols.rs
+++ b/crates/shuck-server/src/symbols.rs
@@ -254,17 +254,17 @@ pub(crate) fn document_symbols(
     _client: &Client,
     _params: types::DocumentSymbolParams,
 ) -> crate::server::Result<DocumentSymbolResponse> {
-    let Some(shell) = crate::lint::document_shell(&snapshot) else {
+    let Some(analysis) = snapshot.analysis() else {
         return Ok(None);
     };
 
     let query = snapshot.query();
-    let source = query.document().contents();
-    let editor_symbols = editor_document_symbols(source, query.file_path().as_deref(), shell);
+    let source = analysis.source();
+    let editor_symbols = analysis.semantic().editor_query().document_symbols();
     let render = SymbolRenderContext {
         uri: query.file_url(),
         source,
-        line_index: query.document().index(),
+        line_index: analysis.line_index(),
         encoding: snapshot.encoding(),
     };
 


### PR DESCRIPTION
## Summary
- add a shared DocumentAnalysis cache for open-document LSP request paths
- reuse cached parse/index analysis across diagnostics, hover, and document symbols
- keep semantic models and raw diagnostics lazy, with cache invalidation on document and settings changes

## Validation
- cargo fmt --all --check
- cargo check -p shuck-server
- cargo test -p shuck-server document_analysis_cache
- cargo test -p shuck-server hover
- cargo test -p shuck-server symbols
- cargo test -p shuck-server diagnostics
- cargo test -p shuck-server
- cargo test -p shuck-semantic editor_hover
- cargo clippy -p shuck-server --all-targets -- -D warnings
- make test (rerun with filesystem permissions after sandbox cache-directory denial)