### PR TITLE
test(server): add LSP fuzz coverage

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -40,6 +40,9 @@ jobs:
           # - formatter_consistency_fuzz
           # - formatter_validity_fuzz
           - linter_no_panic_fuzz
+          - lsp_document_sync_fuzz
+          - lsp_request_surface_fuzz
+          - lsp_protocol_sequence_fuzz
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -181,6 +181,14 @@ Available `cargo-fuzz` targets:
 - `glob_fuzz`
 - `recovered_parser_fuzz`
 - `linter_no_panic_fuzz`
+- `lsp_document_sync_fuzz`
+- `lsp_request_surface_fuzz`
+- `lsp_protocol_sequence_fuzz`
+
+The LSP fuzz targets exercise document synchronization, editor request handlers, and bounded
+in-memory protocol transcripts. Invalid generated LSP inputs may return normal LSP errors; fuzz
+failures are panics, hangs, invalid response ranges/edits, malformed serializations, or server
+sessions that do not shut down cleanly.
 
 Run the CLI generator-driven fuzzer:
 

--- a/Makefile
+++ b/Makefile
@@ -56,6 +56,9 @@ fuzz-smoke:
 	bash -lc '$(FUZZ_CARGO_ENV) cd fuzz && cargo +nightly fuzz run $(FUZZ_SANITIZER_ARG) recovered_parser_fuzz -- $(FUZZ_SMOKE_ARGS)'
 	# bash -lc '$(FUZZ_CARGO_ENV) cd fuzz && cargo +nightly fuzz run $(FUZZ_SANITIZER_ARG) formatter_consistency_fuzz -- $(FUZZ_SMOKE_ARGS)'
 	bash -lc '$(FUZZ_CARGO_ENV) cd fuzz && cargo +nightly fuzz run $(FUZZ_SANITIZER_ARG) linter_no_panic_fuzz -- $(FUZZ_SMOKE_ARGS)'
+	bash -lc '$(FUZZ_CARGO_ENV) cd fuzz && cargo +nightly fuzz run $(FUZZ_SANITIZER_ARG) lsp_document_sync_fuzz -- $(FUZZ_SMOKE_ARGS)'
+	bash -lc '$(FUZZ_CARGO_ENV) cd fuzz && cargo +nightly fuzz run $(FUZZ_SANITIZER_ARG) lsp_request_surface_fuzz -- $(FUZZ_SMOKE_ARGS)'
+	bash -lc '$(FUZZ_CARGO_ENV) cd fuzz && cargo +nightly fuzz run $(FUZZ_SANITIZER_ARG) lsp_protocol_sequence_fuzz -- $(FUZZ_SMOKE_ARGS)'
 
 fuzz-run:
 	test -n "$(FUZZ_TARGET)"

--- a/crates/shuck-server/Cargo.toml
+++ b/crates/shuck-server/Cargo.toml
@@ -8,6 +8,9 @@ authors.workspace = true
 repository.workspace = true
 description = "Language server scaffold for shuck"
 
+[features]
+fuzzing = []
+
 [dependencies]
 anyhow = { workspace = true }
 crossbeam = { workspace = true }

