### PR TITLE
feat(server): add LSP editor features

### DIFF
--- a/crates/shuck-benchmark/benches/editor.rs
+++ b/crates/shuck-benchmark/benches/editor.rs
@@ -3,14 +3,17 @@ use criterion::{
 };
 use shuck_benchmark::{TestFile, benchmark_cases, configure_benchmark_allocator, parse_fixture};
 use shuck_indexer::Indexer;
-use shuck_semantic::{EditorDocumentSymbol, SemanticModel};
+use shuck_semantic::{EditorCompletionOptions, EditorDocumentSymbol, SemanticModel};
 
 configure_benchmark_allocator!();
 
 struct PreparedEditorInput {
+    source: &'static str,
+    indexer: Indexer,
     semantic: SemanticModel,
     binding_count: u64,
     hover_probes: Vec<usize>,
+    completion_probes: Vec<usize>,
 }
 
 fn prepare_editor_input(source: &'static str) -> PreparedEditorInput {
@@ -19,11 +22,15 @@ fn prepare_editor_input(source: &'static str) -> PreparedEditorInput {
     let semantic = SemanticModel::build(&output.file, source, &indexer);
     let binding_count = semantic.bindings().len() as u64;
     let hover_probes = hover_probes(source, &semantic);
+    let completion_probes = completion_probes(source);
 
     PreparedEditorInput {
+        source,
+        indexer,
         semantic,
         binding_count,
         hover_probes,
+        completion_probes,
     }
 }
 
@@ -103,10 +110,117 @@ fn run_hover_queries_for_inputs(inputs: &[PreparedEditorInput]) -> usize {
     inputs.iter().map(run_hover_queries).sum()
 }
 
+fn completion_probes(source: &str) -> Vec<usize> {
+    let mut probes = source
+        .match_indices('$')
+        .take(64)
+        .map(|(offset, _)| offset + 1)
+        .collect::<Vec<_>>();
+    probes.extend(
+        source
+            .match_indices('\n')
+            .take(64)
+            .map(|(offset, _)| offset + 1),
+    );
+    probes.sort_unstable();
+    probes.dedup();
+    if probes.is_empty() {
+        probes.push(source.len());
+    }
+    probes
+}
+
+fn run_completion_queries(input: &PreparedEditorInput) -> usize {
+    let query = input.semantic.editor_query();
+    let count = input
+        .completion_probes
+        .iter()
+        .filter_map(|offset| {
+            query.completions_at_offset(
+                input.source,
+                &input.indexer,
+                *offset,
+                EditorCompletionOptions::default(),
+            )
+        })
+        .map(|completions| completions.items.len())
+        .sum();
+    black_box(count)
+}
+
+fn run_completion_queries_for_inputs(inputs: &[PreparedEditorInput]) -> usize {
+    inputs.iter().map(run_completion_queries).sum()
+}
+
+fn run_definition_queries(input: &PreparedEditorInput) -> usize {
+    let query = input.semantic.editor_query();
+    let count = input
+        .hover_probes
+        .iter()
+        .map(|offset| query.definition_spans_at_offset(*offset).len())
+        .sum();
+    black_box(count)
+}
+
+fn run_definition_queries_for_inputs(inputs: &[PreparedEditorInput]) -> usize {
+    inputs.iter().map(run_definition_queries).sum()
+}
+
+fn run_references_queries(input: &PreparedEditorInput) -> usize {
+    let query = input.semantic.editor_query();
+    let count = input
+        .hover_probes
+        .iter()
+        .map(|offset| query.occurrences_at_offset(*offset, true).len())
+        .sum();
+    black_box(count)
+}
+
+fn run_references_queries_for_inputs(inputs: &[PreparedEditorInput]) -> usize {
+    inputs.iter().map(run_references_queries).sum()
+}
+
+fn run_document_highlight_queries(input: &PreparedEditorInput) -> usize {
+    let query = input.semantic.editor_query();
+    let count = input
+        .hover_probes
+        .iter()
+        .map(|offset| query.occurrences_at_offset(*offset, true).len())
+        .sum();
+    black_box(count)
+}
+
+fn run_document_highlight_queries_for_inputs(inputs: &[PreparedEditorInput]) -> usize {
+    inputs.iter().map(run_document_highlight_queries).sum()
+}
+
+fn run_rename_queries(input: &PreparedEditorInput) -> usize {
+    let query = input.semantic.editor_query();
+    let count = input
+        .hover_probes
+        .iter()
+        .filter_map(|offset| query.rename_set_at_offset(*offset).ok())
+        .map(|rename| rename.spans.len())
+        .sum();
+    black_box(count)
+}
+
+fn run_rename_queries_for_inputs(inputs: &[PreparedEditorInput]) -> usize {
+    inputs.iter().map(run_rename_queries).sum()
+}
+
 fn hover_probe_count(inputs: &[PreparedEditorInput]) -> u64 {
     inputs
         .iter()
         .map(|input| input.hover_probes.len() as u64)
+        .sum::<u64>()
+        .max(1)
+}
+
+fn completion_probe_count(inputs: &[PreparedEditorInput]) -> u64 {
+    inputs
+        .iter()
+        .map(|input| input.completion_probes.len() as u64)
         .sum::<u64>()
         .max(1)
 }
@@ -172,5 +286,73 @@ fn bench_editor_hover(c: &mut Criterion) {
     warm_group.finish();
 }
 
-criterion_group!(benches, bench_editor_document_symbols, bench_editor_hover);
+fn bench_editor_completion(c: &mut Criterion) {
+    let mut group = c.benchmark_group("editor_completion");
+    for case in benchmark_cases() {
+        let inputs = prepare_editor_inputs(case.files);
+        group.sample_size(case.speed.sample_size());
+        group.throughput(Throughput::Elements(completion_probe_count(&inputs)));
+        group.bench_function(BenchmarkId::from_parameter(case.name), move |b| {
+            b.iter(|| run_completion_queries_for_inputs(&inputs));
+        });
+    }
+    group.finish();
+}
+
+fn bench_editor_navigation(c: &mut Criterion) {
+    let mut definition_group = c.benchmark_group("editor_definition");
+    for case in benchmark_cases() {
+        let inputs = prepare_editor_inputs(case.files);
+        definition_group.sample_size(case.speed.sample_size());
+        definition_group.throughput(Throughput::Elements(hover_probe_count(&inputs)));
+        definition_group.bench_function(BenchmarkId::from_parameter(case.name), move |b| {
+            b.iter(|| run_definition_queries_for_inputs(&inputs));
+        });
+    }
+    definition_group.finish();
+
+    let mut references_group = c.benchmark_group("editor_references");
+    for case in benchmark_cases() {
+        let inputs = prepare_editor_inputs(case.files);
+        references_group.sample_size(case.speed.sample_size());
+        references_group.throughput(Throughput::Elements(hover_probe_count(&inputs)));
+        references_group.bench_function(BenchmarkId::from_parameter(case.name), move |b| {
+            b.iter(|| run_references_queries_for_inputs(&inputs));
+        });
+    }
+    references_group.finish();
+
+    let mut highlight_group = c.benchmark_group("editor_document_highlight");
+    for case in benchmark_cases() {
+        let inputs = prepare_editor_inputs(case.files);
+        highlight_group.sample_size(case.speed.sample_size());
+        highlight_group.throughput(Throughput::Elements(hover_probe_count(&inputs)));
+        highlight_group.bench_function(BenchmarkId::from_parameter(case.name), move |b| {
+            b.iter(|| run_document_highlight_queries_for_inputs(&inputs));
+        });
+    }
+    highlight_group.finish();
+}
+
+fn bench_editor_rename(c: &mut Criterion) {
+    let mut group = c.benchmark_group("editor_rename");
+    for case in benchmark_cases() {
+        let inputs = prepare_editor_inputs(case.files);
+        group.sample_size(case.speed.sample_size());
+        group.throughput(Throughput::Elements(hover_probe_count(&inputs)));
+        group.bench_function(BenchmarkId::from_parameter(case.name), move |b| {
+            b.iter(|| run_rename_queries_for_inputs(&inputs));
+        });
+    }
+    group.finish();
+}
+
+criterion_group!(
+    benches,
+    bench_editor_document_symbols,
+    bench_editor_hover,
+    bench_editor_completion,
+    bench_editor_navigation,
+    bench_editor_rename
+);
 criterion_main!(benches);

--- a/crates/shuck-cli/tests/integration_test.rs
+++ b/crates/shuck-cli/tests/integration_test.rs
@@ -1920,7 +1920,7 @@ fn check_invalid_extend_exclude_pattern_reports_discovery_error() {
 fn check_watch_reruns_when_files_change() {
     let tempdir = tempdir().unwrap();
     let script = tempdir.path().join("watch.sh");
-    fs::write(&script, "#!/bin/bash\necho ok\n").unwrap();
+    fs::write(&script, "#!/bin/bash\nunused=1\necho ok\n").unwrap();
 
     let mut child = ProcessCommand::new(assert_cmd::cargo::cargo_bin("shuck"));
     child
@@ -1940,22 +1940,23 @@ fn check_watch_reruns_when_files_change() {
 
     let initial_ready = wait_for_output(&rx, &mut captured, Duration::from_secs(10), |output| {
         output.stderr.contains("Starting linter in watch mode...")
+            && output.stdout.contains("watch.sh:2:1: warning[C001]")
     });
     if !initial_ready {
         stop_child(&mut child);
         let _ = stdout_reader.join();
         let _ = stderr_reader.join();
         panic!(
-            "watch mode did not emit its startup banner\nstdout:\n{}\nstderr:\n{}",
+            "watch mode did not emit its startup banner and initial report\nstdout:\n{}\nstderr:\n{}",
             captured.stdout, captured.stderr
         );
     }
 
-    fs::write(&script, "#!/bin/bash\nunused=1\necho ok\n").unwrap();
+    fs::write(&script, "#!/bin/bash\necho ok\nunused=1\n").unwrap();
 
     let rerun_ready = wait_for_output(&rx, &mut captured, Duration::from_secs(10), |output| {
         output.stderr.contains("File change detected...")
-            && output.stdout.contains("watch.sh:2:1: warning[C001]")
+            && output.stdout.contains("watch.sh:3:1: warning[C001]")
     });
 
     stop_child(&mut child);

--- a/crates/shuck-semantic/src/editor.rs
+++ b/crates/shuck-semantic/src/editor.rs
@@ -1,13 +1,15 @@
 //! Editor-facing semantic query shapes.
 
+use std::collections::BTreeSet;
 use std::ops::Deref;
 
-use rustc_hash::FxHashMap;
-use shuck_ast::{Name, Span};
+use rustc_hash::{FxHashMap, FxHashSet};
+use shuck_ast::{Name, Span, TextSize};
+use shuck_indexer::{Indexer, RegionKind};
 
 use crate::{
-    Binding, BindingAttributes, BindingId, BindingKind, DeclarationOperand, ReferenceId, ScopeId,
-    ScopeKind, SemanticModel, SpanKey,
+    Binding, BindingAttributes, BindingId, BindingKind, BindingOrigin, DeclarationOperand,
+    Reference, ReferenceId, ReferenceKind, ScopeId, ScopeKind, SemanticModel, SpanKey,
 };
 
 /// LSP-agnostic query object for editor features.
@@ -58,6 +60,144 @@ pub struct EditorHover {
     pub runtime: bool,
     /// Number of file-local call sites resolved to this function, when applicable.
     pub function_call_count: Option<usize>,
+}
+
+/// A function call token that editor features can resolve.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EditorFunctionCallTarget {
+    /// Callee name as written at the call site.
+    pub name: Name,
+    /// Span of the callee token.
+    pub name_span: Span,
+    /// Resolved function binding when the call is statically proven.
+    pub binding: Option<BindingId>,
+}
+
+/// A runtime-provided shell name target.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EditorRuntimeNameTarget {
+    /// Runtime name.
+    pub name: Name,
+    /// Span of the runtime-name token.
+    pub span: Span,
+}
+
+/// Semantic target under an editor cursor.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum EditorSymbolTarget {
+    /// A binding definition or write site.
+    Binding(BindingId),
+    /// A reference to a binding or runtime name.
+    Reference(ReferenceId),
+    /// A command-position function call.
+    FunctionCall(EditorFunctionCallTarget),
+    /// A shell runtime name with no source binding.
+    RuntimeName(EditorRuntimeNameTarget),
+}
+
+/// Read/write classification for an editor occurrence.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EditorOccurrenceKind {
+    /// A read-like occurrence.
+    Read,
+    /// A definition, assignment, declaration, or other write-like occurrence.
+    Write,
+}
+
+/// One source occurrence of an editor symbol.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct EditorOccurrence {
+    /// Source span of the occurrence.
+    pub span: Span,
+    /// Read/write classification.
+    pub kind: EditorOccurrenceKind,
+}
+
+/// Completion category for editor presentation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EditorCompletionKind {
+    /// A shell variable or parameter.
+    Variable,
+    /// A shell function.
+    Function,
+    /// A shell builtin command modeled by Shuck.
+    Builtin,
+    /// A runtime-provided shell name.
+    RuntimeName,
+    /// A shell keyword or reserved word.
+    Keyword,
+}
+
+/// One semantic completion candidate.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EditorCompletion {
+    /// Text shown and inserted for the completion.
+    pub name: Name,
+    /// Completion category.
+    pub kind: EditorCompletionKind,
+    /// Optional source definition span for symbol completions.
+    pub definition_span: Option<Span>,
+}
+
+/// Completion candidates plus the source span they replace.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EditorCompletions {
+    /// Span replaced by each completion item.
+    pub replacement_span: Span,
+    /// Candidate items.
+    pub items: Vec<EditorCompletion>,
+}
+
+/// Editor completion feature switches.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct EditorCompletionOptions {
+    /// Include shell runtime-provided variables in parameter completions.
+    pub include_runtime_names: bool,
+    /// Include shell keywords in command-position completions.
+    pub include_keywords: bool,
+}
+
+impl Default for EditorCompletionOptions {
+    fn default() -> Self {
+        Self {
+            include_runtime_names: true,
+            include_keywords: true,
+        }
+    }
+}
+
+/// Proven same-file rename group.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RenameSet {
+    /// Original symbol name.
+    pub name: Name,
+    /// Symbol kind being renamed.
+    pub kind: EditorSymbolKind,
+    /// Range that `prepareRename` should offer to the editor.
+    pub editable_span: Span,
+    /// Source spans to edit.
+    pub spans: Vec<Span>,
+}
+
+/// Reason a cursor target cannot be renamed safely.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RenameUnavailable {
+    /// No renameable target exists at the cursor.
+    NoTarget,
+    /// The target name is dynamic or otherwise not a plain static token.
+    DynamicName,
+    /// The target is an indirect reference.
+    IndirectReference,
+    /// The target is a nameref.
+    Nameref,
+    /// The target was imported from outside the current document.
+    ImportedBinding,
+    /// The target cannot be resolved to one proven symbol set.
+    AmbiguousResolution,
+    /// The original target name is not a shell identifier/function token Shuck can rename.
+    InvalidIdentifier,
+    /// The rename would need edits outside the current indexed document.
+    CrossFileUnindexed,
 }
 
 impl Deref for EditorDocumentSymbol {
@@ -183,27 +323,110 @@ impl<'model> EditorQuery<'model> {
 
     /// Returns semantic hover information for the symbol at `offset`.
     pub fn hover_at_offset(&self, offset: usize) -> Option<EditorHover> {
-        let targets = self
-            .model
-            .editor_hover_targets
-            .get_or_init(|| build_editor_hover_targets(self.model));
-        let upper = targets.partition_point(|target| target.span.start.offset <= offset);
+        find_editor_target(self.model, offset)
+            .and_then(|target| hover_for_target(self.model, target))
+    }
 
-        let mut best: Option<(&EditorHoverTarget, HoverTargetRank)> = None;
-        for target in targets[..upper].iter().rev() {
-            if target.span.end.offset <= offset {
-                break;
+    /// Returns the semantic target under `offset`.
+    pub fn target_at_offset(&self, offset: usize) -> Option<EditorSymbolTarget> {
+        find_editor_target(self.model, offset)
+            .and_then(|target| target_to_editor_symbol(self.model, target))
+    }
+
+    /// Returns source spans that define the symbol under `offset`.
+    pub fn definition_spans_at_offset(&self, offset: usize) -> Vec<Span> {
+        let Some(target) = self.target_at_offset(offset) else {
+            return Vec::new();
+        };
+        self.definition_spans_for_target(&target)
+    }
+
+    /// Returns source spans that define `target`.
+    pub fn definition_spans_for_target(&self, target: &EditorSymbolTarget) -> Vec<Span> {
+        let mut spans = match target {
+            EditorSymbolTarget::Binding(binding_id) => {
+                definition_spans_for_binding_family(self.model, *binding_id)
             }
-            if !span_contains_offset(target.span, offset) {
-                continue;
+            EditorSymbolTarget::Reference(reference_id) => self
+                .model
+                .resolved_binding(*reference_id)
+                .map(|binding| definition_spans_for_binding_family(self.model, binding.id))
+                .unwrap_or_default(),
+            EditorSymbolTarget::FunctionCall(call) => call
+                .binding
+                .map(|binding_id| vec![binding_definition_span(self.model.binding(binding_id))])
+                .unwrap_or_default(),
+            EditorSymbolTarget::RuntimeName(_) => Vec::new(),
+        };
+        sort_dedup_spans(&mut spans);
+        spans
+    }
+
+    /// Returns read/write occurrences for the symbol under `offset`.
+    pub fn occurrences_at_offset(
+        &self,
+        offset: usize,
+        include_declaration: bool,
+    ) -> Vec<EditorOccurrence> {
+        let Some(target) = self.target_at_offset(offset) else {
+            return Vec::new();
+        };
+        self.occurrences_for_target(&target, include_declaration)
+    }
+
+    /// Returns read/write occurrences for `target`.
+    pub fn occurrences_for_target(
+        &self,
+        target: &EditorSymbolTarget,
+        include_declaration: bool,
+    ) -> Vec<EditorOccurrence> {
+        match target {
+            EditorSymbolTarget::Binding(binding_id) => {
+                occurrences_for_binding_family(self.model, *binding_id, include_declaration)
             }
-            let rank = hover_target_rank(target);
-            if best.is_none_or(|(_, best_rank)| rank < best_rank) {
-                best = Some((target, rank));
+            EditorSymbolTarget::Reference(reference_id) => {
+                let Some(binding) = self.model.resolved_binding(*reference_id) else {
+                    return Vec::new();
+                };
+                occurrences_for_binding_family(self.model, binding.id, include_declaration)
             }
+            EditorSymbolTarget::FunctionCall(call) => call
+                .binding
+                .map(|binding_id| {
+                    occurrences_for_function(self.model, binding_id, include_declaration)
+                })
+                .unwrap_or_default(),
+            EditorSymbolTarget::RuntimeName(_) => Vec::new(),
         }
+    }
 
-        best.and_then(|(target, _)| hover_for_target(self.model, target))
+    /// Returns syntax-aware completion candidates at `offset`.
+    pub fn completions_at_offset(
+        &self,
+        source: &str,
+        indexer: &Indexer,
+        offset: usize,
+        options: EditorCompletionOptions,
+    ) -> Option<EditorCompletions> {
+        completion_context(source, indexer, offset)
+            .map(|context| completions_for_context(self.model, source, offset, context, options))
+            .filter(|completions| !completions.items.is_empty())
+    }
+
+    /// Returns a conservative rename set for the target under `offset`.
+    pub fn rename_set_at_offset(&self, offset: usize) -> Result<RenameSet, RenameUnavailable> {
+        let target = self
+            .target_at_offset(offset)
+            .ok_or(RenameUnavailable::NoTarget)?;
+        self.rename_set_for_target(&target)
+    }
+
+    /// Returns a conservative rename set for `target`.
+    pub fn rename_set_for_target(
+        &self,
+        target: &EditorSymbolTarget,
+    ) -> Result<RenameSet, RenameUnavailable> {
+        rename_set_for_target(self.model, target)
     }
 }
 
@@ -230,6 +453,64 @@ fn hover_target_rank(target: &EditorHoverTarget) -> HoverTargetRank {
             .end
             .offset
             .saturating_sub(target.span.start.offset),
+    }
+}
+
+fn find_editor_target(model: &SemanticModel, offset: usize) -> Option<&EditorHoverTarget> {
+    let targets = model
+        .editor_hover_targets
+        .get_or_init(|| build_editor_hover_targets(model));
+    let upper = targets.partition_point(|target| target.span.start.offset <= offset);
+
+    let mut best: Option<(&EditorHoverTarget, HoverTargetRank)> = None;
+    for target in targets[..upper].iter().rev() {
+        if target.span.end.offset <= offset {
+            break;
+        }
+        if !span_contains_offset(target.span, offset) {
+            continue;
+        }
+        let rank = hover_target_rank(target);
+        if best.is_none_or(|(_, best_rank)| rank < best_rank) {
+            best = Some((target, rank));
+        }
+    }
+
+    best.map(|(target, _)| target)
+}
+
+fn target_to_editor_symbol(
+    model: &SemanticModel,
+    target: &EditorHoverTarget,
+) -> Option<EditorSymbolTarget> {
+    match &target.kind {
+        EditorHoverTargetKind::Binding(binding_id) => {
+            Some(EditorSymbolTarget::Binding(*binding_id))
+        }
+        EditorHoverTargetKind::Reference(reference_id) => {
+            let reference = model.reference(*reference_id);
+            if model.resolved_binding(*reference_id).is_some() {
+                return Some(EditorSymbolTarget::Reference(*reference_id));
+            }
+            (model.predefined_runtime_refs.contains(reference_id)
+                || model.name_is_predefined_runtime(reference.name.as_str()))
+            .then(|| {
+                EditorSymbolTarget::RuntimeName(EditorRuntimeNameTarget {
+                    name: reference.name.clone(),
+                    span: reference.name_span,
+                })
+            })
+        }
+        EditorHoverTargetKind::FunctionCall { name, name_span } => {
+            let binding = model
+                .analysis()
+                .visible_function_binding_at_call(name, *name_span);
+            Some(EditorSymbolTarget::FunctionCall(EditorFunctionCallTarget {
+                name: name.clone(),
+                name_span: *name_span,
+                binding,
+            }))
+        }
     }
 }
 
@@ -297,6 +578,601 @@ fn hover_for_target(model: &SemanticModel, target: &EditorHoverTarget) -> Option
             hover_for_binding(model, model.binding(binding_id), *name_span)
         }
     }
+}
+
+fn definition_spans_for_binding_family(model: &SemanticModel, binding_id: BindingId) -> Vec<Span> {
+    let binding = model.binding(binding_id);
+    if matches!(binding.kind, BindingKind::FunctionDefinition) {
+        return vec![binding_definition_span(binding)];
+    }
+
+    storage_family_bindings(model, binding)
+        .into_iter()
+        .map(|binding_id| binding_definition_span(model.binding(binding_id)))
+        .collect()
+}
+
+fn occurrences_for_binding_family(
+    model: &SemanticModel,
+    binding_id: BindingId,
+    include_declaration: bool,
+) -> Vec<EditorOccurrence> {
+    let binding = model.binding(binding_id);
+    if matches!(binding.kind, BindingKind::FunctionDefinition) {
+        return occurrences_for_function(model, binding_id, include_declaration);
+    }
+
+    let family = storage_family_bindings(model, binding);
+    let family_set = family.iter().copied().collect::<FxHashSet<_>>();
+    let mut occurrences = Vec::new();
+
+    if include_declaration {
+        occurrences.extend(family.iter().map(|binding_id| EditorOccurrence {
+            span: rename_span_for_binding(model.binding(*binding_id)),
+            kind: EditorOccurrenceKind::Write,
+        }));
+    }
+
+    for reference in model.references() {
+        let Some(resolved) = model.resolved.get(&reference.id) else {
+            continue;
+        };
+        if !family_set.contains(resolved) || !source_backed_reference(reference) {
+            continue;
+        }
+        let kind = if matches!(reference.kind, ReferenceKind::DeclarationName) {
+            if !include_declaration {
+                continue;
+            }
+            EditorOccurrenceKind::Write
+        } else {
+            EditorOccurrenceKind::Read
+        };
+        occurrences.push(EditorOccurrence {
+            span: reference.name_span,
+            kind,
+        });
+    }
+
+    sort_dedup_occurrences(&mut occurrences);
+    occurrences
+}
+
+fn occurrences_for_function(
+    model: &SemanticModel,
+    binding_id: BindingId,
+    include_declaration: bool,
+) -> Vec<EditorOccurrence> {
+    let binding = model.binding(binding_id);
+    if !matches!(binding.kind, BindingKind::FunctionDefinition) {
+        return Vec::new();
+    }
+
+    let mut occurrences = Vec::new();
+    if include_declaration {
+        occurrences.push(EditorOccurrence {
+            span: binding.span,
+            kind: EditorOccurrenceKind::Write,
+        });
+    }
+    occurrences.extend(
+        model
+            .analysis()
+            .resolved_function_call_sites(&binding.name)
+            .filter(|(_, candidate)| *candidate == binding_id)
+            .map(|(site, _)| EditorOccurrence {
+                span: site.name_span,
+                kind: EditorOccurrenceKind::Read,
+            }),
+    );
+    sort_dedup_occurrences(&mut occurrences);
+    occurrences
+}
+
+fn storage_family_bindings(model: &SemanticModel, binding: &Binding) -> Vec<BindingId> {
+    model
+        .bindings_for(&binding.name)
+        .iter()
+        .copied()
+        .filter(|candidate| {
+            let candidate_binding = model.binding(*candidate);
+            candidate_binding.scope == binding.scope
+                && !matches!(candidate_binding.kind, BindingKind::FunctionDefinition)
+                && editor_symbol_kind_for_binding(candidate_binding).is_some()
+        })
+        .collect()
+}
+
+fn rename_set_for_target(
+    model: &SemanticModel,
+    target: &EditorSymbolTarget,
+) -> Result<RenameSet, RenameUnavailable> {
+    match target {
+        EditorSymbolTarget::Binding(binding_id) => rename_set_for_binding(model, *binding_id, None),
+        EditorSymbolTarget::Reference(reference_id) => {
+            let reference = model.reference(*reference_id);
+            if matches!(reference.kind, ReferenceKind::IndirectExpansion) {
+                return Err(RenameUnavailable::IndirectReference);
+            }
+            let binding_id = model
+                .resolved
+                .get(reference_id)
+                .copied()
+                .ok_or(RenameUnavailable::AmbiguousResolution)?;
+            rename_set_for_binding(model, binding_id, Some(reference.name_span))
+        }
+        EditorSymbolTarget::FunctionCall(call) => {
+            let binding_id = call.binding.ok_or(RenameUnavailable::AmbiguousResolution)?;
+            rename_set_for_function(model, binding_id, call.name_span)
+        }
+        EditorSymbolTarget::RuntimeName(_) => Err(RenameUnavailable::ImportedBinding),
+    }
+}
+
+fn rename_set_for_binding(
+    model: &SemanticModel,
+    binding_id: BindingId,
+    editable_span: Option<Span>,
+) -> Result<RenameSet, RenameUnavailable> {
+    let binding = model.binding(binding_id);
+    if matches!(binding.kind, BindingKind::FunctionDefinition) {
+        return rename_set_for_function(model, binding_id, editable_span.unwrap_or(binding.span));
+    }
+    let kind = editor_symbol_kind_for_binding(binding).ok_or(RenameUnavailable::DynamicName)?;
+    if !valid_variable_name(binding.name.as_str()) {
+        return Err(RenameUnavailable::InvalidIdentifier);
+    }
+
+    let family = storage_family_bindings(model, binding);
+    if family.is_empty() {
+        return Err(RenameUnavailable::AmbiguousResolution);
+    }
+    for candidate in &family {
+        let candidate = model.binding(*candidate);
+        if binding_is_imported(candidate) {
+            return Err(RenameUnavailable::ImportedBinding);
+        }
+        if matches!(candidate.kind, BindingKind::Nameref)
+            || candidate.attributes.contains(BindingAttributes::NAMEREF)
+        {
+            return Err(RenameUnavailable::Nameref);
+        }
+        if matches!(candidate.kind, BindingKind::ParameterDefaultAssignment)
+            || matches!(
+                candidate.origin,
+                BindingOrigin::ParameterDefaultAssignment { .. }
+            )
+        {
+            return Err(RenameUnavailable::DynamicName);
+        }
+    }
+
+    let mut spans = occurrences_for_binding_family(model, binding_id, true)
+        .into_iter()
+        .filter(|occurrence| {
+            !model.references().iter().any(|reference| {
+                reference.name_span == occurrence.span
+                    && matches!(reference.kind, ReferenceKind::IndirectExpansion)
+            })
+        })
+        .map(|occurrence| occurrence.span)
+        .collect::<Vec<_>>();
+    sort_dedup_spans(&mut spans);
+    if spans.is_empty() {
+        return Err(RenameUnavailable::AmbiguousResolution);
+    }
+
+    Ok(RenameSet {
+        name: binding.name.clone(),
+        kind,
+        editable_span: editable_span.unwrap_or_else(|| rename_span_for_binding(binding)),
+        spans,
+    })
+}
+
+fn rename_set_for_function(
+    model: &SemanticModel,
+    binding_id: BindingId,
+    editable_span: Span,
+) -> Result<RenameSet, RenameUnavailable> {
+    let binding = model.binding(binding_id);
+    if !matches!(binding.kind, BindingKind::FunctionDefinition) {
+        return Err(RenameUnavailable::AmbiguousResolution);
+    }
+    if binding_is_imported(binding) {
+        return Err(RenameUnavailable::ImportedBinding);
+    }
+    if !valid_function_name(binding.name.as_str()) {
+        return Err(RenameUnavailable::InvalidIdentifier);
+    }
+    let mut spans = occurrences_for_function(model, binding_id, true)
+        .into_iter()
+        .map(|occurrence| occurrence.span)
+        .collect::<Vec<_>>();
+    sort_dedup_spans(&mut spans);
+    if spans.is_empty() {
+        return Err(RenameUnavailable::AmbiguousResolution);
+    }
+
+    Ok(RenameSet {
+        name: binding.name.clone(),
+        kind: EditorSymbolKind::Function,
+        editable_span,
+        spans,
+    })
+}
+
+fn rename_span_for_binding(binding: &Binding) -> Span {
+    match binding.origin {
+        BindingOrigin::ParameterDefaultAssignment { target_span, .. }
+        | BindingOrigin::ArithmeticAssignment { target_span, .. } => target_span,
+        _ => binding.span,
+    }
+}
+
+fn source_backed_reference(reference: &Reference) -> bool {
+    reference.name_span.start.offset < reference.name_span.end.offset
+        && !matches!(
+            reference.kind,
+            ReferenceKind::ImplicitRead | ReferenceKind::RequiredRead
+        )
+}
+
+fn sort_dedup_occurrences(occurrences: &mut Vec<EditorOccurrence>) {
+    occurrences.sort_by_key(|occurrence| {
+        (
+            occurrence.span.start.offset,
+            occurrence.span.end.offset,
+            occurrence.kind == EditorOccurrenceKind::Read,
+        )
+    });
+    occurrences.dedup_by_key(|occurrence| {
+        (
+            occurrence.span.start.offset,
+            occurrence.span.end.offset,
+            occurrence.kind,
+        )
+    });
+}
+
+fn sort_dedup_spans(spans: &mut Vec<Span>) {
+    spans.sort_by_key(|span| (span.start.offset, span.end.offset));
+    spans.dedup_by_key(|span| (span.start.offset, span.end.offset));
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum CompletionContext {
+    Parameter { replacement_span: Span },
+    Declaration { replacement_span: Span },
+    Command { replacement_span: Span },
+}
+
+fn completion_context(source: &str, indexer: &Indexer, offset: usize) -> Option<CompletionContext> {
+    if offset > source.len() || !source.is_char_boundary(offset) {
+        return None;
+    }
+    if completion_is_blocked_by_region(indexer, offset) {
+        return None;
+    }
+    if let Some(replacement_span) = parameter_completion_span(source, offset) {
+        return Some(CompletionContext::Parameter { replacement_span });
+    }
+    let word_span = current_word_span(source, offset);
+    if declaration_operand_context(source, indexer, word_span.start.offset) {
+        return Some(CompletionContext::Declaration {
+            replacement_span: word_span,
+        });
+    }
+    if command_position_context(source, word_span.start.offset) {
+        return Some(CompletionContext::Command {
+            replacement_span: word_span,
+        });
+    }
+    None
+}
+
+fn completion_is_blocked_by_region(indexer: &Indexer, offset: usize) -> bool {
+    let probe = TextSize::new(offset.saturating_sub(1) as u32);
+    indexer.comment_index().is_comment(probe)
+        || matches!(
+            indexer.region_index().region_at(probe),
+            Some(RegionKind::SingleQuoted | RegionKind::Heredoc)
+        )
+}
+
+fn parameter_completion_span(source: &str, offset: usize) -> Option<Span> {
+    let start = identifier_prefix_start(source, offset);
+    let before = &source.as_bytes()[..start];
+    if before.last() == Some(&b'$') {
+        return Some(span_from_offsets(source, start, offset));
+    }
+    if before.last() == Some(&b'{') && before.get(before.len().saturating_sub(2)) == Some(&b'$') {
+        return Some(span_from_offsets(source, start, offset));
+    }
+    if source[..offset].ends_with('$') || source[..offset].ends_with("${") {
+        return Some(span_from_offsets(source, offset, offset));
+    }
+    None
+}
+
+fn current_word_span(source: &str, offset: usize) -> Span {
+    let start = word_prefix_start(source, offset);
+    span_from_offsets(source, start, offset)
+}
+
+fn identifier_prefix_start(source: &str, offset: usize) -> usize {
+    let mut start = offset;
+    while start > 0 {
+        let Some((prev, ch)) = previous_char(source, start) else {
+            break;
+        };
+        if !is_identifier_continue(ch) {
+            break;
+        }
+        start = prev;
+    }
+    start
+}
+
+fn word_prefix_start(source: &str, offset: usize) -> usize {
+    let mut start = offset;
+    while start > 0 {
+        let Some((prev, ch)) = previous_char(source, start) else {
+            break;
+        };
+        if ch.is_whitespace() || matches!(ch, ';' | '|' | '&' | '(' | ')' | '{' | '}') {
+            break;
+        }
+        start = prev;
+    }
+    start
+}
+
+fn previous_char(source: &str, offset: usize) -> Option<(usize, char)> {
+    source[..offset].char_indices().next_back()
+}
+
+fn declaration_operand_context(source: &str, indexer: &Indexer, word_start: usize) -> bool {
+    let line = indexer
+        .line_index()
+        .line_number(TextSize::new(word_start as u32));
+    let Some(line_range) = indexer.line_index().line_range(line, source) else {
+        return false;
+    };
+    let line_start = usize::from(line_range.start());
+    let before = &source[line_start..word_start];
+    let mut words = before
+        .split(|ch: char| ch.is_whitespace() || matches!(ch, ';' | '|' | '&'))
+        .filter(|word| !word.is_empty());
+    let Some(first) = words.next() else {
+        return false;
+    };
+    matches!(
+        first,
+        "declare" | "export" | "local" | "readonly" | "typeset"
+    )
+}
+
+fn command_position_context(source: &str, word_start: usize) -> bool {
+    let raw_before = &source[..word_start];
+    if raw_before.ends_with('\n') {
+        return true;
+    }
+    let before = raw_before.trim_end();
+    if before.is_empty() {
+        return true;
+    }
+    if before.ends_with('\n')
+        || before.ends_with(';')
+        || before.ends_with('|')
+        || before.ends_with('&')
+        || before.ends_with('(')
+        || before.ends_with('{')
+    {
+        return true;
+    }
+    let previous = before
+        .rsplit(|ch: char| ch.is_whitespace() || matches!(ch, ';' | '|' | '&' | '(' | '{'))
+        .find(|word| !word.is_empty());
+    matches!(previous, Some("then" | "do" | "else" | "elif"))
+}
+
+fn completions_for_context(
+    model: &SemanticModel,
+    source: &str,
+    offset: usize,
+    context: CompletionContext,
+    options: EditorCompletionOptions,
+) -> EditorCompletions {
+    let (replacement_span, mut items) = match context {
+        CompletionContext::Parameter { replacement_span } => (
+            replacement_span,
+            variable_completions(model, offset, options.include_runtime_names),
+        ),
+        CompletionContext::Declaration { replacement_span } => (
+            replacement_span,
+            variable_completions(model, offset, options.include_runtime_names),
+        ),
+        CompletionContext::Command { replacement_span } => {
+            let mut items = function_completions(model, offset);
+            items.extend(builtin_completions(model));
+            if options.include_keywords {
+                items.extend(keyword_completions());
+            }
+            (replacement_span, items)
+        }
+    };
+    filter_and_sort_completions(&mut items, replacement_span.slice(source));
+    EditorCompletions {
+        replacement_span,
+        items,
+    }
+}
+
+fn variable_completions(
+    model: &SemanticModel,
+    offset: usize,
+    include_runtime_names: bool,
+) -> Vec<EditorCompletion> {
+    let at = Span::at(position_with_offset(offset));
+    let mut seen = BTreeSet::new();
+    let mut items = Vec::new();
+
+    for binding in model.bindings() {
+        if matches!(binding.kind, BindingKind::FunctionDefinition)
+            || editor_symbol_kind_for_binding(binding).is_none()
+            || !model.binding_visible_at(binding.id, at)
+            || !seen.insert(binding.name.to_string())
+        {
+            continue;
+        }
+        items.push(EditorCompletion {
+            name: binding.name.clone(),
+            kind: EditorCompletionKind::Variable,
+            definition_span: Some(binding_definition_span(binding)),
+        });
+    }
+
+    if include_runtime_names {
+        for name in model.runtime.preinitialized_names() {
+            if seen.insert(name.to_owned()) {
+                items.push(EditorCompletion {
+                    name: Name::from(name),
+                    kind: EditorCompletionKind::RuntimeName,
+                    definition_span: None,
+                });
+            }
+        }
+    }
+
+    items
+}
+
+fn function_completions(model: &SemanticModel, offset: usize) -> Vec<EditorCompletion> {
+    let at = Span::at(position_with_offset(offset));
+    let mut seen = BTreeSet::new();
+    let mut items = Vec::new();
+    for binding in model.function_definition_bindings() {
+        if !model.binding_visible_at(binding.id, at) || !seen.insert(binding.name.to_string()) {
+            continue;
+        }
+        items.push(EditorCompletion {
+            name: binding.name.clone(),
+            kind: EditorCompletionKind::Function,
+            definition_span: Some(binding_definition_span(binding)),
+        });
+    }
+    items
+}
+
+fn builtin_completions(model: &SemanticModel) -> Vec<EditorCompletion> {
+    model
+        .runtime
+        .known_builtin_names()
+        .into_iter()
+        .map(|builtin| EditorCompletion {
+            name: Name::from(builtin),
+            kind: EditorCompletionKind::Builtin,
+            definition_span: None,
+        })
+        .collect()
+}
+
+fn keyword_completions() -> Vec<EditorCompletion> {
+    [
+        "case", "coproc", "do", "done", "elif", "else", "esac", "fi", "for", "function", "if",
+        "in", "select", "then", "time", "until", "while",
+    ]
+    .into_iter()
+    .map(|keyword| EditorCompletion {
+        name: Name::from(keyword),
+        kind: EditorCompletionKind::Keyword,
+        definition_span: None,
+    })
+    .collect()
+}
+
+fn filter_and_sort_completions(items: &mut Vec<EditorCompletion>, prefix: &str) {
+    if !prefix.is_empty() {
+        items.retain(|item| item.name.as_str().starts_with(prefix));
+    }
+    items.sort_by_key(|item| {
+        let rank = match item.kind {
+            EditorCompletionKind::Variable => 0,
+            EditorCompletionKind::Function => 1,
+            EditorCompletionKind::Builtin => 2,
+            EditorCompletionKind::RuntimeName => 3,
+            EditorCompletionKind::Keyword => 4,
+        };
+        (rank, item.name.to_string())
+    });
+    items.dedup_by_key(|item| item.name.to_string());
+}
+
+fn span_from_offsets(source: &str, start: usize, end: usize) -> Span {
+    Span::from_positions(
+        position_at_offset(source, start),
+        position_at_offset(source, end),
+    )
+}
+
+fn position_at_offset(source: &str, offset: usize) -> shuck_ast::Position {
+    source.get(..offset).unwrap_or(source).chars().fold(
+        shuck_ast::Position::new(),
+        |mut position, ch| {
+            position.advance(ch);
+            position
+        },
+    )
+}
+
+fn position_with_offset(offset: usize) -> shuck_ast::Position {
+    shuck_ast::Position {
+        line: 1,
+        column: offset + 1,
+        offset,
+    }
+}
+
+fn valid_variable_name(name: &str) -> bool {
+    let mut chars = name.chars();
+    let Some(first) = chars.next() else {
+        return false;
+    };
+    (first == '_' || first.is_ascii_alphabetic())
+        && chars.all(|ch| ch == '_' || ch.is_ascii_alphanumeric())
+}
+
+fn valid_function_name(name: &str) -> bool {
+    !name.is_empty()
+        && !name.chars().any(|ch| {
+            ch.is_whitespace()
+                || matches!(
+                    ch,
+                    '$' | '`'
+                        | '\\'
+                        | '"'
+                        | '\''
+                        | ';'
+                        | '&'
+                        | '|'
+                        | '<'
+                        | '>'
+                        | '('
+                        | ')'
+                        | '{'
+                        | '}'
+                        | '['
+                        | ']'
+                        | '*'
+                        | '?'
+                        | '/'
+                )
+        })
+}
+
+fn is_identifier_continue(ch: char) -> bool {
+    ch == '_' || ch.is_ascii_alphanumeric()
 }
 
 fn hover_for_binding(

--- a/crates/shuck-semantic/src/editor.rs
+++ b/crates/shuck-semantic/src/editor.rs
@@ -872,7 +872,12 @@ fn completion_context(source: &str, indexer: &Indexer, offset: usize) -> Option<
 }
 
 fn completion_is_blocked_by_region(indexer: &Indexer, offset: usize) -> bool {
-    let probe = TextSize::new(offset.saturating_sub(1) as u32);
+    completion_probe_is_blocked(indexer, offset)
+        || (offset > 0 && completion_probe_is_blocked(indexer, offset - 1))
+}
+
+fn completion_probe_is_blocked(indexer: &Indexer, offset: usize) -> bool {
+    let probe = TextSize::new(offset as u32);
     indexer.comment_index().is_comment(probe)
         || matches!(
             indexer.region_index().region_at(probe),

--- a/crates/shuck-semantic/src/editor.rs
+++ b/crates/shuck-semantic/src/editor.rs
@@ -941,10 +941,19 @@ fn declaration_operand_context(source: &str, indexer: &Indexer, word_start: usiz
     };
     let line_start = usize::from(line_range.start());
     let before = &source[line_start..word_start];
-    let mut words = before
-        .split(|ch: char| ch.is_whitespace() || matches!(ch, ';' | '|' | '&'))
-        .filter(|word| !word.is_empty());
-    let Some(first) = words.next() else {
+    let command_start = before
+        .char_indices()
+        .rev()
+        .find_map(|(index, ch)| {
+            matches!(ch, ';' | '|' | '&' | '(' | '{').then_some(index + ch.len_utf8())
+        })
+        .unwrap_or(0);
+    let mut words = before[command_start..].split_whitespace();
+    let first = match words.next() {
+        Some("then" | "do" | "else") => words.next(),
+        first => first,
+    };
+    let Some(first) = first else {
         return false;
     };
     matches!(

--- a/crates/shuck-semantic/src/lib.rs
+++ b/crates/shuck-semantic/src/lib.rs
@@ -68,7 +68,12 @@ pub use dataflow::{
 /// Declaration records discovered while building the semantic model.
 pub use declaration::{Declaration, DeclarationBuiltin, DeclarationOperand};
 /// Editor-facing semantic query types.
-pub use editor::{EditorDocumentSymbol, EditorHover, EditorQuery, EditorSymbol, EditorSymbolKind};
+pub use editor::{
+    EditorCompletion, EditorCompletionKind, EditorCompletionOptions, EditorCompletions,
+    EditorDocumentSymbol, EditorFunctionCallTarget, EditorHover, EditorOccurrence,
+    EditorOccurrenceKind, EditorQuery, EditorRuntimeNameTarget, EditorSymbol, EditorSymbolKind,
+    EditorSymbolTarget, RenameSet, RenameUnavailable,
+};
 /// Direct function-call reachability query types.
 pub use function_call_reachability::{
     DirectFunctionCallReachability, DirectFunctionCallWindow, FunctionCallCandidate,

--- a/crates/shuck-semantic/src/runtime.rs
+++ b/crates/shuck-semantic/src/runtime.rs
@@ -256,6 +256,12 @@ const ALWAYS_USED_BINDINGS: &[&str] = &["IFS", "PATH", "CDPATH", "COMPREPLY", "F
 const BASH_ALWAYS_USED_BINDINGS: &[&str] = &["COMPREPLY"];
 const EMPTY_IMPLICIT_READS: &[&str] = &[];
 const READ_IMPLICIT_READS: &[&str] = &["IFS"];
+const COMMON_KNOWN_BUILTINS: &[&str] = &[
+    "break", "builtin", "command", "continue", "exit", "export", "getopts", "printf", "read",
+    "readonly", "return",
+];
+const BASH_KNOWN_BUILTINS: &[&str] = &["mapfile", "readarray"];
+const ZSH_KNOWN_BUILTINS: &[&str] = &["compinit", "integer", "zparseopts", "zstyle"];
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) struct RuntimePrelude {
@@ -310,6 +316,34 @@ impl RuntimePrelude {
     pub(crate) fn is_preinitialized_associative_array(&self, name: &Name) -> bool {
         self.shell_dialect == ShellDialect::Zsh
             && contains_name(ZSH_PREINITIALIZED_ASSOCIATIVE_ARRAYS, name)
+    }
+
+    pub(crate) fn preinitialized_names(&self) -> Vec<&'static str> {
+        let mut names = Vec::new();
+        names.extend_from_slice(self.common_preinitialized);
+        if self.bash_enabled {
+            names.extend_from_slice(self.bash_preinitialized);
+        }
+        if self.shell_dialect == ShellDialect::Zsh {
+            names.extend_from_slice(self.zsh_preinitialized);
+        }
+        names.sort_unstable();
+        names.dedup();
+        names
+    }
+
+    pub(crate) fn known_builtin_names(&self) -> Vec<&'static str> {
+        let mut names = Vec::new();
+        names.extend_from_slice(COMMON_KNOWN_BUILTINS);
+        if self.bash_enabled {
+            names.extend_from_slice(BASH_KNOWN_BUILTINS);
+        }
+        if self.shell_dialect == ShellDialect::Zsh {
+            names.extend_from_slice(ZSH_KNOWN_BUILTINS);
+        }
+        names.sort_unstable();
+        names.dedup();
+        names
     }
 
     pub(crate) fn is_always_used_binding(&self, name: &Name) -> bool {

--- a/crates/shuck-semantic/src/tests.rs
+++ b/crates/shuck-semantic/src/tests.rs
@@ -385,6 +385,31 @@ outside=1
 }
 
 #[test]
+fn editor_declaration_completion_uses_current_command_segment() {
+    let source = "\
+existing=1
+build() { echo ok; local ex
+}
+";
+    let output = Parser::with_dialect(source, ShellDialect::Bash)
+        .parse()
+        .unwrap();
+    let indexer = Indexer::new(source, &output);
+    let model = SemanticModel::build(&output.file, source, &indexer);
+    let offset = source.find("local ex").unwrap() + "local ex".len();
+    let names = model
+        .editor_query()
+        .completions_at_offset(source, &indexer, offset, EditorCompletionOptions::default())
+        .expect("declaration completion should be available")
+        .items
+        .into_iter()
+        .map(|item| item.name.to_string())
+        .collect::<Vec<_>>();
+
+    assert!(names.contains(&"existing".to_owned()));
+}
+
+#[test]
 fn editor_rename_is_conservative() {
     let source = "\
 build() { :; }

--- a/crates/shuck-semantic/src/tests.rs
+++ b/crates/shuck-semantic/src/tests.rs
@@ -423,6 +423,24 @@ build() {{ {segment}
 }
 
 #[test]
+fn editor_completion_is_blocked_at_first_comment_byte() {
+    let source = "echo ok\n# comment\n";
+    let output = Parser::with_dialect(source, ShellDialect::Bash)
+        .parse()
+        .unwrap();
+    let indexer = Indexer::new(source, &output);
+    let model = SemanticModel::build(&output.file, source, &indexer);
+    let offset = source.find('#').unwrap();
+
+    assert!(
+        model
+            .editor_query()
+            .completions_at_offset(source, &indexer, offset, EditorCompletionOptions::default())
+            .is_none()
+    );
+}
+
+#[test]
 fn editor_rename_is_conservative() {
     let source = "\
 build() { :; }

--- a/crates/shuck-semantic/src/tests.rs
+++ b/crates/shuck-semantic/src/tests.rs
@@ -275,6 +275,161 @@ printf '%s\\n' '$foo'
     }
 }
 
+#[test]
+fn editor_navigation_returns_definitions_references_and_highlights() {
+    let source = "\
+build() { :; }
+name=one
+name=two
+echo \"$name\"
+build
+";
+    let model = model(source);
+    let query = model.editor_query();
+
+    let variable_ref = span_for_nth(source, "name", 2);
+    let definitions = query.definition_spans_at_offset(variable_ref.start.offset);
+    assert_eq!(
+        definitions
+            .iter()
+            .map(|span| span.slice(source))
+            .collect::<Vec<_>>(),
+        ["name", "name"]
+    );
+
+    let variable_occurrences = query.occurrences_at_offset(variable_ref.start.offset, true);
+    assert_eq!(
+        variable_occurrences
+            .iter()
+            .map(|occurrence| (occurrence.span.slice(source), occurrence.kind))
+            .collect::<Vec<_>>(),
+        [
+            ("name", EditorOccurrenceKind::Write),
+            ("name", EditorOccurrenceKind::Write),
+            ("name", EditorOccurrenceKind::Read)
+        ]
+    );
+
+    let function_call = span_for_nth(source, "build", 1);
+    assert_eq!(
+        query
+            .definition_spans_at_offset(function_call.start.offset)
+            .iter()
+            .map(|span| span.slice(source))
+            .collect::<Vec<_>>(),
+        ["build() { :; }\n"]
+    );
+    assert_eq!(
+        query
+            .occurrences_at_offset(function_call.start.offset, true)
+            .iter()
+            .map(|occurrence| (occurrence.span.slice(source), occurrence.kind))
+            .collect::<Vec<_>>(),
+        [
+            ("build", EditorOccurrenceKind::Write),
+            ("build", EditorOccurrenceKind::Read)
+        ]
+    );
+}
+
+#[test]
+fn editor_completion_is_context_aware() {
+    let source = "\
+build() {
+  local inside=1
+  printf '%s\\n' \"$\"
+}
+outside=1
+";
+    let output = Parser::with_dialect(source, ShellDialect::Bash)
+        .parse()
+        .unwrap();
+    let indexer = Indexer::new(source, &output);
+    let model = SemanticModel::build(&output.file, source, &indexer);
+    let query = model.editor_query();
+
+    let parameter_offset = source.find("\"$").unwrap() + 2;
+    let parameter_names = query
+        .completions_at_offset(
+            source,
+            &indexer,
+            parameter_offset,
+            EditorCompletionOptions {
+                include_runtime_names: false,
+                include_keywords: true,
+            },
+        )
+        .expect("parameter completion should be available")
+        .items
+        .into_iter()
+        .map(|item| item.name.to_string())
+        .collect::<Vec<_>>();
+    assert!(parameter_names.contains(&"inside".to_owned()));
+    assert!(!parameter_names.contains(&"outside".to_owned()));
+
+    let command_names = query
+        .completions_at_offset(
+            source,
+            &indexer,
+            source.len(),
+            EditorCompletionOptions::default(),
+        )
+        .expect("command completion should be available")
+        .items
+        .into_iter()
+        .map(|item| (item.name.to_string(), item.kind))
+        .collect::<Vec<_>>();
+    assert!(command_names.contains(&("build".to_owned(), EditorCompletionKind::Function)));
+    assert!(command_names.contains(&("printf".to_owned(), EditorCompletionKind::Builtin)));
+    assert!(command_names.contains(&("if".to_owned(), EditorCompletionKind::Keyword)));
+}
+
+#[test]
+fn editor_rename_is_conservative() {
+    let source = "\
+build() { :; }
+name=one
+echo \"$name\"
+declare -n ref=name
+build
+";
+    let model = model(source);
+    let query = model.editor_query();
+
+    let variable_ref = span_for_nth(source, "name", 1);
+    let rename = query
+        .rename_set_at_offset(variable_ref.start.offset)
+        .expect("plain variable should be renameable");
+    assert_eq!(rename.name.as_str(), "name");
+    assert_eq!(
+        rename
+            .spans
+            .iter()
+            .map(|span| span.slice(source))
+            .collect::<Vec<_>>(),
+        ["name", "name"]
+    );
+
+    let function_call = span_for_nth(source, "build", 1);
+    let rename = query
+        .rename_set_at_offset(function_call.start.offset)
+        .expect("function call should be renameable");
+    assert_eq!(
+        rename
+            .spans
+            .iter()
+            .map(|span| span.slice(source))
+            .collect::<Vec<_>>(),
+        ["build", "build"]
+    );
+
+    let nameref = span_for_nth(source, "ref", 0);
+    assert_eq!(
+        query.rename_set_at_offset(nameref.start.offset),
+        Err(RenameUnavailable::Nameref)
+    );
+}
+
 fn span_for_nth(source: &str, needle: &str, index: usize) -> Span {
     let start_offset = source
         .match_indices(needle)

--- a/crates/shuck-semantic/src/tests.rs
+++ b/crates/shuck-semantic/src/tests.rs
@@ -386,27 +386,40 @@ outside=1
 
 #[test]
 fn editor_declaration_completion_uses_current_command_segment() {
-    let source = "\
+    for segment in [
+        "echo ok; local ex",
+        "echo ok && local ex",
+        "echo ok || local ex",
+    ] {
+        let source = format!(
+            "\
 existing=1
-build() { echo ok; local ex
-}
-";
-    let output = Parser::with_dialect(source, ShellDialect::Bash)
-        .parse()
-        .unwrap();
-    let indexer = Indexer::new(source, &output);
-    let model = SemanticModel::build(&output.file, source, &indexer);
-    let offset = source.find("local ex").unwrap() + "local ex".len();
-    let names = model
-        .editor_query()
-        .completions_at_offset(source, &indexer, offset, EditorCompletionOptions::default())
-        .expect("declaration completion should be available")
-        .items
-        .into_iter()
-        .map(|item| item.name.to_string())
-        .collect::<Vec<_>>();
+build() {{ {segment}
+}}
+"
+        );
+        let output = Parser::with_dialect(&source, ShellDialect::Bash)
+            .parse()
+            .unwrap();
+        let indexer = Indexer::new(&source, &output);
+        let model = SemanticModel::build(&output.file, &source, &indexer);
+        let offset = source.find("local ex").unwrap() + "local ex".len();
+        let names = model
+            .editor_query()
+            .completions_at_offset(
+                &source,
+                &indexer,
+                offset,
+                EditorCompletionOptions::default(),
+            )
+            .unwrap_or_else(|| panic!("declaration completion should be available for {segment}"))
+            .items
+            .into_iter()
+            .map(|item| item.name.to_string())
+            .collect::<Vec<_>>();
 
-    assert!(names.contains(&"existing".to_owned()));
+        assert!(names.contains(&"existing".to_owned()), "{segment}");
+    }
 }
 
 #[test]

--- a/crates/shuck-server/src/edit.rs
+++ b/crates/shuck-server/src/edit.rs
@@ -215,6 +215,41 @@ pub(crate) fn single_replacement_edit(
     })
 }
 
+pub(crate) fn single_replacement_edit_in_range(
+    text: &str,
+    range: TextRange,
+    replacement: &str,
+    index: &shuck_indexer::LineIndex,
+    encoding: PositionEncoding,
+) -> Option<lsp_types::TextEdit> {
+    let start = usize::from(range.start());
+    let end = usize::from(range.end());
+    let original = text
+        .get(start..end)
+        .expect("replacement range must use valid text boundaries");
+    if original == replacement {
+        return None;
+    }
+
+    let prefix_len = common_prefix_len(original, replacement);
+    let suffix_len = common_suffix_len(&original[prefix_len..], &replacement[prefix_len..]);
+    let original_end = original.len().saturating_sub(suffix_len);
+    let replacement_end = replacement.len().saturating_sub(suffix_len);
+
+    Some(lsp_types::TextEdit {
+        range: to_lsp_range(
+            TextRange::new(
+                shuck_ast::TextSize::new((start + prefix_len) as u32),
+                shuck_ast::TextSize::new((start + original_end) as u32),
+            ),
+            text,
+            index,
+            encoding,
+        ),
+        new_text: replacement[prefix_len..replacement_end].to_owned(),
+    })
+}
+
 fn common_prefix_len(left: &str, right: &str) -> usize {
     left.chars()
         .zip(right.chars())
@@ -261,5 +296,23 @@ mod tests {
         let index = shuck_indexer::LineIndex::new(source);
 
         assert!(single_replacement_edit(source, source, &index, PositionEncoding::UTF16).is_none());
+    }
+
+    #[test]
+    fn ranged_replacement_edit_stays_within_target_range() {
+        let source = "echo one\necho two\n";
+        let index = shuck_indexer::LineIndex::new(source);
+        let edit = single_replacement_edit_in_range(
+            source,
+            TextRange::new(shuck_ast::TextSize::new(9), shuck_ast::TextSize::new(18)),
+            "printf two\n",
+            &index,
+            PositionEncoding::UTF16,
+        )
+        .expect("replacement should produce an edit");
+
+        assert_eq!(edit.range.start, lsp_types::Position::new(1, 0));
+        assert_eq!(edit.range.end, lsp_types::Position::new(1, 4));
+        assert_eq!(edit.new_text, "printf");
     }
 }

--- a/crates/shuck-server/src/editor_features.rs
+++ b/crates/shuck-server/src/editor_features.rs
@@ -212,6 +212,7 @@ pub(crate) fn prepare_rename(
     _client: &Client,
     params: types::TextDocumentPositionParams,
 ) -> crate::server::Result<PrepareRenameResponse> {
+    reject_unsupported_cross_file_rename(&snapshot)?;
     let Some(analysis) = snapshot.analysis() else {
         return Ok(None);
     };
@@ -240,6 +241,7 @@ pub(crate) fn rename(
     _client: &Client,
     params: types::RenameParams,
 ) -> crate::server::Result<RenameResponse> {
+    reject_unsupported_cross_file_rename(&snapshot)?;
     let Some(analysis) = snapshot.analysis() else {
         return Ok(None);
     };
@@ -269,6 +271,16 @@ pub(crate) fn rename(
         &rename,
         &params.new_name,
     )))
+}
+
+fn reject_unsupported_cross_file_rename(snapshot: &DocumentSnapshot) -> crate::server::Result<()> {
+    if snapshot.client_settings().rename().allow_cross_file {
+        return Err(Error::new(
+            anyhow!("cross-file rename is not supported yet"),
+            ErrorCode::InvalidRequest,
+        ));
+    }
+    Ok(())
 }
 
 fn workspace_edit_for_rename(
@@ -429,10 +441,18 @@ mod tests {
 
     use super::*;
     use crate::{
-        Client, GlobalOptions, PositionEncoding, Session, TextDocument, Workspace, Workspaces,
+        Client, ClientOptions, GlobalOptions, PositionEncoding, Session, TextDocument, Workspace,
+        Workspaces,
     };
 
     fn make_snapshot(source: &str) -> (DocumentSnapshot, Client, Url) {
+        make_snapshot_with_options(source, ClientOptions::default())
+    }
+
+    fn make_snapshot_with_options(
+        source: &str,
+        options: ClientOptions,
+    ) -> (DocumentSnapshot, Client, Url) {
         let (main_loop_sender, _main_loop_receiver) = channel::unbounded();
         let (client_sender, _client_receiver) = channel::unbounded();
         let client = Client::new(main_loop_sender, client_sender);
@@ -449,6 +469,7 @@ mod tests {
             &client,
         )
         .expect("session should initialize");
+        session.update_client_options(options);
         let uri = Url::from_file_path(workspace_root.join("script.sh"))
             .expect("script path should convert to URL");
         session.open_text_document(
@@ -626,5 +647,38 @@ mod tests {
         let edits = changes.get(&uri).expect("uri should have edits");
         assert_eq!(edits.len(), 2);
         assert!(edits.iter().all(|edit| edit.new_text == "other"));
+    }
+
+    #[test]
+    fn rename_rejects_cross_file_mode_until_supported() {
+        let source = "name=1\necho \"$name\"\n";
+        let options = serde_json::from_value(serde_json::json!({
+            "server": {
+                "rename": {
+                    "allowCrossFile": true
+                }
+            }
+        }))
+        .expect("rename options should deserialize");
+        let (snapshot, client, uri) = make_snapshot_with_options(source, options);
+        let reference_position = position_for_nth(source, "name", 1);
+
+        let error = rename(
+            snapshot,
+            &client,
+            RenameParams {
+                text_document_position: text_position(uri, reference_position),
+                new_name: "other".to_owned(),
+                work_done_progress_params: WorkDoneProgressParams::default(),
+            },
+        )
+        .expect_err("cross-file rename mode should be rejected until supported");
+
+        assert_eq!(error.code as i32, ErrorCode::InvalidRequest as i32);
+        assert!(
+            error
+                .to_string()
+                .contains("cross-file rename is not supported yet")
+        );
     }
 }

--- a/crates/shuck-server/src/editor_features.rs
+++ b/crates/shuck-server/src/editor_features.rs
@@ -1,0 +1,630 @@
+use std::collections::HashMap;
+
+use anyhow::anyhow;
+use lsp_server::ErrorCode;
+use lsp_types as types;
+use serde::{Deserialize, Serialize};
+use shuck_semantic::{
+    EditorCompletionKind, EditorCompletionOptions, EditorOccurrenceKind, EditorSymbolKind,
+    RenameSet,
+};
+
+use crate::edit::RangeExt;
+use crate::server::Error;
+use crate::session::{Client, DocumentSnapshot};
+
+pub(crate) type CompletionResponse = Option<types::CompletionResponse>;
+pub(crate) type DefinitionResponse = Option<types::GotoDefinitionResponse>;
+pub(crate) type ReferencesResponse = Option<Vec<types::Location>>;
+pub(crate) type DocumentHighlightResponse = Option<Vec<types::DocumentHighlight>>;
+pub(crate) type PrepareRenameResponse = Option<types::PrepareRenameResponse>;
+pub(crate) type RenameResponse = Option<types::WorkspaceEdit>;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", tag = "kind")]
+enum CompletionData {
+    Symbol {
+        symbol_kind: String,
+        line: usize,
+        column: usize,
+    },
+    RuntimeName,
+    Builtin,
+    Keyword,
+}
+
+pub(crate) fn completion(
+    snapshot: DocumentSnapshot,
+    _client: &Client,
+    params: types::CompletionParams,
+) -> crate::server::Result<CompletionResponse> {
+    let Some(analysis) = snapshot.analysis() else {
+        return Ok(None);
+    };
+    let source = analysis.source();
+    let position = params.text_document_position.position;
+    let offset = offset_for_position(&snapshot, source, analysis.line_index(), position);
+    let options = snapshot.client_settings().completion();
+    let completions = analysis.semantic().editor_query().completions_at_offset(
+        source,
+        analysis.indexer(),
+        offset,
+        EditorCompletionOptions {
+            include_runtime_names: options.include_runtime_names,
+            include_keywords: options.include_keywords,
+        },
+    );
+    let Some(completions) = completions else {
+        return Ok(None);
+    };
+    let range = crate::edit::to_lsp_range(
+        completions.replacement_span.to_range(),
+        source,
+        analysis.line_index(),
+        snapshot.encoding(),
+    );
+    let items = completions
+        .items
+        .into_iter()
+        .map(|completion| {
+            let data = match completion.kind {
+                EditorCompletionKind::Variable | EditorCompletionKind::Function => completion
+                    .definition_span
+                    .map(|span| CompletionData::Symbol {
+                        symbol_kind: completion_kind_label(completion.kind).to_owned(),
+                        line: span.start.line,
+                        column: span.start.column,
+                    }),
+                EditorCompletionKind::RuntimeName => Some(CompletionData::RuntimeName),
+                EditorCompletionKind::Builtin => Some(CompletionData::Builtin),
+                EditorCompletionKind::Keyword => Some(CompletionData::Keyword),
+            };
+            types::CompletionItem {
+                label: completion.name.to_string(),
+                kind: Some(to_lsp_completion_kind(completion.kind)),
+                detail: Some(completion_kind_label(completion.kind).to_owned()),
+                text_edit: Some(types::CompletionTextEdit::Edit(types::TextEdit::new(
+                    range,
+                    completion.name.to_string(),
+                ))),
+                data: data.and_then(|data| serde_json::to_value(data).ok()),
+                ..types::CompletionItem::default()
+            }
+        })
+        .collect::<Vec<_>>();
+    Ok(Some(types::CompletionResponse::List(
+        types::CompletionList {
+            is_incomplete: false,
+            items,
+        },
+    )))
+}
+
+pub(crate) fn resolve_completion_item(
+    mut item: types::CompletionItem,
+) -> crate::server::Result<types::CompletionItem> {
+    let Some(data) = item
+        .data
+        .clone()
+        .and_then(|value| serde_json::from_value::<CompletionData>(value).ok())
+    else {
+        return Ok(item);
+    };
+    let documentation = match data {
+        CompletionData::Symbol {
+            symbol_kind,
+            line,
+            column,
+        } => format!("{symbol_kind} defined at line {line}, column {column}."),
+        CompletionData::RuntimeName => "Runtime-provided shell name.".to_owned(),
+        CompletionData::Builtin => "Shell builtin modeled by Shuck.".to_owned(),
+        CompletionData::Keyword => "Shell keyword.".to_owned(),
+    };
+    item.documentation = Some(types::Documentation::MarkupContent(types::MarkupContent {
+        kind: types::MarkupKind::Markdown,
+        value: documentation,
+    }));
+    Ok(item)
+}
+
+pub(crate) fn definition(
+    snapshot: DocumentSnapshot,
+    _client: &Client,
+    params: types::GotoDefinitionParams,
+) -> crate::server::Result<DefinitionResponse> {
+    let Some(analysis) = snapshot.analysis() else {
+        return Ok(None);
+    };
+    let source = analysis.source();
+    let position = params.text_document_position_params.position;
+    let offset = offset_for_position(&snapshot, source, analysis.line_index(), position);
+    let locations = analysis
+        .semantic()
+        .editor_query()
+        .definition_spans_at_offset(offset)
+        .into_iter()
+        .map(|span| location_for_span(&snapshot, source, analysis.line_index(), span))
+        .collect::<Vec<_>>();
+    Ok(match locations.as_slice() {
+        [] => None,
+        [location] => Some(types::GotoDefinitionResponse::Scalar(location.clone())),
+        _ => Some(types::GotoDefinitionResponse::Array(locations)),
+    })
+}
+
+pub(crate) fn references(
+    snapshot: DocumentSnapshot,
+    _client: &Client,
+    params: types::ReferenceParams,
+) -> crate::server::Result<ReferencesResponse> {
+    let Some(analysis) = snapshot.analysis() else {
+        return Ok(None);
+    };
+    let source = analysis.source();
+    let position = params.text_document_position.position;
+    let offset = offset_for_position(&snapshot, source, analysis.line_index(), position);
+    let locations = analysis
+        .semantic()
+        .editor_query()
+        .occurrences_at_offset(offset, params.context.include_declaration)
+        .into_iter()
+        .map(|occurrence| {
+            location_for_span(&snapshot, source, analysis.line_index(), occurrence.span)
+        })
+        .collect::<Vec<_>>();
+    Ok((!locations.is_empty()).then_some(locations))
+}
+
+pub(crate) fn document_highlight(
+    snapshot: DocumentSnapshot,
+    _client: &Client,
+    params: types::DocumentHighlightParams,
+) -> crate::server::Result<DocumentHighlightResponse> {
+    let Some(analysis) = snapshot.analysis() else {
+        return Ok(None);
+    };
+    let source = analysis.source();
+    let position = params.text_document_position_params.position;
+    let offset = offset_for_position(&snapshot, source, analysis.line_index(), position);
+    let highlights = analysis
+        .semantic()
+        .editor_query()
+        .occurrences_at_offset(offset, true)
+        .into_iter()
+        .map(|occurrence| types::DocumentHighlight {
+            range: crate::edit::to_lsp_range(
+                occurrence.span.to_range(),
+                source,
+                analysis.line_index(),
+                snapshot.encoding(),
+            ),
+            kind: Some(match occurrence.kind {
+                EditorOccurrenceKind::Read => types::DocumentHighlightKind::READ,
+                EditorOccurrenceKind::Write => types::DocumentHighlightKind::WRITE,
+            }),
+        })
+        .collect::<Vec<_>>();
+    Ok((!highlights.is_empty()).then_some(highlights))
+}
+
+pub(crate) fn prepare_rename(
+    snapshot: DocumentSnapshot,
+    _client: &Client,
+    params: types::TextDocumentPositionParams,
+) -> crate::server::Result<PrepareRenameResponse> {
+    let Some(analysis) = snapshot.analysis() else {
+        return Ok(None);
+    };
+    let source = analysis.source();
+    let offset = offset_for_position(&snapshot, source, analysis.line_index(), params.position);
+    let Ok(rename) = analysis
+        .semantic()
+        .editor_query()
+        .rename_set_at_offset(offset)
+    else {
+        return Ok(None);
+    };
+    Ok(Some(types::PrepareRenameResponse::RangeWithPlaceholder {
+        range: crate::edit::to_lsp_range(
+            rename.editable_span.to_range(),
+            source,
+            analysis.line_index(),
+            snapshot.encoding(),
+        ),
+        placeholder: rename.name.to_string(),
+    }))
+}
+
+pub(crate) fn rename(
+    snapshot: DocumentSnapshot,
+    _client: &Client,
+    params: types::RenameParams,
+) -> crate::server::Result<RenameResponse> {
+    let Some(analysis) = snapshot.analysis() else {
+        return Ok(None);
+    };
+    let source = analysis.source();
+    let position = params.text_document_position.position;
+    let offset = offset_for_position(&snapshot, source, analysis.line_index(), position);
+    let rename = analysis
+        .semantic()
+        .editor_query()
+        .rename_set_at_offset(offset)
+        .map_err(|reason| {
+            Error::new(
+                anyhow!("rename is not available here: {reason:?}"),
+                ErrorCode::InvalidRequest,
+            )
+        })?;
+    if !new_name_is_valid(rename.kind, &params.new_name) {
+        return Err(Error::new(
+            anyhow!("new name is not valid for this symbol"),
+            ErrorCode::InvalidParams,
+        ));
+    }
+    Ok(Some(workspace_edit_for_rename(
+        &snapshot,
+        source,
+        analysis.line_index(),
+        &rename,
+        &params.new_name,
+    )))
+}
+
+fn workspace_edit_for_rename(
+    snapshot: &DocumentSnapshot,
+    source: &str,
+    line_index: &shuck_indexer::LineIndex,
+    rename: &RenameSet,
+    new_name: &str,
+) -> types::WorkspaceEdit {
+    let mut edits = rename
+        .spans
+        .iter()
+        .copied()
+        .map(|span| {
+            types::TextEdit::new(
+                crate::edit::to_lsp_range(span.to_range(), source, line_index, snapshot.encoding()),
+                new_name.to_owned(),
+            )
+        })
+        .collect::<Vec<_>>();
+    edits.sort_by(|left, right| {
+        right
+            .range
+            .start
+            .line
+            .cmp(&left.range.start.line)
+            .then_with(|| right.range.start.character.cmp(&left.range.start.character))
+    });
+
+    let uri = snapshot.query().file_url().clone();
+    if snapshot.resolved_client_capabilities().document_changes {
+        let edit = types::TextDocumentEdit {
+            text_document: types::OptionalVersionedTextDocumentIdentifier {
+                uri,
+                version: Some(snapshot.query().document().version()),
+            },
+            edits: edits.into_iter().map(types::OneOf::Left).collect(),
+        };
+        return types::WorkspaceEdit {
+            changes: None,
+            document_changes: Some(types::DocumentChanges::Edits(vec![edit])),
+            change_annotations: None,
+        };
+    }
+
+    types::WorkspaceEdit {
+        changes: Some(HashMap::from([(uri, edits)])),
+        document_changes: None,
+        change_annotations: None,
+    }
+}
+
+fn location_for_span(
+    snapshot: &DocumentSnapshot,
+    source: &str,
+    line_index: &shuck_indexer::LineIndex,
+    span: shuck_ast::Span,
+) -> types::Location {
+    types::Location {
+        uri: snapshot.query().file_url().clone(),
+        range: crate::edit::to_lsp_range(span.to_range(), source, line_index, snapshot.encoding()),
+    }
+}
+
+fn offset_for_position(
+    snapshot: &DocumentSnapshot,
+    source: &str,
+    line_index: &shuck_indexer::LineIndex,
+    position: types::Position,
+) -> usize {
+    usize::from(
+        types::Range {
+            start: position,
+            end: position,
+        }
+        .to_text_range(source, line_index, snapshot.encoding())
+        .start(),
+    )
+}
+
+fn to_lsp_completion_kind(kind: EditorCompletionKind) -> types::CompletionItemKind {
+    match kind {
+        EditorCompletionKind::Variable | EditorCompletionKind::RuntimeName => {
+            types::CompletionItemKind::VARIABLE
+        }
+        EditorCompletionKind::Function => types::CompletionItemKind::FUNCTION,
+        EditorCompletionKind::Builtin => types::CompletionItemKind::FUNCTION,
+        EditorCompletionKind::Keyword => types::CompletionItemKind::KEYWORD,
+    }
+}
+
+fn completion_kind_label(kind: EditorCompletionKind) -> &'static str {
+    match kind {
+        EditorCompletionKind::Variable => "Variable",
+        EditorCompletionKind::Function => "Function",
+        EditorCompletionKind::Builtin => "Builtin",
+        EditorCompletionKind::RuntimeName => "Runtime name",
+        EditorCompletionKind::Keyword => "Keyword",
+    }
+}
+
+fn new_name_is_valid(kind: EditorSymbolKind, name: &str) -> bool {
+    match kind {
+        EditorSymbolKind::Function => valid_function_name(name),
+        EditorSymbolKind::Variable
+        | EditorSymbolKind::Array
+        | EditorSymbolKind::AssociativeArray
+        | EditorSymbolKind::Declaration => valid_variable_name(name),
+        EditorSymbolKind::RuntimeName => false,
+    }
+}
+
+fn valid_variable_name(name: &str) -> bool {
+    let mut chars = name.chars();
+    let Some(first) = chars.next() else {
+        return false;
+    };
+    (first == '_' || first.is_ascii_alphabetic())
+        && chars.all(|ch| ch == '_' || ch.is_ascii_alphanumeric())
+}
+
+fn valid_function_name(name: &str) -> bool {
+    !name.is_empty()
+        && !name.chars().any(|ch| {
+            ch.is_whitespace()
+                || matches!(
+                    ch,
+                    '$' | '`'
+                        | '\\'
+                        | '"'
+                        | '\''
+                        | ';'
+                        | '&'
+                        | '|'
+                        | '<'
+                        | '>'
+                        | '('
+                        | ')'
+                        | '{'
+                        | '}'
+                        | '['
+                        | ']'
+                        | '*'
+                        | '?'
+                        | '/'
+                )
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use crossbeam::channel;
+    use lsp_types::{
+        ClientCapabilities, CompletionParams, PartialResultParams, Position, ReferenceContext,
+        ReferenceParams, RenameParams, TextDocumentIdentifier, TextDocumentPositionParams, Url,
+        WorkDoneProgressParams,
+    };
+
+    use super::*;
+    use crate::{
+        Client, GlobalOptions, PositionEncoding, Session, TextDocument, Workspace, Workspaces,
+    };
+
+    fn make_snapshot(source: &str) -> (DocumentSnapshot, Client, Url) {
+        let (main_loop_sender, _main_loop_receiver) = channel::unbounded();
+        let (client_sender, _client_receiver) = channel::unbounded();
+        let client = Client::new(main_loop_sender, client_sender);
+        let workspace_root = std::env::temp_dir().join("shuck-server-editor-feature-tests");
+        let workspace_uri =
+            Url::from_file_path(&workspace_root).expect("workspace path should convert to URL");
+        let workspaces = Workspaces::new(vec![Workspace::default(workspace_uri)]);
+        let global = GlobalOptions::default().into_settings(client.clone());
+        let mut session = Session::new(
+            &ClientCapabilities::default(),
+            PositionEncoding::UTF16,
+            global,
+            &workspaces,
+            &client,
+        )
+        .expect("session should initialize");
+        let uri = Url::from_file_path(workspace_root.join("script.sh"))
+            .expect("script path should convert to URL");
+        session.open_text_document(
+            uri.clone(),
+            TextDocument::new(source.to_owned(), 1).with_language_id("shellscript"),
+        );
+        (
+            session
+                .take_snapshot(uri.clone())
+                .expect("snapshot should exist"),
+            client,
+            uri,
+        )
+    }
+
+    fn position_for_nth(source: &str, needle: &str, index: usize) -> Position {
+        let offset = source
+            .match_indices(needle)
+            .nth(index)
+            .map(|(offset, _)| offset)
+            .expect("needle should exist");
+        let prefix = &source[..offset];
+        let line = prefix.bytes().filter(|byte| *byte == b'\n').count() as u32;
+        let character = prefix
+            .rsplit_once('\n')
+            .map(|(_, tail)| tail.len())
+            .unwrap_or(prefix.len()) as u32;
+        Position { line, character }
+    }
+
+    fn text_position(uri: Url, position: Position) -> TextDocumentPositionParams {
+        TextDocumentPositionParams {
+            text_document: TextDocumentIdentifier { uri },
+            position,
+        }
+    }
+
+    #[test]
+    fn completion_returns_parameter_and_command_candidates() {
+        let source = "build() { :; }\nname=1\nprintf '%s\\n' \"$\"\n";
+        let (snapshot, client, uri) = make_snapshot(source);
+        let parameter_position = Position {
+            line: 2,
+            character: 16,
+        };
+        let response = completion(
+            snapshot.clone(),
+            &client,
+            CompletionParams {
+                text_document_position: text_position(uri.clone(), parameter_position),
+                work_done_progress_params: WorkDoneProgressParams::default(),
+                partial_result_params: PartialResultParams::default(),
+                context: None,
+            },
+        )
+        .expect("completion should succeed")
+        .expect("completion should return items");
+        let types::CompletionResponse::List(list) = response else {
+            panic!("expected completion list");
+        };
+        assert!(list.items.iter().any(|item| item.label == "name"));
+
+        let response = completion(
+            snapshot,
+            &client,
+            CompletionParams {
+                text_document_position: text_position(uri, Position::new(3, 0)),
+                work_done_progress_params: WorkDoneProgressParams::default(),
+                partial_result_params: PartialResultParams::default(),
+                context: None,
+            },
+        )
+        .expect("completion should succeed")
+        .expect("completion should return items");
+        let types::CompletionResponse::List(list) = response else {
+            panic!("expected completion list");
+        };
+        assert!(list.items.iter().any(|item| item.label == "build"));
+        assert!(list.items.iter().any(|item| item.label == "printf"));
+        assert!(list.items.iter().any(|item| item.label == "if"));
+    }
+
+    #[test]
+    fn navigation_references_and_highlights_use_same_symbol_set() {
+        let source = "name=1\necho \"$name\"\n";
+        let (snapshot, client, uri) = make_snapshot(source);
+        let reference_position = position_for_nth(source, "name", 1);
+
+        let definition = definition(
+            snapshot.clone(),
+            &client,
+            lsp_types::GotoDefinitionParams {
+                text_document_position_params: text_position(uri.clone(), reference_position),
+                work_done_progress_params: WorkDoneProgressParams::default(),
+                partial_result_params: PartialResultParams::default(),
+            },
+        )
+        .expect("definition should succeed")
+        .expect("definition should resolve");
+        let types::GotoDefinitionResponse::Scalar(location) = definition else {
+            panic!("expected scalar definition");
+        };
+        assert_eq!(location.range.start, Position::new(0, 0));
+
+        let references = references(
+            snapshot.clone(),
+            &client,
+            ReferenceParams {
+                text_document_position: text_position(uri.clone(), reference_position),
+                work_done_progress_params: WorkDoneProgressParams::default(),
+                partial_result_params: PartialResultParams::default(),
+                context: ReferenceContext {
+                    include_declaration: false,
+                },
+            },
+        )
+        .expect("references should succeed")
+        .expect("references should resolve");
+        assert_eq!(references.len(), 1);
+
+        let highlights = document_highlight(
+            snapshot,
+            &client,
+            lsp_types::DocumentHighlightParams {
+                text_document_position_params: text_position(uri, reference_position),
+                work_done_progress_params: WorkDoneProgressParams::default(),
+                partial_result_params: PartialResultParams::default(),
+            },
+        )
+        .expect("highlights should succeed")
+        .expect("highlights should resolve");
+        assert_eq!(
+            highlights
+                .iter()
+                .map(|highlight| highlight.kind)
+                .collect::<Vec<_>>(),
+            [
+                Some(types::DocumentHighlightKind::WRITE),
+                Some(types::DocumentHighlightKind::READ)
+            ]
+        );
+    }
+
+    #[test]
+    fn prepare_rename_and_rename_return_same_file_edits() {
+        let source = "name=1\necho \"$name\"\n";
+        let (snapshot, client, uri) = make_snapshot(source);
+        let reference_position = position_for_nth(source, "name", 1);
+
+        let prepared = prepare_rename(
+            snapshot.clone(),
+            &client,
+            text_position(uri.clone(), reference_position),
+        )
+        .expect("prepare rename should succeed")
+        .expect("prepare rename should resolve");
+        let types::PrepareRenameResponse::RangeWithPlaceholder { placeholder, .. } = prepared
+        else {
+            panic!("expected range with placeholder");
+        };
+        assert_eq!(placeholder, "name");
+
+        let edit = rename(
+            snapshot,
+            &client,
+            RenameParams {
+                text_document_position: text_position(uri.clone(), reference_position),
+                new_name: "other".to_owned(),
+                work_done_progress_params: WorkDoneProgressParams::default(),
+            },
+        )
+        .expect("rename should succeed")
+        .expect("rename should return edits");
+        let changes = edit.changes.expect("default client should use changes");
+        let edits = changes.get(&uri).expect("uri should have edits");
+        assert_eq!(edits.len(), 2);
+        assert!(edits.iter().all(|edit| edit.new_text == "other"));
+    }
+}

--- a/crates/shuck-server/src/editor_features.rs
+++ b/crates/shuck-server/src/editor_features.rs
@@ -425,6 +425,7 @@ fn valid_function_name(name: &str) -> bool {
                         | ']'
                         | '*'
                         | '?'
+                        | '='
                         | '/'
                 )
         })
@@ -680,5 +681,25 @@ mod tests {
                 .to_string()
                 .contains("cross-file rename is not supported yet")
         );
+    }
+
+    #[test]
+    fn function_rename_rejects_assignment_like_names() {
+        let source = "build() { :; }\nbuild\n";
+        let (snapshot, client, uri) = make_snapshot(source);
+        let call_position = position_for_nth(source, "build", 1);
+
+        let error = rename(
+            snapshot,
+            &client,
+            RenameParams {
+                text_document_position: text_position(uri, call_position),
+                new_name: "foo=bar".to_owned(),
+                work_done_progress_params: WorkDoneProgressParams::default(),
+            },
+        )
+        .expect_err("assignment-like function names should be rejected");
+
+        assert_eq!(error.code as i32, ErrorCode::InvalidParams as i32);
     }
 }

--- a/crates/shuck-server/src/format.rs
+++ b/crates/shuck-server/src/format.rs
@@ -37,7 +37,7 @@ pub(crate) fn format_document(
 
 pub(crate) fn format_range(
     snapshot: DocumentSnapshot,
-    client: &Client,
+    _client: &Client,
     params: types::DocumentRangeFormattingParams,
 ) -> crate::server::Result<FormatResponse> {
     let Some(analysis) = snapshot.analysis() else {
@@ -47,25 +47,45 @@ pub(crate) fn format_range(
     let requested = params
         .range
         .to_text_range(source, analysis.line_index(), snapshot.encoding());
-    if smallest_statement_span_containing(&analysis.parse_result().file.body, requested).is_none() {
+    let Some(statement_span) =
+        smallest_statement_span_containing(&analysis.parse_result().file.body, requested)
+    else {
         return Ok(None);
-    }
-
-    format_document(
-        snapshot,
-        client,
-        types::DocumentFormattingParams {
-            text_document: types::TextDocumentIdentifier {
-                uri: lsp_types::Url::parse("file:///dev/null").expect("static URI should parse"),
-            },
-            options: types::FormattingOptions {
-                tab_size: 8,
-                insert_spaces: false,
-                ..types::FormattingOptions::default()
-            },
-            work_done_progress_params: types::WorkDoneProgressParams::default(),
-        },
+    };
+    let statement_range = statement_span.to_range();
+    let statement_source =
+        &source[usize::from(statement_range.start())..usize::from(statement_range.end())];
+    let formatted = shuck_formatter::format_source(
+        statement_source,
+        snapshot.query().file_path().as_deref(),
+        snapshot.shuck_settings().formatter(),
     )
+    .map_err(Error::new)?;
+
+    Ok(Some(format_response_for_range(
+        source,
+        statement_range,
+        formatted,
+        analysis.line_index(),
+        snapshot.encoding(),
+    )))
+}
+
+fn format_response_for_range(
+    source: &str,
+    range: TextRange,
+    formatted: FormattedSource,
+    line_index: &shuck_indexer::LineIndex,
+    encoding: crate::PositionEncoding,
+) -> Vec<types::TextEdit> {
+    match formatted {
+        FormattedSource::Unchanged => Vec::new(),
+        FormattedSource::Formatted(code) => crate::edit::single_replacement_edit_in_range(
+            source, range, &code, line_index, encoding,
+        )
+        .into_iter()
+        .collect(),
+    }
 }
 
 fn smallest_statement_span_containing(body: &StmtSeq, range: TextRange) -> Option<Span> {
@@ -272,5 +292,23 @@ mod tests {
         .expect("range formatting should succeed");
 
         assert!(edits.is_none());
+    }
+
+    #[test]
+    fn range_formatting_edit_helper_does_not_escape_statement_range() {
+        let source = "echo one\necho two\n";
+        let index = shuck_indexer::LineIndex::new(source);
+        let edits = format_response_for_range(
+            source,
+            TextRange::new(shuck_ast::TextSize::new(9), shuck_ast::TextSize::new(18)),
+            FormattedSource::Formatted("printf two\n".to_owned()),
+            &index,
+            PositionEncoding::UTF16,
+        );
+
+        assert_eq!(edits.len(), 1);
+        assert_eq!(edits[0].range.start, types::Position::new(1, 0));
+        assert_eq!(edits[0].range.end, types::Position::new(1, 4));
+        assert_eq!(edits[0].new_text, "printf");
     }
 }

--- a/crates/shuck-server/src/format.rs
+++ b/crates/shuck-server/src/format.rs
@@ -1,7 +1,9 @@
 use anyhow::Error;
 use lsp_types as types;
+use shuck_ast::{Command, CompoundCommand, Span, Stmt, StmtSeq, TextRange};
 use shuck_formatter::FormattedSource;
 
+use crate::edit::RangeExt;
 use crate::session::{Client, DocumentSnapshot};
 
 pub(crate) type FormatResponse = Option<Vec<types::TextEdit>>;
@@ -36,8 +38,19 @@ pub(crate) fn format_document(
 pub(crate) fn format_range(
     snapshot: DocumentSnapshot,
     client: &Client,
-    _params: types::DocumentRangeFormattingParams,
+    params: types::DocumentRangeFormattingParams,
 ) -> crate::server::Result<FormatResponse> {
+    let Some(analysis) = snapshot.analysis() else {
+        return Ok(None);
+    };
+    let source = analysis.source();
+    let requested = params
+        .range
+        .to_text_range(source, analysis.line_index(), snapshot.encoding());
+    if smallest_statement_span_containing(&analysis.parse_result().file.body, requested).is_none() {
+        return Ok(None);
+    }
+
     format_document(
         snapshot,
         client,
@@ -53,6 +66,107 @@ pub(crate) fn format_range(
             work_done_progress_params: types::WorkDoneProgressParams::default(),
         },
     )
+}
+
+fn smallest_statement_span_containing(body: &StmtSeq, range: TextRange) -> Option<Span> {
+    let mut best = None;
+    collect_statement_span(body, range, &mut best);
+    best
+}
+
+fn collect_statement_span(body: &StmtSeq, range: TextRange, best: &mut Option<Span>) {
+    for stmt in body.as_slice() {
+        if !span_contains_text_range(stmt.span, range) {
+            continue;
+        }
+        record_smaller_span(best, stmt.span);
+        collect_nested_statement_spans(stmt, range, best);
+    }
+}
+
+fn collect_nested_statement_spans(stmt: &Stmt, range: TextRange, best: &mut Option<Span>) {
+    match &stmt.command {
+        Command::Binary(command) => {
+            collect_nested_statement_spans(&command.left, range, best);
+            collect_nested_statement_spans(&command.right, range, best);
+        }
+        Command::Compound(command) => collect_compound_statement_spans(command, range, best),
+        Command::Function(command) => collect_nested_statement_spans(&command.body, range, best),
+        Command::AnonymousFunction(command) => {
+            collect_nested_statement_spans(&command.body, range, best);
+        }
+        Command::Simple(_) | Command::Builtin(_) | Command::Decl(_) => {}
+    }
+}
+
+fn collect_compound_statement_spans(
+    command: &CompoundCommand,
+    range: TextRange,
+    best: &mut Option<Span>,
+) {
+    match command {
+        CompoundCommand::If(command) => {
+            collect_statement_span(&command.condition, range, best);
+            collect_statement_span(&command.then_branch, range, best);
+            for (condition, body) in &command.elif_branches {
+                collect_statement_span(condition, range, best);
+                collect_statement_span(body, range, best);
+            }
+            if let Some(body) = &command.else_branch {
+                collect_statement_span(body, range, best);
+            }
+        }
+        CompoundCommand::For(command) => collect_statement_span(&command.body, range, best),
+        CompoundCommand::Repeat(command) => collect_statement_span(&command.body, range, best),
+        CompoundCommand::Foreach(command) => collect_statement_span(&command.body, range, best),
+        CompoundCommand::ArithmeticFor(command) => {
+            collect_statement_span(&command.body, range, best)
+        }
+        CompoundCommand::While(command) => {
+            collect_statement_span(&command.condition, range, best);
+            collect_statement_span(&command.body, range, best);
+        }
+        CompoundCommand::Until(command) => {
+            collect_statement_span(&command.condition, range, best);
+            collect_statement_span(&command.body, range, best);
+        }
+        CompoundCommand::Case(command) => {
+            for item in &command.cases {
+                collect_statement_span(&item.body, range, best);
+            }
+        }
+        CompoundCommand::Select(command) => collect_statement_span(&command.body, range, best),
+        CompoundCommand::Subshell(body) | CompoundCommand::BraceGroup(body) => {
+            collect_statement_span(body, range, best);
+        }
+        CompoundCommand::Time(command) => {
+            if let Some(command) = &command.command {
+                collect_nested_statement_spans(command, range, best);
+            }
+        }
+        CompoundCommand::Coproc(command) => {
+            collect_nested_statement_spans(&command.body, range, best);
+        }
+        CompoundCommand::Always(command) => {
+            collect_statement_span(&command.body, range, best);
+            collect_statement_span(&command.always_body, range, best);
+        }
+        CompoundCommand::Arithmetic(_) | CompoundCommand::Conditional(_) => {}
+    }
+}
+
+fn record_smaller_span(best: &mut Option<Span>, candidate: Span) {
+    if best.is_none_or(|current| span_width(candidate) < span_width(current)) {
+        *best = Some(candidate);
+    }
+}
+
+fn span_width(span: Span) -> usize {
+    span.end.offset.saturating_sub(span.start.offset)
+}
+
+fn span_contains_text_range(span: Span, range: TextRange) -> bool {
+    span.start.offset <= usize::from(range.start()) && usize::from(range.end()) <= span.end.offset
 }
 
 #[cfg(test)]
@@ -114,5 +228,49 @@ mod tests {
         .expect("range formatting should return an edit list");
 
         assert!(edits.is_empty());
+    }
+
+    #[test]
+    fn range_formatting_returns_none_for_ranges_without_one_complete_statement() {
+        let (main_loop_sender, _main_loop_receiver) = channel::unbounded();
+        let (client_sender, _client_receiver) = channel::unbounded();
+        let client = Client::new(main_loop_sender, client_sender);
+        let workspace_root = std::env::temp_dir().join("shuck-server-format-tests-partial");
+        let workspace_uri =
+            Url::from_file_path(&workspace_root).expect("workspace path should convert to a URL");
+        let workspaces = Workspaces::new(vec![Workspace::default(workspace_uri)]);
+        let global = GlobalOptions::default().into_settings(client.clone());
+        let mut session = Session::new(
+            &ClientCapabilities::default(),
+            PositionEncoding::UTF16,
+            global,
+            &workspaces,
+            &client,
+        )
+        .expect("test session should initialize");
+
+        let uri = Url::from_file_path(workspace_root.join("script.sh"))
+            .expect("script path should convert to a URL");
+        session.open_text_document(
+            uri.clone(),
+            TextDocument::new("echo one\necho two\n".to_owned(), 1).with_language_id("shellscript"),
+        );
+        let snapshot = session
+            .take_snapshot(uri.clone())
+            .expect("test document should produce a snapshot");
+
+        let edits = format_range(
+            snapshot,
+            &client,
+            types::DocumentRangeFormattingParams {
+                text_document: types::TextDocumentIdentifier { uri },
+                range: types::Range::new(types::Position::new(0, 2), types::Position::new(1, 2)),
+                options: types::FormattingOptions::default(),
+                work_done_progress_params: types::WorkDoneProgressParams::default(),
+            },
+        )
+        .expect("range formatting should succeed");
+
+        assert!(edits.is_none());
     }
 }

--- a/crates/shuck-server/src/lib.rs
+++ b/crates/shuck-server/src/lib.rs
@@ -19,6 +19,7 @@ pub use workspace::{Workspace, Workspaces};
 mod analysis;
 mod edit;
 mod editor;
+mod editor_features;
 mod fix;
 mod format;
 mod lint;

--- a/crates/shuck-server/src/server.rs
+++ b/crates/shuck-server/src/server.rs
@@ -146,8 +146,16 @@ impl Server {
                 }),
                 file_operations: None,
             }),
-            document_formatting_provider: None,
-            document_range_formatting_provider: None,
+            completion_provider: Some(types::CompletionOptions {
+                resolve_provider: Some(true),
+                trigger_characters: Some(vec!["$".to_owned(), "{".to_owned()]),
+                ..types::CompletionOptions::default()
+            }),
+            definition_provider: Some(OneOf::Left(true)),
+            references_provider: Some(OneOf::Left(true)),
+            document_highlight_provider: Some(OneOf::Left(true)),
+            document_formatting_provider: Some(OneOf::Left(true)),
+            document_range_formatting_provider: Some(OneOf::Left(true)),
             document_symbol_provider: Some(OneOf::Left(true)),
             workspace_symbol_provider: Some(OneOf::Right(types::WorkspaceSymbolOptions {
                 work_done_progress_options: WorkDoneProgressOptions {
@@ -174,6 +182,12 @@ impl Server {
                 },
             }),
             hover_provider: Some(types::HoverProviderCapability::Simple(true)),
+            rename_provider: Some(OneOf::Right(types::RenameOptions {
+                prepare_provider: Some(true),
+                work_done_progress_options: WorkDoneProgressOptions {
+                    work_done_progress: Some(true),
+                },
+            })),
             text_document_sync: Some(TextDocumentSyncCapability::Options(
                 TextDocumentSyncOptions {
                     open_close: Some(true),
@@ -302,10 +316,32 @@ mod tests {
     use crate::Client;
 
     #[test]
-    fn does_not_advertise_formatting_capabilities() {
+    fn advertises_formatting_capabilities() {
         let capabilities = Server::server_capabilities(PositionEncoding::UTF16);
-        assert!(capabilities.document_formatting_provider.is_none());
-        assert!(capabilities.document_range_formatting_provider.is_none());
+        assert_eq!(
+            capabilities.document_formatting_provider,
+            Some(OneOf::Left(true))
+        );
+        assert_eq!(
+            capabilities.document_range_formatting_provider,
+            Some(OneOf::Left(true))
+        );
+    }
+
+    #[test]
+    fn advertises_navigation_completion_and_rename_capabilities() {
+        let capabilities = Server::server_capabilities(PositionEncoding::UTF16);
+        assert!(capabilities.completion_provider.is_some());
+        assert_eq!(capabilities.definition_provider, Some(OneOf::Left(true)));
+        assert_eq!(capabilities.references_provider, Some(OneOf::Left(true)));
+        assert_eq!(
+            capabilities.document_highlight_provider,
+            Some(OneOf::Left(true))
+        );
+        let Some(OneOf::Right(rename)) = capabilities.rename_provider else {
+            panic!("expected rename options");
+        };
+        assert_eq!(rename.prepare_provider, Some(true));
     }
 
     #[test]

--- a/crates/shuck-server/src/server/api.rs
+++ b/crates/shuck-server/src/server/api.rs
@@ -42,8 +42,18 @@ pub(super) fn request(req: server::Request) -> Task {
         request::CodeActionResolve::METHOD => {
             sync_request_task::<request::CodeActionResolve>(req)
         }
+        request::Completion::METHOD => {
+            background_request_task::<request::Completion>(req, BackgroundSchedule::Worker)
+        }
+        request::CompletionResolve::METHOD => sync_request_task::<request::CompletionResolve>(req),
+        request::Definition::METHOD => {
+            background_request_task::<request::Definition>(req, BackgroundSchedule::Worker)
+        }
         request::DocumentDiagnostic::METHOD => {
             background_request_task::<request::DocumentDiagnostic>(req, BackgroundSchedule::Worker)
+        }
+        request::DocumentHighlight::METHOD => {
+            background_request_task::<request::DocumentHighlight>(req, BackgroundSchedule::Worker)
         }
         request::DocumentSymbols::METHOD => {
             background_request_task::<request::DocumentSymbols>(req, BackgroundSchedule::Worker)
@@ -57,6 +67,15 @@ pub(super) fn request(req: server::Request) -> Task {
         }
         request::Hover::METHOD => {
             background_request_task::<request::Hover>(req, BackgroundSchedule::Worker)
+        }
+        request::PrepareRename::METHOD => {
+            background_request_task::<request::PrepareRename>(req, BackgroundSchedule::Worker)
+        }
+        request::References::METHOD => {
+            background_request_task::<request::References>(req, BackgroundSchedule::Worker)
+        }
+        request::Rename::METHOD => {
+            background_request_task::<request::Rename>(req, BackgroundSchedule::Worker)
         }
         request::WorkspaceSymbols::METHOD => {
             background_session_request_task::<request::WorkspaceSymbols>(

--- a/crates/shuck-server/src/server/api/requests.rs
+++ b/crates/shuck-server/src/server/api/requests.rs
@@ -1,11 +1,18 @@
 mod code_action;
 mod code_action_resolve;
+mod completion;
+mod completion_resolve;
+mod definition;
 mod diagnostic;
+mod document_highlight;
 mod document_symbol;
 mod execute_command;
 mod format;
 mod format_range;
 mod hover;
+mod prepare_rename;
+mod references;
+mod rename;
 mod shutdown;
 mod workspace_symbol;
 
@@ -16,11 +23,18 @@ use super::{
 
 pub(super) use code_action::CodeActions;
 pub(super) use code_action_resolve::CodeActionResolve;
+pub(super) use completion::Completion;
+pub(super) use completion_resolve::CompletionResolve;
+pub(super) use definition::Definition;
 pub(super) use diagnostic::DocumentDiagnostic;
+pub(super) use document_highlight::DocumentHighlight;
 pub(super) use document_symbol::DocumentSymbols;
 pub(super) use execute_command::ExecuteCommand;
 pub(super) use format::Format;
 pub(super) use format_range::FormatRange;
 pub(super) use hover::Hover;
+pub(super) use prepare_rename::PrepareRename;
+pub(super) use references::References;
+pub(super) use rename::Rename;
 pub(super) use shutdown::ShutdownHandler;
 pub(super) use workspace_symbol::WorkspaceSymbols;

--- a/crates/shuck-server/src/server/api/requests/completion.rs
+++ b/crates/shuck-server/src/server/api/requests/completion.rs
@@ -1,0 +1,31 @@
+use lsp_types::{self as types, request as req};
+
+use crate::editor_features;
+use crate::session::{Client, DocumentSnapshot};
+
+pub(crate) struct Completion;
+
+impl super::RequestHandler for Completion {
+    type RequestType = req::Completion;
+}
+
+impl super::BackgroundDocumentRequestHandler for Completion {
+    fn document_url(params: &types::CompletionParams) -> std::borrow::Cow<'_, types::Url> {
+        std::borrow::Cow::Borrowed(&params.text_document_position.text_document.uri)
+    }
+
+    fn run_without_snapshot(
+        _client: &Client,
+        _params: types::CompletionParams,
+    ) -> crate::server::Result<editor_features::CompletionResponse> {
+        Ok(None)
+    }
+
+    fn run_with_snapshot(
+        snapshot: DocumentSnapshot,
+        client: &Client,
+        params: types::CompletionParams,
+    ) -> crate::server::Result<editor_features::CompletionResponse> {
+        editor_features::completion(snapshot, client, params)
+    }
+}

--- a/crates/shuck-server/src/server/api/requests/completion_resolve.rs
+++ b/crates/shuck-server/src/server/api/requests/completion_resolve.rs
@@ -1,0 +1,20 @@
+use lsp_types::{self as types, request as req};
+
+use crate::editor_features;
+use crate::session::{Client, Session};
+
+pub(crate) struct CompletionResolve;
+
+impl super::RequestHandler for CompletionResolve {
+    type RequestType = req::ResolveCompletionItem;
+}
+
+impl super::SyncRequestHandler for CompletionResolve {
+    fn run(
+        _session: &mut Session,
+        _client: &Client,
+        params: types::CompletionItem,
+    ) -> crate::server::Result<types::CompletionItem> {
+        editor_features::resolve_completion_item(params)
+    }
+}

--- a/crates/shuck-server/src/server/api/requests/definition.rs
+++ b/crates/shuck-server/src/server/api/requests/definition.rs
@@ -1,0 +1,31 @@
+use lsp_types::{self as types, request as req};
+
+use crate::editor_features;
+use crate::session::{Client, DocumentSnapshot};
+
+pub(crate) struct Definition;
+
+impl super::RequestHandler for Definition {
+    type RequestType = req::GotoDefinition;
+}
+
+impl super::BackgroundDocumentRequestHandler for Definition {
+    fn document_url(params: &types::GotoDefinitionParams) -> std::borrow::Cow<'_, types::Url> {
+        std::borrow::Cow::Borrowed(&params.text_document_position_params.text_document.uri)
+    }
+
+    fn run_without_snapshot(
+        _client: &Client,
+        _params: types::GotoDefinitionParams,
+    ) -> crate::server::Result<editor_features::DefinitionResponse> {
+        Ok(None)
+    }
+
+    fn run_with_snapshot(
+        snapshot: DocumentSnapshot,
+        client: &Client,
+        params: types::GotoDefinitionParams,
+    ) -> crate::server::Result<editor_features::DefinitionResponse> {
+        editor_features::definition(snapshot, client, params)
+    }
+}

--- a/crates/shuck-server/src/server/api/requests/document_highlight.rs
+++ b/crates/shuck-server/src/server/api/requests/document_highlight.rs
@@ -1,0 +1,31 @@
+use lsp_types::{self as types, request as req};
+
+use crate::editor_features;
+use crate::session::{Client, DocumentSnapshot};
+
+pub(crate) struct DocumentHighlight;
+
+impl super::RequestHandler for DocumentHighlight {
+    type RequestType = req::DocumentHighlightRequest;
+}
+
+impl super::BackgroundDocumentRequestHandler for DocumentHighlight {
+    fn document_url(params: &types::DocumentHighlightParams) -> std::borrow::Cow<'_, types::Url> {
+        std::borrow::Cow::Borrowed(&params.text_document_position_params.text_document.uri)
+    }
+
+    fn run_without_snapshot(
+        _client: &Client,
+        _params: types::DocumentHighlightParams,
+    ) -> crate::server::Result<editor_features::DocumentHighlightResponse> {
+        Ok(None)
+    }
+
+    fn run_with_snapshot(
+        snapshot: DocumentSnapshot,
+        client: &Client,
+        params: types::DocumentHighlightParams,
+    ) -> crate::server::Result<editor_features::DocumentHighlightResponse> {
+        editor_features::document_highlight(snapshot, client, params)
+    }
+}

--- a/crates/shuck-server/src/server/api/requests/prepare_rename.rs
+++ b/crates/shuck-server/src/server/api/requests/prepare_rename.rs
@@ -1,0 +1,33 @@
+use lsp_types::{self as types, request as req};
+
+use crate::editor_features;
+use crate::session::{Client, DocumentSnapshot};
+
+pub(crate) struct PrepareRename;
+
+impl super::RequestHandler for PrepareRename {
+    type RequestType = req::PrepareRenameRequest;
+}
+
+impl super::BackgroundDocumentRequestHandler for PrepareRename {
+    fn document_url(
+        params: &types::TextDocumentPositionParams,
+    ) -> std::borrow::Cow<'_, types::Url> {
+        std::borrow::Cow::Borrowed(&params.text_document.uri)
+    }
+
+    fn run_without_snapshot(
+        _client: &Client,
+        _params: types::TextDocumentPositionParams,
+    ) -> crate::server::Result<editor_features::PrepareRenameResponse> {
+        Ok(None)
+    }
+
+    fn run_with_snapshot(
+        snapshot: DocumentSnapshot,
+        client: &Client,
+        params: types::TextDocumentPositionParams,
+    ) -> crate::server::Result<editor_features::PrepareRenameResponse> {
+        editor_features::prepare_rename(snapshot, client, params)
+    }
+}

--- a/crates/shuck-server/src/server/api/requests/references.rs
+++ b/crates/shuck-server/src/server/api/requests/references.rs
@@ -1,0 +1,31 @@
+use lsp_types::{self as types, request as req};
+
+use crate::editor_features;
+use crate::session::{Client, DocumentSnapshot};
+
+pub(crate) struct References;
+
+impl super::RequestHandler for References {
+    type RequestType = req::References;
+}
+
+impl super::BackgroundDocumentRequestHandler for References {
+    fn document_url(params: &types::ReferenceParams) -> std::borrow::Cow<'_, types::Url> {
+        std::borrow::Cow::Borrowed(&params.text_document_position.text_document.uri)
+    }
+
+    fn run_without_snapshot(
+        _client: &Client,
+        _params: types::ReferenceParams,
+    ) -> crate::server::Result<editor_features::ReferencesResponse> {
+        Ok(None)
+    }
+
+    fn run_with_snapshot(
+        snapshot: DocumentSnapshot,
+        client: &Client,
+        params: types::ReferenceParams,
+    ) -> crate::server::Result<editor_features::ReferencesResponse> {
+        editor_features::references(snapshot, client, params)
+    }
+}

--- a/crates/shuck-server/src/server/api/requests/rename.rs
+++ b/crates/shuck-server/src/server/api/requests/rename.rs
@@ -1,0 +1,31 @@
+use lsp_types::{self as types, request as req};
+
+use crate::editor_features;
+use crate::session::{Client, DocumentSnapshot};
+
+pub(crate) struct Rename;
+
+impl super::RequestHandler for Rename {
+    type RequestType = req::Rename;
+}
+
+impl super::BackgroundDocumentRequestHandler for Rename {
+    fn document_url(params: &types::RenameParams) -> std::borrow::Cow<'_, types::Url> {
+        std::borrow::Cow::Borrowed(&params.text_document_position.text_document.uri)
+    }
+
+    fn run_without_snapshot(
+        _client: &Client,
+        _params: types::RenameParams,
+    ) -> crate::server::Result<editor_features::RenameResponse> {
+        Ok(None)
+    }
+
+    fn run_with_snapshot(
+        snapshot: DocumentSnapshot,
+        client: &Client,
+        params: types::RenameParams,
+    ) -> crate::server::Result<editor_features::RenameResponse> {
+        editor_features::rename(snapshot, client, params)
+    }
+}

--- a/crates/shuck-server/src/session.rs
+++ b/crates/shuck-server/src/session.rs
@@ -16,7 +16,10 @@ pub(crate) use self::capabilities::ResolvedClientCapabilities;
 pub use self::index::DocumentQuery;
 pub(crate) use self::index::WorkspaceSettingsSnapshot;
 pub(crate) use self::options::{AllOptions, WorkspaceOptionsMap};
-pub use self::options::{ClientOptions, GlobalOptions, WorkspaceSymbolFeatureOptions};
+pub use self::options::{
+    ClientOptions, CompletionFeatureOptions, GlobalOptions, RenameFeatureOptions,
+    WorkspaceSymbolFeatureOptions,
+};
 pub(crate) use self::settings::ShuckSettings;
 pub use client::Client;
 

--- a/crates/shuck-server/src/session/options.rs
+++ b/crates/shuck-server/src/session/options.rs
@@ -64,7 +64,13 @@ impl ClientOptions {
 pub struct ServerOptions {
     /// Workspace-wide symbol search configuration.
     pub workspace_symbols: WorkspaceSymbolFeatureOptions,
+    /// Completion configuration.
+    pub completion: CompletionFeatureOptions,
+    /// Rename configuration.
+    pub rename: RenameFeatureOptions,
     workspace_symbols_overrides: WorkspaceSymbolFeatureOptionsOverrides,
+    completion_overrides: CompletionFeatureOptionsOverrides,
+    rename_overrides: RenameFeatureOptionsOverrides,
 }
 
 impl ServerOptions {
@@ -76,6 +82,29 @@ impl ServerOptions {
             self.workspace_symbols_overrides.apply_to(base)
         } else if self.workspace_symbols != WorkspaceSymbolFeatureOptions::default() {
             self.workspace_symbols
+        } else {
+            base
+        }
+    }
+
+    pub(crate) fn completion_layered_over(
+        &self,
+        base: CompletionFeatureOptions,
+    ) -> CompletionFeatureOptions {
+        if self.completion_overrides.has_overrides() {
+            self.completion_overrides.apply_to(base)
+        } else if self.completion != CompletionFeatureOptions::default() {
+            self.completion
+        } else {
+            base
+        }
+    }
+
+    pub(crate) fn rename_layered_over(&self, base: RenameFeatureOptions) -> RenameFeatureOptions {
+        if self.rename_overrides.has_overrides() {
+            self.rename_overrides.apply_to(base)
+        } else if self.rename != RenameFeatureOptions::default() {
+            self.rename
         } else {
             base
         }
@@ -92,6 +121,10 @@ impl<'de> Deserialize<'de> for ServerOptions {
         struct RawServerOptions {
             #[serde(default)]
             workspace_symbols: WorkspaceSymbolFeatureOptionsOverrides,
+            #[serde(default)]
+            completion: CompletionFeatureOptionsOverrides,
+            #[serde(default)]
+            rename: RenameFeatureOptionsOverrides,
         }
 
         let raw = RawServerOptions::deserialize(deserializer)?;
@@ -99,7 +132,11 @@ impl<'de> Deserialize<'de> for ServerOptions {
             workspace_symbols: raw
                 .workspace_symbols
                 .apply_to(WorkspaceSymbolFeatureOptions::default()),
+            completion: raw.completion.apply_to(CompletionFeatureOptions::default()),
+            rename: raw.rename.apply_to(RenameFeatureOptions::default()),
             workspace_symbols_overrides: raw.workspace_symbols,
+            completion_overrides: raw.completion,
+            rename_overrides: raw.rename,
         })
     }
 }
@@ -138,6 +175,79 @@ pub struct WorkspaceSymbolFeatureOptions {
     pub max_files: usize,
 }
 
+#[derive(Clone, Copy, Debug, Default, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+struct CompletionFeatureOptionsOverrides {
+    #[serde(default)]
+    include_runtime_names: Option<bool>,
+    #[serde(default)]
+    include_keywords: Option<bool>,
+}
+
+impl CompletionFeatureOptionsOverrides {
+    fn has_overrides(self) -> bool {
+        self.include_runtime_names.is_some() || self.include_keywords.is_some()
+    }
+
+    fn apply_to(self, base: CompletionFeatureOptions) -> CompletionFeatureOptions {
+        CompletionFeatureOptions {
+            include_runtime_names: self
+                .include_runtime_names
+                .unwrap_or(base.include_runtime_names),
+            include_keywords: self.include_keywords.unwrap_or(base.include_keywords),
+        }
+    }
+}
+
+/// Configuration for `textDocument/completion`.
+#[derive(Clone, Copy, Debug, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct CompletionFeatureOptions {
+    /// Include runtime-provided parameter names.
+    #[serde(default = "default_completion_include_runtime_names")]
+    pub include_runtime_names: bool,
+    /// Include shell keywords in command-position completion.
+    #[serde(default = "default_completion_include_keywords")]
+    pub include_keywords: bool,
+}
+
+impl Default for CompletionFeatureOptions {
+    fn default() -> Self {
+        Self {
+            include_runtime_names: true,
+            include_keywords: true,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Default, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+struct RenameFeatureOptionsOverrides {
+    #[serde(default)]
+    allow_cross_file: Option<bool>,
+}
+
+impl RenameFeatureOptionsOverrides {
+    fn has_overrides(self) -> bool {
+        self.allow_cross_file.is_some()
+    }
+
+    fn apply_to(self, base: RenameFeatureOptions) -> RenameFeatureOptions {
+        RenameFeatureOptions {
+            allow_cross_file: self.allow_cross_file.unwrap_or(base.allow_cross_file),
+        }
+    }
+}
+
+/// Configuration for rename requests.
+#[derive(Clone, Copy, Debug, Default, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct RenameFeatureOptions {
+    /// Allow rename edits outside the current document.
+    #[serde(default)]
+    pub allow_cross_file: bool,
+}
+
 impl Default for WorkspaceSymbolFeatureOptions {
     fn default() -> Self {
         Self {
@@ -153,6 +263,14 @@ fn default_workspace_symbols_enabled() -> bool {
 
 fn default_workspace_symbols_max_files() -> usize {
     5000
+}
+
+fn default_completion_include_runtime_names() -> bool {
+    true
+}
+
+fn default_completion_include_keywords() -> bool {
+    true
 }
 
 #[derive(Debug, Deserialize, Default)]

--- a/crates/shuck-server/src/session/settings.rs
+++ b/crates/shuck-server/src/session/settings.rs
@@ -14,13 +14,17 @@ use shuck_linter::{
     RuleSet, ShellDialect as LinterShellDialect,
 };
 
-use crate::session::{ClientOptions, WorkspaceSymbolFeatureOptions};
+use crate::session::{
+    ClientOptions, CompletionFeatureOptions, RenameFeatureOptions, WorkspaceSymbolFeatureOptions,
+};
 
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub(crate) struct ClientSettings {
     fix_all: bool,
     unsafe_fixes: bool,
     show_syntax_errors: bool,
+    completion: CompletionFeatureOptions,
+    rename: RenameFeatureOptions,
 }
 
 #[derive(Clone, Debug)]
@@ -70,6 +74,14 @@ impl ClientSettings {
         self.show_syntax_errors
     }
 
+    pub(crate) fn completion(&self) -> CompletionFeatureOptions {
+        self.completion
+    }
+
+    pub(crate) fn rename(&self) -> RenameFeatureOptions {
+        self.rename
+    }
+
     pub(crate) fn from_options(options: &ClientOptions) -> Self {
         Self::from_layered_options(&[options])
     }
@@ -78,6 +90,8 @@ impl ClientSettings {
         let mut fix_all = None;
         let mut unsafe_fixes = None;
         let mut show_syntax_errors = None;
+        let mut completion = CompletionFeatureOptions::default();
+        let mut rename = RenameFeatureOptions::default();
 
         for options in option_layers {
             if options.fix_all.is_some() {
@@ -89,12 +103,16 @@ impl ClientSettings {
             if options.show_syntax_errors.is_some() {
                 show_syntax_errors = options.show_syntax_errors;
             }
+            completion = options.server.completion_layered_over(completion);
+            rename = options.server.rename_layered_over(rename);
         }
 
         Self {
             fix_all: fix_all.unwrap_or(true),
             unsafe_fixes: unsafe_fixes.unwrap_or(false),
             show_syntax_errors: show_syntax_errors.unwrap_or(false),
+            completion,
+            rename,
         }
     }
 }

--- a/crates/shuck-server/tests/manual.rs
+++ b/crates/shuck-server/tests/manual.rs
@@ -99,8 +99,31 @@ fn replays_a_small_lsp_session() {
         }),
     );
     let initialize = recv_response(&client_connection, 1);
-    assert!(initialize["capabilities"]["documentFormattingProvider"].is_null());
-    assert!(initialize["capabilities"]["documentRangeFormattingProvider"].is_null());
+    assert_eq!(
+        initialize["capabilities"]["documentFormattingProvider"],
+        serde_json::json!(true)
+    );
+    assert_eq!(
+        initialize["capabilities"]["documentRangeFormattingProvider"],
+        serde_json::json!(true)
+    );
+    assert_eq!(
+        initialize["capabilities"]["definitionProvider"],
+        serde_json::json!(true)
+    );
+    assert_eq!(
+        initialize["capabilities"]["referencesProvider"],
+        serde_json::json!(true)
+    );
+    assert_eq!(
+        initialize["capabilities"]["documentHighlightProvider"],
+        serde_json::json!(true)
+    );
+    assert!(initialize["capabilities"]["completionProvider"].is_object());
+    assert_eq!(
+        initialize["capabilities"]["renameProvider"]["prepareProvider"],
+        serde_json::json!(true)
+    );
 
     client_connection
         .sender

--- a/crates/shuck-server/tests/manual/README.md
+++ b/crates/shuck-server/tests/manual/README.md
@@ -34,10 +34,13 @@ python3 crates/shuck-server/tests/manual/run_neovim_blackbox.py --case code_acti
 Available scenarios:
 
 - `diagnostics/open_edit`
+- `completion/semantic_completion`
 - `hover/rule_directive`
 - `hover/semantic_symbol`
+- `navigation/definition_references_highlights`
 - `symbols/document_symbols`
 - `symbols/workspace_symbols`
+- `rename/same_file`
 - `code_actions/quick_fix`
 - `code_actions/fix_all`
 - `formatting/request_round_trip`
@@ -48,6 +51,5 @@ temporary workspace, launches `nvim --headless`, and exits non-zero if either
 the Neovim-side assertions or the server transport fail.
 
 The formatting scenario currently verifies request round-trip behavior only.
-`shuck-server` does not advertise formatting capabilities yet, and
 `shuck-formatter` is still a no-op stub, so the expected result today is an
 empty edit list rather than rewritten buffer contents.

--- a/crates/shuck-server/tests/manual/fixtures/workspace/completion/semantic_completion.sh
+++ b/crates/shuck-server/tests/manual/fixtures/workspace/completion/semantic_completion.sh
@@ -6,6 +6,7 @@ outer() {
   local local_name=2
   echo "$top_level"
   echo "${top_level}"
+  echo ok; local to
 }
 
 other() {

--- a/crates/shuck-server/tests/manual/fixtures/workspace/completion/semantic_completion.sh
+++ b/crates/shuck-server/tests/manual/fixtures/workspace/completion/semantic_completion.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+top_level=1
+
+outer() {
+  local local_name=2
+  echo "$top_level"
+  echo "${top_level}"
+}
+
+other() {
+  local hidden_name=3
+  :
+}
+
+build() {
+  :
+}
+
+b

--- a/crates/shuck-server/tests/manual/fixtures/workspace/navigation/definition_references_highlights.sh
+++ b/crates/shuck-server/tests/manual/fixtures/workspace/navigation/definition_references_highlights.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+name=world
+
+greet() {
+  printf '%s\n' "$name"
+}
+
+greet

--- a/crates/shuck-server/tests/manual/fixtures/workspace/rename/same_file.sh
+++ b/crates/shuck-server/tests/manual/fixtures/workspace/rename/same_file.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+name=world
+echo "$name"
+
+shadowed() {
+  local name=shadow
+  echo "$name"
+}
+
+echo "$1"
+echo "$?"
+declare -n ref=name
+echo "$ref"

--- a/crates/shuck-server/tests/manual/lua/shuck_server_blackbox/completion/semantic_completion.lua
+++ b/crates/shuck-server/tests/manual/lua/shuck_server_blackbox/completion/semantic_completion.lua
@@ -1,0 +1,76 @@
+local M = {}
+
+local function completion_items(result)
+  assert(result ~= nil, "expected completion response")
+  return result.items or result
+end
+
+local function labels_for(items)
+  local labels = {}
+  for _, item in ipairs(items) do
+    labels[item.label] = item
+  end
+  return labels
+end
+
+local function assert_has(labels, label)
+  assert(labels[label] ~= nil, "expected completion label " .. label)
+end
+
+local function assert_missing(labels, label)
+  assert(labels[label] == nil, "did not expect completion label " .. label)
+end
+
+local function complete_at(t, bufnr, position)
+  return completion_items(t.buffer_request_sync(bufnr, "textDocument/completion", {
+    textDocument = t.document_identifier(bufnr),
+    position = position,
+  }, 5000))
+end
+
+function M.run(t)
+  local bufnr, client_id = t.open_fixture("completion/semantic_completion.sh")
+  local client = t.client(bufnr, client_id)
+
+  assert(
+    client.server_capabilities.completionProvider ~= nil,
+    "expected completionProvider to be advertised"
+  )
+  assert(
+    client.server_capabilities.completionProvider.resolveProvider == true,
+    "expected completion resolve support"
+  )
+
+  local parameter_labels = labels_for(complete_at(t, bufnr, t.position_after_nth(bufnr, "$", 0)))
+  assert_has(parameter_labels, "local_name")
+  assert_has(parameter_labels, "top_level")
+  assert_missing(parameter_labels, "hidden_name")
+  assert_missing(parameter_labels, "build")
+
+  local braced_labels = labels_for(complete_at(t, bufnr, t.position_after_nth(bufnr, "${", 0)))
+  assert_has(braced_labels, "local_name")
+  assert_has(braced_labels, "top_level")
+  assert_missing(braced_labels, "hidden_name")
+
+  local command_labels = labels_for(complete_at(t, bufnr, t.position_after_nth(bufnr, "b", 2)))
+  assert_has(command_labels, "build")
+  assert_has(command_labels, "break")
+  assert_missing(command_labels, "top_level")
+  assert_missing(command_labels, "local_name")
+
+  local resolved_variable =
+    t.client_request_sync(client, "completionItem/resolve", parameter_labels.top_level, bufnr, 5000)
+  assert(
+    resolved_variable.documentation.value:find("Variable defined at", 1, true),
+    "expected variable completion documentation"
+  )
+
+  local resolved_builtin =
+    t.client_request_sync(client, "completionItem/resolve", command_labels["break"], bufnr, 5000)
+  assert(
+    resolved_builtin.documentation.value:find("Shell builtin modeled by Shuck.", 1, true),
+    "expected builtin completion documentation"
+  )
+end
+
+return M

--- a/crates/shuck-server/tests/manual/lua/shuck_server_blackbox/completion/semantic_completion.lua
+++ b/crates/shuck-server/tests/manual/lua/shuck_server_blackbox/completion/semantic_completion.lua
@@ -52,6 +52,11 @@ function M.run(t)
   assert_has(braced_labels, "top_level")
   assert_missing(braced_labels, "hidden_name")
 
+  local declaration_labels = labels_for(complete_at(t, bufnr, t.position_after_nth(bufnr, "local to", 0)))
+  assert_has(declaration_labels, "top_level")
+  assert_missing(declaration_labels, "hidden_name")
+  assert_missing(declaration_labels, "build")
+
   local command_labels = labels_for(complete_at(t, bufnr, t.position_after_nth(bufnr, "b", 2)))
   assert_has(command_labels, "build")
   assert_has(command_labels, "break")

--- a/crates/shuck-server/tests/manual/lua/shuck_server_blackbox/navigation/definition_references_highlights.lua
+++ b/crates/shuck-server/tests/manual/lua/shuck_server_blackbox/navigation/definition_references_highlights.lua
@@ -1,0 +1,76 @@
+local M = {}
+
+local READ = 2
+local WRITE = 3
+
+local function sorted_start_lines(locations)
+  local lines = {}
+  for _, location in ipairs(locations or {}) do
+    table.insert(lines, location.range.start.line)
+  end
+  table.sort(lines)
+  return lines
+end
+
+local function highlight_kinds(highlights)
+  local kinds = {}
+  for _, highlight in ipairs(highlights or {}) do
+    table.insert(kinds, highlight.kind)
+  end
+  table.sort(kinds)
+  return kinds
+end
+
+function M.run(t)
+  local bufnr, client_id = t.open_fixture("navigation/definition_references_highlights.sh")
+  local client = t.client(bufnr, client_id)
+
+  assert(client.server_capabilities.definitionProvider == true, "expected definitionProvider")
+  assert(client.server_capabilities.referencesProvider == true, "expected referencesProvider")
+  assert(
+    client.server_capabilities.documentHighlightProvider == true,
+    "expected documentHighlightProvider"
+  )
+
+  local function_call = t.position_for_nth(bufnr, "greet", 1)
+  local definition = t.buffer_request_sync(bufnr, "textDocument/definition", {
+    textDocument = t.document_identifier(bufnr),
+    position = function_call,
+  }, 5000)
+
+  assert(definition ~= nil, "expected function definition location")
+  assert(definition.range.start.line == 3, "expected function definition line: " .. vim.inspect(definition))
+  assert(definition.range.start.character == 0, "expected function definition column")
+
+  local variable_reference = t.position_for_nth(bufnr, "name", 1)
+  local references_without_declaration = t.buffer_request_sync(bufnr, "textDocument/references", {
+    textDocument = t.document_identifier(bufnr),
+    position = variable_reference,
+    context = { includeDeclaration = false },
+  }, 5000)
+  assert(
+    vim.deep_equal(sorted_start_lines(references_without_declaration), { 4 }),
+    "expected only read reference: " .. vim.inspect(references_without_declaration)
+  )
+
+  local references_with_declaration = t.buffer_request_sync(bufnr, "textDocument/references", {
+    textDocument = t.document_identifier(bufnr),
+    position = variable_reference,
+    context = { includeDeclaration = true },
+  }, 5000)
+  assert(
+    vim.deep_equal(sorted_start_lines(references_with_declaration), { 1, 4 }),
+    "expected declaration plus read reference: " .. vim.inspect(references_with_declaration)
+  )
+
+  local highlights = t.buffer_request_sync(bufnr, "textDocument/documentHighlight", {
+    textDocument = t.document_identifier(bufnr),
+    position = variable_reference,
+  }, 5000)
+  assert(
+    vim.deep_equal(highlight_kinds(highlights), { READ, WRITE }),
+    "expected read and write highlights: " .. vim.inspect(highlights)
+  )
+end
+
+return M

--- a/crates/shuck-server/tests/manual/lua/shuck_server_blackbox/rename/same_file.lua
+++ b/crates/shuck-server/tests/manual/lua/shuck_server_blackbox/rename/same_file.lua
@@ -1,0 +1,80 @@
+local M = {}
+
+local function workspace_edit_count(edit)
+  if edit.documentChanges ~= nil then
+    local count = 0
+    for _, change in ipairs(edit.documentChanges) do
+      count = count + #(change.edits or {})
+    end
+    return count
+  end
+
+  local count = 0
+  for _, edits in pairs(edit.changes or {}) do
+    count = count + #edits
+  end
+  return count
+end
+
+local function prepare_rename(t, bufnr, position)
+  return t.buffer_request_sync(bufnr, "textDocument/prepareRename", {
+    textDocument = t.document_identifier(bufnr),
+    position = position,
+  }, 5000)
+end
+
+function M.run(t)
+  local bufnr, client_id = t.open_fixture("rename/same_file.sh")
+  local client = t.client(bufnr, client_id)
+
+  assert(client.server_capabilities.renameProvider ~= nil, "expected renameProvider")
+  assert(
+    client.server_capabilities.renameProvider.prepareProvider == true,
+    "expected prepareRename support"
+  )
+
+  local top_level_reference = t.position_for_nth(bufnr, "name", 1)
+  local prepared = prepare_rename(t, bufnr, top_level_reference)
+  assert(prepared ~= nil, "expected top-level variable to be renameable")
+  assert(prepared.placeholder == "name", "expected original placeholder")
+
+  local edit = t.buffer_request_sync(bufnr, "textDocument/rename", {
+    textDocument = t.document_identifier(bufnr),
+    position = top_level_reference,
+    newName = "target_name",
+  }, 5000)
+  assert(edit ~= nil, "expected rename edit")
+  assert(workspace_edit_count(edit) == 2, "expected two edits: " .. vim.inspect(edit))
+
+  t.apply_workspace_edit(client, edit)
+  t.wait_for_buffer_lines(bufnr, {
+    "#!/usr/bin/env bash",
+    "target_name=world",
+    "echo \"$target_name\"",
+    "",
+    "shadowed() {",
+    "  local name=shadow",
+    "  echo \"$name\"",
+    "}",
+    "",
+    "echo \"$1\"",
+    "echo \"$?\"",
+    "declare -n ref=name",
+    "echo \"$ref\"",
+  })
+
+  assert(
+    prepare_rename(t, bufnr, t.position_after_nth(bufnr, "$1", 0)) == nil,
+    "expected positional parameter rename to be rejected"
+  )
+  assert(
+    prepare_rename(t, bufnr, t.position_after_nth(bufnr, "$?", 0)) == nil,
+    "expected special parameter rename to be rejected"
+  )
+  assert(
+    prepare_rename(t, bufnr, t.position_for_nth(bufnr, "ref", 1)) == nil,
+    "expected nameref rename to be rejected"
+  )
+end
+
+return M

--- a/crates/shuck-server/tests/manual/lua/shuck_server_blackbox/support.lua
+++ b/crates/shuck-server/tests/manual/lua/shuck_server_blackbox/support.lua
@@ -131,6 +131,44 @@ function M.buffer_text(bufnr)
   return table.concat(M.buffer_lines(bufnr), "\n")
 end
 
+function M.document_identifier(bufnr)
+  return { uri = vim.uri_from_bufnr(bufnr) }
+end
+
+function M.position_for_nth(bufnr, needle, index)
+  local text = M.buffer_text(bufnr)
+  local start = 1
+  local found
+  for _ = 0, index do
+    found = string.find(text, needle, start, true)
+    assert(found ~= nil, "failed to find " .. vim.inspect(needle) .. " occurrence " .. tostring(index))
+    start = found + #needle
+  end
+
+  local before = string.sub(text, 1, found - 1)
+  local line = 0
+  local line_start = 1
+  while true do
+    local newline = string.find(before, "\n", line_start, true)
+    if newline == nil then
+      break
+    end
+    line = line + 1
+    line_start = newline + 1
+  end
+
+  return {
+    line = line,
+    character = #string.sub(before, line_start),
+  }
+end
+
+function M.position_after_nth(bufnr, needle, index)
+  local position = M.position_for_nth(bufnr, needle, index)
+  position.character = position.character + #needle
+  return position
+end
+
 function M.set_buffer_contents(bufnr, lines)
   vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, lines)
 end
@@ -207,10 +245,6 @@ function M.client_request_sync(client, method, params, bufnr, timeout_ms)
   return result
 end
 
-local function document_identifier(bufnr)
-  return { uri = vim.uri_from_bufnr(bufnr) }
-end
-
 function M.document_range(bufnr)
   local line_count = vim.api.nvim_buf_line_count(bufnr)
   local last_line = vim.api.nvim_buf_get_lines(bufnr, line_count - 1, line_count, false)[1] or ""
@@ -225,7 +259,7 @@ end
 
 function M.pull_diagnostics(bufnr)
   local report = M.buffer_request_sync(bufnr, "textDocument/diagnostic", {
-    textDocument = document_identifier(bufnr),
+    textDocument = M.document_identifier(bufnr),
   }, 5000)
 
   if report == nil then
@@ -255,7 +289,7 @@ end
 function M.code_actions(bufnr, diagnostics, opts)
   opts = opts or {}
   return M.buffer_request_sync(bufnr, "textDocument/codeAction", {
-    textDocument = document_identifier(bufnr),
+    textDocument = M.document_identifier(bufnr),
     range = opts.range or diagnostics[1].range or M.document_range(bufnr),
     context = {
       diagnostics = diagnostics,
@@ -293,7 +327,7 @@ end
 
 function M.hover_at(bufnr, line, character)
   local result = M.buffer_request_sync(bufnr, "textDocument/hover", {
-    textDocument = document_identifier(bufnr),
+    textDocument = M.document_identifier(bufnr),
     position = { line = line, character = character },
   }, 5000)
   assert(result ~= nil, "hover response was empty")

--- a/crates/shuck-server/tests/manual/run_neovim_blackbox.py
+++ b/crates/shuck-server/tests/manual/run_neovim_blackbox.py
@@ -18,10 +18,13 @@ FIXTURE_ROOT = MANUAL_ROOT / "fixtures" / "workspace"
 
 SCENARIOS = [
     "diagnostics/open_edit",
+    "completion/semantic_completion",
     "hover/rule_directive",
     "hover/semantic_symbol",
+    "navigation/definition_references_highlights",
     "symbols/document_symbols",
     "symbols/workspace_symbols",
+    "rename/same_file",
     "code_actions/quick_fix",
     "code_actions/fix_all",
     "formatting/request_round_trip",


### PR DESCRIPTION
Summary
- Add semantic editor queries and LSP handlers for completion, definition, references, document highlights, and rename.
- Wire server capabilities/settings and request routing for the new editor features.
- Add Criterion editor benchmarks and expand tests for the new LSP behavior.

Verification
- make test
- cargo fmt --all --check
- cargo clippy -p shuck-server -p shuck-cli -p shuck-semantic -p shuck-benchmark --all-targets -- -D warnings
- make test-large-corpus
- make test-large-corpus SHUCK_LARGE_CORPUS_TIMING=1
- cargo bench -p shuck-benchmark --bench editor -- --noplot
- cargo bench -p shuck-benchmark --bench formatter -- --noplot