### PR TITLE
test(formatter): cover zsh formatter plumbing

### DIFF
--- a/crates/shuck-formatter/src/lib.rs
+++ b/crates/shuck-formatter/src/lib.rs
@@ -518,7 +518,6 @@ mod tests {
             .unwrap()
         );
     }
-
     #[test]
     fn formats_heredoc_command_heads_structurally() {
         let formatted = format_source(
@@ -1846,5 +1845,24 @@ print hidden &!
             formatted_c001 <= original_c001,
             "formatter introduced extra C001 diagnostics: original={original_c001}, formatted={formatted_c001}\nformatted source:\n{formatted:?}"
         );
+    }
+
+    #[test]
+    fn explicit_zsh_mode_preserves_zsh_source_idempotently() {
+        let source = "\
+#!/bin/zsh
+print ${(m)name}
+repeat 2; do print $name; done
+foreach item (alpha beta) { print $item }
+";
+        let options = ShellFormatOptions::default().with_dialect(ShellDialect::Zsh);
+        let path = Some(Path::new("script.zsh"));
+        let formatted = format_to_string(source, path, &options);
+
+        assert!(formatted.contains("${(m)name}"));
+        assert!(formatted.contains("repeat 2"));
+        assert!(formatted.contains("foreach item"));
+        assert_idempotent(&formatted, path, &options);
+        assert!(source_is_formatted(&formatted, path, &options).unwrap());
     }
 }

--- a/crates/shuck-formatter/src/options.rs
+++ b/crates/shuck-formatter/src/options.rs
@@ -314,3 +314,36 @@ fn detect_line_ending(source: &str) -> LineEnding {
         LineEnding::Lf
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::path::Path;
+
+    use super::*;
+
+    #[test]
+    fn zsh_extension_resolves_to_zsh_dialect() {
+        let resolved = ShellFormatOptions::default()
+            .resolve("print ${(m)name}\n", Some(Path::new("script.zsh")));
+
+        assert_eq!(resolved.dialect(), ParseDialect::Zsh);
+    }
+
+    #[test]
+    fn zsh_shebang_resolves_to_zsh_dialect() {
+        let resolved = ShellFormatOptions::default().resolve(
+            "#!/bin/zsh\nprint ${(m)name}\n",
+            Some(Path::new("script.sh")),
+        );
+
+        assert_eq!(resolved.dialect(), ParseDialect::Zsh);
+    }
+
+    #[test]
+    fn explicit_zsh_dialect_overrides_path_inference() {
+        let options = ShellFormatOptions::default().with_dialect(ShellDialect::Zsh);
+        let resolved = options.resolve("print ${(m)name}\n", Some(Path::new("script.sh")));
+
+        assert_eq!(resolved.dialect(), ParseDialect::Zsh);
+    }
+}


### PR DESCRIPTION
## Summary
- Add formatter option tests for zsh extension and direct zsh shebang inference
- Add an explicit zsh-mode no-op formatter test using zsh-native syntax

## Validation
- `cargo test -p shuck-formatter`
- `cargo test -p shuck-cli --test integration_test format_stdin -- --nocapture`