--- a/crates/shuck-server/src/fuzzing.rs
+++ b/crates/shuck-server/src/fuzzing.rs
@@ -1,0 +1,346 @@
+//! Fuzz-only harnesses for exercising private LSP server surfaces.
+
+use std::path::PathBuf;
+
+use anyhow::{Context, anyhow};
+use crossbeam::channel;
+use lsp_types as types;
+use serde::Serialize;
+use serde_json::json;
+
+use crate::edit::DocumentVersion;
+use crate::session::{ClientOptions, GlobalOptions};
+use crate::{Client, PositionEncoding, Session, TextDocument, Workspace, Workspaces};
+
+/// Input for the direct LSP request-surface fuzz harness.
+#[derive(Clone, Debug)]
+pub struct RequestSurfaceInput<'a> {
+    /// Source text to open as an in-memory document.
+    pub source: &'a str,
+    /// LSP language identifier supplied by the client.
+    pub language_id: &'a str,
+    /// File name used for shell dialect inference.
+    pub file_name: &'a str,
+    /// Position encoding negotiated with the client.
+    pub encoding: PositionEncoding,
+    /// Client capabilities used to resolve response shapes.
+    pub capabilities: types::ClientCapabilities,
+    /// Client options layered over default Shuck settings.
+    pub client_options: ClientOptions,
+    /// Position used by hover, completion, navigation, and rename requests.
+    pub position: types::Position,
+    /// Range used by code action and range-formatting requests.
+    pub range: types::Range,
+    /// Candidate replacement name for rename requests.
+    pub new_name: &'a str,
+    /// Query string for workspace symbol requests.
+    pub workspace_query: &'a str,
+}
+
+/// Final state after applying LSP text document changes.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct TextDocumentState {
+    /// Current document contents.
+    pub contents: String,
+    /// Current document version.
+    pub version: DocumentVersion,
+}
+
+/// Apply LSP text document changes through the server document type.
+pub fn apply_text_document_changes(
+    source: &str,
+    version: DocumentVersion,
+    changes: Vec<types::TextDocumentContentChangeEvent>,
+    new_version: DocumentVersion,
+    encoding: PositionEncoding,
+) -> TextDocumentState {
+    let mut document =
+        TextDocument::new(source.to_owned(), version).with_language_id("shellscript");
+    document.apply_changes(changes, new_version, encoding);
+    TextDocumentState {
+        contents: document.contents().to_owned(),
+        version: document.version(),
+    }
+}
+
+/// Exercise diagnostics, fixes, editor features, symbols, and formatting.
+pub fn exercise_request_surface(
+    input: RequestSurfaceInput<'_>,
+) -> anyhow::Result<Vec<serde_json::Value>> {
+    let (mut session, client, _client_receiver, uri) = build_session(
+        input.encoding,
+        input.capabilities,
+        input.client_options,
+        input.file_name,
+    )?;
+    session.open_text_document(
+        uri.clone(),
+        TextDocument::new(input.source.to_owned(), 1).with_language_id(input.language_id),
+    );
+    let Some(snapshot) = session.take_snapshot(uri.clone()) else {
+        return Err(anyhow!("opened fuzz document did not produce a snapshot"));
+    };
+
+    let mut outputs = Vec::new();
+    let diagnostics = crate::lint::generate_diagnostics(&snapshot);
+    record_value(&mut outputs, "textDocument/diagnostic", &diagnostics)?;
+
+    let code_actions = crate::fix::code_actions(
+        snapshot.clone(),
+        &client,
+        types::CodeActionParams {
+            text_document: text_document_identifier(uri.clone()),
+            range: input.range,
+            context: types::CodeActionContext {
+                diagnostics: diagnostics.clone(),
+                only: None,
+                trigger_kind: None,
+            },
+            work_done_progress_params: types::WorkDoneProgressParams::default(),
+            partial_result_params: types::PartialResultParams::default(),
+        },
+    );
+    if let Some(Some(actions)) =
+        record_server_result(&mut outputs, "textDocument/codeAction", code_actions)?
+    {
+        for action in actions.into_iter().take(4) {
+            let types::CodeActionOrCommand::CodeAction(action) = action else {
+                continue;
+            };
+            let resolved = crate::fix::resolve_code_action(&session, &client, action);
+            let _ = record_server_result(&mut outputs, "codeAction/resolve", resolved)?;
+        }
+    }
+
+    let text_position = text_document_position(uri.clone(), input.position);
+    let hover = crate::resolve::hover(
+        snapshot.clone(),
+        &client,
+        types::HoverParams {
+            text_document_position_params: text_position.clone(),
+            work_done_progress_params: types::WorkDoneProgressParams::default(),
+        },
+    );
+    let _ = record_server_result(&mut outputs, "textDocument/hover", hover)?;
+
+    let completion = crate::editor_features::completion(
+        snapshot.clone(),
+        &client,
+        types::CompletionParams {
+            text_document_position: text_position.clone(),
+            work_done_progress_params: types::WorkDoneProgressParams::default(),
+            partial_result_params: types::PartialResultParams::default(),
+            context: None,
+        },
+    );
+    if let Some(Some(completion)) =
+        record_server_result(&mut outputs, "textDocument/completion", completion)?
+    {
+        let items = match completion {
+            types::CompletionResponse::Array(items) => items,
+            types::CompletionResponse::List(list) => list.items,
+        };
+        for item in items.into_iter().take(4) {
+            let resolved = crate::editor_features::resolve_completion_item(item);
+            let _ = record_server_result(&mut outputs, "completionItem/resolve", resolved)?;
+        }
+    }
+
+    let definition = crate::editor_features::definition(
+        snapshot.clone(),
+        &client,
+        types::GotoDefinitionParams {
+            text_document_position_params: text_position.clone(),
+            work_done_progress_params: types::WorkDoneProgressParams::default(),
+            partial_result_params: types::PartialResultParams::default(),
+        },
+    );
+    let _ = record_server_result(&mut outputs, "textDocument/definition", definition)?;
+
+    let references = crate::editor_features::references(
+        snapshot.clone(),
+        &client,
+        types::ReferenceParams {
+            text_document_position: text_position.clone(),
+            work_done_progress_params: types::WorkDoneProgressParams::default(),
+            partial_result_params: types::PartialResultParams::default(),
+            context: types::ReferenceContext {
+                include_declaration: true,
+            },
+        },
+    );
+    let _ = record_server_result(&mut outputs, "textDocument/references", references)?;
+
+    let highlights = crate::editor_features::document_highlight(
+        snapshot.clone(),
+        &client,
+        types::DocumentHighlightParams {
+            text_document_position_params: text_position.clone(),
+            work_done_progress_params: types::WorkDoneProgressParams::default(),
+            partial_result_params: types::PartialResultParams::default(),
+        },
+    );
+    let _ = record_server_result(&mut outputs, "textDocument/documentHighlight", highlights)?;
+
+    let prepare_rename =
+        crate::editor_features::prepare_rename(snapshot.clone(), &client, text_position.clone());
+    let _ = record_server_result(&mut outputs, "textDocument/prepareRename", prepare_rename)?;
+
+    let rename = crate::editor_features::rename(
+        snapshot.clone(),
+        &client,
+        types::RenameParams {
+            text_document_position: text_position,
+            new_name: input.new_name.to_owned(),
+            work_done_progress_params: types::WorkDoneProgressParams::default(),
+        },
+    );
+    let _ = record_server_result(&mut outputs, "textDocument/rename", rename)?;
+
+    let document_symbols = crate::symbols::document_symbols(
+        snapshot.clone(),
+        &client,
+        types::DocumentSymbolParams {
+            text_document: text_document_identifier(uri.clone()),
+            work_done_progress_params: types::WorkDoneProgressParams::default(),
+            partial_result_params: types::PartialResultParams::default(),
+        },
+    );
+    let _ = record_server_result(
+        &mut outputs,
+        "textDocument/documentSymbol",
+        document_symbols,
+    )?;
+
+    let workspace_symbols = crate::symbols::workspace_symbols(
+        session.workspace_symbol_context(),
+        &client,
+        types::WorkspaceSymbolParams {
+            query: input.workspace_query.to_owned(),
+            work_done_progress_params: types::WorkDoneProgressParams::default(),
+            partial_result_params: types::PartialResultParams::default(),
+        },
+    );
+    let _ = record_server_result(&mut outputs, "workspace/symbol", workspace_symbols)?;
+
+    let format_document = crate::format::format_document(
+        snapshot.clone(),
+        &client,
+        types::DocumentFormattingParams {
+            text_document: text_document_identifier(uri.clone()),
+            options: types::FormattingOptions {
+                tab_size: 4,
+                insert_spaces: true,
+                ..types::FormattingOptions::default()
+            },
+            work_done_progress_params: types::WorkDoneProgressParams::default(),
+        },
+    );
+    let _ = record_server_result(&mut outputs, "textDocument/formatting", format_document)?;
+
+    let format_range = crate::format::format_range(
+        snapshot,
+        &client,
+        types::DocumentRangeFormattingParams {
+            text_document: text_document_identifier(uri),
+            range: input.range,
+            options: types::FormattingOptions {
+                tab_size: 4,
+                insert_spaces: true,
+                ..types::FormattingOptions::default()
+            },
+            work_done_progress_params: types::WorkDoneProgressParams::default(),
+        },
+    );
+    let _ = record_server_result(&mut outputs, "textDocument/rangeFormatting", format_range)?;
+
+    Ok(outputs)
+}
+
+fn build_session(
+    encoding: PositionEncoding,
+    capabilities: types::ClientCapabilities,
+    client_options: ClientOptions,
+    file_name: &str,
+) -> anyhow::Result<(
+    Session,
+    Client,
+    channel::Receiver<lsp_server::Message>,
+    types::Url,
+)> {
+    let (main_loop_sender, _main_loop_receiver) = channel::unbounded();
+    let (client_sender, client_receiver) = channel::unbounded();
+    let client = Client::new(main_loop_sender, client_sender);
+    let workspace_root = fuzz_workspace_root()?;
+    let workspace_uri = types::Url::from_file_path(&workspace_root)
+        .map_err(|()| anyhow!("failed to build fuzz workspace URI"))?;
+    let workspaces = Workspaces::new(vec![Workspace::default(workspace_uri)]);
+    let global = GlobalOptions::default().into_settings(client.clone());
+    let mut session = Session::new(&capabilities, encoding, global, &workspaces, &client)?;
+    session.update_client_options(client_options);
+    let uri = types::Url::from_file_path(workspace_root.join(file_name))
+        .map_err(|()| anyhow!("failed to build fuzz document URI"))?;
+    Ok((session, client, client_receiver, uri))
+}
+
+fn fuzz_workspace_root() -> anyhow::Result<PathBuf> {
+    let root = std::env::temp_dir().join(format!("shuck-lsp-fuzz-{}", std::process::id()));
+    std::fs::create_dir_all(&root)
+        .with_context(|| format!("create fuzz workspace {}", root.display()))?;
+    Ok(root)
+}
+
+fn text_document_identifier(uri: types::Url) -> types::TextDocumentIdentifier {
+    types::TextDocumentIdentifier { uri }
+}
+
+fn text_document_position(
+    uri: types::Url,
+    position: types::Position,
+) -> types::TextDocumentPositionParams {
+    types::TextDocumentPositionParams {
+        text_document: text_document_identifier(uri),
+        position,
+    }
+}
+
+fn record_server_result<T>(
+    outputs: &mut Vec<serde_json::Value>,
+    method: &str,
+    result: crate::server::Result<T>,
+) -> anyhow::Result<Option<T>>
+where
+    T: Serialize,
+{
+    match result {
+        Ok(value) => {
+            record_value(outputs, method, &value)?;
+            Ok(Some(value))
+        }
+        Err(error) => {
+            outputs.push(json!({
+                "method": method,
+                "ok": false,
+                "code": error.code as i32,
+                "message": error.to_string(),
+            }));
+            Ok(None)
+        }
+    }
+}
+
+fn record_value<T>(
+    outputs: &mut Vec<serde_json::Value>,
+    method: &str,
+    value: &T,
+) -> anyhow::Result<()>
+where
+    T: Serialize,
+{
+    outputs.push(json!({
+        "method": method,
+        "ok": true,
+        "result": serde_json::to_value(value)?,
+    }));
+    Ok(())
+}

--- a/crates/shuck-server/src/lib.rs
+++ b/crates/shuck-server/src/lib.rs
@@ -22,6 +22,9 @@ mod editor;
 mod editor_features;
 mod fix;
 mod format;
+#[cfg(feature = "fuzzing")]
+#[doc(hidden)]
+pub mod fuzzing;
 mod lint;
 mod logging;
 mod resolve;

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -12,6 +12,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
+
+[[package]]
+name = "anstyle-parse"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -24,10 +74,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
 
 [[package]]
+name = "arraydeque"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d902e3d592a523def97af8f317b08ce16b7ab854c1985a0c671e6f15cebc236"
+
+[[package]]
+name = "autocfg"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
 name = "bitflags"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+
+[[package]]
+name = "block-buffer"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
+dependencies = [
+ "hybrid-array",
+]
 
 [[package]]
 name = "bstr"
@@ -67,6 +144,52 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "clap"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
+
+[[package]]
 name = "compact_str"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -81,16 +204,169 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crossbeam"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1137cd7e7fc0fb5d3c5a8678be38ec56e819125d8d7907411fe24ccb943faca8"
+dependencies = [
+ "crossbeam-channel",
+ "crossbeam-deque",
+ "crossbeam-epoch",
+ "crossbeam-queue",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-queue"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f58bbc28f91df819d0aa2a2c00cd19754769c2fad90579b3592b1c9ba7a3115"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crypto-common"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77727bb15fa921304124b128af125e7e3b968275d1b108b379190264f4423710"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer",
+ "const-oid",
+ "crypto-common",
+]
+
+[[package]]
+name = "displaydoc"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "etcetera"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "136d1b5283a1ab77bd9257427ffd09d8667ced0570b6f938942bc7568ed5b943"
+dependencies = [
+ "cfg-if",
+ "home",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "form_urlencoded"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
+dependencies = [
+ "percent-encoding",
+]
 
 [[package]]
 name = "getrandom"
@@ -119,9 +395,170 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+
+[[package]]
+name = "hashlink"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
+dependencies = [
+ "hashbrown 0.15.5",
+]
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "home"
+version = "0.5.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da"
+dependencies = [
+ "typenum",
+]
+
+[[package]]
+name = "icu_collections"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "utf8_iter",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
+dependencies = [
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
+
+[[package]]
+name = "icu_properties"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
+dependencies = [
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
+
+[[package]]
+name = "icu_provider"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+]
+
+[[package]]
+name = "ignore"
+version = "0.4.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3d782a365a015e0f5c04902246139249abf769125006fbe7649e2ee88169b4a"
+dependencies = [
+ "crossbeam-deque",
+ "globset",
+ "log",
+ "memchr",
+ "regex-automata",
+ "same-file",
+ "walkdir",
+ "winapi-util",
+]
 
 [[package]]
 name = "indexmap"
@@ -130,8 +567,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.17.0",
 ]
+
+[[package]]
+name = "is_terminal_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "itoa"
@@ -150,6 +593,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
 name = "libc"
 version = "0.2.184"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -166,16 +615,105 @@ dependencies = [
 ]
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
+name = "litemap"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
+
+[[package]]
 name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
+name = "lsp-server"
+version = "0.7.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d6ada348dbc2703cbe7637b2dda05cff84d3da2819c24abcb305dd613e0ba2e"
+dependencies = [
+ "crossbeam-channel",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+]
+
+[[package]]
+name = "lsp-types"
+version = "0.95.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e34d33a8e9b006cd3fc4fe69a921affa097bae4bb65f76271f4644f9a334365"
+dependencies = [
+ "bitflags 1.3.2",
+ "serde",
+ "serde_json",
+ "serde_repr",
+ "url",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "once_cell"
+version = "1.21.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "once_cell_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "ordered-float"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7d950ca161dc355eaf28f82b11345ed76c6e1f6eb1f4f4479e0323b9e2fbd0e"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "percent-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "potential_utf"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
+dependencies = [
+ "zerovec",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -225,6 +763,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags 2.11.0",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -235,6 +786,38 @@ name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
+name = "saphyr"
+version = "0.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3767dfe8889ebb55a21409df2b6f36e66abfbe1eb92d64ff76ae799d3f91016"
+dependencies = [
+ "arraydeque",
+ "encoding_rs",
+ "hashlink",
+ "ordered-float",
+ "saphyr-parser",
+]
+
+[[package]]
+name = "saphyr-parser"
+version = "0.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fb771b59f6b1985d1406325ec28f97cfb14256abcec4fdfb37b36a1766d6af7"
+dependencies = [
+ "arraydeque",
+ "hashlink",
+]
 
 [[package]]
 name = "serde"
@@ -267,6 +850,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_json"
+version = "1.0.149"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+dependencies = [
+ "itoa",
+ "memchr",
+ "serde",
+ "serde_core",
+ "zmij",
+]
+
+[[package]]
+name = "serde_repr"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_yaml"
 version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -277,6 +893,26 @@ dependencies = [
  "ryu",
  "serde",
  "unsafe-libyaml",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
 ]
 
 [[package]]
@@ -293,14 +929,57 @@ dependencies = [
 ]
 
 [[package]]
+name = "shuck-config"
+version = "0.0.40"
+dependencies = [
+ "anyhow",
+ "clap",
+ "serde",
+ "shuck-formatter",
+ "shuck-run",
+ "toml",
+]
+
+[[package]]
+name = "shuck-discover"
+version = "0.0.40"
+dependencies = [
+ "anyhow",
+ "globset",
+ "ignore",
+ "shuck-config",
+ "shuck-extract",
+ "shuck-linter",
+ "shuck-parser",
+]
+
+[[package]]
+name = "shuck-extract"
+version = "0.0.40"
+dependencies = [
+ "anyhow",
+ "saphyr",
+ "saphyr-parser",
+]
+
+[[package]]
+name = "shuck-formatter"
+version = "0.0.40"
+
+[[package]]
 name = "shuck-fuzz"
 version = "0.0.0"
 dependencies = [
+ "crossbeam",
  "libfuzzer-sys",
+ "lsp-server",
+ "lsp-types",
+ "serde_json",
  "shuck-ast",
  "shuck-indexer",
  "shuck-linter",
  "shuck-parser",
+ "shuck-server",
  "similar",
 ]
 
@@ -340,16 +1019,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "shuck-run"
+version = "0.0.40"
+dependencies = [
+ "anyhow",
+ "etcetera",
+ "serde",
+ "serde_json",
+ "sha2",
+ "shuck-parser",
+ "tempfile",
+ "toml",
+ "url",
+]
+
+[[package]]
 name = "shuck-semantic"
 version = "0.0.40"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "compact_str",
  "rustc-hash",
  "shuck-ast",
  "shuck-indexer",
  "shuck-parser",
  "smallvec",
+]
+
+[[package]]
+name = "shuck-server"
+version = "0.0.40"
+dependencies = [
+ "anyhow",
+ "crossbeam",
+ "globset",
+ "lsp-server",
+ "lsp-types",
+ "rustc-hash",
+ "serde",
+ "serde_json",
+ "sha2",
+ "shuck-ast",
+ "shuck-config",
+ "shuck-discover",
+ "shuck-formatter",
+ "shuck-indexer",
+ "shuck-linter",
+ "shuck-parser",
+ "shuck-semantic",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -365,10 +1084,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
 name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
@@ -379,6 +1110,30 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -402,6 +1157,114 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "tinystr"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
+dependencies = [
+ "displaydoc",
+ "zerovec",
+]
+
+[[package]]
+name = "toml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_write",
+ "winnow",
+]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
+
+[[package]]
+name = "tracing"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
+dependencies = [
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
+dependencies = [
+ "sharded-slab",
+ "thread_local",
+ "tracing-core",
+]
+
+[[package]]
+name = "typenum"
+version = "1.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -414,6 +1277,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
+name = "url"
+version = "2.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+ "serde",
+ "serde_derive",
+]
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
 name = "wasip2"
 version = "1.0.2+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -423,7 +1321,195 @@ dependencies = [
 ]
 
 [[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
+
+[[package]]
+name = "winnow"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "wit-bindgen"
 version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+
+[[package]]
+name = "writeable"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
+name = "yoke"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
+dependencies = [
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "zerofrom"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "zerotrie"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -8,13 +8,18 @@ edition = "2024"
 cargo-fuzz = true
 
 [dependencies]
+crossbeam = "0.8.4"
 libfuzzer-sys = "0.4"
+lsp-server = "0.7.6"
+lsp-types = { version = "0.95.1", features = ["proposed"] }
+serde_json = "1"
 similar = "2"
 shuck-ast = { path = "../crates/shuck-ast" }
 # shuck-formatter = { path = "../crates/shuck-formatter" }
 shuck-indexer = { path = "../crates/shuck-indexer" }
 shuck-linter = { path = "../crates/shuck-linter" }
 shuck-parser = { path = "../crates/shuck-parser" }
+shuck-server = { path = "../crates/shuck-server", features = ["fuzzing"] }
 
 [workspace]
 members = ["."]
@@ -74,6 +79,27 @@ bench = false
 [[bin]]
 name = "linter_no_panic_fuzz"
 path = "fuzz_targets/linter_no_panic_fuzz.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "lsp_document_sync_fuzz"
+path = "fuzz_targets/lsp_document_sync_fuzz.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "lsp_request_surface_fuzz"
+path = "fuzz_targets/lsp_request_surface_fuzz.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "lsp_protocol_sequence_fuzz"
+path = "fuzz_targets/lsp_protocol_sequence_fuzz.rs"
 test = false
 doc = false
 bench = false

--- a/fuzz/fuzz_targets/lsp_common.rs
+++ b/fuzz/fuzz_targets/lsp_common.rs
@@ -1,0 +1,245 @@
+#![allow(dead_code)]
+
+use lsp_types as types;
+use serde_json::Value;
+use shuck_server::{ClientOptions, PositionEncoding};
+
+pub(crate) const LSP_ENCODINGS: [PositionEncoding; 3] = [
+    PositionEncoding::UTF8,
+    PositionEncoding::UTF16,
+    PositionEncoding::UTF32,
+];
+
+pub(crate) fn encoding_from_byte(byte: u8) -> PositionEncoding {
+    LSP_ENCODINGS[usize::from(byte) % LSP_ENCODINGS.len()]
+}
+
+pub(crate) fn language_id_from_byte(byte: u8) -> &'static str {
+    match byte % 6 {
+        0 => "shellscript",
+        1 => "bash",
+        2 => "sh",
+        3 => "zsh",
+        4 => "ksh",
+        _ => "markdown",
+    }
+}
+
+pub(crate) fn file_name_for_language(language_id: &str) -> &'static str {
+    match language_id {
+        "bash" => "fuzz.bash",
+        "zsh" => "fuzz.zsh",
+        "ksh" => "fuzz.ksh",
+        "markdown" => "fuzz.md",
+        _ => "fuzz.sh",
+    }
+}
+
+pub(crate) fn position_from_bytes(
+    source: &str,
+    bytes: &[u8],
+    encoding: PositionEncoding,
+) -> types::Position {
+    let first = bytes.first().copied().unwrap_or_default();
+    let second = bytes.get(1).copied().unwrap_or_default();
+    let lines = source_lines(source);
+    let line_count = lines.len().max(1);
+    let line = usize::from(first) % (line_count + 2);
+    let line_text = lines.get(line.min(line_count - 1)).copied().unwrap_or("");
+    let units = line_units(line_text, encoding).saturating_add(5).max(1);
+    types::Position {
+        line: u32::try_from(line).unwrap_or(u32::MAX),
+        character: u32::try_from(usize::from(second) % units).unwrap_or(u32::MAX),
+    }
+}
+
+pub(crate) fn range_from_bytes(
+    source: &str,
+    bytes: &[u8],
+    encoding: PositionEncoding,
+) -> types::Range {
+    let start = position_from_bytes(source, bytes, encoding);
+    let end = position_from_bytes(source, bytes.get(2..).unwrap_or_default(), encoding);
+    if bytes.get(4).copied().unwrap_or_default() & 1 == 0 {
+        types::Range { start, end }
+    } else {
+        types::Range {
+            start: end,
+            end: start,
+        }
+    }
+}
+
+pub(crate) fn replacement_from_bytes(source: &str, bytes: &[u8]) -> String {
+    let selector = bytes.first().copied().unwrap_or_default();
+    let count = usize::from(bytes.get(1).copied().unwrap_or(8) % 32);
+    match selector % 8 {
+        0 => String::new(),
+        1 => "\n".to_owned(),
+        2 => "_".to_owned(),
+        3 => "name=value\n".to_owned(),
+        4 => "echo ${value}\n".to_owned(),
+        5 => format!("unicode_{}\n", "\u{1f642}"),
+        6 => source.chars().take(count).collect(),
+        _ => {
+            let mut chars = source.chars().rev().take(count).collect::<Vec<_>>();
+            chars.reverse();
+            chars.into_iter().collect()
+        }
+    }
+}
+
+pub(crate) fn new_name_from_byte(byte: u8) -> &'static str {
+    match byte % 8 {
+        0 => "renamed",
+        1 => "_",
+        2 => "name_1",
+        3 => "foo=bar",
+        4 => "",
+        5 => "with space",
+        6 => "new-function",
+        _ => "z",
+    }
+}
+
+pub(crate) fn workspace_query_from_byte(byte: u8) -> &'static str {
+    match byte % 6 {
+        0 => "",
+        1 => "f",
+        2 => "name",
+        3 => "build",
+        4 => "_",
+        _ => "zz",
+    }
+}
+
+pub(crate) fn client_options_from_byte(byte: u8) -> ClientOptions {
+    ClientOptions {
+        fix_all: Some(true),
+        unsafe_fixes: Some(byte & 1 == 0),
+        show_syntax_errors: Some(byte & 2 == 0),
+        ..ClientOptions::default()
+    }
+}
+
+pub(crate) fn capabilities_from_byte(byte: u8, encoding: PositionEncoding) -> types::ClientCapabilities {
+    let encoding_name = match encoding {
+        PositionEncoding::UTF8 => "utf-8",
+        PositionEncoding::UTF16 => "utf-16",
+        PositionEncoding::UTF32 => "utf-32",
+    };
+    serde_json::from_value(serde_json::json!({
+        "general": {
+            "positionEncodings": [encoding_name]
+        },
+        "textDocument": {
+            "diagnostic": {
+                "dynamicRegistration": false,
+                "relatedDocumentSupport": false
+            },
+            "codeAction": {
+                "dataSupport": byte & 1 == 0,
+                "resolveSupport": { "properties": ["edit"] }
+            },
+            "documentSymbol": {
+                "hierarchicalDocumentSymbolSupport": byte & 2 == 0
+            },
+            "hover": {
+                "contentFormat": ["markdown", "plaintext"]
+            }
+        },
+        "workspace": {
+            "applyEdit": true,
+            "workspaceEdit": {
+                "documentChanges": byte & 4 == 0
+            },
+            "workspaceFolders": true,
+            "configuration": false
+        }
+    }))
+    .unwrap_or_default()
+}
+
+pub(crate) fn validate_lsp_ranges_in_values(
+    source: &str,
+    encoding: PositionEncoding,
+    values: &[Value],
+) {
+    for value in values {
+        validate_lsp_ranges_in_value(source, encoding, value);
+    }
+}
+
+pub(crate) fn validate_lsp_ranges_in_value(source: &str, encoding: PositionEncoding, value: &Value) {
+    match value {
+        Value::Array(values) => {
+            for value in values {
+                validate_lsp_ranges_in_value(source, encoding, value);
+            }
+        }
+        Value::Object(object) => {
+            if let Some(range) = object.get("range")
+                && let Ok(range) = serde_json::from_value::<types::Range>(range.clone())
+            {
+                assert_valid_range(source, encoding, range);
+            }
+            for value in object.values() {
+                validate_lsp_ranges_in_value(source, encoding, value);
+            }
+        }
+        Value::Null | Value::Bool(_) | Value::Number(_) | Value::String(_) => {}
+    }
+}
+
+pub(crate) fn assert_valid_range(
+    source: &str,
+    encoding: PositionEncoding,
+    range: types::Range,
+) {
+    assert!(
+        position_leq(range.start, range.end),
+        "LSP range is not ordered: {:?}",
+        range
+    );
+    assert_valid_position(source, encoding, range.start);
+    assert_valid_position(source, encoding, range.end);
+}
+
+fn assert_valid_position(source: &str, encoding: PositionEncoding, position: types::Position) {
+    let lines = source_lines(source);
+    let line = usize::try_from(position.line).unwrap_or(usize::MAX);
+    assert!(
+        line < lines.len(),
+        "LSP position line is out of bounds: {:?} for {} lines",
+        position,
+        lines.len()
+    );
+    let max_units = line_units(lines[line], encoding);
+    let character = usize::try_from(position.character).unwrap_or(usize::MAX);
+    assert!(
+        character <= max_units,
+        "LSP position character is out of bounds: {:?} for {} units",
+        position,
+        max_units
+    );
+}
+
+fn position_leq(left: types::Position, right: types::Position) -> bool {
+    (left.line, left.character) <= (right.line, right.character)
+}
+
+fn source_lines(source: &str) -> Vec<&str> {
+    let mut lines = source.split('\n').collect::<Vec<_>>();
+    if lines.is_empty() {
+        lines.push("");
+    }
+    lines
+}
+
+fn line_units(line: &str, encoding: PositionEncoding) -> usize {
+    match encoding {
+        PositionEncoding::UTF8 => line.len(),
+        PositionEncoding::UTF16 => line.encode_utf16().count(),
+        PositionEncoding::UTF32 => line.chars().count(),
+    }
+}

--- a/fuzz/fuzz_targets/lsp_document_sync_fuzz.rs
+++ b/fuzz/fuzz_targets/lsp_document_sync_fuzz.rs
@@ -1,0 +1,48 @@
+//! Fuzz target for LSP document synchronization edits.
+
+#![no_main]
+
+mod common;
+mod lsp_common;
+
+use libfuzzer_sys::{Corpus, fuzz_target};
+use lsp_types::TextDocumentContentChangeEvent;
+
+fuzz_target!(|data: &[u8]| -> Corpus {
+    let input = match common::filtered_input(data) {
+        Ok(input) => input,
+        Err(reject) => return reject,
+    };
+
+    for encoding in lsp_common::LSP_ENCODINGS {
+        let mut source = input.to_owned();
+        let mut version = 1;
+        for chunk in data.chunks(6).take(10) {
+            let text = lsp_common::replacement_from_bytes(input, chunk);
+            let range = (chunk.first().copied().unwrap_or_default() % 4 != 0)
+                .then(|| lsp_common::range_from_bytes(&source, chunk, encoding));
+            let range_length = chunk
+                .get(5)
+                .copied()
+                .map(u32::from)
+                .filter(|_| chunk.first().copied().unwrap_or_default() & 1 == 0);
+            let state = shuck_server::fuzzing::apply_text_document_changes(
+                &source,
+                version,
+                vec![TextDocumentContentChangeEvent {
+                    range,
+                    range_length,
+                    text,
+                }],
+                version + 1,
+                encoding,
+            );
+
+            assert_eq!(state.version, version + 1);
+            source = state.contents;
+            version += 1;
+        }
+    }
+
+    Corpus::Keep
+});

--- a/fuzz/fuzz_targets/lsp_protocol_sequence_fuzz.rs
+++ b/fuzz/fuzz_targets/lsp_protocol_sequence_fuzz.rs
@@ -10,7 +10,7 @@ use std::time::{Duration, Instant};
 
 use libfuzzer_sys::{Corpus, fuzz_target};
 use lsp_server::{Connection, Message, Notification, Request, RequestId, Response};
-use lsp_types::Url;
+use lsp_types::{TextDocumentContentChangeEvent, Url};
 
 fuzz_target!(|data: &[u8]| -> Corpus {
     let input = match common::filtered_input(data) {
@@ -99,6 +99,18 @@ fn run_protocol_sequence(source: &str, data: &[u8]) -> Result<(), String> {
                 version += 1;
                 let range = lsp_common::range_from_bytes(&current_source, chunk, encoding);
                 let text = lsp_common::replacement_from_bytes(source, chunk);
+                let state = shuck_server::fuzzing::apply_text_document_changes(
+                    &current_source,
+                    version - 1,
+                    vec![TextDocumentContentChangeEvent {
+                        range: Some(range.clone()),
+                        range_length: None,
+                        text: text.clone(),
+                    }],
+                    version,
+                    encoding,
+                );
+                current_source = state.contents;
                 send_notification(
                     &client_connection,
                     "textDocument/didChange",

--- a/fuzz/fuzz_targets/lsp_protocol_sequence_fuzz.rs
+++ b/fuzz/fuzz_targets/lsp_protocol_sequence_fuzz.rs
@@ -1,0 +1,425 @@
+//! Fuzz target for bounded in-memory LSP protocol sessions.
+
+#![no_main]
+
+mod common;
+mod lsp_common;
+
+use std::thread;
+use std::time::{Duration, Instant};
+
+use libfuzzer_sys::{Corpus, fuzz_target};
+use lsp_server::{Connection, Message, Notification, Request, RequestId, Response};
+use lsp_types::Url;
+
+fuzz_target!(|data: &[u8]| -> Corpus {
+    let input = match common::filtered_input(data) {
+        Ok(input) => input,
+        Err(reject) => return reject,
+    };
+
+    run_protocol_sequence(input, data).expect("LSP protocol sequence should shut down cleanly");
+
+    Corpus::Keep
+});
+
+fn run_protocol_sequence(source: &str, data: &[u8]) -> Result<(), String> {
+    let encoding = lsp_common::encoding_from_byte(data.first().copied().unwrap_or_default());
+    let language_id = lsp_common::language_id_from_byte(data.get(1).copied().unwrap_or_default());
+    let file_name = lsp_common::file_name_for_language(language_id);
+    let workspace_root =
+        std::env::temp_dir().join(format!("shuck-lsp-protocol-fuzz-{}", std::process::id()));
+    std::fs::create_dir_all(&workspace_root)
+        .map_err(|error| format!("create fuzz workspace: {error}"))?;
+    let root_uri = Url::from_file_path(&workspace_root)
+        .map_err(|()| "failed to build workspace URI".to_owned())?;
+    let script_uri = Url::from_file_path(workspace_root.join(file_name))
+        .map_err(|()| "failed to build document URI".to_owned())?;
+
+    let (server_connection, client_connection) = Connection::memory();
+    let server_thread = thread::spawn(move || shuck_server::run_connection(server_connection));
+
+    send_request(
+        &client_connection,
+        1,
+        "initialize",
+        serde_json::json!({
+            "capabilities": lsp_common::capabilities_from_byte(
+                data.get(2).copied().unwrap_or_default(),
+                encoding,
+            ),
+            "rootUri": root_uri,
+            "initializationOptions": {
+                "shuck": {
+                    "fixAll": true,
+                    "unsafeFixes": data.get(3).copied().unwrap_or_default() & 1 == 0,
+                    "showSyntaxErrors": true,
+                    "server": {
+                        "workspaceSymbols": { "maxFiles": 0 }
+                    }
+                }
+            }
+        }),
+    )?;
+    recv_response(&client_connection, 1)?;
+    send_notification(
+        &client_connection,
+        "initialized",
+        serde_json::json!({}),
+    )?;
+
+    let mut current_source = source.to_owned();
+    let mut version = 1i32;
+    let mut open = true;
+    send_did_open(
+        &client_connection,
+        &script_uri,
+        language_id,
+        version,
+        &current_source,
+    )?;
+
+    let mut next_id = 2i32;
+    let mut last_request_id = None;
+    for chunk in data.chunks(8).take(12) {
+        match chunk.first().copied().unwrap_or_default() % 15 {
+            0 => {
+                version += 1;
+                current_source = lsp_common::replacement_from_bytes(source, chunk);
+                send_notification(
+                    &client_connection,
+                    "textDocument/didChange",
+                    serde_json::json!({
+                        "textDocument": { "uri": script_uri, "version": version },
+                        "contentChanges": [{ "text": current_source }],
+                    }),
+                )?;
+            }
+            1 => {
+                version += 1;
+                let range = lsp_common::range_from_bytes(&current_source, chunk, encoding);
+                let text = lsp_common::replacement_from_bytes(source, chunk);
+                send_notification(
+                    &client_connection,
+                    "textDocument/didChange",
+                    serde_json::json!({
+                        "textDocument": { "uri": script_uri, "version": version },
+                        "contentChanges": [{ "range": range, "text": text }],
+                    }),
+                )?;
+            }
+            2 => {
+                send_document_request(
+                    &client_connection,
+                    &mut next_id,
+                    &mut last_request_id,
+                    "textDocument/diagnostic",
+                    &script_uri,
+                    serde_json::json!({
+                        "textDocument": { "uri": script_uri },
+                    }),
+                )?;
+            }
+            3 => {
+                let position = lsp_common::position_from_bytes(&current_source, chunk, encoding);
+                send_document_request(
+                    &client_connection,
+                    &mut next_id,
+                    &mut last_request_id,
+                    "textDocument/hover",
+                    &script_uri,
+                    serde_json::json!({
+                        "textDocument": { "uri": script_uri },
+                        "position": position,
+                    }),
+                )?;
+            }
+            4 => {
+                let position = lsp_common::position_from_bytes(&current_source, chunk, encoding);
+                send_document_request(
+                    &client_connection,
+                    &mut next_id,
+                    &mut last_request_id,
+                    "textDocument/completion",
+                    &script_uri,
+                    serde_json::json!({
+                        "textDocument": { "uri": script_uri },
+                        "position": position,
+                    }),
+                )?;
+            }
+            5 => {
+                let range = lsp_common::range_from_bytes(&current_source, chunk, encoding);
+                send_document_request(
+                    &client_connection,
+                    &mut next_id,
+                    &mut last_request_id,
+                    "textDocument/codeAction",
+                    &script_uri,
+                    serde_json::json!({
+                        "textDocument": { "uri": script_uri },
+                        "range": range,
+                        "context": { "diagnostics": [] },
+                    }),
+                )?;
+            }
+            6 => {
+                send_document_request(
+                    &client_connection,
+                    &mut next_id,
+                    &mut last_request_id,
+                    "textDocument/documentSymbol",
+                    &script_uri,
+                    serde_json::json!({
+                        "textDocument": { "uri": script_uri },
+                    }),
+                )?;
+            }
+            7 => {
+                send_document_request(
+                    &client_connection,
+                    &mut next_id,
+                    &mut last_request_id,
+                    "textDocument/formatting",
+                    &script_uri,
+                    serde_json::json!({
+                        "textDocument": { "uri": script_uri },
+                        "options": { "tabSize": 4, "insertSpaces": true },
+                    }),
+                )?;
+            }
+            8 => {
+                let range = lsp_common::range_from_bytes(&current_source, chunk, encoding);
+                send_document_request(
+                    &client_connection,
+                    &mut next_id,
+                    &mut last_request_id,
+                    "textDocument/rangeFormatting",
+                    &script_uri,
+                    serde_json::json!({
+                        "textDocument": { "uri": script_uri },
+                        "range": range,
+                        "options": { "tabSize": 4, "insertSpaces": true },
+                    }),
+                )?;
+            }
+            9 => {
+                let position = lsp_common::position_from_bytes(&current_source, chunk, encoding);
+                send_document_request(
+                    &client_connection,
+                    &mut next_id,
+                    &mut last_request_id,
+                    "textDocument/prepareRename",
+                    &script_uri,
+                    serde_json::json!({
+                        "textDocument": { "uri": script_uri },
+                        "position": position,
+                    }),
+                )?;
+            }
+            10 => {
+                let position = lsp_common::position_from_bytes(&current_source, chunk, encoding);
+                send_document_request(
+                    &client_connection,
+                    &mut next_id,
+                    &mut last_request_id,
+                    "textDocument/rename",
+                    &script_uri,
+                    serde_json::json!({
+                        "textDocument": { "uri": script_uri },
+                        "position": position,
+                        "newName": lsp_common::new_name_from_byte(chunk.get(1).copied().unwrap_or_default()),
+                    }),
+                )?;
+            }
+            11 => {
+                let request_id = next_id;
+                next_id += 1;
+                last_request_id = Some(request_id);
+                send_request(
+                    &client_connection,
+                    request_id,
+                    "workspace/symbol",
+                    serde_json::json!({
+                        "query": lsp_common::workspace_query_from_byte(
+                            chunk.get(1).copied().unwrap_or_default(),
+                        ),
+                    }),
+                )?;
+            }
+            12 => {
+                send_notification(
+                    &client_connection,
+                    "workspace/didChangeConfiguration",
+                    serde_json::json!({
+                        "settings": {
+                            "shuck": {
+                                "fixAll": true,
+                                "unsafeFixes": chunk.get(1).copied().unwrap_or_default() & 1 == 0,
+                                "showSyntaxErrors": chunk.get(2).copied().unwrap_or_default() & 1 == 0,
+                            }
+                        }
+                    }),
+                )?;
+            }
+            13 => {
+                if let Some(id) = last_request_id {
+                    send_notification(
+                        &client_connection,
+                        "$/cancelRequest",
+                        serde_json::json!({ "id": id }),
+                    )?;
+                }
+            }
+            _ => {
+                if open {
+                    send_notification(
+                        &client_connection,
+                        "textDocument/didClose",
+                        serde_json::json!({
+                            "textDocument": { "uri": script_uri },
+                        }),
+                    )?;
+                    open = false;
+                } else {
+                    version += 1;
+                    send_did_open(
+                        &client_connection,
+                        &script_uri,
+                        language_id,
+                        version,
+                        &current_source,
+                    )?;
+                    open = true;
+                }
+            }
+        }
+        drain_messages(&client_connection, Duration::from_millis(2))?;
+    }
+
+    let shutdown_id = next_id;
+    send_request(
+        &client_connection,
+        shutdown_id,
+        "shutdown",
+        serde_json::Value::Null,
+    )?;
+    recv_response(&client_connection, shutdown_id)?;
+    send_notification(&client_connection, "exit", serde_json::json!({}))?;
+
+    server_thread
+        .join()
+        .map_err(|_| "server thread panicked".to_owned())?
+        .map_err(|error| error.to_string())
+}
+
+fn send_document_request(
+    connection: &Connection,
+    next_id: &mut i32,
+    last_request_id: &mut Option<i32>,
+    method: &str,
+    _uri: &Url,
+    params: serde_json::Value,
+) -> Result<(), String> {
+    let request_id = *next_id;
+    *next_id += 1;
+    *last_request_id = Some(request_id);
+    send_request(connection, request_id, method, params)
+}
+
+fn send_did_open(
+    connection: &Connection,
+    uri: &Url,
+    language_id: &str,
+    version: i32,
+    text: &str,
+) -> Result<(), String> {
+    send_notification(
+        connection,
+        "textDocument/didOpen",
+        serde_json::json!({
+            "textDocument": {
+                "uri": uri,
+                "languageId": language_id,
+                "version": version,
+                "text": text,
+            }
+        }),
+    )
+}
+
+fn send_request(
+    connection: &Connection,
+    id: i32,
+    method: &str,
+    params: serde_json::Value,
+) -> Result<(), String> {
+    connection
+        .sender
+        .send(Message::Request(Request {
+            id: RequestId::from(id),
+            method: method.to_owned(),
+            params,
+        }))
+        .map_err(|error| format!("send request {method}: {error}"))
+}
+
+fn send_notification(
+    connection: &Connection,
+    method: &str,
+    params: serde_json::Value,
+) -> Result<(), String> {
+    connection
+        .sender
+        .send(Message::Notification(Notification::new(method.to_owned(), params)))
+        .map_err(|error| format!("send notification {method}: {error}"))
+}
+
+fn recv_response(connection: &Connection, id: i32) -> Result<(), String> {
+    let deadline = Instant::now() + Duration::from_secs(2);
+    loop {
+        let now = Instant::now();
+        if now >= deadline {
+            return Err(format!("timed out waiting for response {id}"));
+        }
+        let timeout = deadline.saturating_duration_since(now).min(Duration::from_millis(25));
+        match connection.receiver.recv_timeout(timeout) {
+            Ok(Message::Response(response)) if response.id == RequestId::from(id) => {
+                return Ok(());
+            }
+            Ok(message) => handle_server_message(connection, message)?,
+            Err(crossbeam::channel::RecvTimeoutError::Timeout) => {}
+            Err(error) => return Err(format!("receive response {id}: {error}")),
+        }
+    }
+}
+
+fn drain_messages(connection: &Connection, duration: Duration) -> Result<(), String> {
+    let deadline = Instant::now() + duration;
+    while Instant::now() < deadline {
+        match connection.receiver.recv_timeout(Duration::from_millis(1)) {
+            Ok(message) => handle_server_message(connection, message)?,
+            Err(crossbeam::channel::RecvTimeoutError::Timeout) => return Ok(()),
+            Err(error) => return Err(format!("drain server messages: {error}")),
+        }
+    }
+    Ok(())
+}
+
+fn handle_server_message(connection: &Connection, message: Message) -> Result<(), String> {
+    match message {
+        Message::Request(request) => {
+            let result = if request.method == "workspace/applyEdit" {
+                serde_json::json!({ "applied": false })
+            } else {
+                serde_json::Value::Null
+            };
+            connection
+                .sender
+                .send(Message::Response(Response::new_ok(request.id, result)))
+                .map_err(|error| format!("respond to server request: {error}"))?;
+        }
+        Message::Response(_) | Message::Notification(_) => {}
+    }
+    Ok(())
+}

--- a/fuzz/fuzz_targets/lsp_request_surface_fuzz.rs
+++ b/fuzz/fuzz_targets/lsp_request_surface_fuzz.rs
@@ -1,0 +1,47 @@
+//! Fuzz target for direct LSP request handler surfaces.
+
+#![no_main]
+
+mod common;
+mod lsp_common;
+
+use libfuzzer_sys::{Corpus, fuzz_target};
+
+fuzz_target!(|data: &[u8]| -> Corpus {
+    let input = match common::filtered_input(data) {
+        Ok(input) => input,
+        Err(reject) => return reject,
+    };
+
+    let encoding = lsp_common::encoding_from_byte(data.first().copied().unwrap_or_default());
+    let language_id = lsp_common::language_id_from_byte(data.get(1).copied().unwrap_or_default());
+    let file_name = lsp_common::file_name_for_language(language_id);
+    let position = lsp_common::position_from_bytes(input, data.get(2..).unwrap_or_default(), encoding);
+    let range = lsp_common::range_from_bytes(input, data.get(4..).unwrap_or_default(), encoding);
+    let capabilities =
+        lsp_common::capabilities_from_byte(data.get(6).copied().unwrap_or_default(), encoding);
+    let client_options = lsp_common::client_options_from_byte(data.get(7).copied().unwrap_or_default());
+    let new_name = lsp_common::new_name_from_byte(data.get(8).copied().unwrap_or_default());
+    let workspace_query =
+        lsp_common::workspace_query_from_byte(data.get(9).copied().unwrap_or_default());
+
+    let outputs = shuck_server::fuzzing::exercise_request_surface(
+        shuck_server::fuzzing::RequestSurfaceInput {
+            source: input,
+            language_id,
+            file_name,
+            encoding,
+            capabilities,
+            client_options,
+            position,
+            range,
+            new_name,
+            workspace_query,
+        },
+    )
+    .expect("LSP request surface harness should run");
+
+    lsp_common::validate_lsp_ranges_in_values(input, encoding, &outputs);
+
+    Corpus::Keep
+});

--- a/scripts/fuzz-init.sh
+++ b/scripts/fuzz-init.sh
@@ -16,6 +16,9 @@ COMMON_TARGETS=(
   glob_fuzz
   recovered_parser_fuzz
   linter_no_panic_fuzz
+  lsp_document_sync_fuzz
+  lsp_request_surface_fuzz
+  lsp_protocol_sequence_fuzz
 )
 
 # FORMATTER_TARGETS=(


### PR DESCRIPTION
## Summary
- add a non-default `shuck-server` fuzzing feature with fuzz-only harness entrypoints for LSP document sync and request surfaces
- add document sync, direct request-surface, and bounded in-memory protocol sequence fuzz targets
- wire the new LSP targets into corpus initialization, PR smoke fuzzing, scheduled fuzz CI, and contributor docs

## Validation
- `cargo fmt --check`
- `cargo check -p shuck-server --features fuzzing`
- `cargo check --manifest-path fuzz/Cargo.toml --bins`
- `cargo test -p shuck-server`
- `make fuzz-list`
- `make fuzz-smoke`
- `make fuzz-run FUZZ_TARGET=lsp_document_sync_fuzz FUZZ_ARGS='-runs=100'`
- `make fuzz-run FUZZ_TARGET=lsp_request_surface_fuzz FUZZ_ARGS='-runs=100'`
- `make fuzz-run FUZZ_TARGET=lsp_protocol_sequence_fuzz FUZZ_ARGS='-runs=100'`
- `SHUCK_CACHE_DIR=/private/tmp/shuck-cache-test cargo test --workspace --all-features -- --skip check_watch_reruns_when_files_change`

Note: the unskipped all-features workspace run hit `check_watch_reruns_when_files_change`, and that same watch-mode case failed when rerun by itself in this local environment.