### PR TITLE
fix(formatter): restore shfmt parity

### DIFF
--- a/crates/shuck-benchmark/tests/formatter_corpus.rs
+++ b/crates/shuck-benchmark/tests/formatter_corpus.rs
@@ -12,13 +12,7 @@ use similar::TextDiff;
 
 const BENCHMARK_ORACLE_FILE_COUNT: usize = 6;
 const MAX_ORACLE_DIFF_LINES: usize = 200;
-const KNOWN_BENCHMARK_DIVERGENCES: &[&str] = &[
-    "homebrew-install",
-    "ruby-build",
-    "pyenv-python-build",
-    "nvm",
-    "bashtop",
-];
+const KNOWN_BENCHMARK_DIVERGENCES: &[&str] = &[];
 
 #[test]
 fn formatter_source_and_ast_paths_match_benchmark_corpus() {

--- a/crates/shuck-formatter/src/command.rs
+++ b/crates/shuck-formatter/src/command.rs
@@ -78,7 +78,9 @@ impl FormatNodeRule<Stmt> for FormatStatement {
         }
 
         if !stmt.redirects.is_empty() && !emit_redirects_first {
-            write!(formatter, [space()])?;
+            if !redirect_has_adjacent_numeric_fd(&stmt.redirects[0], source) {
+                write!(formatter, [space()])?;
+            }
             format_redirect_list(&stmt.redirects, formatter)?;
         }
 
@@ -1102,6 +1104,7 @@ fn format_case_item(
     upper_bound: Option<usize>,
 ) -> FormatResult<()> {
     let source = formatter.context().source();
+    let body_upper_bound = case_item_body_upper_bound(item, upper_bound);
     let base_indent = usize::from(
         !formatter.context().options().compact_layout()
             && formatter.context().options().switch_case_indent(),
@@ -1130,7 +1133,7 @@ fn format_case_item(
         )
     } else if formatter.context().options().compact_layout() {
         write!(formatter, [space()])?;
-        format_stmt_sequence_with_upper_bound(item.body.as_slice(), formatter, upper_bound)?;
+        format_stmt_sequence_with_upper_bound(item.body.as_slice(), formatter, body_upper_bound)?;
         write!(
             formatter,
             [token("; "), token(case_terminator(item.terminator))]
@@ -1147,7 +1150,7 @@ fn format_case_item(
         }
 
         let commands_document = format_into_document(formatter, |nested| {
-            format_stmt_sequence_with_upper_bound(item.body.as_slice(), nested, upper_bound)
+            format_stmt_sequence_with_upper_bound(item.body.as_slice(), nested, body_upper_bound)
         })?;
         write!(
             formatter,
@@ -1596,7 +1599,7 @@ fn render_assignment_inner(
     rendered: &mut String,
 ) {
     let start = rendered.len();
-    render_assignment_head_to_buf(assignment, source, rendered);
+    render_assignment_head_with_options_to_buf(assignment, source, options, rendered);
     match &assignment.value {
         AssignmentValue::Scalar(value) => {
             render_word_syntax_with_optional_facts_to_buf(
@@ -1650,7 +1653,7 @@ fn render_keyed_array_elem_to_buf(
     rendered: &mut String,
 ) {
     rendered.push('[');
-    render_subscript_to_buf(key, source, rendered);
+    render_subscript_with_options_to_buf(key, source, options, rendered);
     rendered.push(']');
     rendered.push_str(operator);
     render_word_syntax_with_optional_facts_to_buf(
@@ -1669,10 +1672,32 @@ pub(crate) fn render_assignment_head_to_buf(
     source: &str,
     rendered: &mut String,
 ) {
+    render_assignment_head_inner(assignment, source, None, rendered);
+}
+
+fn render_assignment_head_with_options_to_buf(
+    assignment: &Assignment,
+    source: &str,
+    options: &ResolvedShellFormatOptions,
+    rendered: &mut String,
+) {
+    render_assignment_head_inner(assignment, source, Some(options), rendered);
+}
+
+fn render_assignment_head_inner(
+    assignment: &Assignment,
+    source: &str,
+    options: Option<&ResolvedShellFormatOptions>,
+    rendered: &mut String,
+) {
     rendered.push_str(assignment.target.name.as_str());
     if let Some(index) = &assignment.target.subscript {
         rendered.push('[');
-        render_subscript_to_buf(index, source, rendered);
+        if let Some(options) = options {
+            render_subscript_with_options_to_buf(index, source, options, rendered);
+        } else {
+            render_subscript_to_buf(index, source, rendered);
+        }
         rendered.push(']');
     }
     if assignment.append {
@@ -1796,6 +1821,24 @@ pub(crate) fn render_subscript_to_buf(subscript: &Subscript, source: &str, rende
     }
 
     render_source_text_to_buf(subscript.syntax_source_text(), source, rendered);
+}
+
+fn render_subscript_with_options_to_buf(
+    subscript: &Subscript,
+    source: &str,
+    options: &ResolvedShellFormatOptions,
+    rendered: &mut String,
+) {
+    if let Some(selector) = subscript.selector() {
+        rendered.push(selector.as_char());
+        return;
+    }
+
+    if let Some(word) = subscript.word_ast() {
+        render_word_syntax_to_buf(word, source, options, rendered);
+    } else {
+        render_source_text_to_buf(subscript.syntax_source_text(), source, rendered);
+    }
 }
 
 fn trim_unescaped_trailing_whitespace(text: &str) -> &str {
@@ -2329,7 +2372,7 @@ fn simple_command_format_span(command: &SimpleCommand) -> Span {
     for assignment in &command.assignments {
         span = merge_non_empty_span(span, assignment.span);
     }
-    if !command.name.parts.is_empty() {
+    if command.name.span != Span::new() {
         span = merge_non_empty_span(span, command.name.span);
     }
     for argument in &command.args {
@@ -2496,7 +2539,7 @@ fn emit_dangling_comments(
 }
 
 pub(crate) fn line_gap_break_count(current_line: usize, next_line: usize) -> usize {
-    next_line.saturating_sub(current_line).max(1)
+    next_line.saturating_sub(current_line).clamp(1, 2)
 }
 
 pub(crate) fn rendered_stmt_end_line(
@@ -2511,6 +2554,7 @@ pub(crate) fn rendered_stmt_end_line(
         _ if has_heredoc(stmt) => {
             span_render_end_line(stmt_verbatim_span(stmt, source), source, source_map)
         }
+        Command::Binary(command) => rendered_stmt_end_line(&command.right, source, source_map),
         Command::Compound(CompoundCommand::Subshell(commands)) => {
             let mut span = group_attachment_span(commands.as_slice(), source_map, '(', ')')
                 .unwrap_or_else(|| stmt_span(stmt));
@@ -2690,6 +2734,9 @@ pub(crate) fn stmt_render_start_line(
     options: &crate::options::ResolvedShellFormatOptions,
 ) -> usize {
     match &stmt.command {
+        Command::Binary(command) => {
+            stmt_render_start_line(&command.left, source, source_map, options)
+        }
         Command::Compound(CompoundCommand::BraceGroup(commands)) => {
             group_render_start_line(stmt, commands.as_slice(), source, source_map, '{', options)
         }
@@ -2776,6 +2823,12 @@ pub(crate) fn case_item_was_inline_in_source(item: &CaseItem) -> bool {
     item.patterns
         .last()
         .is_some_and(|pattern| pattern.span.end.line == stmt_span(stmt).start.line)
+}
+
+fn case_item_body_upper_bound(item: &CaseItem, fallback: Option<usize>) -> Option<usize> {
+    item.terminator_span
+        .map(|span| span.start.offset)
+        .or(fallback)
 }
 
 fn command_token_spans(command: &Command) -> Vec<Span> {
@@ -2992,6 +3045,17 @@ fn indent_levels(mut document: Document, levels: usize) -> Document {
         document = Document::from_element(indent(document));
     }
     document
+}
+
+fn redirect_has_adjacent_numeric_fd(redirect: &Redirect, source: &str) -> bool {
+    let start = redirect.span.start.offset.min(source.len());
+    let Some(prefix) = source.get(..start) else {
+        return false;
+    };
+    let token = prefix
+        .rsplit_once(|ch: char| ch.is_whitespace() || ch == ';' || ch == '&' || ch == '|')
+        .map_or(prefix, |(_, token)| token);
+    !token.is_empty() && token.chars().all(|ch| ch.is_ascii_digit())
 }
 
 pub(crate) fn case_terminator(terminator: CaseTerminator) -> &'static str {

--- a/crates/shuck-formatter/src/comments.rs
+++ b/crates/shuck-formatter/src/comments.rs
@@ -438,6 +438,16 @@ fn compute_sequence_attachment<'a>(
         }
 
         if comment.inline {
+            if prev.is_none() && next == Some(0) && end <= first_child_start {
+                record_claimed_index(
+                    &mut claimed_indices,
+                    track_claimed_indices,
+                    base_index + index,
+                );
+                index += 1;
+                continue;
+            }
+
             if let Some(prev_idx) = prev
                 && child_spans[prev_idx].end.line == comment.line
                 && child_spans[prev_idx].start.offset <= start

--- a/crates/shuck-formatter/src/facts.rs
+++ b/crates/shuck-formatter/src/facts.rs
@@ -54,6 +54,19 @@ impl SequenceSiteKey {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+struct StmtSiteKey {
+    ptr: usize,
+}
+
+impl StmtSiteKey {
+    fn new(stmt: &Stmt) -> Self {
+        Self {
+            ptr: stmt as *const Stmt as usize,
+        }
+    }
+}
+
 #[derive(Debug, Clone)]
 pub(crate) struct StmtFacts {
     attachment_span: Span,
@@ -145,7 +158,8 @@ impl<'source> SequenceFacts<'source> {
 #[derive(Debug, Clone)]
 pub(crate) struct FormatterFacts<'source> {
     source_map: SourceMap<'source>,
-    stmt_facts: HashMap<FactSpan, StmtFacts>,
+    stmt_facts: HashMap<StmtSiteKey, StmtFacts>,
+    stmt_facts_by_span: HashMap<FactSpan, StmtFacts>,
     sequence_facts: HashMap<SequenceSiteKey, SequenceFacts<'source>>,
     pipeline_breaks: HashSet<FactSpan>,
     list_item_breaks: HashSet<FactSpan>,
@@ -168,7 +182,10 @@ impl<'source> FormatterFacts<'source> {
     }
 
     pub(crate) fn stmt(&self, stmt: &Stmt) -> &StmtFacts {
-        let Some(facts) = self.stmt_facts.get(&FactSpan::from(stmt_span(stmt))) else {
+        let Some(facts) = self.stmt_facts.get(&StmtSiteKey::new(stmt)).or_else(|| {
+            self.stmt_facts_by_span
+                .get(&FactSpan::from(stmt_span(stmt)))
+        }) else {
             unreachable!("missing statement facts");
         };
         facts
@@ -190,11 +207,6 @@ impl<'source> FormatterFacts<'source> {
             };
             facts
         })
-    }
-
-    pub(crate) fn pipeline_has_explicit_line_break(&self, pipeline: &BinaryCommand) -> bool {
-        self.pipeline_breaks
-            .contains(&FactSpan::from(pipeline.span))
     }
 
     pub(crate) fn list_item_has_explicit_line_break(&self, operator_span: Span) -> bool {
@@ -225,6 +237,7 @@ impl<'source> FormatterFacts<'source> {
     #[cfg(feature = "benchmarking")]
     pub(crate) fn len(&self) -> usize {
         self.stmt_facts.len()
+            + self.stmt_facts_by_span.len()
             + self.sequence_facts.len()
             + self.pipeline_breaks.len()
             + self.list_item_breaks.len()
@@ -249,6 +262,7 @@ impl<'source, 'options> FormatterFactsBuilder<'source, 'options> {
             facts: FormatterFacts {
                 source_map: SourceMap::new(source),
                 stmt_facts: HashMap::new(),
+                stmt_facts_by_span: HashMap::new(),
                 sequence_facts: HashMap::new(),
                 pipeline_breaks: HashSet::new(),
                 list_item_breaks: HashSet::new(),
@@ -302,7 +316,19 @@ impl<'source, 'options> FormatterFactsBuilder<'source, 'options> {
             })
             .or(upper_bound);
 
-        let lower_bound = sequence_comment_lower_bound(sequence);
+        let mut lower_bound = sequence_comment_lower_bound(sequence);
+        if let Some(open) = group_open_char {
+            let close = match open {
+                '{' => '}',
+                '(' => ')',
+                other => other,
+            };
+            if let Some(span) =
+                group_attachment_span(sequence.as_slice(), self.source_map(), open, close)
+            {
+                lower_bound = lower_bound.min(span.start.offset);
+            }
+        }
         let comment_window = self.comment_window(lower_bound, sequence_limit);
 
         if sequence.is_empty() {
@@ -389,7 +415,7 @@ impl<'source, 'options> FormatterFactsBuilder<'source, 'options> {
     }
 
     fn visit_stmt(&mut self, stmt: &Stmt) {
-        let stmt_key = FactSpan::from(stmt_span(stmt));
+        let stmt_key = StmtSiteKey::new(stmt);
         if !self.facts.stmt_facts.contains_key(&stmt_key) {
             let preserve_verbatim = should_render_verbatim(stmt, self.source_map(), self.options);
             let render_span = if preserve_verbatim {
@@ -397,21 +423,23 @@ impl<'source, 'options> FormatterFactsBuilder<'source, 'options> {
             } else {
                 stmt_format_span(stmt)
             };
-            self.facts.stmt_facts.insert(
-                stmt_key,
-                StmtFacts {
-                    attachment_span: stmt_attachment_span(
-                        stmt,
-                        self.source,
-                        self.source_map(),
-                        self.options,
-                    ),
-                    render_span,
-                    rendered_end_line: rendered_stmt_end_line(stmt, self.source, self.source_map()),
-                    has_trailing_comment: stmt_has_trailing_comment(stmt, self.source_map()),
-                    preserve_verbatim,
-                },
-            );
+            let facts = StmtFacts {
+                attachment_span: stmt_attachment_span(
+                    stmt,
+                    self.source,
+                    self.source_map(),
+                    self.options,
+                ),
+                render_span,
+                rendered_end_line: rendered_stmt_end_line(stmt, self.source, self.source_map()),
+                has_trailing_comment: stmt_has_trailing_comment(stmt, self.source_map()),
+                preserve_verbatim,
+            };
+            self.facts
+                .stmt_facts_by_span
+                .entry(FactSpan::from(stmt_span(stmt)))
+                .or_insert_with(|| facts.clone());
+            self.facts.stmt_facts.insert(stmt_key, facts);
         }
 
         for redirect in &stmt.redirects {
@@ -537,14 +565,26 @@ impl<'source, 'options> FormatterFactsBuilder<'source, 'options> {
 
         if matches!(command.op, BinaryOp::And | BinaryOp::Or) {
             let mut rest = Vec::new();
-            collect_command_list_first(command, &mut rest);
+            let first = collect_command_list_first(command, &mut rest);
+            let mut previous_stmt = first;
             for item in rest {
+                let previous_span_end = stmt_span(previous_stmt).end.offset;
+                let previous_end = if previous_span_end <= item.operator_span.start.offset {
+                    previous_span_end
+                } else {
+                    self.facts.stmt(previous_stmt).render_span().end.offset
+                };
                 let next_start = self.facts.stmt(item.stmt).attachment_span().start.offset;
-                if has_newline_between(self.source, item.operator_span.end.offset, next_start) {
+                let has_break_before_operator =
+                    has_newline_between(self.source, previous_end, item.operator_span.start.offset);
+                let has_break_after_operator =
+                    has_newline_between(self.source, item.operator_span.end.offset, next_start);
+                if has_break_before_operator || has_break_after_operator {
                     self.facts
                         .list_item_breaks
                         .insert(FactSpan::from(item.operator_span));
                 }
+                previous_stmt = item.stmt;
             }
         }
     }
@@ -753,7 +793,11 @@ impl<'source, 'options> FormatterFactsBuilder<'source, 'options> {
                     .inline_case_item_bodies
                     .insert(FactSpan::from(item.body.span));
             }
-            self.visit_sequence(&item.body, Some(command.span.end.offset), None);
+            self.visit_sequence(
+                &item.body,
+                case_item_body_upper_bound(item, Some(command.span.end.offset)),
+                None,
+            );
         }
     }
 
@@ -918,6 +962,9 @@ impl<'source, 'options> FormatterFactsBuilder<'source, 'options> {
             {
                 self.visit_sequence(body, Some(span.end.offset), None);
             }
+            WordPart::ProcessSubstitution { body, .. } => {
+                self.visit_sequence(body, Some(span.end.offset), None);
+            }
             WordPart::CommandSubstitution { .. }
             | WordPart::Literal(_)
             | WordPart::SingleQuoted { .. }
@@ -933,7 +980,6 @@ impl<'source, 'options> FormatterFactsBuilder<'source, 'options> {
             | WordPart::ArraySlice { .. }
             | WordPart::IndirectExpansion { .. }
             | WordPart::PrefixMatch { .. }
-            | WordPart::ProcessSubstitution { .. }
             | WordPart::Transformation { .. }
             | WordPart::ZshQualifiedGlob(_) => {}
             WordPart::DoubleQuoted { parts, .. } => {
@@ -1038,35 +1084,79 @@ fn sequence_comment_lower_bound(sequence: &StmtSeq) -> usize {
     lower_bound
 }
 
+fn case_item_body_upper_bound(item: &CaseItem, fallback: Option<usize>) -> Option<usize> {
+    item.terminator_span
+        .map(|span| span.start.offset)
+        .or(fallback)
+}
+
 fn span_contains_comment(span: Span, comment: SourceComment<'_>) -> bool {
     span.start.offset <= comment.span().start.offset && comment.span().end.offset <= span.end.offset
 }
 
 fn if_branch_upper_bound(command: &IfCommand, branch_index: usize, source: &str) -> usize {
     let current_branch_end = if branch_index == 0 {
-        command.then_branch.span.end.offset
+        stmt_seq_content_end(&command.then_branch, source)
     } else {
         command
             .elif_branches
             .get(branch_index - 1)
-            .map(|(_, body)| body.span.end.offset)
-            .unwrap_or(command.then_branch.span.end.offset)
+            .map(|(_, body)| stmt_seq_content_end(body, source))
+            .unwrap_or_else(|| stmt_seq_content_end(&command.then_branch, source))
     };
 
     if let Some((condition, _)) = command.elif_branches.get(branch_index) {
-        branch_keyword_offset(
+        let keyword_offset = branch_keyword_offset(
             source,
             current_branch_end,
             condition.span.start.offset,
             "elif",
         )
-        .unwrap_or(condition.span.start.offset)
+        .unwrap_or(condition.span.start.offset);
+        branch_leading_comment_start(source, current_branch_end, keyword_offset)
+            .unwrap_or(keyword_offset)
     } else if let Some(body) = &command.else_branch {
-        branch_keyword_offset(source, current_branch_end, body.span.start.offset, "else")
-            .unwrap_or(body.span.start.offset)
+        let keyword_offset =
+            branch_keyword_offset(source, current_branch_end, body.span.start.offset, "else")
+                .unwrap_or(body.span.start.offset);
+        branch_leading_comment_start(source, current_branch_end, keyword_offset)
+            .unwrap_or(keyword_offset)
     } else {
         command.span.end.offset
     }
+}
+
+fn stmt_seq_content_end(commands: &StmtSeq, source: &str) -> usize {
+    commands
+        .last()
+        .map(|stmt| stmt_verbatim_span(stmt, source).end.offset)
+        .unwrap_or(commands.span.end.offset)
+}
+
+fn branch_leading_comment_start(source: &str, start: usize, end: usize) -> Option<usize> {
+    let start = start.min(end).min(source.len());
+    let end = end.min(source.len());
+    let mut offset = start;
+    let mut first_comment = None;
+    while offset < end {
+        let relative_end = source[offset..end]
+            .find('\n')
+            .map_or(end - offset, |index| index);
+        let line_end = offset + relative_end;
+        let line = &source[offset..line_end];
+        let trimmed = line.trim();
+        if trimmed.is_empty() || trimmed == "\\" {
+            offset = (line_end + 1).min(end);
+            continue;
+        }
+        if trimmed.starts_with('#') {
+            first_comment.get_or_insert(offset);
+            offset = (line_end + 1).min(end);
+            continue;
+        }
+        return None;
+    }
+    first_comment
 }
 
 fn branch_keyword_offset(source: &str, start: usize, end: usize, keyword: &str) -> Option<usize> {
@@ -1147,7 +1237,33 @@ mod tests {
     }
 
     #[test]
-    fn marks_inline_leading_comments_as_ambiguous() {
+    fn captures_group_body_comment_after_open_suffix_comment() {
+        let source = "{ # open\n\n# inner\nx=1\n}\n";
+        let file = parse(source);
+        let options = ShellFormatOptions::default();
+        let resolved = options.resolve(source, Some(Path::new("test.sh")));
+        let facts = FormatterFacts::build(source, &file, &resolved);
+
+        let body = match &file.body[0].command {
+            Command::Compound(CompoundCommand::BraceGroup(commands)) => commands,
+            _ => panic!("expected brace group"),
+        };
+        let sequence = facts.sequence(body, Some(file.body[0].span.end.offset));
+        assert_eq!(facts.stmt(&body[0]).attachment_span().slice(source), "x=1");
+
+        assert!(sequence.group_open_suffix_span().is_some());
+        assert_eq!(
+            sequence
+                .leading_for(0)
+                .iter()
+                .map(SourceComment::text)
+                .collect::<Vec<_>>(),
+            ["# inner"]
+        );
+    }
+
+    #[test]
+    fn skips_header_suffix_comments_before_first_body_statement() {
         let source = "if foo; then # note\n  bar\nfi\n";
         let file = parse(source);
         let options = ShellFormatOptions::default();
@@ -1169,7 +1285,8 @@ mod tests {
                 source,
             )),
         );
-        assert!(sequence.is_ambiguous());
+        assert!(!sequence.is_ambiguous());
+        assert!(!sequence.has_comments());
     }
 
     #[test]

--- a/crates/shuck-formatter/src/lib.rs
+++ b/crates/shuck-formatter/src/lib.rs
@@ -766,9 +766,13 @@ mod tests {
 
     #[test]
     fn heredoc_delimiter_scan_ignores_non_redirection_operators() {
+        let delimiters = heredoc_delimiters_in_rendered_line("cat <<EOF 2<<-'ERR'");
         assert_eq!(
-            heredoc_delimiters_in_rendered_line("cat <<EOF 2<<-'ERR'"),
-            vec!["EOF".to_string(), "ERR".to_string()]
+            delimiters
+                .iter()
+                .map(|delimiter| (delimiter.delimiter.as_str(), delimiter.strip_tabs))
+                .collect::<Vec<_>>(),
+            vec![("EOF", false), ("ERR", true)]
         );
         assert!(heredoc_delimiters_in_rendered_line("echo $((1 << 2))").is_empty());
         assert!(heredoc_delimiters_in_rendered_line("((1 << 2))").is_empty());
@@ -1155,6 +1159,23 @@ mod tests {
             formatted,
             FormattedSource::Formatted(
                 "num=\"$({ getconf _NPROCESSORS_ONLN ||\n\tgrep -c ^processor /proc/cpuinfo; } 2>/dev/null)\"\n"
+                    .to_string()
+            )
+        );
+    }
+
+    #[test]
+    fn compacted_inline_brace_group_command_substitution_honors_space_indent() {
+        let source = "num=\"$({ getconf _NPROCESSORS_ONLN ||\n             grep -c ^processor /proc/cpuinfo; } 2>/dev/null)\"\n";
+        let options = ShellFormatOptions::default()
+            .with_indent_style(IndentStyle::Space)
+            .with_indent_width(2);
+        let formatted = format_source(source, None, &options).unwrap();
+
+        assert_eq!(
+            formatted,
+            FormattedSource::Formatted(
+                "num=\"$({ getconf _NPROCESSORS_ONLN ||\n  grep -c ^processor /proc/cpuinfo; } 2>/dev/null)\"\n"
                     .to_string()
             )
         );

--- a/crates/shuck-formatter/src/lib.rs
+++ b/crates/shuck-formatter/src/lib.rs
@@ -38,7 +38,6 @@ mod streaming;
 mod word;
 
 use std::path::Path;
-use std::process::{Command, Stdio};
 
 use shuck_ast::File;
 use shuck_format::{FormatResult, LineEnding};
@@ -125,10 +124,6 @@ pub fn format_source(
     options: &ShellFormatOptions,
 ) -> Result<FormattedSource> {
     let resolved = options.resolve(source, path);
-    if let Some(output) = format_with_external_shfmt(source, path, &resolved)? {
-        return Ok(formatted_source_from_output(source, output));
-    }
-
     let dialect = resolved.dialect();
     let parsed = Parser::with_dialect(source, dialect).parse();
     if parsed.is_err() {
@@ -145,10 +140,6 @@ pub fn source_is_formatted(
     options: &ShellFormatOptions,
 ) -> Result<bool> {
     let resolved = options.resolve(source, path);
-    if let Some(output) = format_with_external_shfmt(source, path, &resolved)? {
-        return Ok(output == source);
-    }
-
     let dialect = resolved.dialect();
     let parsed = Parser::with_dialect(source, dialect).parse();
     if parsed.is_err() {
@@ -180,16 +171,20 @@ fn format_file(
 }
 
 fn check_file(source: &str, mut file: File, resolved: ResolvedShellFormatOptions) -> Result<bool> {
-    if resolved.minify() {
-        let output = format_output(source, file, &resolved)?;
-        return Ok(output == source);
-    }
-
     if resolved.simplify() {
         simplify::simplify_file(&mut file, source);
     }
 
-    streaming::format_file_streaming_matches_source(source, &file, &resolved)
+    if !resolved.minify()
+        && !resolved.simplify()
+        && !source_may_need_case_comment_alignment(source)
+        && !source_may_need_branch_comment_relocation(source)
+    {
+        return streaming::format_file_streaming_matches_source(source, &file, &resolved);
+    }
+
+    let output = format_output(source, file, &resolved)?;
+    Ok(output == source)
 }
 
 fn format_output(
@@ -204,10 +199,157 @@ fn format_output(
     let mut output = streaming::format_file_streaming(source, &file, resolved)?;
     if resolved.minify() {
         preserve_initial_shebang(source, &mut output, resolved.line_ending());
+    } else {
+        align_adjacent_case_terminator_comments(&mut output, resolved.line_ending());
+        relocate_branch_leading_comments(&mut output, resolved.line_ending());
     }
     ensure_single_trailing_newline(&mut output, resolved.line_ending());
 
     Ok(output)
+}
+
+fn align_adjacent_case_terminator_comments(output: &mut String, line_ending: LineEnding) {
+    let line_ending = line_ending_str(line_ending);
+    let had_trailing_line_ending = trailing_line_ending_start(output).is_some();
+    let body = output.trim_end_matches(['\r', '\n']);
+    if body.is_empty() {
+        return;
+    }
+
+    let mut lines = body
+        .split(line_ending)
+        .map(str::to_string)
+        .collect::<Vec<_>>();
+    let mut index = 0;
+    while index < lines.len() {
+        let Some(_) = case_alignment_inline_comment_code_width(&lines[index]) else {
+            index += 1;
+            continue;
+        };
+
+        let start = index;
+        let mut has_case_terminator =
+            case_terminator_inline_comment_code_width(&lines[index]).is_some();
+        index += 1;
+        while index < lines.len()
+            && case_alignment_inline_comment_code_width(&lines[index]).is_some()
+        {
+            has_case_terminator |=
+                case_terminator_inline_comment_code_width(&lines[index]).is_some();
+            index += 1;
+        }
+
+        if index - start < 2 || !has_case_terminator {
+            continue;
+        }
+
+        let target = lines[start..index]
+            .iter()
+            .filter_map(|line| case_alignment_inline_comment_code_width(line))
+            .max()
+            .unwrap_or(0)
+            + 1;
+        for line in &mut lines[start..index] {
+            align_inline_comment_to_column(line, target);
+        }
+    }
+
+    let mut aligned = lines.join(line_ending);
+    if had_trailing_line_ending {
+        aligned.push_str(line_ending);
+    }
+    *output = aligned;
+}
+
+fn case_terminator_inline_comment_code_width(line: &str) -> Option<usize> {
+    let comment_start = line.find('#')?;
+    let code = line[..comment_start].trim_end();
+    if code.trim().is_empty() || !(code.contains(";;") || code.contains(";&")) {
+        return None;
+    }
+    Some(code.chars().count())
+}
+
+fn case_alignment_inline_comment_code_width(line: &str) -> Option<usize> {
+    let comment_start = line.find('#')?;
+    let code = line[..comment_start].trim_end();
+    if code.trim().is_empty() {
+        return None;
+    }
+    (code.contains(";;") || code.contains(";&") || code.trim_end().ends_with(')'))
+        .then_some(code.chars().count())
+}
+
+fn align_inline_comment_to_column(line: &mut String, target: usize) {
+    let Some(comment_start) = line.find('#') else {
+        return;
+    };
+    let code = line[..comment_start].trim_end();
+    let comment = &line[comment_start..];
+    let padding = target.saturating_sub(code.chars().count()).max(1);
+    let mut aligned = String::with_capacity(code.len() + padding + comment.len());
+    aligned.push_str(code);
+    aligned.push_str(&" ".repeat(padding));
+    aligned.push_str(comment);
+    *line = aligned;
+}
+
+fn source_may_need_case_comment_alignment(source: &str) -> bool {
+    source
+        .lines()
+        .any(|line| case_terminator_inline_comment_code_width(line).is_some())
+}
+
+fn source_may_need_branch_comment_relocation(source: &str) -> bool {
+    let lines = source.lines().collect::<Vec<_>>();
+    lines.windows(2).any(|window| {
+        window[0].trim_start().starts_with('#')
+            && (window[1].trim_start() == "else" || window[1].trim_start().starts_with("elif "))
+    })
+}
+
+fn relocate_branch_leading_comments(output: &mut String, line_ending: LineEnding) {
+    let line_ending = line_ending_str(line_ending);
+    let had_trailing_line_ending = trailing_line_ending_start(output).is_some();
+    let body = output.trim_end_matches(['\r', '\n']);
+    if body.is_empty() {
+        return;
+    }
+
+    let mut lines = body
+        .split(line_ending)
+        .map(str::to_string)
+        .collect::<Vec<_>>();
+    for index in 1..lines.len().saturating_sub(2) {
+        if !lines[index].trim_start().starts_with('#') || !lines[index + 1].is_empty() {
+            continue;
+        }
+        let next_trimmed = lines[index + 2].trim_start();
+        if !(next_trimmed == "else" || next_trimmed.starts_with("elif ")) {
+            continue;
+        }
+
+        let comment_indent = leading_whitespace_len(&lines[index]);
+        let keyword_indent = leading_whitespace_len(&lines[index + 2]);
+        if comment_indent <= keyword_indent {
+            continue;
+        }
+
+        let keyword_prefix = lines[index + 2][..keyword_indent].to_string();
+        let comment = lines[index].trim_start().to_string();
+        lines[index].clear();
+        lines[index + 1] = format!("{keyword_prefix}{comment}");
+    }
+
+    let mut relocated = lines.join(line_ending);
+    if had_trailing_line_ending {
+        relocated.push_str(line_ending);
+    }
+    *output = relocated;
+}
+
+fn leading_whitespace_len(line: &str) -> usize {
+    line.chars().take_while(|ch| ch.is_whitespace()).count()
 }
 
 fn formatted_source_from_output(source: &str, output: String) -> FormattedSource {
@@ -215,90 +357,6 @@ fn formatted_source_from_output(source: &str, output: String) -> FormattedSource
         FormattedSource::Unchanged
     } else {
         FormattedSource::Formatted(output)
-    }
-}
-
-fn format_with_external_shfmt(
-    source: &str,
-    path: Option<&Path>,
-    resolved: &ResolvedShellFormatOptions,
-) -> Result<Option<String>> {
-    if std::env::var_os("SHUCK_FORMAT_USE_SHFMT").is_none() {
-        return Ok(None);
-    }
-
-    let Some(language) = shfmt_language_flag(resolved.dialect()) else {
-        return Ok(None);
-    };
-
-    let mut command = Command::new("shfmt");
-    command
-        .arg("-filename")
-        .arg(path.unwrap_or(Path::new("script.sh")));
-    command.arg(format!("-ln={language}"));
-    if matches!(resolved.indent_style(), IndentStyle::Space) {
-        command.arg(format!("-i={}", resolved.indent_width()));
-    }
-    if resolved.binary_next_line() {
-        command.arg("-bn");
-    }
-    if resolved.switch_case_indent() {
-        command.arg("-ci");
-    }
-    if resolved.space_redirects() {
-        command.arg("-sr");
-    }
-    if resolved.keep_padding() {
-        command.arg("-kp");
-    }
-    if resolved.function_next_line() {
-        command.arg("-fn");
-    }
-    if resolved.never_split() {
-        command.arg("-ns");
-    }
-    if resolved.simplify() {
-        command.arg("-s");
-    }
-    if resolved.minify() {
-        command.arg("-mn");
-    }
-    command.stdin(Stdio::piped()).stdout(Stdio::piped());
-
-    let mut child = match command.spawn() {
-        Ok(child) => child,
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
-        Err(error) => return Err(FormatError::Internal(error.to_string())),
-    };
-    {
-        use std::io::Write;
-        let stdin = child
-            .stdin
-            .as_mut()
-            .ok_or_else(|| FormatError::Internal("failed to open shfmt stdin".to_string()))?;
-        stdin
-            .write_all(source.as_bytes())
-            .map_err(|error| FormatError::Internal(error.to_string()))?;
-    }
-
-    let output = child
-        .wait_with_output()
-        .map_err(|error| FormatError::Internal(error.to_string()))?;
-    if !output.status.success() {
-        return Ok(None);
-    }
-
-    String::from_utf8(output.stdout)
-        .map(Some)
-        .map_err(|error| FormatError::Internal(error.to_string()))
-}
-
-fn shfmt_language_flag(dialect: shuck_parser::ShellDialect) -> Option<&'static str> {
-    match dialect {
-        shuck_parser::ShellDialect::Bash => Some("bash"),
-        shuck_parser::ShellDialect::Posix => Some("posix"),
-        shuck_parser::ShellDialect::Mksh => Some("mksh"),
-        shuck_parser::ShellDialect::Zsh => Some("zsh"),
     }
 }
 
@@ -508,6 +566,46 @@ mod tests {
     }
 
     #[test]
+    fn preserves_source_backed_double_quoted_backslashes_like_shfmt() {
+        let source = "fgc=\"\\e[38;2;${red};${green};${blue}m\"\n";
+        let options = ShellFormatOptions::default();
+
+        assert_eq!(
+            format_source(source, None, &options).unwrap(),
+            FormattedSource::Unchanged
+        );
+        assert_source_and_ast_paths_match(source, None, &options);
+    }
+
+    #[test]
+    fn formats_process_substitution_bodies_like_shfmt() {
+        let source = "read -r misc_var < <(${sensor_comm} measure_temp 2>/dev/null ||true)\n";
+        let formatted = format_source(source, None, &ShellFormatOptions::default()).unwrap();
+
+        assert_eq!(
+            formatted,
+            FormattedSource::Formatted(
+                "read -r misc_var < <(${sensor_comm} measure_temp 2>/dev/null || true)\n"
+                    .to_string()
+            )
+        );
+    }
+
+    #[test]
+    fn aligns_adjacent_trailing_comments_like_shfmt() {
+        let source = "printf -v backspace \"\\u7F\" #? Backspace set to DELETE\nprintf -v backspace_real \"\\u08\" #? Real backspace\n";
+        let formatted = format_source(source, None, &ShellFormatOptions::default()).unwrap();
+
+        assert_eq!(
+            formatted,
+            FormattedSource::Formatted(
+                "printf -v backspace \"\\u7F\"      #? Backspace set to DELETE\nprintf -v backspace_real \"\\u08\" #? Real backspace\n"
+                    .to_string()
+            )
+        );
+    }
+
+    #[test]
     fn check_path_reports_already_formatted_sources() {
         assert!(
             source_is_formatted(
@@ -709,6 +807,14 @@ mod tests {
     }
 
     #[test]
+    fn preserves_escaped_quotes_around_parameter_expansion_in_double_quotes() {
+        let source = "nvm_echo \"Running node LTS \\\"${NVM_LTS-}\\\" -> $(nvm_version \"${VERSION}\")$(nvm use --silent \"${VERSION}\" && nvm_print_npm_version)\"\n";
+        let formatted = format_source(source, None, &ShellFormatOptions::default()).unwrap();
+
+        assert_eq!(formatted, FormattedSource::Unchanged);
+    }
+
+    #[test]
     fn preserves_nested_parameter_expansions_inside_quoted_strings() {
         let source = "nvm_err \"N/A: version \\\"${PREFIXED_VERSION:-$PROVIDED_VERSION}\\\" is not yet installed.\"\n";
         let formatted = format_source(source, None, &ShellFormatOptions::default()).unwrap();
@@ -732,6 +838,70 @@ mod tests {
     }
 
     #[test]
+    fn preserves_explicit_default_redirect_fds() {
+        let source = "cmd 1>/dev/null\ncmd 0<input\n";
+        let options = ShellFormatOptions::default();
+
+        assert_eq!(
+            format_source(source, None, &options).unwrap(),
+            FormattedSource::Unchanged
+        );
+        assert_source_and_ast_paths_match(source, None, &options);
+    }
+
+    #[test]
+    fn preserves_line_continuation_before_trailing_redirects() {
+        let source = "nvm_echo_with_colors nvm_err_with_colors \\\n  >/dev/null 2>&1\n";
+        let formatted = format_source(source, None, &ShellFormatOptions::default()).unwrap();
+
+        assert_eq!(
+            formatted,
+            FormattedSource::Formatted(
+                "nvm_echo_with_colors nvm_err_with_colors \\\n\t>/dev/null 2>&1\n".to_string()
+            )
+        );
+    }
+
+    #[test]
+    fn preserves_line_continuation_before_later_arguments_like_shfmt() {
+        let source = "notify-send \"title\" \"long body\" \\\n  -i face-glasses -t 10000\n";
+        let formatted = format_source(source, None, &ShellFormatOptions::default()).unwrap();
+
+        assert_eq!(
+            formatted,
+            FormattedSource::Formatted(
+                "notify-send \"title\" \"long body\" \\\n\t-i face-glasses -t 10000\n".to_string()
+            )
+        );
+    }
+
+    #[test]
+    fn collapses_no_space_continuation_before_quoted_argument_like_shfmt() {
+        let source =
+            "notify-send -u normal\\\n  \"title\" \"long body\"\\\n  -i face-glasses -t 10000\n";
+        let formatted = format_source(source, None, &ShellFormatOptions::default()).unwrap();
+
+        assert_eq!(
+            formatted,
+            FormattedSource::Formatted(
+                "notify-send -u normal \"title\" \"long body\" \\\n\t-i face-glasses -t 10000\n"
+                    .to_string()
+            )
+        );
+    }
+
+    #[test]
+    fn collapses_no_space_continuation_before_variable_argument_like_shfmt() {
+        let source = "cmd -rs\\\n  ${reverse_string}\\\n  -fg x\\\n  -fg y\n";
+        let formatted = format_source(source, None, &ShellFormatOptions::default()).unwrap();
+
+        assert_eq!(
+            formatted,
+            FormattedSource::Formatted("cmd -rs ${reverse_string} \\\n\t-fg x -fg y\n".to_string())
+        );
+    }
+
+    #[test]
     fn preserves_empty_command_substitutions() {
         let source = "result=$()\n";
         let options = ShellFormatOptions::default();
@@ -751,6 +921,30 @@ mod tests {
         assert_eq!(
             format_source(source, None, &options).unwrap(),
             FormattedSource::Formatted("result=$(\n\techo foo\n\techo bar\n)\n".to_string())
+        );
+        assert_source_and_ast_paths_match(source, None, &options);
+    }
+
+    #[test]
+    fn formats_command_substitutions_with_rendered_line_breaks_as_multiline() {
+        let source = "result=$(echo foo\necho bar)\n";
+        let options = ShellFormatOptions::default();
+
+        assert_eq!(
+            format_source(source, None, &options).unwrap(),
+            FormattedSource::Formatted("result=$(\n\techo foo\n\techo bar\n)\n".to_string())
+        );
+        assert_source_and_ast_paths_match(source, None, &options);
+    }
+
+    #[test]
+    fn spaces_command_substitution_before_inline_subshell() {
+        let source = "result=$( (foo) || bar)\n";
+        let options = ShellFormatOptions::default();
+
+        assert_eq!(
+            format_source(source, None, &options).unwrap(),
+            FormattedSource::Unchanged
         );
         assert_source_and_ast_paths_match(source, None, &options);
     }
@@ -783,15 +977,40 @@ mod tests {
     }
 
     #[test]
-    fn command_substitutions_with_heredocs_fall_back_to_raw_source() {
+    fn command_substitutions_with_heredocs_format_shell_lines_but_not_bodies() {
         let source = "result=$(cat <<EOF\nhello\nEOF\n)\n";
         let options = ShellFormatOptions::default();
 
         assert_eq!(
             format_source(source, None, &options).unwrap(),
-            FormattedSource::Unchanged
+            FormattedSource::Formatted("result=$(\n\tcat <<EOF\nhello\nEOF\n)\n".to_string())
         );
         assert_source_and_ast_paths_match(source, None, &options);
+    }
+
+    #[test]
+    fn preserves_post_heredoc_quote_line_like_shfmt() {
+        let source = "f() {\n  echo \"$(\n    cat <<EOS\nbody\nEOS\n  )\n\" | tr -d \"\\\\\"\n}\n";
+        let formatted = format_source(source, None, &ShellFormatOptions::default()).unwrap();
+
+        assert_eq!(
+            formatted,
+            FormattedSource::Formatted(
+                "f() {\n\techo \"$(\n\t\tcat <<EOS\nbody\nEOS\n\t)\n\" | tr -d \"\\\\\"\n}\n"
+                    .to_string()
+            )
+        );
+    }
+
+    #[test]
+    fn formats_tab_stripped_heredoc_indentation_like_shfmt() {
+        let source = "f() {\n  cat <<-EOF\n\thi\n\tEOF\n}\n";
+        let formatted = format_source(source, None, &ShellFormatOptions::default()).unwrap();
+
+        assert_eq!(
+            formatted,
+            FormattedSource::Formatted("f() {\n\tcat <<-EOF\n\t\thi\n\tEOF\n}\n".to_string())
+        );
     }
 
     #[test]
@@ -897,6 +1116,20 @@ mod tests {
     }
 
     #[test]
+    fn compacts_inline_brace_group_command_substitution_like_shfmt() {
+        let source = "num=\"$({ getconf _NPROCESSORS_ONLN ||\n             grep -c ^processor /proc/cpuinfo; } 2>/dev/null)\"\n";
+        let formatted = format_source(source, None, &ShellFormatOptions::default()).unwrap();
+
+        assert_eq!(
+            formatted,
+            FormattedSource::Formatted(
+                "num=\"$({ getconf _NPROCESSORS_ONLN ||\n\tgrep -c ^processor /proc/cpuinfo; } 2>/dev/null)\"\n"
+                    .to_string()
+            )
+        );
+    }
+
+    #[test]
     fn formats_nvm_args_command_substitution_without_losing_sed_body_layout() {
         let source = "ARGS=$(\n  nvm_echo \"$@\" | command sed \"\n    s/--progress-bar /--progress=bar /\n    s/-s /-q /\n  \"\n)\n";
         let options = ShellFormatOptions::default();
@@ -912,6 +1145,75 @@ mod tests {
     }
 
     #[test]
+    fn formats_inline_command_substitution_with_continuations_as_multiline() {
+        let source = "VERSIONS=\"$(command find foo \\\n  | command sed -e \"\n    s#x#y#;\n  \" \\\n    -e z)\"\n";
+        let options = ShellFormatOptions::default();
+
+        assert_eq!(
+            format_source(source, None, &options).unwrap(),
+            FormattedSource::Formatted(
+                "VERSIONS=\"$(\n\tcommand find foo |\n\t\tcommand sed -e \"\n    s#x#y#;\n  \" \\\n\t\t\t-e z\n)\"\n"
+                    .to_string()
+            )
+        );
+    }
+
+    #[test]
+    fn preserves_break_before_leading_pipeline_operator_like_shfmt() {
+        let source =
+            "VERSIONS=\"$(command find foo \\\n  | command sed q \\\n  | command sort \\\n)\"\n";
+        let formatted = format_source(source, None, &ShellFormatOptions::default()).unwrap();
+
+        assert_eq!(
+            formatted,
+            FormattedSource::Formatted(
+                "VERSIONS=\"$(\n\tcommand find foo |\n\t\tcommand sed q |\n\t\tcommand sort\n)\"\n"
+                    .to_string()
+            )
+        );
+    }
+
+    #[test]
+    fn keeps_inline_brace_group_command_substitution_with_pipeline_like_shfmt() {
+        let source = "nvm_err \"awk: $(nvm_command_info awk), $({ command awk --version 2>/dev/null || command awk -W version; } \\\n  | command head -n 1)\"\n";
+        let formatted = format_source(source, None, &ShellFormatOptions::default()).unwrap();
+
+        assert_eq!(
+            formatted,
+            FormattedSource::Formatted(
+                "nvm_err \"awk: $(nvm_command_info awk), $({ command awk --version 2>/dev/null || command awk -W version; } |\n\tcommand head -n 1)\"\n"
+                    .to_string()
+            )
+        );
+    }
+
+    #[test]
+    fn keeps_inline_command_substitution_for_single_command_with_multiline_string() {
+        let source = "ARGS=$(nvm_echo \"$@\" | command sed \"\n    s/--progress-bar /--progress=bar /\n    s/-s /-q /\n  \")\n";
+        let options = ShellFormatOptions::default();
+
+        assert_eq!(
+            format_source(source, None, &options).unwrap(),
+            FormattedSource::Unchanged
+        );
+        assert_source_and_ast_paths_match(source, None, &options);
+    }
+
+    #[test]
+    fn preserves_multiline_assignment_string_continuation_indentation() {
+        let source = "f() {\n  label=\"one |\n                      two |\n                      three\"\n}\n";
+        let formatted = format_source(source, None, &ShellFormatOptions::default()).unwrap();
+
+        assert_eq!(
+            formatted,
+            FormattedSource::Formatted(
+                "f() {\n\tlabel=\"one |\n                      two |\n                      three\"\n}\n"
+                    .to_string()
+            )
+        );
+    }
+
+    #[test]
     fn formats_arithmetic_expansions_from_ruby_build() {
         let source = "echo $(( ver[0]*100 + ver[1] ))\n";
         let formatted = format_source(source, None, &ShellFormatOptions::default()).unwrap();
@@ -919,6 +1221,275 @@ mod tests {
         assert_eq!(
             formatted,
             FormattedSource::Formatted("echo $((ver[0] * 100 + ver[1]))\n".to_string())
+        );
+    }
+
+    #[test]
+    fn formats_arithmetic_commands_like_shfmt() {
+        let source = "if ((system_version < lower_bound || system_version >= upper_bound)); then\n  return 1\nfi\n";
+        let formatted = format_source(source, None, &ShellFormatOptions::default()).unwrap();
+
+        assert_eq!(
+            formatted,
+            FormattedSource::Formatted(
+                "if ((system_version < lower_bound || system_version >= upper_bound)); then\n\treturn 1\nfi\n"
+                    .to_string()
+            )
+        );
+    }
+
+    #[test]
+    fn formats_shell_style_variables_inside_arithmetic_commands_like_shfmt() {
+        let source = "if (($tty_width<80 | $tty_height<24)); then\n  return 1\nfi\n";
+        let formatted = format_source(source, None, &ShellFormatOptions::default()).unwrap();
+
+        assert_eq!(
+            formatted,
+            FormattedSource::Formatted(
+                "if (($tty_width < 80 | $tty_height < 24)); then\n\treturn 1\nfi\n".to_string()
+            )
+        );
+    }
+
+    #[test]
+    fn formats_arithmetic_for_headers_like_shfmt() {
+        let source = "for ((i=0;i<${#items[@]};i++)); do\n  echo \"$i\"\ndone\nfor ((;;)); do\n  break\ndone\n";
+        let formatted = format_source(source, None, &ShellFormatOptions::default()).unwrap();
+
+        assert_eq!(
+            formatted,
+            FormattedSource::Formatted(
+                "for ((i = 0; i < ${#items[@]}; i++)); do\n\techo \"$i\"\ndone\nfor (( ; ; )); do\n\tbreak\ndone\n"
+                    .to_string()
+            )
+        );
+    }
+
+    #[test]
+    fn formats_arithmetic_for_comma_headers_like_shfmt() {
+        let source = "for ((i=0;i<=100;i++,y=0)); do\n  :\ndone\n";
+        let formatted = format_source(source, None, &ShellFormatOptions::default()).unwrap();
+
+        assert_eq!(
+            formatted,
+            FormattedSource::Formatted(
+                "for ((i = 0; i <= 100; i++, y = 0)); do\n\t:\ndone\n".to_string()
+            )
+        );
+    }
+
+    #[test]
+    fn preserves_multiline_compound_assignment_in_declare() {
+        let source = "declare -a items=(\"one\" \"two\"\n  \"three\" \"four\")\n";
+        let formatted = format_source(source, None, &ShellFormatOptions::default()).unwrap();
+
+        assert_eq!(
+            formatted,
+            FormattedSource::Formatted(
+                "declare -a items=(\"one\" \"two\"\n\t\"three\" \"four\")\n".to_string()
+            )
+        );
+    }
+
+    #[test]
+    fn preserves_multiline_conditional_layout_like_shfmt() {
+        let source = "if [[ a == b &&\n      c == d ]]; then\n  echo ok\nfi\n";
+        let formatted = format_source(source, None, &ShellFormatOptions::default()).unwrap();
+
+        assert_eq!(
+            formatted,
+            FormattedSource::Formatted(
+                "if [[ a == b &&\n\tc == d ]]; then\n\techo ok\nfi\n".to_string()
+            )
+        );
+    }
+
+    #[test]
+    fn formats_multiline_conditional_groups_like_shfmt() {
+        let source = "if [[ -n $brew_prefix && ( $prefix == foo/* || \\\n       $prefix == bar/* ) ]]; then\n  return 1\nfi\n";
+        let formatted = format_source(source, None, &ShellFormatOptions::default()).unwrap();
+
+        assert_eq!(
+            formatted,
+            FormattedSource::Formatted(
+                "if [[ -n $brew_prefix && ($prefix == foo/* ||\n\t$prefix == bar/*) ]]; then\n\treturn 1\nfi\n"
+                    .to_string()
+            )
+        );
+    }
+
+    #[test]
+    fn preserves_then_suffix_comments_and_indents_body() {
+        let source = "if foo; then # note\n  bar\nelif baz; then # alt\n  qux\nfi\n";
+        let formatted = format_source(source, None, &ShellFormatOptions::default()).unwrap();
+
+        assert_eq!(
+            formatted,
+            FormattedSource::Formatted(
+                "if foo; then # note\n\tbar\nelif baz; then # alt\n\tqux\nfi\n".to_string()
+            )
+        );
+    }
+
+    #[test]
+    fn preserves_multiline_elif_continuation_headers_like_shfmt() {
+        let source =
+            "if true; then\n  :\nelif \\\n  { foo; } \\\n  || { bar; } \\\n; then\n  :\nfi\n";
+        let formatted = format_source(source, None, &ShellFormatOptions::default()).unwrap();
+
+        assert_eq!(
+            formatted,
+            FormattedSource::Formatted(
+                "if true; then\n\t:\nelif\n\t{ foo; } ||\n\t\t{ bar; } \\\n\t\t;\nthen\n\t:\nfi\n"
+                    .to_string()
+            )
+        );
+    }
+
+    #[test]
+    fn keeps_pre_elif_comments_with_the_elif_branch() {
+        let source =
+            "if foo; then\n  bar\n# first\n# second\nelif baz &&\n  qux; then\n  zap\nfi\n";
+        let formatted = format_source(source, None, &ShellFormatOptions::default()).unwrap();
+
+        assert_eq!(
+            formatted,
+            FormattedSource::Formatted(
+                "if foo; then\n\tbar\n# first\n# second\nelif baz &&\n\tqux; then\n\tzap\nfi\n"
+                    .to_string()
+            )
+        );
+    }
+
+    #[test]
+    fn keeps_pre_else_comments_with_the_else_branch() {
+        let source = "if foo; then\n  fn() {\n    bar\n  }\n\n# else branch\nelse\n  baz\nfi\n";
+        let formatted = format_source(source, None, &ShellFormatOptions::default()).unwrap();
+
+        assert_eq!(
+            formatted,
+            FormattedSource::Formatted(
+                "if foo; then\n\tfn() {\n\t\tbar\n\t}\n\n# else branch\nelse\n\tbaz\nfi\n"
+                    .to_string()
+            )
+        );
+    }
+
+    #[test]
+    fn keeps_body_indented_comments_before_elif_at_body_depth_like_shfmt() {
+        let source = "if [[ $letter =~ [a-z] ]]; then\n  string_out=x\n  #if [[ $font ]]; then string_out=y; fi\nelif [[ $letter =~ [A-Z] ]]; then\n  string_out=z\nfi\n";
+        let formatted = format_source(source, None, &ShellFormatOptions::default()).unwrap();
+
+        assert_eq!(
+            formatted,
+            FormattedSource::Formatted(
+                "if [[ $letter =~ [a-z] ]]; then\n\tstring_out=x\n\t#if [[ $font ]]; then string_out=y; fi\nelif [[ $letter =~ [A-Z] ]]; then\n\tstring_out=z\nfi\n"
+                    .to_string()
+            )
+        );
+    }
+
+    #[test]
+    fn keeps_simple_then_else_on_one_line() {
+        let source = "if foo; then a=1; else b=2; fi\n";
+        let formatted = format_source(source, None, &ShellFormatOptions::default()).unwrap();
+
+        assert_eq!(formatted, FormattedSource::Unchanged);
+    }
+
+    #[test]
+    fn keeps_short_then_body_inline_before_multiline_else_like_shfmt() {
+        let source = "if ((items > height)); then pages=$((items / height + 1)); else height=$items; unset pages; fi\n";
+        let formatted = format_source(source, None, &ShellFormatOptions::default()).unwrap();
+
+        assert_eq!(
+            formatted,
+            FormattedSource::Formatted(
+                "if ((items > height)); then pages=$((items / height + 1)); else\n\theight=$items\n\tunset pages\nfi\n"
+                    .to_string()
+            )
+        );
+    }
+
+    #[test]
+    fn preserves_inline_else_body_when_then_branch_is_multiline() {
+        let source = "if [[ $letter == \"█\" ]]; then\n  b_color=x\nelse b_color=y; fi\n";
+        let formatted = format_source(source, None, &ShellFormatOptions::default()).unwrap();
+
+        assert_eq!(
+            formatted,
+            FormattedSource::Formatted(
+                "if [[ $letter == \"█\" ]]; then\n\tb_color=x\nelse b_color=y; fi\n".to_string()
+            )
+        );
+    }
+
+    #[test]
+    fn keeps_multiline_compound_assignment_on_else_line_like_shfmt() {
+        let source = "if foo; then\n  bar\nelse desc+=(\"one\"\n  \"two\"); fi\n";
+        let formatted = format_source(source, None, &ShellFormatOptions::default()).unwrap();
+
+        assert_eq!(
+            formatted,
+            FormattedSource::Formatted(
+                "if foo; then\n\tbar\nelse desc+=(\"one\"\n\t\"two\"); fi\n".to_string()
+            )
+        );
+    }
+
+    #[test]
+    fn preserves_inline_elif_body_when_then_branch_is_multiline() {
+        let source = "if ((per_second == 1 & unit_mult == 1)); then\n  per_second=\"/s\"\nelif ((per_second == 1)); then per_second=\"ps\"; fi\n";
+        let formatted = format_source(source, None, &ShellFormatOptions::default()).unwrap();
+
+        assert_eq!(
+            formatted,
+            FormattedSource::Formatted(
+                "if ((per_second == 1 & unit_mult == 1)); then\n\tper_second=\"/s\"\nelif ((per_second == 1)); then per_second=\"ps\"; fi\n"
+                    .to_string()
+            )
+        );
+    }
+
+    #[test]
+    fn expands_final_elif_body_before_multiline_else_like_shfmt() {
+        let source = "if [[ $pos = cpu ]]; then\n  percent=32\nelif [[ $pos = mem ]]; then percent=40\nelse percent=28; fi\n";
+        let formatted = format_source(source, None, &ShellFormatOptions::default()).unwrap();
+
+        assert_eq!(
+            formatted,
+            FormattedSource::Formatted(
+                "if [[ $pos = cpu ]]; then\n\tpercent=32\nelif [[ $pos = mem ]]; then\n\tpercent=40\nelse percent=28; fi\n"
+                    .to_string()
+            )
+        );
+    }
+
+    #[test]
+    fn keeps_short_then_body_inline_before_inline_elif_like_shfmt() {
+        let source = "if ((acolor>100)); then acolor=100; elif ((acolor<0)); then acolor=0; fi\n";
+        let formatted = format_source(source, None, &ShellFormatOptions::default()).unwrap();
+
+        assert_eq!(
+            formatted,
+            FormattedSource::Formatted(
+                "if ((acolor > 100)); then acolor=100; elif ((acolor < 0)); then acolor=0; fi\n"
+                    .to_string()
+            )
+        );
+    }
+
+    #[test]
+    fn does_not_inline_final_elif_body_when_fi_is_on_next_line_like_shfmt() {
+        let source = "if [[ -z $no_guide ]]; then\n  ((height--))\nelif [[ -n $invert ]]; then ((line--))\nfi\n";
+        let formatted = format_source(source, None, &ShellFormatOptions::default()).unwrap();
+
+        assert_eq!(
+            formatted,
+            FormattedSource::Formatted(
+                "if [[ -z $no_guide ]]; then\n\t((height--))\nelif [[ -n $invert ]]; then\n\t((line--))\nfi\n"
+                    .to_string()
+            )
         );
     }
 
@@ -946,6 +1517,41 @@ mod tests {
     }
 
     #[test]
+    fn formats_arithmetic_array_subscripts_like_shfmt() {
+        let source = "found=\"${line_array[$((line_pos+match_key))]}\"\n";
+        let formatted = format_source(source, None, &ShellFormatOptions::default()).unwrap();
+
+        assert_eq!(
+            formatted,
+            FormattedSource::Formatted(
+                "found=\"${line_array[$((line_pos + match_key))]}\"\n".to_string()
+            )
+        );
+    }
+
+    #[test]
+    fn formats_arithmetic_expansions_inside_mixed_array_subscripts_like_shfmt() {
+        let source = "print -v graph_array[y] -t \"${graph_symbol[${invert:+-}$(( (input_array[x]*virt_height/100)-next_value ))]}\"\n";
+        let formatted = format_source(source, None, &ShellFormatOptions::default()).unwrap();
+
+        assert_eq!(
+            formatted,
+            FormattedSource::Formatted(
+                "print -v graph_array[y] -t \"${graph_symbol[${invert:+-}$(((input_array[x] * virt_height / 100) - next_value))]}\"\n"
+                    .to_string()
+            )
+        );
+    }
+
+    #[test]
+    fn preserves_plain_array_subscript_arithmetic_like_shfmt() {
+        let source = "org_value=${input_array[offset+x]}\n";
+        let formatted = format_source(source, None, &ShellFormatOptions::default()).unwrap();
+
+        assert_eq!(formatted, FormattedSource::Unchanged);
+    }
+
+    #[test]
     fn formats_braced_shell_style_variables_inside_arithmetic_expansions_like_shfmt() {
         let source = "echo $(( ${ver[0]}*100 + ${ver[1]} ))\n";
         let formatted = format_source(source, None, &ShellFormatOptions::default()).unwrap();
@@ -967,6 +1573,73 @@ mod tests {
             FormattedSource::Formatted(
                 "for arg in \"${@:$(($package_type_nargs + 1))}\"; do\n\techo \"$arg\"\ndone\n"
                     .to_string()
+            )
+        );
+    }
+
+    #[test]
+    fn formats_arithmetic_expansions_inside_parameter_slices_like_shfmt() {
+        let source =
+            "graph_array[i]=\"${graph_array[i]::$search}${graph_array[i]:$((search+1))}\"\n";
+        let formatted = format_source(source, None, &ShellFormatOptions::default()).unwrap();
+
+        assert_eq!(
+            formatted,
+            FormattedSource::Formatted(
+                "graph_array[i]=\"${graph_array[i]::$search}${graph_array[i]:$((search + 1))}\"\n"
+                    .to_string()
+            )
+        );
+    }
+
+    #[test]
+    fn formats_parenthesized_negative_parameter_offsets_like_shfmt() {
+        let source = "filter_string=\"${filter: (-$((width-35-reverse_pos)))}\"\n";
+        let formatted = format_source(source, None, &ShellFormatOptions::default()).unwrap();
+
+        assert_eq!(
+            formatted,
+            FormattedSource::Formatted(
+                "filter_string=\"${filter:(-$((width - 35 - reverse_pos)))}\"\n".to_string()
+            )
+        );
+    }
+
+    #[test]
+    fn formats_arithmetic_expansions_inside_parameter_defaults_like_shfmt() {
+        let source = "create_box -h ${desc_height:-$((${#selected_desc[@]}+2))}\n";
+        let formatted = format_source(source, None, &ShellFormatOptions::default()).unwrap();
+
+        assert_eq!(
+            formatted,
+            FormattedSource::Formatted(
+                "create_box -h ${desc_height:-$((${#selected_desc[@]} + 2))}\n".to_string()
+            )
+        );
+    }
+
+    #[test]
+    fn formats_arithmetic_subscripts_inside_parameter_operations_like_shfmt() {
+        let source = "tree_compare1=\"${proc_array[$((count+1))]%'|'*}\"\n";
+        let formatted = format_source(source, None, &ShellFormatOptions::default()).unwrap();
+
+        assert_eq!(
+            formatted,
+            FormattedSource::Formatted(
+                "tree_compare1=\"${proc_array[$((count + 1))]%'|'*}\"\n".to_string()
+            )
+        );
+    }
+
+    #[test]
+    fn formats_arithmetic_expansions_inside_assignment_subscripts_like_shfmt() {
+        let source = "cpu[temp_$((threads/2+i))]=\"${core_value}\"\n";
+        let formatted = format_source(source, None, &ShellFormatOptions::default()).unwrap();
+
+        assert_eq!(
+            formatted,
+            FormattedSource::Formatted(
+                "cpu[temp_$((threads / 2 + i))]=\"${core_value}\"\n".to_string()
             )
         );
     }
@@ -1014,6 +1687,31 @@ mod tests {
             formatted,
             FormattedSource::Formatted(
                 "\"$1\" --enable-frozen-string-literal --disable=gems,did_you_mean,rubyopt -rrubygems -e \\\n\t\"abort if Gem::Version.new(RUBY_VERSION) < \\\n              Gem::Version.new('${REQUIRED_RUBY_VERSION}')\" 2>/dev/null\n"
+                    .to_string()
+            )
+        );
+    }
+
+    #[test]
+    fn formats_pipeline_inside_broken_list_like_shfmt() {
+        let source = "foo &&\n  a |\n    b |\n    c\n";
+        let formatted = format_source(source, None, &ShellFormatOptions::default()).unwrap();
+
+        assert_eq!(
+            formatted,
+            FormattedSource::Formatted("foo &&\n\ta |\n\tb |\n\t\tc\n".to_string())
+        );
+    }
+
+    #[test]
+    fn only_breaks_pipeline_operators_that_break_in_source() {
+        let source = "sort_versions() {\n  sed 's/x/y/' |\n    LC_ALL=C sort -t. -k 1,1 | awk '{print $2}'\n}\n";
+        let formatted = format_source(source, None, &ShellFormatOptions::default()).unwrap();
+
+        assert_eq!(
+            formatted,
+            FormattedSource::Formatted(
+                "sort_versions() {\n\tsed 's/x/y/' |\n\t\tLC_ALL=C sort -t. -k 1,1 | awk '{print $2}'\n}\n"
                     .to_string()
             )
         );
@@ -1069,6 +1767,41 @@ mod tests {
     }
 
     #[test]
+    fn preserves_blank_line_after_else_like_shfmt() {
+        let source = "if foo; then\n  bar\nelse\n\n  if baz; then\n    qux\n  fi\nfi\n";
+        let formatted = format_source(source, None, &ShellFormatOptions::default()).unwrap();
+
+        assert_eq!(
+            formatted,
+            FormattedSource::Formatted(
+                "if foo; then\n\tbar\nelse\n\n\tif baz; then\n\t\tqux\n\tfi\nfi\n".to_string()
+            )
+        );
+    }
+
+    #[test]
+    fn preserves_blank_line_before_else_like_shfmt() {
+        let source = "if foo; then\n  bar\n\nelse\n  baz\nfi\n";
+        let formatted = format_source(source, None, &ShellFormatOptions::default()).unwrap();
+
+        assert_eq!(
+            formatted,
+            FormattedSource::Formatted("if foo; then\n\tbar\n\nelse\n\tbaz\nfi\n".to_string())
+        );
+    }
+
+    #[test]
+    fn preserves_blank_line_before_fi_like_shfmt() {
+        let source = "if foo; then\n  bar\n\nfi\n";
+        let formatted = format_source(source, None, &ShellFormatOptions::default()).unwrap();
+
+        assert_eq!(
+            formatted,
+            FormattedSource::Formatted("if foo; then\n\tbar\n\nfi\n".to_string())
+        );
+    }
+
+    #[test]
     fn formats_multiline_compound_assignments_structurally() {
         let source = "directories=(\n  bin\n  etc\n  Frameworks\n)\n";
         let formatted = format_source(source, None, &ShellFormatOptions::default()).unwrap();
@@ -1101,6 +1834,17 @@ mod tests {
     }
 
     #[test]
+    fn preserves_group_body_comments_after_open_suffix() {
+        let source = "{ # open\n\n# inner\nx=1\n}\n";
+        let formatted = format_source(source, None, &ShellFormatOptions::default()).unwrap();
+
+        assert_eq!(
+            formatted,
+            FormattedSource::Formatted("{ # open\n\n\t# inner\n\tx=1\n}\n".to_string())
+        );
+    }
+
+    #[test]
     fn standalone_brace_groups_do_not_consume_later_file_comments() {
         let source = "[ -n \"$x\" ] && {\nset -x\n}\n# later\nnext\n";
         let formatted = format_source(source, None, &ShellFormatOptions::default()).unwrap();
@@ -1108,7 +1852,7 @@ mod tests {
         assert_eq!(
             formatted,
             FormattedSource::Formatted(
-                "[ -n \"$x\" ] && {\n\tset -x\n}\n\n# later\nnext\n".to_string()
+                "[ -n \"$x\" ] && {\n\tset -x\n}\n# later\nnext\n".to_string()
             )
         );
     }
@@ -1144,6 +1888,139 @@ mod tests {
     }
 
     #[test]
+    fn preserves_inline_case_commands_like_shfmt() {
+        let source = "if case \"$line\" in *'='*) true ;; *) false ;; esac; then\nx=1\nfi\n";
+        let formatted = format_source(source, None, &ShellFormatOptions::default()).unwrap();
+
+        assert_eq!(
+            formatted,
+            FormattedSource::Formatted(
+                "if case \"$line\" in *'='*) true ;; *) false ;; esac then\n\tx=1\nfi\n"
+                    .to_string()
+            )
+        );
+    }
+
+    #[test]
+    fn preserves_standalone_inline_case_commands_like_shfmt() {
+        let source = "f() {\n  case \"${1-}\" in iojs-*) return 0 ;; esac\n  return 1\n}\n";
+        let formatted = format_source(source, None, &ShellFormatOptions::default()).unwrap();
+
+        assert_eq!(
+            formatted,
+            FormattedSource::Formatted(
+                "f() {\n\tcase \"${1-}\" in iojs-*) return 0 ;; esac\n\treturn 1\n}\n".to_string()
+            )
+        );
+    }
+
+    #[test]
+    fn case_arm_comments_do_not_attach_to_previous_arms() {
+        let source = "case \"$option\" in\n\"h\" | \"help\")\nusage\n;;\n\"g\" | \"debug\")\nDEBUG=true\n# Disable optimization\nPYTHON_CFLAGS=-O0\n;;\nesac\n";
+        let formatted = format_source(source, None, &ShellFormatOptions::default()).unwrap();
+
+        assert_eq!(
+            formatted,
+            FormattedSource::Formatted(
+                "case \"$option\" in\n\"h\" | \"help\")\n\tusage\n\t;;\n\"g\" | \"debug\")\n\tDEBUG=true\n\t# Disable optimization\n\tPYTHON_CFLAGS=-O0\n\t;;\nesac\n"
+                    .to_string()
+            )
+        );
+    }
+
+    #[test]
+    fn preserves_case_pattern_suffix_comments_like_shfmt() {
+        let source = "case \"$keypress\" in\nleft) #* Move left\nprocess_left\n;;\nright) #* Move right\nprocess_right\n;;\nesac\n";
+        let formatted = format_source(source, None, &ShellFormatOptions::default()).unwrap();
+
+        assert_eq!(
+            formatted,
+            FormattedSource::Formatted(
+                "case \"$keypress\" in\nleft) #* Move left\n\tprocess_left\n\t;;\nright) #* Move right\n\tprocess_right\n\t;;\nesac\n"
+                    .to_string()
+            )
+        );
+    }
+
+    #[test]
+    fn preserves_case_pattern_suffix_comment_before_empty_body_terminator_like_shfmt() {
+        let source = "case \"$keypress\" in\nleft) #* Move left\n;;\nesac\n";
+        let formatted = format_source(source, None, &ShellFormatOptions::default()).unwrap();
+
+        assert_eq!(
+            formatted,
+            FormattedSource::Formatted(
+                "case \"$keypress\" in\nleft) #* Move left\n\t;;\nesac\n".to_string()
+            )
+        );
+    }
+
+    #[test]
+    fn keeps_commented_case_arm_before_next_pattern_like_shfmt() {
+        let source = "case \"$font\" in\n\"sans-serif italic\")\nlower=1\n;;\n#\"sans-serif bold italic\") lower=2;;\n\"script\")\nlower=3\n;;\nesac\n";
+        let formatted = format_source(source, None, &ShellFormatOptions::default()).unwrap();
+
+        assert_eq!(
+            formatted,
+            FormattedSource::Formatted(
+                "case \"$font\" in\n\"sans-serif italic\")\n\tlower=1\n\t;;\n#\"sans-serif bold italic\") lower=2;;\n\"script\")\n\tlower=3\n\t;;\nesac\n"
+                    .to_string()
+            )
+        );
+    }
+
+    #[test]
+    fn preserves_multiline_case_pattern_lists_like_shfmt() {
+        let source = "case \"${DEFINITION_PATH##*/}\" in\n\"2.\"* | \\\n  \"3.0\" | \"3.1\" | \\\n  \"3.2\"*)\npackage_option python configure --enable-unicode=ucs4\n;;\nesac\n";
+        let formatted = format_source(source, None, &ShellFormatOptions::default()).unwrap();
+
+        assert_eq!(
+            formatted,
+            FormattedSource::Formatted(
+                "case \"${DEFINITION_PATH##*/}\" in\n\"2.\"* | \\\n\t\"3.0\" | \"3.1\" | \\\n\t\"3.2\"*)\n\tpackage_option python configure --enable-unicode=ucs4\n\t;;\nesac\n"
+                    .to_string()
+            )
+        );
+    }
+
+    #[test]
+    fn normalizes_case_terminator_comment_padding_like_shfmt() {
+        let source = "case $flag in\n-a)\nall=1\n;;                 # all\nesac\n";
+        let formatted = format_source(source, None, &ShellFormatOptions::default()).unwrap();
+
+        assert_eq!(
+            formatted,
+            FormattedSource::Formatted(
+                "case $flag in\n-a)\n\tall=1\n\t;; # all\nesac\n".to_string()
+            )
+        );
+    }
+
+    #[test]
+    fn preserves_blank_line_before_case_terminator_like_shfmt() {
+        let source = "case $flag in\n-a)\nfoo\n\n;;\n-b)\nbar\n;;\nesac\n";
+        let formatted = format_source(source, None, &ShellFormatOptions::default()).unwrap();
+
+        assert_eq!(
+            formatted,
+            FormattedSource::Formatted(
+                "case $flag in\n-a)\n\tfoo\n\n\t;;\n-b)\n\tbar\n\t;;\nesac\n".to_string()
+            )
+        );
+    }
+
+    #[test]
+    fn preserves_blank_line_before_esac_like_shfmt() {
+        let source = "case $flag in\n-a)\nfoo\n;;\n\nesac\n";
+        let formatted = format_source(source, None, &ShellFormatOptions::default()).unwrap();
+
+        assert_eq!(
+            formatted,
+            FormattedSource::Formatted("case $flag in\n-a)\n\tfoo\n\t;;\n\nesac\n".to_string())
+        );
+    }
+
+    #[test]
     fn preserves_inline_group_redirect_suffixes() {
         let source = "build_package_activepython() {\n  local package_name=\"$1\"\n  { bash \"install.sh\" --install-dir \"${PREFIX_PATH}\"\n  } >&4 2>&1\n}\n";
         let formatted = format_source(source, None, &ShellFormatOptions::default()).unwrap();
@@ -1152,6 +2029,139 @@ mod tests {
             formatted,
             FormattedSource::Formatted(
                 "build_package_activepython() {\n\tlocal package_name=\"$1\"\n\t{\n\t\tbash \"install.sh\" --install-dir \"${PREFIX_PATH}\"\n\t} >&4 2>&1\n}\n".to_string()
+            )
+        );
+    }
+
+    #[test]
+    fn list_ending_in_multiline_group_does_not_add_blank_before_next_statement() {
+        let source = "foo && {\n  echo\n}\nbar\n";
+        let formatted = format_source(source, None, &ShellFormatOptions::default()).unwrap();
+
+        assert_eq!(
+            formatted,
+            FormattedSource::Formatted("foo && {\n\techo\n}\nbar\n".to_string())
+        );
+    }
+
+    #[test]
+    fn then_suffix_comments_do_not_flatten_nested_body_indentation() {
+        let source = "f() {\n  if [ -f x ]; then # pypy 2.x\n    if [ -z y ]; then\n      local X=1\n    fi\n  fi\n}\n";
+        let formatted = format_source(source, None, &ShellFormatOptions::default()).unwrap();
+
+        assert_eq!(
+            formatted,
+            FormattedSource::Formatted(
+                "f() {\n\tif [ -f x ]; then # pypy 2.x\n\t\tif [ -z y ]; then\n\t\t\tlocal X=1\n\t\tfi\n\tfi\n}\n"
+                    .to_string()
+            )
+        );
+    }
+
+    #[test]
+    fn preserves_multiline_conditions_after_if_keyword_like_shfmt() {
+        let source = "if [ -n \"$brew_prefix\" ] &&\n\n  [ -n \"$CFLAGS\" ]; then # comment\nexport CPPFLAGS=1\nfi\n";
+        let formatted = format_source(source, None, &ShellFormatOptions::default()).unwrap();
+
+        assert_eq!(
+            formatted,
+            FormattedSource::Formatted(
+                "if [ -n \"$brew_prefix\" ] &&\n\n\t[ -n \"$CFLAGS\" ]; then # comment\n\texport CPPFLAGS=1\nfi\n".to_string()
+            )
+        );
+    }
+
+    #[test]
+    fn preserves_multiline_elif_conditions_after_keyword_like_shfmt() {
+        let source = "if foo; then\nbar\nelif ! nvm_echo \"$1\" | nvm_grep -q \"$2\" &&\n  ! nvm_echo \"$1\" | nvm_grep -q \"$3\"; then\nbaz\nfi\n";
+        let formatted = format_source(source, None, &ShellFormatOptions::default()).unwrap();
+
+        assert_eq!(
+            formatted,
+            FormattedSource::Formatted(
+                "if foo; then\n\tbar\nelif ! nvm_echo \"$1\" | nvm_grep -q \"$2\" &&\n\t! nvm_echo \"$1\" | nvm_grep -q \"$3\"; then\n\tbaz\nfi\n"
+                    .to_string()
+            )
+        );
+    }
+
+    #[test]
+    fn folds_multiline_condition_semicolon_line_like_shfmt() {
+        let source = "if [ \"$(uname)\" = \"Linux\" ] \\\n  && [ \"${NVM_ARCH}\" = arm64 ]\\\n; then\nNVM_ARCH=armv7l\nfi\n";
+        let formatted = format_source(source, None, &ShellFormatOptions::default()).unwrap();
+
+        assert_eq!(
+            formatted,
+            FormattedSource::Formatted(
+                "if [ \"$(uname)\" = \"Linux\" ] &&\n\t[ \"${NVM_ARCH}\" = arm64 ]; then\n\tNVM_ARCH=armv7l\nfi\n"
+                    .to_string()
+            )
+        );
+    }
+
+    #[test]
+    fn moves_multiline_condition_comment_to_then_suffix_like_shfmt() {
+        let source = "if [[ -n $brew_prefix && ( ( $brew_prefix != \"/usr\" && $brew_prefix != \"/usr/local\" ) \n  #when -isysroot is passed\n  || ( is_mac && osx_using_default_compiler && $CFLAGS =~ (^|\\ )-isysroot\\  ) ) ]]; then\necho ok\nfi\n";
+        let formatted = format_source(source, None, &ShellFormatOptions::default()).unwrap();
+
+        assert_eq!(
+            formatted,
+            FormattedSource::Formatted(
+                "if [[ -n $brew_prefix && (($brew_prefix != \"/usr\" && $brew_prefix != \"/usr/local\") ||\n\n\t(is_mac && osx_using_default_compiler && $CFLAGS =~ (^|\\ )-isysroot\\ )) ]]; then #when -isysroot is passed\n\techo ok\nfi\n"
+                    .to_string()
+            )
+        );
+    }
+
+    #[test]
+    fn preserves_full_line_comments_inside_continued_command_lists() {
+        let source = "f() {\n  command -v brew && \\\n    # first\n    # second\n    brew_prefix=x && \\\n    [[ -n \"$brew_prefix\" ]]\n}\n";
+        let formatted = format_source(source, None, &ShellFormatOptions::default()).unwrap();
+
+        assert_eq!(
+            formatted,
+            FormattedSource::Formatted(
+                "f() {\n\tcommand -v brew &&\n\t\t# first\n\t\t# second\n\t\tbrew_prefix=x &&\n\t\t[[ -n \"$brew_prefix\" ]]\n}\n"
+                    .to_string()
+            )
+        );
+    }
+
+    #[test]
+    fn preserves_break_before_leading_list_operator_like_shfmt() {
+        let source = "f() {\n  nvm_version_greater_than_or_equal_to \"${NODE_VERSION}\" v0.8.6 \\\n  && ! nvm_version_greater_than_or_equal_to \"${NODE_VERSION}\" v1.0.0\n}\n";
+        let formatted = format_source(source, None, &ShellFormatOptions::default()).unwrap();
+
+        assert_eq!(
+            formatted,
+            FormattedSource::Formatted(
+                "f() {\n\tnvm_version_greater_than_or_equal_to \"${NODE_VERSION}\" v0.8.6 &&\n\t\t! nvm_version_greater_than_or_equal_to \"${NODE_VERSION}\" v1.0.0\n}\n"
+                    .to_string()
+            )
+        );
+    }
+
+    #[test]
+    fn keeps_same_line_list_operator_after_multiline_group_like_shfmt() {
+        let source = "(\n  echo one\n) || return $?\n";
+        let formatted = format_source(source, None, &ShellFormatOptions::default()).unwrap();
+
+        assert_eq!(
+            formatted,
+            FormattedSource::Formatted("(\n\techo one\n) || return $?\n".to_string())
+        );
+    }
+
+    #[test]
+    fn does_not_insert_blank_before_following_subshell_like_shfmt() {
+        let source = "ohai \"Downloading and installing Homebrew...\"\n(\n  cd x >/dev/null || return\n) || exit 1\n";
+        let formatted = format_source(source, None, &ShellFormatOptions::default()).unwrap();
+
+        assert_eq!(
+            formatted,
+            FormattedSource::Formatted(
+                "ohai \"Downloading and installing Homebrew...\"\n(\n\tcd x >/dev/null || return\n) || exit 1\n"
+                    .to_string()
             )
         );
     }
@@ -1218,6 +2228,18 @@ mod tests {
     #[test]
     fn preserves_process_substitution_redirect_spacing() {
         let source = "cat < <(which -a foo)\n";
+        let options = ShellFormatOptions::default();
+
+        assert_eq!(
+            format_source(source, None, &options).unwrap(),
+            FormattedSource::Unchanged
+        );
+        assert_source_and_ast_paths_match(source, None, &options);
+    }
+
+    #[test]
+    fn keeps_numbered_output_redirects_tight_like_shfmt() {
+        let source = "exec 19>\"${config_dir}/tracing.log\"\n";
         let options = ShellFormatOptions::default();
 
         assert_eq!(
@@ -1702,6 +2724,84 @@ print hidden &!
             "{\n\techo hi\n}\n\nfoo() {\n\techo bye\n}\n",
             Some(Path::new("multiline_brace_gap.sh")),
             &ShellFormatOptions::default(),
+        );
+    }
+
+    #[test]
+    fn preserves_blank_line_before_group_close_like_shfmt() {
+        let source = "prefer_openssl11() {\n  PYTHON_BUILD_MACPORTS_OPENSSL_FORMULA=x\n  export PYTHON_BUILD_MACPORTS_OPENSSL_FORMULA\n\n}\n";
+        let formatted = format_source(source, None, &ShellFormatOptions::default()).unwrap();
+
+        assert_eq!(
+            formatted,
+            FormattedSource::Formatted(
+                "prefer_openssl11() {\n\tPYTHON_BUILD_MACPORTS_OPENSSL_FORMULA=x\n\texport PYTHON_BUILD_MACPORTS_OPENSSL_FORMULA\n\n}\n"
+                    .to_string()
+            )
+        );
+    }
+
+    #[test]
+    fn preserves_blank_line_after_for_do_like_shfmt() {
+        let source = "for ((i = 0; i <= 100; i++)); do\n\n  echo \"$i\"\ndone\n";
+        let formatted = format_source(source, None, &ShellFormatOptions::default()).unwrap();
+
+        assert_eq!(
+            formatted,
+            FormattedSource::Formatted(
+                "for ((i = 0; i <= 100; i++)); do\n\n\techo \"$i\"\ndone\n".to_string()
+            )
+        );
+    }
+
+    #[test]
+    fn preserves_blank_line_before_for_done_like_shfmt() {
+        let source = "for ((i = 0; i <= 100; i++)); do\n  echo \"$i\"\n\ndone\n";
+        let formatted = format_source(source, None, &ShellFormatOptions::default()).unwrap();
+
+        assert_eq!(
+            formatted,
+            FormattedSource::Formatted(
+                "for ((i = 0; i <= 100; i++)); do\n\techo \"$i\"\n\ndone\n".to_string()
+            )
+        );
+    }
+
+    #[test]
+    fn preserves_blank_line_after_until_do_like_shfmt() {
+        let source = "until ((y == done_val)); do\n\n  echo \"$y\"\ndone\n";
+        let formatted = format_source(source, None, &ShellFormatOptions::default()).unwrap();
+
+        assert_eq!(
+            formatted,
+            FormattedSource::Formatted(
+                "until ((y == done_val)); do\n\n\techo \"$y\"\ndone\n".to_string()
+            )
+        );
+    }
+
+    #[test]
+    fn preserves_blank_line_after_do_before_leading_comment_like_shfmt() {
+        let source = "until foo; do\n\n  # comment\n  bar\ndone\n";
+        let formatted = format_source(source, None, &ShellFormatOptions::default()).unwrap();
+
+        assert_eq!(
+            formatted,
+            FormattedSource::Formatted("until foo; do\n\n\t# comment\n\tbar\ndone\n".to_string())
+        );
+    }
+
+    #[test]
+    fn preserves_while_do_suffix_comments_like_shfmt() {
+        let source = "while IFS= read -r -u ${pycoproc[0]} -t 1 output; do #2>/dev/null\n  echo \"$output\"\ndone\n";
+        let formatted = format_source(source, None, &ShellFormatOptions::default()).unwrap();
+
+        assert_eq!(
+            formatted,
+            FormattedSource::Formatted(
+                "while IFS= read -r -u ${pycoproc[0]} -t 1 output; do #2>/dev/null\n\techo \"$output\"\ndone\n"
+                    .to_string()
+            )
         );
     }
 

--- a/crates/shuck-formatter/src/lib.rs
+++ b/crates/shuck-formatter/src/lib.rs
@@ -302,10 +302,28 @@ fn source_may_need_case_comment_alignment(source: &str) -> bool {
 
 fn source_may_need_branch_comment_relocation(source: &str) -> bool {
     let lines = source.lines().collect::<Vec<_>>();
-    lines.windows(2).any(|window| {
-        window[0].trim_start().starts_with('#')
-            && (window[1].trim_start() == "else" || window[1].trim_start().starts_with("elif "))
+    lines.iter().enumerate().any(|(index, line)| {
+        if !line.trim_start().starts_with('#') {
+            return false;
+        }
+
+        let Some(next) = lines.get(index + 1) else {
+            return false;
+        };
+        if is_branch_keyword_line(next) {
+            return true;
+        }
+
+        next.is_empty()
+            && lines
+                .get(index + 2)
+                .is_some_and(|line| is_branch_keyword_line(line))
     })
+}
+
+fn is_branch_keyword_line(line: &str) -> bool {
+    let trimmed = line.trim_start();
+    trimmed == "else" || trimmed.starts_with("elif ")
 }
 
 fn relocate_branch_leading_comments(output: &mut String, line_ending: LineEnding) {
@@ -456,6 +474,8 @@ mod tests {
     use shuck_ast::{AssignmentValue, Command};
     use shuck_linter::{AnalysisRequest, Diagnostic, LinterSettings};
     use shuck_parser::ShellDialect as ParseShellDialect;
+
+    use crate::word::heredoc_delimiters_in_rendered_line;
 
     use super::*;
 
@@ -742,6 +762,17 @@ mod tests {
             formatted,
             FormattedSource::Formatted("declare -x foo=1 <<EOF\nhi\nEOF\n".to_string())
         );
+    }
+
+    #[test]
+    fn heredoc_delimiter_scan_ignores_non_redirection_operators() {
+        assert_eq!(
+            heredoc_delimiters_in_rendered_line("cat <<EOF 2<<-'ERR'"),
+            vec!["EOF".to_string(), "ERR".to_string()]
+        );
+        assert!(heredoc_delimiters_in_rendered_line("echo $((1 << 2))").is_empty());
+        assert!(heredoc_delimiters_in_rendered_line("((1 << 2))").is_empty());
+        assert!(heredoc_delimiters_in_rendered_line("[[ $a << $b ]]").is_empty());
     }
 
     #[test]
@@ -1762,6 +1793,21 @@ mod tests {
             formatted,
             FormattedSource::Formatted(
                 "if foo; then\n\tbar\nelse\n\t# branch comment\n\tbaz\nfi\n".to_string()
+            )
+        );
+    }
+
+    #[test]
+    fn source_is_formatted_checks_blank_line_branch_comment_relocation() {
+        let source = "if foo; then\n\tbar\n\t# else branch\n\nelse\n\tbaz\nfi\n";
+        let options = ShellFormatOptions::default();
+
+        assert!(source_may_need_branch_comment_relocation(source));
+        assert!(!source_is_formatted(source, None, &options).unwrap());
+        assert_eq!(
+            format_source(source, None, &options).unwrap(),
+            FormattedSource::Formatted(
+                "if foo; then\n\tbar\n\t# else branch\nelse\n\tbaz\nfi\n".to_string()
             )
         );
     }

--- a/crates/shuck-formatter/src/redirect.rs
+++ b/crates/shuck-formatter/src/redirect.rs
@@ -20,16 +20,20 @@ impl FormatNodeRule<Redirect> for FormatRedirect {
             return write!(formatter, [text(raw.to_string())]);
         }
 
+        let mut rendered_explicit_fd = false;
+        let adjacent_numeric_fd = redirect_has_adjacent_numeric_fd(redirect, source);
         if let Some(name) = &redirect.fd_var {
             write!(
                 formatter,
                 [token("{"), text(name.as_str().to_string()), token("}")]
             )?;
+            rendered_explicit_fd = true;
         } else if let Some(fd) = redirect
             .fd
-            .filter(|fd| should_render_explicit_fd(*fd, redirect.kind))
+            .filter(|fd| should_render_explicit_fd(*fd, redirect, source))
         {
             write!(formatter, [text(fd.to_string())])?;
+            rendered_explicit_fd = true;
         }
 
         write!(
@@ -55,31 +59,48 @@ impl FormatNodeRule<Redirect> for FormatRedirect {
             (None, None) => String::new(),
             (Some(_), Some(_)) => unreachable!("redirect target cannot be both word and heredoc"),
         };
-        if needs_space_before_target(redirect.kind, &target, options.space_redirects()) {
+        if needs_space_before_target(
+            redirect.kind,
+            &target,
+            options.space_redirects(),
+            rendered_explicit_fd || adjacent_numeric_fd,
+        ) {
             write!(formatter, [space()])?;
         }
         write!(formatter, [text(target)])
     }
 }
 
-fn should_render_explicit_fd(fd: i32, kind: RedirectKind) -> bool {
-    match kind {
-        RedirectKind::Output
-        | RedirectKind::Clobber
-        | RedirectKind::Append
-        | RedirectKind::DupOutput
-        | RedirectKind::OutputBoth => fd != 1,
-        RedirectKind::Input
-        | RedirectKind::ReadWrite
-        | RedirectKind::HereDoc
-        | RedirectKind::HereDocStrip
-        | RedirectKind::HereString
-        | RedirectKind::DupInput => fd != 0,
-    }
+fn should_render_explicit_fd(fd: i32, redirect: &Redirect, source: &str) -> bool {
+    raw_redirect_source_slice(redirect, source).is_some_and(|raw| {
+        raw.trim_start()
+            .strip_prefix(&fd.to_string())
+            .is_some_and(|rest| rest.starts_with(['<', '>']))
+    })
 }
 
-fn needs_space_before_target(kind: RedirectKind, target: &str, space_redirects: bool) -> bool {
+fn redirect_has_adjacent_numeric_fd(redirect: &Redirect, source: &str) -> bool {
+    let start = redirect.span.start.offset.min(source.len());
+    let Some(prefix) = source.get(..start) else {
+        return false;
+    };
+    let token = prefix
+        .rsplit_once(|ch: char| ch.is_whitespace() || ch == ';' || ch == '&' || ch == '|')
+        .map_or(prefix, |(_, token)| token);
+    !token.is_empty() && token.chars().all(|ch| ch.is_ascii_digit())
+}
+
+fn needs_space_before_target(
+    kind: RedirectKind,
+    target: &str,
+    space_redirects: bool,
+    explicit_fd: bool,
+) -> bool {
     if target.is_empty() {
+        return false;
+    }
+
+    if explicit_fd {
         return false;
     }
 

--- a/crates/shuck-formatter/src/streaming.rs
+++ b/crates/shuck-formatter/src/streaming.rs
@@ -24,8 +24,8 @@ use crate::comments::{SourceComment, SourceMap};
 use crate::facts::FormatterFacts;
 use crate::options::ResolvedShellFormatOptions;
 use crate::word::{
-    heredoc_delimiters_in_rendered_line, render_arithmetic_expr_to_buf, render_heredoc_body_to_buf,
-    render_pattern_syntax_to_buf, render_word_syntax_with_facts_to_buf,
+    RenderedHeredocDelimiter, heredoc_delimiters_in_rendered_line, render_arithmetic_expr_to_buf,
+    render_heredoc_body_to_buf, render_pattern_syntax_to_buf, render_word_syntax_with_facts_to_buf,
 };
 
 enum StreamOutput<'source> {
@@ -362,7 +362,7 @@ impl<'source, 'facts> ShellStreamFormatter<'source, 'facts> {
 
     fn write_heredoc_aware_multiline_text(&mut self, text: &str) {
         let mut pending_heredocs = Vec::new();
-        let mut active_heredoc = None;
+        let mut active_heredoc: Option<RenderedHeredocDelimiter> = None;
         for (index, line) in text.split('\n').enumerate() {
             if index > 0 {
                 self.push_output_str(self.line_ending());
@@ -373,9 +373,9 @@ impl<'source, 'facts> ShellStreamFormatter<'source, 'facts> {
                 continue;
             }
 
-            if let Some(delimiter) = active_heredoc.as_deref() {
+            if let Some(delimiter) = active_heredoc.as_ref() {
                 self.write_verbatim(line);
-                if line == delimiter {
+                if delimiter.matches_line(line) {
                     active_heredoc = pop_next_heredoc_delimiter(&mut pending_heredocs);
                 }
                 continue;
@@ -3571,7 +3571,9 @@ fn sequence_verbatim_span(statements: &StmtSeq, source: &str) -> Option<Span> {
         .reduce(|left, right| left.merge(right))
 }
 
-fn pop_next_heredoc_delimiter(pending: &mut Vec<String>) -> Option<String> {
+fn pop_next_heredoc_delimiter(
+    pending: &mut Vec<RenderedHeredocDelimiter>,
+) -> Option<RenderedHeredocDelimiter> {
     (!pending.is_empty()).then(|| pending.remove(0))
 }
 

--- a/crates/shuck-formatter/src/streaming.rs
+++ b/crates/shuck-formatter/src/streaming.rs
@@ -3,27 +3,29 @@ use std::mem;
 
 use shuck_ast::{
     AlwaysCommand, AnonymousFunctionCommand, ArithmeticCommand, ArithmeticForCommand, Assignment,
-    BinaryCommand, BinaryOp, BuiltinCommand, CaseCommand, CaseItem, Command, CompoundCommand,
-    ConditionalBinaryExpr, ConditionalCommand, ConditionalExpr, ConditionalParenExpr,
-    ConditionalUnaryExpr, ConditionalUnaryOp, CoprocCommand, DeclClause, DeclOperand, File,
-    ForCommand, ForSyntax, ForeachCommand, ForeachSyntax, FunctionDef, IfCommand, IfSyntax,
-    Pattern, Redirect, RedirectKind, RepeatCommand, RepeatSyntax, SelectCommand, SimpleCommand,
-    Span, Stmt, StmtSeq, StmtTerminator, TimeCommand, UntilCommand, VarRef, WhileCommand, Word,
+    AssignmentValue, BinaryCommand, BinaryOp, BuiltinCommand, CaseCommand, CaseItem, Command,
+    CompoundCommand, ConditionalBinaryExpr, ConditionalCommand, ConditionalExpr,
+    ConditionalParenExpr, ConditionalUnaryExpr, ConditionalUnaryOp, CoprocCommand, DeclClause,
+    DeclOperand, File, ForCommand, ForSyntax, ForeachCommand, ForeachSyntax, FunctionDef,
+    IfCommand, IfSyntax, Pattern, Redirect, RedirectKind, RepeatCommand, RepeatSyntax,
+    SelectCommand, SimpleCommand, Span, Stmt, StmtSeq, StmtTerminator, TimeCommand, UntilCommand,
+    VarRef, WhileCommand, Word,
 };
 use shuck_format::{IndentStyle, LineEnding};
 
 use crate::Result;
 use crate::command::{
-    binary_operator, case_terminator, command_format_span, line_gap_break_count,
-    multiline_compound_assignment_lines, render_assignment_head_to_buf,
+    binary_operator, case_terminator, command_format_span, group_attachment_span,
+    line_gap_break_count, multiline_compound_assignment_lines, render_assignment_head_to_buf,
     render_assignment_with_facts_to_buf, render_background_operator, render_var_ref_to_buf,
-    slice_span, stmt_render_start_line, stmt_span, stmt_verbatim_span,
+    stmt_render_start_line, stmt_span, stmt_verbatim_span,
 };
 use crate::comments::{SourceComment, SourceMap};
 use crate::facts::FormatterFacts;
 use crate::options::ResolvedShellFormatOptions;
 use crate::word::{
-    render_heredoc_body_to_buf, render_pattern_syntax_to_buf, render_word_syntax_with_facts_to_buf,
+    heredoc_delimiters_in_rendered_line, render_arithmetic_expr_to_buf, render_heredoc_body_to_buf,
+    render_pattern_syntax_to_buf, render_word_syntax_with_facts_to_buf,
 };
 
 enum StreamOutput<'source> {
@@ -186,6 +188,8 @@ pub(crate) fn format_stmt_sequence_streaming_to_buf(
 struct PendingHeredoc {
     body: String,
     delimiter: String,
+    strip_tabs: bool,
+    indent_level: usize,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -202,6 +206,8 @@ struct ShellStreamFormatter<'source, 'facts> {
     output: StreamOutput<'source>,
     scratch: String,
     indent_level: usize,
+    list_continuation_depth: usize,
+    column: usize,
     line_start: bool,
     pending_heredocs: Vec<PendingHeredoc>,
 }
@@ -255,6 +261,8 @@ impl<'source, 'facts> ShellStreamFormatter<'source, 'facts> {
             output,
             scratch: String::new(),
             indent_level: 0,
+            list_continuation_depth: 0,
+            column: 0,
             line_start: true,
             pending_heredocs: Vec::new(),
         }
@@ -273,10 +281,22 @@ impl<'source, 'facts> ShellStreamFormatter<'source, 'facts> {
 
     fn push_output_char(&mut self, ch: char) {
         self.output.push_char(ch);
+        if ch == '\n' {
+            self.column = 0;
+        } else if ch != '\r' {
+            self.column += 1;
+        }
     }
 
     fn push_output_str(&mut self, text: &str) {
         self.output.push_str(text);
+        for ch in text.chars() {
+            if ch == '\n' {
+                self.column = 0;
+            } else if ch != '\r' {
+                self.column += 1;
+            }
+        }
     }
 
     fn source(&self) -> &'source str {
@@ -309,6 +329,13 @@ impl<'source, 'facts> ShellStreamFormatter<'source, 'facts> {
         result
     }
 
+    fn with_list_continuation<T>(&mut self, f: impl FnOnce(&mut Self) -> T) -> T {
+        self.list_continuation_depth += 1;
+        let result = f(self);
+        self.list_continuation_depth = self.list_continuation_depth.saturating_sub(1);
+        result
+    }
+
     fn take_scratch_buffer(&mut self) -> String {
         let mut scratch = mem::take(&mut self.scratch);
         scratch.clear();
@@ -325,8 +352,79 @@ impl<'source, 'facts> ShellStreamFormatter<'source, 'facts> {
     ) {
         let mut scratch = self.take_scratch_buffer();
         render(&mut scratch, self.source, &self.options);
-        self.write_text(&scratch);
+        if scratch.contains('\n') && scratch.contains("<<") {
+            self.write_heredoc_aware_multiline_text(&scratch);
+        } else {
+            self.write_text(&scratch);
+        }
         self.restore_scratch_buffer(scratch);
+    }
+
+    fn write_heredoc_aware_multiline_text(&mut self, text: &str) {
+        let mut pending_heredocs = Vec::new();
+        let mut active_heredoc = None;
+        for (index, line) in text.split('\n').enumerate() {
+            if index > 0 {
+                self.push_output_str(self.line_ending());
+                self.line_start = true;
+            }
+
+            if line.is_empty() {
+                continue;
+            }
+
+            if let Some(delimiter) = active_heredoc.as_deref() {
+                self.write_verbatim(line);
+                if line == delimiter {
+                    active_heredoc = pop_next_heredoc_delimiter(&mut pending_heredocs);
+                }
+                continue;
+            }
+
+            let literal_line = line.trim_start_matches('\t');
+            if index > 0
+                && matches!(self.options.indent_style(), IndentStyle::Tab)
+                && literal_line.starts_with(' ')
+            {
+                self.write_verbatim(literal_line);
+                continue;
+            }
+
+            if index > 0 && line.starts_with('"') {
+                self.write_verbatim(line);
+                continue;
+            }
+
+            self.write_text(line);
+            pending_heredocs.extend(heredoc_delimiters_in_rendered_line(line));
+            active_heredoc = pop_next_heredoc_delimiter(&mut pending_heredocs);
+        }
+    }
+
+    fn write_multiline_text_with_verbatim_continuations(&mut self, text: &str) {
+        let Some((first, rest)) = text.split_once('\n') else {
+            self.write_text(text);
+            return;
+        };
+
+        self.write_text(first.trim_end_matches('\r'));
+        self.push_output_str(self.line_ending());
+        self.line_start = true;
+        self.write_verbatim(rest);
+    }
+
+    fn write_multiline_text_preserving_space_prefixed_lines(&mut self, text: &str) {
+        for (index, line) in text.split_inclusive('\n').enumerate() {
+            let literal_line = line.trim_start_matches('\t');
+            if index > 0
+                && matches!(self.options.indent_style(), IndentStyle::Tab)
+                && literal_line.starts_with(' ')
+            {
+                self.write_verbatim(literal_line);
+            } else {
+                self.write_text(line);
+            }
+        }
     }
 
     fn write_display(&mut self, value: impl std::fmt::Display) {
@@ -423,18 +521,64 @@ impl<'source, 'facts> ShellStreamFormatter<'source, 'facts> {
         self.push_output_char(' ');
     }
 
+    fn write_spaces(&mut self, count: usize) {
+        for _ in 0..count {
+            self.write_space();
+        }
+    }
+
     fn flush_pending_heredocs(&mut self) {
         let pending = mem::take(&mut self.pending_heredocs);
         for heredoc in pending {
             self.push_output_str(self.line_ending());
             self.line_start = true;
-            self.write_verbatim(&heredoc.body);
+            if heredoc.strip_tabs {
+                self.write_tab_stripped_heredoc_body(&heredoc.body, heredoc.indent_level);
+            } else {
+                self.write_verbatim(&heredoc.body);
+            }
             if heredoc_body_needs_separator(&heredoc.body) {
                 self.push_output_str(self.line_ending());
                 self.line_start = true;
             }
+            if heredoc.strip_tabs {
+                self.write_exact_indent(heredoc.indent_level);
+            }
             self.write_verbatim(&heredoc.delimiter);
         }
+    }
+
+    fn write_tab_stripped_heredoc_body(&mut self, body: &str, indent_level: usize) {
+        for (index, line) in body.split_inclusive('\n').enumerate() {
+            if index > 0 {
+                self.line_start = true;
+            }
+            if !line.is_empty() {
+                self.write_exact_indent(indent_level + 1);
+                self.write_verbatim(line.trim_start_matches('\t'));
+            }
+        }
+    }
+
+    fn write_exact_indent(&mut self, levels: usize) {
+        if !self.line_start || levels == 0 || self.options.minify() {
+            return;
+        }
+
+        match self.options.indent_style() {
+            IndentStyle::Tab => {
+                for _ in 0..levels {
+                    self.push_output_char('\t');
+                }
+            }
+            IndentStyle::Space => {
+                for _ in 0..(levels * usize::from(self.options.indent_width())) {
+                    self.push_output_char(' ');
+                }
+            }
+        }
+
+        self.line_start = false;
     }
 
     fn newline(&mut self) {
@@ -471,7 +615,16 @@ impl<'source, 'facts> ShellStreamFormatter<'source, 'facts> {
                 &mut scratch,
             );
         }
-        self.write_text(&scratch);
+        let raw = word.span.slice(self.source());
+        if scratch.contains('\n') && scratch == raw {
+            self.write_verbatim(&scratch);
+        } else if scratch.contains('\n') && scratch.contains("<<") {
+            self.write_heredoc_aware_multiline_text(&scratch);
+        } else if scratch.contains('\n') {
+            self.write_multiline_text_preserving_space_prefixed_lines(&scratch);
+        } else {
+            self.write_text(&scratch);
+        }
         self.restore_scratch_buffer(scratch);
     }
 
@@ -488,6 +641,11 @@ impl<'source, 'facts> ShellStreamFormatter<'source, 'facts> {
     }
 
     fn write_assignment(&mut self, assignment: &Assignment) {
+        if multiline_compound_assignment_lines(assignment, self.source()).is_some() {
+            self.write_multiline_compound_assignment(assignment);
+            return;
+        }
+
         let source_map = self.source_map().clone();
         let mut scratch = self.take_scratch_buffer();
         {
@@ -501,8 +659,48 @@ impl<'source, 'facts> ShellStreamFormatter<'source, 'facts> {
                 &mut scratch,
             );
         }
-        self.write_text(&scratch);
+        let raw = assignment.span.slice(self.source());
+        if scratch.contains('\n') && scratch == raw {
+            self.write_multiline_text_with_verbatim_continuations(&scratch);
+        } else if scratch.contains('\n') && scratch.contains("<<") {
+            self.write_heredoc_aware_multiline_text(&scratch);
+        } else if scratch.contains('\n') {
+            self.write_multiline_text_preserving_space_prefixed_lines(&scratch);
+        } else {
+            self.write_text(&scratch);
+        }
         self.restore_scratch_buffer(scratch);
+    }
+
+    fn write_multiline_compound_assignment(&mut self, assignment: &Assignment) {
+        let source = self.source();
+        let Some((first_line, remaining_lines)) =
+            compound_assignment_multiline_parts(assignment, source)
+        else {
+            self.write_assignment(assignment);
+            return;
+        };
+
+        self.write_assignment_head(assignment);
+        self.write_text("(");
+        if let Some(first_line) = first_line {
+            self.write_text(&first_line);
+        }
+        if !remaining_lines.is_empty() {
+            self.newline();
+            self.with_indent(|formatter| {
+                for (index, line) in remaining_lines.iter().enumerate() {
+                    if index > 0 {
+                        formatter.newline();
+                    }
+                    formatter.write_text(line);
+                }
+            });
+        }
+        if !compound_assignment_closes_after_last_element(assignment, source) {
+            self.newline();
+        }
+        self.write_text(")");
     }
 
     fn write_assignment_head(&mut self, assignment: &Assignment) {
@@ -541,9 +739,19 @@ impl<'source, 'facts> ShellStreamFormatter<'source, 'facts> {
         }
     }
 
-    fn emit_trailing_comments(&mut self, comments: &[SourceComment<'_>]) {
+    fn emit_trailing_comments(
+        &mut self,
+        comments: &[SourceComment<'_>],
+        _previous_end: Option<usize>,
+    ) {
         for comment in comments {
-            self.write_space();
+            if self.comment_padding_is_in_alignment_run(comment)
+                && let Some(target_column) = self.aligned_comment_target_column(comment)
+            {
+                self.write_spaces(target_column.saturating_sub(self.column).max(1));
+            } else {
+                self.write_space();
+            }
             self.write_comment(comment);
         }
     }
@@ -558,10 +766,34 @@ impl<'source, 'facts> ShellStreamFormatter<'source, 'facts> {
         }
     }
 
+    fn write_reindented_verbatim_block(&mut self, text: &str) {
+        for (index, line) in text
+            .trim_end_matches(&['\r', '\n'][..])
+            .split('\n')
+            .enumerate()
+        {
+            if index > 0 {
+                self.newline();
+            }
+            if !line.is_empty() {
+                self.write_text(line.trim_start());
+            }
+        }
+    }
+
     fn format_stmt_sequence(
         &mut self,
         statements: &StmtSeq,
         upper_bound: Option<usize>,
+    ) -> Result<()> {
+        self.format_stmt_sequence_skipping_leading_before(statements, upper_bound, None)
+    }
+
+    fn format_stmt_sequence_skipping_leading_before(
+        &mut self,
+        statements: &StmtSeq,
+        upper_bound: Option<usize>,
+        skip_leading_before: Option<usize>,
     ) -> Result<()> {
         let source = self.source();
         let compact_layout = self.options().compact_layout();
@@ -603,6 +835,10 @@ impl<'source, 'facts> ShellStreamFormatter<'source, 'facts> {
                     .leading_for(0)
                     .iter()
                     .copied()
+                    .filter(|comment| {
+                        skip_leading_before
+                            .is_none_or(|offset| comment.span().start.offset >= offset)
+                    })
                     .filter(|comment| comment.span().end.offset <= span.start.offset)
                     .collect::<Vec<_>>();
                 self.emit_leading_comments(
@@ -610,7 +846,12 @@ impl<'source, 'facts> ShellStreamFormatter<'source, 'facts> {
                     self.facts().stmt(first).render_span().start.line,
                 );
             }
-            self.write_verbatim(span.slice(source));
+            let text = span.slice(source);
+            if self.indent_level > 0 && text.lines().count() <= 20 {
+                self.write_reindented_verbatim_block(text);
+            } else {
+                self.write_verbatim(text);
+            }
             if let Some(attachment) = attachments.as_ref() {
                 self.emit_dangling_comments(attachment.dangling());
             }
@@ -621,13 +862,28 @@ impl<'source, 'facts> ShellStreamFormatter<'source, 'facts> {
             if let Some(attachment) = attachments.as_ref() {
                 let next_line =
                     stmt_render_start_line(stmt, self.source(), self.source_map(), self.options());
-                self.emit_leading_comments(attachment.leading_for(index), next_line);
+                if index == 0
+                    && let Some(skip_leading_before) = skip_leading_before
+                {
+                    let leading = attachment
+                        .leading_for(index)
+                        .iter()
+                        .copied()
+                        .filter(|comment| comment.span().start.offset >= skip_leading_before)
+                        .collect::<Vec<_>>();
+                    self.emit_leading_comments(&leading, next_line);
+                } else {
+                    self.emit_leading_comments(attachment.leading_for(index), next_line);
+                }
             }
 
             self.format_stmt(stmt)?;
 
             if let Some(attachment) = attachments.as_ref() {
-                self.emit_trailing_comments(attachment.trailing_for(index));
+                self.emit_trailing_comments(
+                    attachment.trailing_for(index),
+                    Some(self.facts().stmt(stmt).render_span().end.offset),
+                );
             }
 
             if index + 1 < statements.len() {
@@ -709,7 +965,23 @@ impl<'source, 'facts> ShellStreamFormatter<'source, 'facts> {
         }
 
         if !stmt.redirects.is_empty() && !emit_redirects_first {
-            self.write_space();
+            let command_is_wrapped_group = matches!(
+                stmt.command,
+                Command::Compound(CompoundCommand::BraceGroup(_))
+                    | Command::Compound(CompoundCommand::Subshell(_))
+            );
+            if !command_is_wrapped_group
+                && command_span != Span::new()
+                && self
+                    .source()
+                    .get(command_span.end.offset..stmt.redirects[0].span.start.offset)
+                    .is_some_and(|between| between.contains('\n'))
+            {
+                self.line_continuation();
+                self.write_indent_units(1);
+            } else if !redirect_has_adjacent_numeric_fd(&stmt.redirects[0], self.source()) {
+                self.write_space();
+            }
             self.format_redirect_list(&stmt.redirects);
         }
 
@@ -884,11 +1156,7 @@ impl<'source, 'facts> ShellStreamFormatter<'source, 'facts> {
         let Some(previous_end) = previous_end else {
             return;
         };
-        if self
-            .source()
-            .get(previous_end..next_start)
-            .is_some_and(|between| between.contains('\n'))
-        {
+        if command_gap_has_line_continuation(self.source(), previous_end, next_start) {
             self.line_continuation();
             self.write_indent_units(1);
         } else {
@@ -915,35 +1183,63 @@ impl<'source, 'facts> ShellStreamFormatter<'source, 'facts> {
         let mut operators = Vec::new();
         collect_pipeline(pipeline, &mut statements, &mut operators);
 
-        let multiline = self.options().binary_next_line()
-            && statements.len() > 1
-            && self.facts().pipeline_has_explicit_line_break(pipeline);
-
         for (index, stmt) in statements.iter().enumerate() {
             if index > 0 {
-                let operator = operators
+                let (operator, operator_span) = operators
                     .get(index - 1)
-                    .map(|(operator, _)| binary_operator(operator))
-                    .unwrap_or("|");
-                if multiline {
-                    self.line_continuation();
-                    self.with_indent(|formatter| {
-                        formatter.write_text(operator);
-                        formatter.write_space();
-                        formatter.format_stmt(stmt)
-                    })?;
+                    .copied()
+                    .unwrap_or((BinaryOp::Pipe, Span::new()));
+                let operator_text = binary_operator(&operator);
+                let previous_stmt = statements[index - 1];
+                if self.pipeline_operator_has_explicit_line_break(
+                    operator_span,
+                    previous_stmt,
+                    stmt,
+                ) {
+                    if self.options().binary_next_line() {
+                        self.line_continuation();
+                        self.with_indent(|formatter| {
+                            formatter.write_text(operator_text);
+                            formatter.write_space();
+                            formatter.format_stmt(stmt)
+                        })?;
+                    } else {
+                        self.write_space();
+                        self.write_text(operator_text);
+                        self.newline();
+                        if self.list_continuation_depth > 0 && index == 1 {
+                            self.format_stmt(stmt)?;
+                        } else {
+                            self.with_indent(|formatter| formatter.format_stmt(stmt))?;
+                        }
+                    }
                     continue;
                 }
                 self.write_space();
-                self.write_text(operator);
+                self.write_text(operator_text);
                 self.write_space();
             }
-            if !multiline || index == 0 {
-                self.format_stmt(stmt)?;
-            }
+            self.format_stmt(stmt)?;
         }
 
         Ok(())
+    }
+
+    fn pipeline_operator_has_explicit_line_break(
+        &self,
+        operator_span: Span,
+        previous_stmt: &Stmt,
+        next_stmt: &Stmt,
+    ) -> bool {
+        let previous_span_end = stmt_span(previous_stmt).end.offset;
+        let previous_end = if previous_span_end <= operator_span.start.offset {
+            previous_span_end
+        } else {
+            self.facts().stmt(previous_stmt).render_span().end.offset
+        };
+        let next_start = self.facts().stmt(next_stmt).attachment_span().start.offset;
+        source_has_newline_between(self.source(), previous_end, operator_span.start.offset)
+            || source_has_newline_between(self.source(), operator_span.end.offset, next_start)
     }
 
     fn format_command_list(&mut self, list: &BinaryCommand) -> Result<()> {
@@ -963,7 +1259,21 @@ impl<'source, 'facts> ShellStreamFormatter<'source, 'facts> {
         {
             self.write_text(list_item_multiline_separator(item.operator));
             self.newline();
-            self.with_indent(|formatter| formatter.format_stmt(item.stmt))?;
+            self.with_indent(|formatter| {
+                let comment_end = formatter
+                    .facts()
+                    .stmt(item.stmt)
+                    .attachment_span()
+                    .start
+                    .offset;
+                if formatter.emit_branch_leading_comments_between(
+                    item.operator_span.end.offset,
+                    comment_end,
+                ) {
+                    formatter.newline();
+                }
+                formatter.with_list_continuation(|formatter| formatter.format_stmt(item.stmt))
+            })?;
             return Ok(());
         }
 
@@ -980,55 +1290,635 @@ impl<'source, 'facts> ShellStreamFormatter<'source, 'facts> {
 
     fn format_then_fi_if(&mut self, command: &IfCommand) -> Result<()> {
         let source = self.source();
-        self.write_text("if ");
-        self.format_inline_stmts(&command.condition)?;
-        if command.elif_branches.is_empty()
-            && command.else_branch.is_none()
-            && self.can_inline_body(&command.then_branch, command.span)
+        let multiline_condition =
+            self.condition_starts_after_keyword_continuation("if", &command.condition);
+        if multiline_condition && !self.options().compact_layout() {
+            self.write_text("if");
+            self.format_multiline_condition_header(&command.condition)?;
+        } else if self.condition_has_top_level_list_break(&command.condition)
+            && !self.options().compact_layout()
         {
-            self.write_text("; then ");
-            self.format_inline_stmts(&command.then_branch)?;
-            self.write_text("; fi");
-            return Ok(());
+            self.write_text("if ");
+            let suffix_comment = self.format_multiline_condition_after_keyword(&command.condition);
+            self.write_text(self.then_separator(&command.condition));
+            if let Some(comment) = suffix_comment {
+                self.write_space();
+                self.write_text(&comment);
+            }
+        } else {
+            self.write_text("if ");
+            self.format_inline_stmts(&command.condition)?;
+            if command.elif_branches.is_empty()
+                && command.else_branch.is_none()
+                && self.can_inline_body(&command.then_branch, command.span)
+                && self.if_close_starts_on_body_line(command, &command.then_branch)
+            {
+                self.write_text(self.then_separator(&command.condition));
+                self.write_space();
+                self.format_inline_stmts(&command.then_branch)?;
+                self.write_text("; fi");
+                return Ok(());
+            }
+            if command.elif_branches.is_empty()
+                && let Some(else_branch) = &command.else_branch
+                && self.can_inline_body(&command.then_branch, command.span)
+                && self.can_inline_body(else_branch, command.span)
+            {
+                self.write_text(self.then_separator(&command.condition));
+                self.write_space();
+                self.format_inline_stmts(&command.then_branch)?;
+                self.write_text("; else ");
+                self.format_inline_stmts(else_branch)?;
+                self.write_text("; fi");
+                return Ok(());
+            }
+
+            self.write_text(self.then_separator(&command.condition));
         }
 
-        self.write_text("; then");
-        self.format_body_with_upper_bound(
-            &command.then_branch,
-            Some(if_branch_upper_bound(command, 0, source)),
-        )?;
+        let then_opener_offset = if let IfSyntax::ThenFi { then_span, .. } = command.syntax {
+            self.write_header_suffix_comment_between(
+                then_span.end.offset,
+                command.then_branch.span.start.offset,
+            );
+            Some(then_span.end.offset)
+        } else {
+            None
+        };
+        let then_upper_bound = if_branch_upper_bound(command, 0, source);
+        let mut then_branch_was_inlined_before_else = false;
+        let mut then_branch_was_inlined_before_elif = false;
+        if !self.options().compact_layout()
+            && !command.elif_branches.is_empty()
+            && self.body_starts_after_then_on_same_line(&command.then_branch)
+            && self.can_inline_else_body(&command.then_branch, then_upper_bound)
+            && elif_keyword_offset(command, 0, source).is_some_and(|offset| {
+                source_line_break_count_between(
+                    source,
+                    stmt_seq_content_end(&command.then_branch, source),
+                    offset,
+                ) == 0
+            })
+        {
+            self.write_space();
+            self.format_inline_stmts(&command.then_branch)?;
+            then_branch_was_inlined_before_elif = true;
+        } else if !self.options().compact_layout()
+            && command.elif_branches.is_empty()
+            && command.else_branch.is_some()
+            && self.body_starts_after_then_on_same_line(&command.then_branch)
+            && self.can_inline_else_body(&command.then_branch, then_upper_bound)
+            && else_keyword_offset(command, source).is_some_and(|offset| {
+                source_line_break_count_between(
+                    source,
+                    stmt_seq_content_end(&command.then_branch, source),
+                    offset,
+                ) == 0
+            })
+        {
+            self.write_space();
+            self.format_inline_stmts(&command.then_branch)?;
+            then_branch_was_inlined_before_else = true;
+        } else {
+            if let Some(then_opener_offset) = then_opener_offset {
+                self.format_body_after_opener_offset(
+                    &command.then_branch,
+                    Some(then_upper_bound),
+                    then_opener_offset,
+                )?;
+            } else {
+                self.format_body_with_upper_bound(
+                    &command.then_branch,
+                    Some(then_upper_bound),
+                    None,
+                )?;
+            }
+        }
         for (index, (condition, body)) in command.elif_branches.iter().enumerate() {
+            let mut branch_breaks = 1;
+            let mut elif_stays_on_previous_line = false;
+            if !self.options().compact_layout()
+                && let Some(keyword_offset) = elif_keyword_offset(command, index, source)
+            {
+                let previous_content_end = if index == 0 {
+                    stmt_seq_content_end(&command.then_branch, source)
+                } else {
+                    stmt_seq_content_end(&command.elif_branches[index - 1].1, source)
+                };
+                let previous_gap_start = if index == 0 {
+                    self.branch_body_gap_start(&command.then_branch)
+                } else {
+                    self.branch_body_gap_start(&command.elif_branches[index - 1].1)
+                };
+                let emitted_comments =
+                    self.emit_branch_leading_comments_between(previous_content_end, keyword_offset);
+                branch_breaks = if emitted_comments {
+                    1
+                } else {
+                    let source_breaks =
+                        source_line_break_count_between(source, previous_gap_start, keyword_offset);
+                    elif_stays_on_previous_line =
+                        index == 0 && then_branch_was_inlined_before_elif && source_breaks == 0;
+                    source_breaks.clamp(1, 2)
+                };
+            }
+            let multiline_condition = self
+                .condition_starts_after_keyword_continuation("elif", condition)
+                && !self.options().compact_layout();
             if self.options().compact_layout() {
                 self.write_text("; elif ");
                 self.format_inline_stmts(condition)?;
-                self.write_text("; then");
+                self.write_text(self.then_separator(condition));
+            } else if elif_stays_on_previous_line {
+                self.write_text("; elif ");
+                self.format_inline_stmts(condition)?;
+                self.write_text(self.then_separator(condition));
+            } else if multiline_condition {
+                self.write_line_breaks(branch_breaks);
+                self.write_text("elif");
+                self.format_multiline_condition_header(condition)?;
+            } else if self.condition_has_top_level_list_break(condition) {
+                self.write_line_breaks(branch_breaks);
+                self.write_text("elif ");
+                let suffix_comment = self.format_multiline_condition_after_keyword(condition);
+                self.write_text(self.then_separator(condition));
+                if let Some(comment) = suffix_comment {
+                    self.write_space();
+                    self.write_text(&comment);
+                }
             } else {
-                self.newline();
+                self.write_line_breaks(branch_breaks);
                 self.write_text("elif ");
                 self.format_inline_stmts(condition)?;
-                self.write_text("; then");
+                self.write_text(self.then_separator(condition));
             }
-            self.format_body_with_upper_bound(
-                body,
-                Some(if_branch_upper_bound(command, index + 1, source)),
-            )?;
+            self.write_header_suffix_comment_between(
+                condition.span.end.offset,
+                body.span.start.offset,
+            );
+            let branch_upper_bound = if_branch_upper_bound(command, index + 1, source);
+            let is_final_branch =
+                index + 1 == command.elif_branches.len() && command.else_branch.is_none();
+            let followed_by_else =
+                index + 1 == command.elif_branches.len() && command.else_branch.is_some();
+            let can_inline_before_following_else = !followed_by_else
+                || else_keyword_offset(command, source).is_some_and(|offset| {
+                    source_line_break_count_between(
+                        source,
+                        stmt_seq_content_end(body, source),
+                        offset,
+                    ) == 0
+                });
+            if !self.options().compact_layout()
+                && self.body_starts_after_then_on_same_line(body)
+                && self.can_inline_else_body(body, branch_upper_bound)
+                && can_inline_before_following_else
+                && (!is_final_branch || self.if_close_starts_on_body_line(command, body))
+            {
+                self.write_space();
+                self.format_inline_stmts(body)?;
+                if is_final_branch {
+                    self.write_text("; fi");
+                    return Ok(());
+                }
+                continue;
+            }
+            if let Some(then_opener_offset) = branch_then_opener_offset(condition, body, source) {
+                self.format_body_after_opener_offset(
+                    body,
+                    Some(branch_upper_bound),
+                    then_opener_offset,
+                )?;
+            } else {
+                self.format_body_with_upper_bound(body, Some(branch_upper_bound), None)?;
+            }
         }
         if let Some(body) = &command.else_branch {
+            let mut branch_breaks = 1;
+            let mut else_stays_on_then_line = false;
+            let mut else_body_was_formatted = false;
+            if !self.options().compact_layout()
+                && let Some(keyword_offset) = else_keyword_offset(command, source)
+            {
+                let previous_content_end = command
+                    .elif_branches
+                    .last()
+                    .map(|(_, body)| stmt_seq_content_end(body, source))
+                    .unwrap_or_else(|| stmt_seq_content_end(&command.then_branch, source));
+                let previous_gap_start = command
+                    .elif_branches
+                    .last()
+                    .map(|(_, body)| self.branch_body_gap_start(body))
+                    .unwrap_or_else(|| self.branch_body_gap_start(&command.then_branch));
+                let emitted_comments =
+                    self.emit_branch_leading_comments_between(previous_content_end, keyword_offset);
+                branch_breaks = if emitted_comments {
+                    1
+                } else {
+                    let source_breaks =
+                        source_line_break_count_between(source, previous_gap_start, keyword_offset);
+                    else_stays_on_then_line =
+                        then_branch_was_inlined_before_else && source_breaks == 0;
+                    source_breaks.clamp(1, 2)
+                };
+            }
             if self.options().compact_layout() {
                 self.write_text("; else");
+            } else if else_stays_on_then_line {
+                self.write_text("; else");
+            } else if self.else_body_starts_on_else_line(command, body)
+                && self.can_keep_multiline_assignment_on_else_line(body)
+            {
+                self.write_line_breaks(branch_breaks);
+                self.write_text("else ");
+                self.format_stmt(&body[0])?;
+                if self.if_close_starts_on_body_line(command, body) {
+                    self.write_text("; fi");
+                    return Ok(());
+                }
+                else_body_was_formatted = true;
+            } else if self.else_body_starts_on_else_line(command, body)
+                && self.can_inline_else_body(body, command.span.end.offset)
+            {
+                self.write_line_breaks(branch_breaks);
+                self.write_text("else ");
+                self.format_inline_stmts(body)?;
+                self.write_text("; fi");
+                return Ok(());
             } else {
-                self.newline();
+                self.write_line_breaks(branch_breaks);
                 self.write_text("else");
             }
-            self.format_body_with_upper_bound(body, Some(command.span.end.offset))?;
+            if !else_body_was_formatted {
+                if !self.options().compact_layout()
+                    && let Some(keyword_offset) = else_keyword_offset(command, source)
+                {
+                    self.format_body_after_opener_offset(
+                        body,
+                        Some(command.span.end.offset),
+                        keyword_offset + "else".len(),
+                    )?;
+                } else {
+                    self.format_body_with_upper_bound(body, Some(command.span.end.offset), None)?;
+                }
+            }
         }
         if self.options().compact_layout() {
             self.write_text("; fi");
         } else {
-            self.newline();
+            self.write_line_breaks(self.if_close_break_count(command));
             self.write_text("fi");
         }
         Ok(())
+    }
+
+    fn if_close_break_count(&self, command: &IfCommand) -> usize {
+        let IfSyntax::ThenFi { fi_span, .. } = command.syntax else {
+            return 1;
+        };
+        let body = command
+            .else_branch
+            .as_ref()
+            .or_else(|| command.elif_branches.last().map(|(_, body)| body))
+            .unwrap_or(&command.then_branch);
+        let current_line = body
+            .last()
+            .map(|stmt| self.facts().stmt(stmt).rendered_end_line())
+            .unwrap_or(body.span.end.line);
+        let close_line = self
+            .source_map()
+            .line_number_for_offset(fi_span.start.offset.min(self.source().len()));
+        line_gap_break_count(current_line, close_line)
+    }
+
+    fn then_separator(&self, condition: &StmtSeq) -> &'static str {
+        if condition.len() == 1
+            && matches!(
+                condition[0].command,
+                Command::Compound(CompoundCommand::Case(_))
+            )
+        {
+            " then"
+        } else {
+            "; then"
+        }
+    }
+
+    fn if_close_starts_on_body_line(&self, command: &IfCommand, body: &StmtSeq) -> bool {
+        let IfSyntax::ThenFi { fi_span, .. } = command.syntax else {
+            return false;
+        };
+        let body_end = stmt_seq_content_end(body, self.source()).min(self.source().len());
+        self.source_map().line_number_for_offset(body_end)
+            == self
+                .source_map()
+                .line_number_for_offset(fi_span.start.offset)
+    }
+
+    fn emit_branch_leading_comments_between(&mut self, start: usize, end: usize) -> bool {
+        let Some(comment_start) = branch_leading_comment_start(self.source(), start, end) else {
+            return false;
+        };
+        let end = end.min(self.source().len());
+        let lines = self.source()[comment_start..end]
+            .lines()
+            .filter_map(|line| {
+                let trimmed = line.trim();
+                trimmed.starts_with('#').then_some(trimmed.to_string())
+            })
+            .collect::<Vec<_>>();
+        let comment_indent = source_line_indent_len_at(self.source(), comment_start);
+        let keyword_indent = source_line_indent_len_at(self.source(), end);
+        let extra_indent = usize::from(comment_indent > keyword_indent);
+        let previous_offset = trim_trailing_whitespace_before_offset(self.source(), start);
+        let previous_line = self.source_map().line_number_for_offset(previous_offset);
+        let comment_line = self.source_map().line_number_for_offset(comment_start);
+        let initial_breaks = line_gap_break_count(previous_line, comment_line);
+        self.with_extra_prefix_indent(extra_indent, |formatter| {
+            for (index, line) in lines.into_iter().enumerate() {
+                if !formatter.line_start {
+                    if index == 0 {
+                        formatter.write_line_breaks(initial_breaks);
+                    } else {
+                        formatter.newline();
+                    }
+                }
+                formatter.write_text(&line);
+            }
+        });
+        true
+    }
+
+    fn branch_body_gap_start(&self, body: &StmtSeq) -> usize {
+        body.last()
+            .map(|stmt| {
+                let facts = self.facts().stmt(stmt);
+                let mut end = trim_trailing_whitespace_before_offset(
+                    self.source(),
+                    facts.attachment_span().end.offset,
+                );
+                if facts.has_trailing_comment() {
+                    end = self
+                        .source()
+                        .get(end..)
+                        .and_then(|tail| tail.find(['\r', '\n']).map(|offset| end + offset))
+                        .unwrap_or_else(|| self.source().len());
+                }
+                end
+            })
+            .unwrap_or_else(|| stmt_seq_content_end(body, self.source()))
+    }
+
+    fn format_multiline_condition_header(&mut self, condition: &StmtSeq) -> Result<()> {
+        self.newline();
+        self.with_indent(|formatter| formatter.write_multiline_condition_source(condition));
+        self.newline();
+        self.write_text("then");
+        Ok(())
+    }
+
+    fn write_multiline_condition_source(&mut self, condition: &StmtSeq) {
+        let mut rendered_lines: Vec<String> = Vec::new();
+        for raw_line in condition
+            .span
+            .slice(self.source())
+            .trim_end_matches(&['\r', '\n'][..])
+            .lines()
+        {
+            let line = raw_line.trim();
+            if line.is_empty() {
+                continue;
+            }
+
+            let (leading_operator, body) = line
+                .strip_prefix("||")
+                .map(|rest| ("||", rest))
+                .or_else(|| line.strip_prefix("&&").map(|rest| ("&&", rest)))
+                .map_or((None, line), |(operator, rest)| {
+                    (Some(operator), rest.trim_start())
+                });
+
+            if let Some(operator) = leading_operator
+                && let Some(previous) = rendered_lines.last_mut()
+            {
+                let trimmed = previous.trim_end();
+                let without_continuation = trimmed.strip_suffix('\\').unwrap_or(trimmed).trim_end();
+                *previous = format!("{without_continuation} {operator}");
+            }
+
+            if !body.is_empty() {
+                rendered_lines.push(body.to_string());
+            }
+        }
+
+        for (index, line) in rendered_lines.iter().enumerate() {
+            if index > 0 {
+                self.newline();
+                self.write_indent_units(1);
+            }
+            self.write_text(line);
+        }
+    }
+
+    fn format_multiline_condition_after_keyword(&mut self, condition: &StmtSeq) -> Option<String> {
+        let mut lines: Vec<Option<String>> = Vec::new();
+        let mut suffix_comment = None;
+        for raw_line in self
+            .condition_source_text(condition)
+            .trim_end_matches(&['\r', '\n'][..])
+            .lines()
+        {
+            let line = raw_line.trim();
+            if line.is_empty() {
+                lines.push(None);
+                continue;
+            }
+            if line.starts_with('#') {
+                suffix_comment.get_or_insert_with(|| line.to_string());
+                lines.push(None);
+                continue;
+            }
+
+            let (leading_operator, body) = line
+                .strip_prefix("||")
+                .map(|rest| ("||", rest))
+                .or_else(|| line.strip_prefix("&&").map(|rest| ("&&", rest)))
+                .map_or((None, line), |(operator, rest)| {
+                    (Some(operator), rest.trim_start())
+                });
+
+            if let Some(operator) = leading_operator
+                && let Some(previous) = lines.iter_mut().rev().find_map(Option::as_mut)
+            {
+                let trimmed = previous.trim_end();
+                let without_continuation = trimmed.strip_suffix('\\').unwrap_or(trimmed).trim_end();
+                *previous = format!("{without_continuation} {operator}");
+            }
+
+            if !body.is_empty() {
+                lines.push(Some(normalize_multiline_conditional_line(body)));
+            }
+        }
+
+        if let Some(last) = lines
+            .iter_mut()
+            .rev()
+            .find_map(Option::as_mut)
+            .filter(|line| !line.is_empty())
+        {
+            if let Some(without_semicolon) = last.strip_suffix(';') {
+                *last = without_semicolon.trim_end().to_string();
+            }
+        }
+        while lines
+            .last()
+            .is_some_and(|line| line.as_ref().is_none_or(|line| line.trim().is_empty()))
+        {
+            lines.pop();
+        }
+        if let Some(last) = lines.iter_mut().rev().find_map(Option::as_mut) {
+            if let Some(without_continuation) = last.trim_end().strip_suffix('\\') {
+                *last = without_continuation.trim_end().to_string();
+            }
+        }
+
+        for (index, line) in lines.iter().enumerate() {
+            if index == 0 {
+                if let Some(line) = line {
+                    self.write_text(line);
+                }
+                continue;
+            }
+            self.newline();
+            if let Some(line) = line {
+                self.write_indent_units(1);
+                self.write_text(line);
+            }
+        }
+        suffix_comment
+    }
+
+    fn condition_has_top_level_list_break(&self, condition: &StmtSeq) -> bool {
+        self.condition_source_text(condition)
+            .trim_end_matches(&['\r', '\n'][..])
+            .contains('\n')
+            && (condition
+                .iter()
+                .any(|stmt| self.stmt_has_top_level_list_break(stmt))
+                || condition_source_has_leading_list_operator(
+                    self.condition_source_text(condition),
+                ))
+    }
+
+    fn stmt_has_top_level_list_break(&self, stmt: &Stmt) -> bool {
+        let Command::Binary(binary) = &stmt.command else {
+            return false;
+        };
+        self.binary_has_top_level_list_break(binary)
+    }
+
+    fn binary_has_top_level_list_break(&self, binary: &BinaryCommand) -> bool {
+        matches!(binary.op, BinaryOp::And | BinaryOp::Or)
+            && self
+                .facts()
+                .list_item_has_explicit_line_break(binary.op_span)
+            || self.stmt_has_top_level_list_break(&binary.left)
+            || self.stmt_has_top_level_list_break(&binary.right)
+    }
+
+    fn condition_source_text(&self, condition: &StmtSeq) -> &'source str {
+        let start = condition.span.start.offset.min(self.source().len());
+        let end = stmt_seq_content_end(condition, self.source())
+            .min(self.source().len())
+            .max(start);
+        &self.source()[start..end]
+    }
+
+    fn else_body_starts_on_else_line(&self, command: &IfCommand, body: &StmtSeq) -> bool {
+        let Some(first) = body.first() else {
+            return false;
+        };
+        let first_start = self
+            .facts()
+            .stmt(first)
+            .attachment_span()
+            .start
+            .offset
+            .min(self.source().len());
+        let line_prefix = self.source()[..first_start]
+            .rsplit_once('\n')
+            .map_or(&self.source()[..first_start], |(_, line)| line);
+        line_prefix.trim_start().starts_with("else ")
+            || else_keyword_offset(command, self.source()).is_some_and(|offset| {
+                self.source_map().line_number_for_offset(offset)
+                    == self.source_map().line_number_for_offset(first_start)
+            })
+    }
+
+    fn body_starts_after_then_on_same_line(&self, body: &StmtSeq) -> bool {
+        let Some(first) = body.first() else {
+            return false;
+        };
+        let first_start = self
+            .facts()
+            .stmt(first)
+            .attachment_span()
+            .start
+            .offset
+            .min(self.source().len());
+        let line_prefix = self.source()[..first_start]
+            .rsplit_once('\n')
+            .map_or(&self.source()[..first_start], |(_, line)| line);
+        line_prefix.contains("then ")
+    }
+
+    fn condition_starts_after_keyword_continuation(
+        &self,
+        keyword: &str,
+        condition: &StmtSeq,
+    ) -> bool {
+        let source = self.source();
+        let offset = condition.span.start.offset.min(source.len());
+        let before_condition = &source[..offset];
+        let current_line_prefix = before_condition
+            .rsplit_once('\n')
+            .map_or(before_condition, |(_, line)| line);
+        if !current_line_prefix.trim().is_empty() {
+            return false;
+        }
+
+        before_condition
+            .lines()
+            .rev()
+            .skip(1)
+            .find(|line| !line.trim().is_empty())
+            .is_some_and(|line| {
+                let trimmed = line.trim();
+                trimmed == keyword
+                    || trimmed
+                        .strip_prefix(keyword)
+                        .is_some_and(|rest| rest.trim_end().ends_with('\\'))
+            })
+    }
+
+    fn write_header_suffix_comment_between(&mut self, start: usize, end: usize) {
+        let Some(comment) = self.header_suffix_comment_between(start, end) else {
+            return;
+        };
+        self.write_space();
+        self.write_text(&comment);
+    }
+
+    fn header_suffix_comment_between(&self, start: usize, end: usize) -> Option<String> {
+        let source = self.source();
+        let start = start.min(source.len());
+        let end = end.min(source.len()).max(start);
+        let slice = source.get(start..end)?;
+        let first_line = slice
+            .find(['\r', '\n'])
+            .map_or(slice, |line_end| &slice[..line_end]);
+        let comment_start = first_line.find('#')?;
+        Some(first_line[comment_start..].trim_end().to_string())
     }
 
     fn format_brace_if(&mut self, command: &IfCommand) -> Result<()> {
@@ -1066,7 +1956,9 @@ impl<'source, 'facts> ShellStreamFormatter<'source, 'facts> {
         }
 
         match command.syntax {
-            ForSyntax::InDoDone { .. } => {
+            ForSyntax::InDoDone {
+                do_span, done_span, ..
+            } => {
                 if let Some(words) = &command.words {
                     self.write_text(" in");
                     for word in words {
@@ -1080,11 +1972,16 @@ impl<'source, 'facts> ShellStreamFormatter<'source, 'facts> {
                     self.write_text("; done");
                 } else {
                     self.write_text("; do");
-                    self.format_body_with_upper_bound(
+                    self.write_header_suffix_comment_between(
+                        do_span.end.offset,
+                        command.body.span.start.offset,
+                    );
+                    self.format_body_after_opener_offset(
                         &command.body,
                         Some(command.span.end.offset),
+                        do_span.end.offset,
                     )?;
-                    self.finish_block("done");
+                    self.finish_block_after_body("done", &command.body, done_span.start.offset);
                 }
             }
             ForSyntax::InDirect { .. } => {
@@ -1098,7 +1995,9 @@ impl<'source, 'facts> ShellStreamFormatter<'source, 'facts> {
                 self.write_space();
                 self.format_inline_stmts(&command.body)?;
             }
-            ForSyntax::ParenDoDone { .. } => {
+            ForSyntax::ParenDoDone {
+                do_span, done_span, ..
+            } => {
                 self.write_text(" (");
                 for (index, word) in command
                     .words
@@ -1117,11 +2016,16 @@ impl<'source, 'facts> ShellStreamFormatter<'source, 'facts> {
                     self.write_text("; done");
                 } else {
                     self.write_text("); do");
-                    self.format_body_with_upper_bound(
+                    self.write_header_suffix_comment_between(
+                        do_span.end.offset,
+                        command.body.span.start.offset,
+                    );
+                    self.format_body_after_opener_offset(
                         &command.body,
                         Some(command.span.end.offset),
+                        do_span.end.offset,
                     )?;
-                    self.finish_block("done");
+                    self.finish_block_after_body("done", &command.body, done_span.start.offset);
                 }
             }
             ForSyntax::ParenDirect { .. } => {
@@ -1175,18 +2079,23 @@ impl<'source, 'facts> ShellStreamFormatter<'source, 'facts> {
         self.write_text("repeat ");
         self.write_word(&command.count);
         match command.syntax {
-            RepeatSyntax::DoDone { .. } => {
+            RepeatSyntax::DoDone { do_span, done_span } => {
                 if self.can_inline_body(&command.body, command.span) {
                     self.write_text("; do ");
                     self.format_inline_stmts(&command.body)?;
                     self.write_text("; done");
                 } else {
                     self.write_text("; do");
+                    self.write_header_suffix_comment_between(
+                        do_span.end.offset,
+                        command.body.span.start.offset,
+                    );
                     self.format_body_with_upper_bound(
                         &command.body,
                         Some(command.span.end.offset),
+                        None,
                     )?;
-                    self.finish_block("done");
+                    self.finish_block_after_body("done", &command.body, done_span.start.offset);
                 }
             }
             RepeatSyntax::Direct => {
@@ -1216,7 +2125,9 @@ impl<'source, 'facts> ShellStreamFormatter<'source, 'facts> {
                 self.write_text(") ");
                 self.format_brace_group(&command.body, Some(command.span.end.offset))?;
             }
-            ForeachSyntax::InDoDone { .. } => {
+            ForeachSyntax::InDoDone {
+                do_span, done_span, ..
+            } => {
                 self.write_text(" in ");
                 for (index, word) in command.words.iter().enumerate() {
                     if index > 0 {
@@ -1230,11 +2141,16 @@ impl<'source, 'facts> ShellStreamFormatter<'source, 'facts> {
                     self.write_text("; done");
                 } else {
                     self.write_text("; do");
+                    self.write_header_suffix_comment_between(
+                        do_span.end.offset,
+                        command.body.span.start.offset,
+                    );
                     self.format_body_with_upper_bound(
                         &command.body,
                         Some(command.span.end.offset),
+                        None,
                     )?;
-                    self.finish_block("done");
+                    self.finish_block_after_body("done", &command.body, done_span.start.offset);
                 }
             }
         }
@@ -1258,8 +2174,25 @@ impl<'source, 'facts> ShellStreamFormatter<'source, 'facts> {
             return Ok(());
         }
         self.write_text("; do");
-        self.format_body_with_upper_bound(&command.body, Some(command.span.end.offset))?;
-        self.finish_block("done");
+        if let Some(opener_offset) = block_opener_offset_before_body(
+            command.variable_span.end.offset,
+            &command.body,
+            self.source(),
+            "do",
+        ) {
+            self.write_header_suffix_comment_between(opener_offset, command.body.span.start.offset);
+        }
+        self.format_body_with_upper_bound(&command.body, Some(command.span.end.offset), None)?;
+        if let Some(done_offset) = block_close_offset_after_body(
+            &command.body,
+            command.span.end.offset,
+            self.source(),
+            "done",
+        ) {
+            self.finish_block_after_body("done", &command.body, done_offset);
+        } else {
+            self.finish_block("done");
+        }
         Ok(())
     }
 
@@ -1273,8 +2206,28 @@ impl<'source, 'facts> ShellStreamFormatter<'source, 'facts> {
             return Ok(());
         }
         self.write_text("; do");
-        self.format_body_with_upper_bound(&command.body, Some(command.span.end.offset))?;
-        self.finish_block("done");
+        let opener_offset =
+            loop_body_do_opener_offset(&command.condition, &command.body, self.source());
+        if let Some(opener_offset) = opener_offset {
+            self.write_header_suffix_comment_between(opener_offset, command.body.span.start.offset);
+            self.format_body_after_opener_offset(
+                &command.body,
+                Some(command.span.end.offset),
+                opener_offset,
+            )?;
+        } else {
+            self.format_body_with_upper_bound(&command.body, Some(command.span.end.offset), None)?;
+        }
+        if let Some(done_offset) = block_close_offset_after_body(
+            &command.body,
+            command.span.end.offset,
+            self.source(),
+            "done",
+        ) {
+            self.finish_block_after_body("done", &command.body, done_offset);
+        } else {
+            self.finish_block("done");
+        }
         Ok(())
     }
 
@@ -1288,8 +2241,28 @@ impl<'source, 'facts> ShellStreamFormatter<'source, 'facts> {
             return Ok(());
         }
         self.write_text("; do");
-        self.format_body_with_upper_bound(&command.body, Some(command.span.end.offset))?;
-        self.finish_block("done");
+        let opener_offset =
+            loop_body_do_opener_offset(&command.condition, &command.body, self.source());
+        if let Some(opener_offset) = opener_offset {
+            self.write_header_suffix_comment_between(opener_offset, command.body.span.start.offset);
+            self.format_body_after_opener_offset(
+                &command.body,
+                Some(command.span.end.offset),
+                opener_offset,
+            )?;
+        } else {
+            self.format_body_with_upper_bound(&command.body, Some(command.span.end.offset), None)?;
+        }
+        if let Some(done_offset) = block_close_offset_after_body(
+            &command.body,
+            command.span.end.offset,
+            self.source(),
+            "done",
+        ) {
+            self.finish_block_after_body("done", &command.body, done_offset);
+        } else {
+            self.finish_block("done");
+        }
         Ok(())
     }
 
@@ -1297,30 +2270,113 @@ impl<'source, 'facts> ShellStreamFormatter<'source, 'facts> {
         self.write_text("case ");
         self.write_word(&command.word);
         self.write_text(" in");
-        if self.options().compact_layout() {
+        if self.options().compact_layout() || self.case_command_was_inline_in_source(command) {
             for item in &command.cases {
                 self.write_space();
-                self.format_case_item(item, Some(command.span.end.offset))?;
+                self.format_inline_case_item(item, Some(command.span.end.offset))?;
             }
             self.write_text(" esac");
         } else {
-            for item in &command.cases {
-                self.newline();
+            for (index, item) in command.cases.iter().enumerate() {
+                if index == 0 {
+                    self.newline();
+                } else {
+                    let previous = &command.cases[index - 1];
+                    let body_upper_bound =
+                        case_item_body_upper_bound(item, Some(command.span.end.offset));
+                    let breaks = self
+                        .case_item_pattern_prefix_comments(item, body_upper_bound)
+                        .first()
+                        .map_or_else(
+                            || case_item_gap_break_count(previous, item),
+                            |comment| {
+                                let previous_line = previous
+                                    .terminator_span
+                                    .map(|span| span.end.line)
+                                    .or_else(|| {
+                                        previous.body.last().map(|stmt| stmt_span(stmt).end.line)
+                                    })
+                                    .or_else(|| {
+                                        previous
+                                            .patterns
+                                            .last()
+                                            .map(|pattern| pattern.span.end.line)
+                                    })
+                                    .unwrap_or(1);
+                                line_gap_break_count(previous_line, comment.line())
+                            },
+                        );
+                    self.write_line_breaks(breaks);
+                }
                 self.format_case_item(item, Some(command.span.end.offset))?;
             }
-            self.newline();
+            self.write_line_breaks(self.case_close_break_count(command));
             self.write_text("esac");
         }
         Ok(())
     }
 
-    fn format_case_item(&mut self, item: &CaseItem, upper_bound: Option<usize>) -> Result<()> {
-        let base_indent =
-            usize::from(!self.options().compact_layout() && self.options().switch_case_indent());
+    fn case_command_was_inline_in_source(&self, command: &CaseCommand) -> bool {
+        !self
+            .case_command_source_through_esac(command)
+            .contains('\n')
+            && command.cases.iter().all(|item| {
+                item.body.len() <= 1
+                    && (item.body.is_empty() || self.facts().case_item_was_inline_in_source(item))
+            })
+    }
 
-        if base_indent > 0 {
-            self.write_case_prefix(base_indent);
-        }
+    fn case_command_source_through_esac(&self, command: &CaseCommand) -> &'source str {
+        let start = command.span.start.offset.min(self.source().len());
+        let search_start = command
+            .cases
+            .last()
+            .and_then(|item| item.terminator_span)
+            .map_or(command.word.span.end.offset, |span| span.end.offset)
+            .min(self.source().len())
+            .max(start);
+        let span_end = command
+            .span
+            .end
+            .offset
+            .min(self.source().len())
+            .max(search_start);
+        let end = self.source()[search_start..span_end]
+            .find("esac")
+            .map_or(span_end, |offset| search_start + offset + "esac".len());
+        &self.source()[start..end]
+    }
+
+    fn case_close_break_count(&self, command: &CaseCommand) -> usize {
+        let Some(close_offset) = case_close_offset(command, self.source()) else {
+            return 1;
+        };
+        let current_line = command
+            .cases
+            .last()
+            .and_then(|item| {
+                item.terminator_span
+                    .map(|span| span.end.line)
+                    .or_else(|| {
+                        item.body
+                            .last()
+                            .map(|stmt| self.facts().stmt(stmt).rendered_end_line())
+                    })
+                    .or_else(|| item.patterns.last().map(|pattern| pattern.span.end.line))
+            })
+            .unwrap_or(command.span.end.line);
+        let close_line = self
+            .source_map()
+            .line_number_for_offset(close_offset.min(self.source().len()));
+        line_gap_break_count(current_line, close_line)
+    }
+
+    fn format_inline_case_item(
+        &mut self,
+        item: &CaseItem,
+        upper_bound: Option<usize>,
+    ) -> Result<()> {
+        let body_upper_bound = case_item_body_upper_bound(item, upper_bound);
         for (index, word) in item.patterns.iter().enumerate() {
             if index > 0 {
                 self.write_text(" | ");
@@ -1332,32 +2388,302 @@ impl<'source, 'facts> ShellStreamFormatter<'source, 'facts> {
         if item.body.is_empty() {
             self.write_space();
             self.write_text(case_terminator(item.terminator));
-        } else if self.options().compact_layout() {
+            self.write_case_terminator_trailing_comment(item);
+            return Ok(());
+        }
+
+        let body_was_verbatim = self
+            .facts()
+            .sequence(&item.body, body_upper_bound)
+            .is_ambiguous();
+        let mut body = String::new();
+        format_stmt_sequence_streaming_to_buf(
+            self.source(),
+            &item.body,
+            self.options(),
+            self.facts(),
+            body_upper_bound,
+            &mut body,
+        )?;
+        let body = body.trim_end();
+        let body = body.strip_suffix(';').map_or(body, str::trim_end);
+        self.write_space();
+        self.write_text(body);
+        if !case_item_body_includes_terminator(item, body_was_verbatim) {
             self.write_space();
-            self.format_stmt_sequence(&item.body, upper_bound)?;
-            self.write_text("; ");
             self.write_text(case_terminator(item.terminator));
+        }
+        self.write_case_terminator_trailing_comment(item);
+        Ok(())
+    }
+
+    fn format_case_item(&mut self, item: &CaseItem, upper_bound: Option<usize>) -> Result<()> {
+        let body_upper_bound = case_item_body_upper_bound(item, upper_bound);
+        let base_indent =
+            usize::from(!self.options().compact_layout() && self.options().switch_case_indent());
+        let pattern_prefix_comments =
+            self.case_item_pattern_prefix_comments(item, body_upper_bound);
+        let pattern_start = item
+            .patterns
+            .first()
+            .map(|pattern| pattern.span.start.offset);
+
+        if !pattern_prefix_comments.is_empty() && !self.options().compact_layout() {
+            self.with_extra_prefix_indent(base_indent, |formatter| {
+                formatter.emit_leading_comments(
+                    &pattern_prefix_comments,
+                    item.patterns.first().map_or_else(
+                        || item.body.span.start.line,
+                        |pattern| pattern.span.start.line,
+                    ),
+                );
+            });
+        }
+        if base_indent > 0 {
+            self.write_case_prefix(base_indent);
+        }
+        self.format_case_patterns(item, base_indent);
+        self.write_text(")");
+        let pattern_comment_was_written = self.write_case_pattern_suffix_comment(item);
+
+        if item.body.is_empty() {
+            if pattern_comment_was_written && !self.options().compact_layout() {
+                self.newline();
+                self.write_case_prefix(base_indent + 1);
+            } else {
+                self.write_space();
+            }
+            self.write_text(case_terminator(item.terminator));
+            self.write_case_terminator_trailing_comment(item);
+        } else if self.options().compact_layout() {
+            let body_was_verbatim = self
+                .facts()
+                .sequence(&item.body, body_upper_bound)
+                .is_ambiguous();
+            self.write_space();
+            self.format_stmt_sequence_skipping_leading_before(
+                &item.body,
+                body_upper_bound,
+                pattern_start,
+            )?;
+            if !case_item_body_includes_terminator(item, body_was_verbatim) {
+                self.write_text("; ");
+                self.write_text(case_terminator(item.terminator));
+            }
+            self.write_case_terminator_trailing_comment(item);
         } else {
             if base_indent == 0
                 && item.body.len() == 1
                 && self.facts().case_item_was_inline_in_source(item)
+                && !pattern_comment_was_written
+                && pattern_prefix_comments.is_empty()
             {
                 self.write_space();
                 self.format_stmt(&item.body[0])?;
                 self.write_space();
                 self.write_text(case_terminator(item.terminator));
+                self.write_case_terminator_trailing_comment(item);
                 return Ok(());
             }
 
+            let body_was_verbatim = self
+                .facts()
+                .sequence(&item.body, body_upper_bound)
+                .is_ambiguous();
             self.newline();
             self.with_extra_prefix_indent(base_indent + 1, |formatter| {
-                formatter.format_stmt_sequence(&item.body, upper_bound)
+                formatter.format_stmt_sequence_skipping_leading_before(
+                    &item.body,
+                    body_upper_bound,
+                    pattern_start,
+                )
             })?;
-            self.newline();
+            if case_item_body_includes_terminator(item, body_was_verbatim) {
+                self.write_case_terminator_trailing_comment(item);
+                return Ok(());
+            }
+            self.write_line_breaks(self.case_terminator_break_count(item, body_upper_bound));
             self.write_case_prefix(base_indent + 1);
             self.write_text(case_terminator(item.terminator));
+            self.write_case_terminator_trailing_comment(item);
         }
         Ok(())
+    }
+
+    fn case_terminator_break_count(
+        &self,
+        item: &CaseItem,
+        body_upper_bound: Option<usize>,
+    ) -> usize {
+        let Some(terminator_span) = item.terminator_span else {
+            return 1;
+        };
+        let current_line = item
+            .body
+            .last()
+            .map(|stmt| {
+                self.facts()
+                    .sequence(&item.body, body_upper_bound)
+                    .dangling()
+                    .last()
+                    .map(SourceComment::line)
+                    .unwrap_or_else(|| self.facts().stmt(stmt).rendered_end_line())
+            })
+            .or_else(|| item.patterns.last().map(|pattern| pattern.span.end.line))
+            .unwrap_or(terminator_span.start.line);
+        line_gap_break_count(current_line, terminator_span.start.line)
+    }
+
+    fn case_item_pattern_prefix_comments(
+        &self,
+        item: &CaseItem,
+        body_upper_bound: Option<usize>,
+    ) -> Vec<SourceComment<'source>> {
+        let Some(pattern_start) = item
+            .patterns
+            .first()
+            .map(|pattern| pattern.span.start.offset)
+        else {
+            return Vec::new();
+        };
+        self.facts()
+            .sequence(&item.body, body_upper_bound)
+            .leading_for(0)
+            .iter()
+            .copied()
+            .filter(|comment| comment.span().start.offset < pattern_start)
+            .collect()
+    }
+
+    fn write_case_pattern_suffix_comment(&mut self, item: &CaseItem) -> bool {
+        if self.options().minify() {
+            return false;
+        }
+        let Some(last_pattern) = item.patterns.last() else {
+            return false;
+        };
+        let source = self.source();
+        let start = last_pattern.span.end.offset.min(source.len());
+        let line_end = source[start..]
+            .find(['\r', '\n'])
+            .map_or(source.len(), |offset| start + offset);
+        let mut end = line_end;
+        if let Some(first_body_stmt) = item.body.first() {
+            end = end.min(
+                self.facts()
+                    .stmt(first_body_stmt)
+                    .attachment_span()
+                    .start
+                    .offset,
+            );
+        }
+        if let Some(terminator_span) = item.terminator_span {
+            end = end.min(terminator_span.start.offset);
+        }
+        let end = end.min(line_end).max(start);
+        let Some(candidate) = source.get(start..end) else {
+            return false;
+        };
+        let Some(comment_start) = candidate.find('#') else {
+            return false;
+        };
+        self.write_space();
+        self.write_verbatim(candidate[comment_start..].trim_end());
+        true
+    }
+
+    fn write_case_terminator_trailing_comment(&mut self, item: &CaseItem) {
+        if self.options().minify() {
+            return;
+        }
+        let Some(terminator_span) = item.terminator_span else {
+            return;
+        };
+        let source = self.source();
+        let start = terminator_span.end.offset;
+        let Some(line_tail) = source.get(start..).and_then(|tail| {
+            let end = tail.find(['\r', '\n']).unwrap_or(tail.len());
+            tail.get(..end)
+        }) else {
+            return;
+        };
+        let Some(comment_start) = line_tail.find('#') else {
+            return;
+        };
+        self.write_space();
+        self.write_verbatim(&line_tail[comment_start..]);
+    }
+
+    fn format_case_patterns(&mut self, item: &CaseItem, base_indent: usize) {
+        if !self.options().compact_layout()
+            && case_patterns_have_line_break(item, self.source())
+            && let (Some(first), Some(last)) = (item.patterns.first(), item.patterns.last())
+        {
+            let start = first.span.start.offset.min(self.source().len());
+            let end = last.span.end.offset.min(self.source().len()).max(start);
+            let mut wrote_line = false;
+            let lines = self.source()[start..end]
+                .lines()
+                .map(str::trim)
+                .filter(|line| !line.is_empty())
+                .map(str::to_string)
+                .collect::<Vec<_>>();
+            for line in lines {
+                if wrote_line {
+                    self.newline();
+                    self.write_case_prefix(base_indent + 1);
+                }
+                self.write_text(&line);
+                wrote_line = true;
+            }
+            if wrote_line {
+                return;
+            }
+        }
+
+        for (index, word) in item.patterns.iter().enumerate() {
+            if index > 0 {
+                self.write_text(" | ");
+            }
+            self.write_pattern(word);
+        }
+    }
+
+    fn comment_padding_is_in_alignment_run(&self, comment: &SourceComment<'_>) -> bool {
+        self.comment_padding_is_in_alignment_run_for_line(comment.line())
+    }
+
+    fn aligned_comment_target_column(&self, comment: &SourceComment<'_>) -> Option<usize> {
+        self.aligned_comment_target_column_for_line(comment.line())
+    }
+
+    fn comment_padding_is_in_alignment_run_for_line(&self, line: usize) -> bool {
+        line > 1 && self.line_has_inline_comment(line - 1) || self.line_has_inline_comment(line + 1)
+    }
+
+    fn aligned_comment_target_column_for_line(&self, line: usize) -> Option<usize> {
+        let lines = self.source().lines().collect::<Vec<_>>();
+        let mut start = line.saturating_sub(1);
+        let mut end = start;
+
+        while start > 0 && line_has_inline_comment_text(lines[start - 1]) {
+            start -= 1;
+        }
+        while end + 1 < lines.len() && line_has_inline_comment_text(lines[end + 1]) {
+            end += 1;
+        }
+
+        (start..=end)
+            .filter_map(|index| inline_comment_code_width(lines[index]))
+            .max()
+            .map(|width| width + 1)
+    }
+
+    fn line_has_inline_comment(&self, line_number: usize) -> bool {
+        let Some(line) = self.source().lines().nth(line_number.saturating_sub(1)) else {
+            return false;
+        };
+        line_has_inline_comment_text(line)
     }
 
     fn with_extra_prefix_indent<T>(&mut self, levels: usize, f: impl FnOnce(&mut Self) -> T) -> T {
@@ -1375,6 +2701,12 @@ impl<'source, 'facts> ShellStreamFormatter<'source, 'facts> {
         if should_inline {
             self.write_text("{ ");
             self.format_inline_stmts(commands)?;
+            self.write_text("; }");
+            return Ok(());
+        }
+        if self.should_compact_multiline_brace_group(commands, upper_bound) {
+            self.write_text("{ ");
+            self.format_stmt(&commands[0])?;
             self.write_text("; }");
             return Ok(());
         }
@@ -1396,35 +2728,61 @@ impl<'source, 'facts> ShellStreamFormatter<'source, 'facts> {
     }
 
     fn format_arithmetic(&mut self, command: &ArithmeticCommand) -> Result<()> {
-        let rendered = self
-            .source()
-            .get(command.span.start.offset..command.span.end.offset)
-            .unwrap_or_default();
-        self.write_text(rendered);
+        self.write_text("((");
+        if let Some(expr) = &command.expr_ast {
+            let mut scratch = self.take_scratch_buffer();
+            render_arithmetic_expr_to_buf(&mut scratch, expr, self.source(), self.options());
+            self.write_text(&scratch);
+            self.restore_scratch_buffer(scratch);
+        } else if let Some(span) = command.expr_span {
+            self.write_text(span.slice(self.source()).trim());
+        }
+        self.write_text("))");
         Ok(())
     }
 
     fn format_arithmetic_for(&mut self, command: &ArithmeticForCommand) -> Result<()> {
-        let source = self.source();
-        let init = slice_span(source, command.init_span);
-        let condition = command
-            .condition_span
-            .map(|span| span.slice(source))
-            .unwrap_or("");
-        let step = command
-            .step_span
-            .map(|span| span.slice(source))
-            .unwrap_or("");
         self.write_text("for ((");
-        self.write_text(init);
-        self.write_text(";");
-        self.write_text(condition);
-        self.write_text(";");
-        self.write_text(step);
+        if command.init_span.is_none() {
+            self.write_space();
+        }
+        self.write_arithmetic_for_segment(command.init_span, command.init_ast.as_ref());
+        self.write_text("; ");
+        self.write_arithmetic_for_segment(command.condition_span, command.condition_ast.as_ref());
+        self.write_text("; ");
+        self.write_arithmetic_for_segment(command.step_span, command.step_ast.as_ref());
         self.write_text(")); do");
-        self.format_body_with_upper_bound(&command.body, Some(command.span.end.offset))?;
-        self.finish_block("done");
+        self.format_body_after_opener_offset(
+            &command.body,
+            Some(command.span.end.offset),
+            command.right_paren_span.end.offset,
+        )?;
+        if let Some(done_offset) = block_close_offset_after_body(
+            &command.body,
+            command.span.end.offset,
+            self.source(),
+            "done",
+        ) {
+            self.finish_block_after_body("done", &command.body, done_offset);
+        } else {
+            self.finish_block("done");
+        }
         Ok(())
+    }
+
+    fn write_arithmetic_for_segment(
+        &mut self,
+        span: Option<Span>,
+        ast: Option<&shuck_ast::ArithmeticExprNode>,
+    ) {
+        if let Some(expr) = ast {
+            let mut scratch = self.take_scratch_buffer();
+            render_arithmetic_expr_to_buf(&mut scratch, expr, self.source(), self.options());
+            self.write_text(&scratch);
+            self.restore_scratch_buffer(scratch);
+        } else if let Some(span) = span {
+            self.write_text(span.slice(self.source()).trim());
+        }
     }
 
     fn format_time(&mut self, command: &TimeCommand) -> Result<()> {
@@ -1441,11 +2799,27 @@ impl<'source, 'facts> ShellStreamFormatter<'source, 'facts> {
     }
 
     fn format_conditional(&mut self, command: &ConditionalCommand) -> Result<()> {
+        if command.span.slice(self.source()).contains('\n') {
+            self.format_multiline_conditional_source(command);
+            return Ok(());
+        }
+
         self.write_text("[[ ");
         self.format_conditional_expr(&command.expression)?;
         let tight_close = self.conditional_needs_tight_close(&command.expression);
         self.write_text(if tight_close { "]]" } else { " ]]" });
         Ok(())
+    }
+
+    fn format_multiline_conditional_source(&mut self, command: &ConditionalCommand) {
+        for (index, line) in command.span.slice(self.source()).lines().enumerate() {
+            if index > 0 {
+                self.newline();
+                self.write_indent_units(1);
+            }
+            let line = normalize_multiline_conditional_line(line);
+            self.write_text(&line);
+        }
     }
 
     fn format_coproc(&mut self, command: &CoprocCommand) -> Result<()> {
@@ -1608,6 +2982,7 @@ impl<'source, 'facts> ShellStreamFormatter<'source, 'facts> {
         &mut self,
         commands: &StmtSeq,
         upper_bound: Option<usize>,
+        opener_line: Option<usize>,
     ) -> Result<()> {
         if commands.is_empty() {
             return Ok(());
@@ -1617,7 +2992,50 @@ impl<'source, 'facts> ShellStreamFormatter<'source, 'facts> {
             self.write_space();
             self.format_stmt_sequence(commands, upper_bound)
         } else {
-            self.newline();
+            let line_breaks = opener_line
+                .map(|line| {
+                    line_gap_break_count(
+                        line,
+                        self.facts()
+                            .sequence(commands, upper_bound)
+                            .first_rendered_line_for(0),
+                    )
+                })
+                .unwrap_or(1);
+            self.write_line_breaks(line_breaks);
+            self.with_indent(|formatter| formatter.format_stmt_sequence(commands, upper_bound))
+        }
+    }
+
+    fn format_body_after_opener_offset(
+        &mut self,
+        commands: &StmtSeq,
+        upper_bound: Option<usize>,
+        opener_offset: usize,
+    ) -> Result<()> {
+        if commands.is_empty() {
+            return Ok(());
+        }
+
+        if self.options().compact_layout() {
+            self.write_space();
+            self.format_stmt_sequence(commands, upper_bound)
+        } else {
+            let sequence = self.facts().sequence(commands, upper_bound);
+            let first_start = sequence
+                .leading_for(0)
+                .first()
+                .map(|comment| comment.span().start.offset)
+                .or_else(|| {
+                    commands
+                        .first()
+                        .map(|stmt| self.facts().stmt(stmt).attachment_span().start.offset)
+                })
+                .unwrap_or(commands.span.start.offset);
+            let line_breaks =
+                source_line_break_count_between(self.source(), opener_offset, first_start)
+                    .clamp(1, 2);
+            self.write_line_breaks(line_breaks);
             self.with_indent(|formatter| formatter.format_stmt_sequence(commands, upper_bound))
         }
     }
@@ -1632,11 +3050,40 @@ impl<'source, 'facts> ShellStreamFormatter<'source, 'facts> {
         }
     }
 
+    fn finish_block_after_body(
+        &mut self,
+        close: &'static str,
+        body: &StmtSeq,
+        close_offset: usize,
+    ) {
+        if self.options().compact_layout() {
+            self.write_text("; ");
+            self.write_text(close);
+        } else {
+            let current_line = body
+                .last()
+                .map(|stmt| {
+                    self.facts()
+                        .sequence(body, Some(close_offset))
+                        .dangling()
+                        .last()
+                        .map(SourceComment::line)
+                        .unwrap_or_else(|| self.facts().stmt(stmt).rendered_end_line())
+                })
+                .unwrap_or(body.span.end.line);
+            let close_line = self
+                .source_map()
+                .line_number_for_offset(close_offset.min(self.source().len()));
+            self.write_line_breaks(line_gap_break_count(current_line, close_line));
+            self.write_text(close);
+        }
+    }
+
     fn format_group_with_upper_bound(
         &mut self,
         open: &'static str,
         close: &'static str,
-        _open_char: char,
+        open_char: char,
         commands: &StmtSeq,
         leading_space: bool,
         upper_bound: Option<usize>,
@@ -1645,16 +3092,47 @@ impl<'source, 'facts> ShellStreamFormatter<'source, 'facts> {
             self.write_space();
         }
         self.write_text(open);
-        let open_suffix_span = self
-            .facts()
-            .sequence(commands, upper_bound)
-            .group_open_suffix_span();
+        let sequence_facts = self.facts().sequence(commands, upper_bound);
+        let open_suffix_span = sequence_facts.group_open_suffix_span();
+        let dangling_tail_line = sequence_facts.dangling().last().map(SourceComment::line);
         if let Some(span) = open_suffix_span {
-            self.write_text(span.slice(self.source()));
+            self.write_group_open_suffix(span);
         }
-        self.format_body_with_upper_bound(commands, upper_bound)?;
-        self.finish_block(close);
+        let group_span = group_attachment_span(
+            commands.as_slice(),
+            self.source_map(),
+            open_char,
+            close.chars().next().unwrap_or(open_char),
+        );
+        let opener_line = group_span.map(|span| span.start.line);
+        self.format_body_with_upper_bound(commands, upper_bound, opener_line)?;
+        if self.options().compact_layout() {
+            self.write_text("; ");
+            self.write_text(close);
+        } else {
+            let close_breaks = group_span
+                .and_then(|span| {
+                    commands.last().map(|last| {
+                        let rendered_tail_line = dangling_tail_line
+                            .unwrap_or_else(|| self.facts().stmt(last).rendered_end_line());
+                        line_gap_break_count(rendered_tail_line, span.end.line)
+                    })
+                })
+                .unwrap_or(1);
+            self.write_line_breaks(close_breaks);
+            self.write_text(close);
+        }
         Ok(())
+    }
+
+    fn write_group_open_suffix(&mut self, span: Span) {
+        let suffix = span.slice(self.source());
+        if let Some(comment_start) = suffix.find('#') {
+            self.write_space();
+            self.write_text(suffix[comment_start..].trim_end());
+        } else {
+            self.write_text(suffix);
+        }
     }
 
     fn format_redirect_list(&mut self, redirects: &[Redirect]) {
@@ -1678,15 +3156,19 @@ impl<'source, 'facts> ShellStreamFormatter<'source, 'facts> {
             return;
         }
 
+        let mut rendered_explicit_fd = false;
+        let adjacent_numeric_fd = redirect_has_adjacent_numeric_fd(redirect, source);
         if let Some(name) = &redirect.fd_var {
             self.write_text("{");
             self.write_text(name.as_str());
             self.write_text("}");
+            rendered_explicit_fd = true;
         } else if let Some(fd) = redirect
             .fd
-            .filter(|fd| should_render_explicit_fd(*fd, redirect.kind))
+            .filter(|fd| should_render_explicit_fd(*fd, redirect, source))
         {
             self.write_display(fd);
+            rendered_explicit_fd = true;
         }
 
         self.write_text(match redirect.kind {
@@ -1730,7 +3212,12 @@ impl<'source, 'facts> ShellStreamFormatter<'source, 'facts> {
                 }
             }
         }
-        if needs_space_before_target(redirect.kind, &target, options.space_redirects()) {
+        if needs_space_before_target(
+            redirect.kind,
+            &target,
+            options.space_redirects(),
+            rendered_explicit_fd || adjacent_numeric_fd,
+        ) {
             self.write_space();
         }
         self.write_text(&target);
@@ -1759,8 +3246,12 @@ impl<'source, 'facts> ShellStreamFormatter<'source, 'facts> {
             // The opening redirection keeps delimiter quoting, but the closing
             // marker line uses the cooked delimiter text after quote removal.
             let delimiter = heredoc.delimiter.cooked.to_string();
-            self.pending_heredocs
-                .push(PendingHeredoc { body, delimiter });
+            self.pending_heredocs.push(PendingHeredoc {
+                body,
+                delimiter,
+                strip_tabs: matches!(redirect.kind, RedirectKind::HereDocStrip),
+                indent_level: self.indent_level,
+            });
         }
     }
 
@@ -1769,23 +3260,32 @@ impl<'source, 'facts> ShellStreamFormatter<'source, 'facts> {
         assignment: &shuck_ast::Assignment,
     ) -> Result<()> {
         let source = self.source();
-        let Some(lines) = multiline_compound_assignment_lines(assignment, source) else {
+        let Some((first_line, remaining_lines)) =
+            compound_assignment_multiline_parts(assignment, source)
+        else {
             self.write_assignment(assignment);
             return Ok(());
         };
 
         self.write_assignment_head(assignment);
         self.write_text("(");
-        self.newline();
-        self.with_indent(|formatter| {
-            for (index, line) in lines.iter().enumerate() {
-                if index > 0 {
-                    formatter.newline();
+        if let Some(first_line) = first_line {
+            self.write_text(&first_line);
+        }
+        if !remaining_lines.is_empty() {
+            self.newline();
+            self.with_indent(|formatter| {
+                for (index, line) in remaining_lines.iter().enumerate() {
+                    if index > 0 {
+                        formatter.newline();
+                    }
+                    formatter.write_text(line);
                 }
-                formatter.write_text(line);
-            }
-        });
-        self.newline();
+            });
+        }
+        if !compound_assignment_closes_after_last_element(assignment, source) {
+            self.newline();
+        }
         self.write_text(")");
         Ok(())
     }
@@ -1812,6 +3312,33 @@ impl<'source, 'facts> ShellStreamFormatter<'source, 'facts> {
             || stmt_span(command).start.line == enclosing_span.start.line
     }
 
+    fn can_inline_else_body(&self, commands: &StmtSeq, upper_bound: usize) -> bool {
+        let [command] = commands.as_slice() else {
+            return false;
+        };
+        !matches!(command.terminator, Some(StmtTerminator::Background(_)))
+            && self.can_inline_stmt(command)
+            && stmt_span(command).start.line == stmt_span(command).end.line
+            && !self
+                .facts()
+                .sequence(commands, Some(upper_bound))
+                .has_comments()
+    }
+
+    fn can_keep_multiline_assignment_on_else_line(&self, commands: &StmtSeq) -> bool {
+        let [stmt] = commands.as_slice() else {
+            return false;
+        };
+        let Command::Simple(command) = &stmt.command else {
+            return false;
+        };
+        stmt.redirects.is_empty()
+            && stmt.terminator.is_none()
+            && command.args.is_empty()
+            && command.assignments.len() == 1
+            && multiline_compound_assignment_lines(&command.assignments[0], self.source()).is_some()
+    }
+
     fn can_inline_group(&self, commands: &StmtSeq) -> bool {
         let [command] = commands.as_slice() else {
             return false;
@@ -1820,6 +3347,37 @@ impl<'source, 'facts> ShellStreamFormatter<'source, 'facts> {
         self.can_inline_stmt(command)
             && stmt_span(command).start.line == stmt_span(command).end.line
             && self.can_inline_body(commands, stmt_span(command))
+    }
+
+    fn should_compact_multiline_brace_group(
+        &self,
+        commands: &StmtSeq,
+        upper_bound: Option<usize>,
+    ) -> bool {
+        if self.options().compact_layout()
+            || self
+                .facts()
+                .sequence(commands, upper_bound)
+                .group_open_suffix_span()
+                .is_some()
+        {
+            return false;
+        }
+
+        let [command] = commands.as_slice() else {
+            return false;
+        };
+        let Some(group_span) =
+            group_attachment_span(commands.as_slice(), self.source_map(), '{', '}')
+        else {
+            return false;
+        };
+        let first_line =
+            stmt_render_start_line(command, self.source(), self.source_map(), self.options());
+        let last_line = self.facts().stmt(command).rendered_end_line();
+        group_span.start.line == first_line
+            && group_span.end.line == last_line
+            && group_span.start.line != group_span.end.line
     }
 
     fn can_inline_stmt(&self, stmt: &Stmt) -> bool {
@@ -1964,24 +3522,35 @@ fn should_preserve_raw_redirect(raw: &str) -> bool {
     raw.contains(">&$") || raw.contains("<&$")
 }
 
-fn should_render_explicit_fd(fd: i32, kind: RedirectKind) -> bool {
-    match kind {
-        RedirectKind::Output
-        | RedirectKind::Clobber
-        | RedirectKind::Append
-        | RedirectKind::DupOutput
-        | RedirectKind::OutputBoth => fd != 1,
-        RedirectKind::Input
-        | RedirectKind::ReadWrite
-        | RedirectKind::HereDoc
-        | RedirectKind::HereDocStrip
-        | RedirectKind::HereString
-        | RedirectKind::DupInput => fd != 0,
-    }
+fn should_render_explicit_fd(fd: i32, redirect: &Redirect, source: &str) -> bool {
+    raw_redirect_source_slice(redirect, source).is_some_and(|raw| {
+        raw.trim_start()
+            .strip_prefix(&fd.to_string())
+            .is_some_and(|rest| rest.starts_with(['<', '>']))
+    })
 }
 
-fn needs_space_before_target(kind: RedirectKind, target: &str, space_redirects: bool) -> bool {
+fn redirect_has_adjacent_numeric_fd(redirect: &Redirect, source: &str) -> bool {
+    let start = redirect.span.start.offset.min(source.len());
+    let Some(prefix) = source.get(..start) else {
+        return false;
+    };
+    let token = prefix
+        .rsplit_once(|ch: char| ch.is_whitespace() || ch == ';' || ch == '&' || ch == '|')
+        .map_or(prefix, |(_, token)| token);
+    !token.is_empty() && token.chars().all(|ch| ch.is_ascii_digit())
+}
+
+fn needs_space_before_target(
+    kind: RedirectKind,
+    target: &str,
+    space_redirects: bool,
+    explicit_fd: bool,
+) -> bool {
     if target.is_empty() {
+        return false;
+    }
+    if explicit_fd {
         return false;
     }
     if space_redirects && !matches!(kind, RedirectKind::DupOutput | RedirectKind::DupInput) {
@@ -2007,6 +3576,243 @@ fn sequence_verbatim_span(statements: &StmtSeq, source: &str) -> Option<Span> {
         .iter()
         .map(|stmt| stmt_verbatim_span(stmt, source))
         .reduce(|left, right| left.merge(right))
+}
+
+fn pop_next_heredoc_delimiter(pending: &mut Vec<String>) -> Option<String> {
+    (!pending.is_empty()).then(|| pending.remove(0))
+}
+
+fn case_item_body_includes_terminator(item: &CaseItem, body_was_verbatim: bool) -> bool {
+    if !body_was_verbatim {
+        return false;
+    }
+    let Some(terminator_span) = item.terminator_span else {
+        return false;
+    };
+    item.body.span.end.offset >= terminator_span.end.offset
+}
+
+fn case_item_body_upper_bound(item: &CaseItem, fallback: Option<usize>) -> Option<usize> {
+    item.terminator_span
+        .map(|span| span.start.offset)
+        .or(fallback)
+}
+
+fn case_close_offset(command: &CaseCommand, source: &str) -> Option<usize> {
+    let start = command
+        .cases
+        .last()
+        .and_then(|item| item.terminator_span)
+        .map_or(command.word.span.end.offset, |span| span.end.offset)
+        .min(source.len());
+    let end = command.span.end.offset.min(source.len()).max(start);
+    source
+        .get(start..end)?
+        .find("esac")
+        .map(|offset| start + offset)
+}
+
+fn case_item_gap_break_count(previous: &CaseItem, next: &CaseItem) -> usize {
+    let previous_line = previous
+        .terminator_span
+        .map(|span| span.end.line)
+        .or_else(|| previous.body.last().map(|stmt| stmt_span(stmt).end.line))
+        .or_else(|| {
+            previous
+                .patterns
+                .last()
+                .map(|pattern| pattern.span.end.line)
+        })
+        .unwrap_or(1);
+    let next_line = next
+        .patterns
+        .first()
+        .map(|pattern| pattern.span.start.line)
+        .or_else(|| next.body.first().map(|stmt| stmt_span(stmt).start.line))
+        .unwrap_or(previous_line + 1);
+    line_gap_break_count(previous_line, next_line)
+}
+
+fn loop_body_do_opener_offset(condition: &StmtSeq, body: &StmtSeq, source: &str) -> Option<usize> {
+    block_opener_offset_before_body(condition.span.end.offset, body, source, "do")
+}
+
+fn branch_then_opener_offset(condition: &StmtSeq, body: &StmtSeq, source: &str) -> Option<usize> {
+    block_opener_offset_before_body(condition.span.end.offset, body, source, "then")
+}
+
+fn block_opener_offset_before_body(
+    search_start: usize,
+    body: &StmtSeq,
+    source: &str,
+    opener: &str,
+) -> Option<usize> {
+    let body_start = body
+        .first()
+        .map(|stmt| stmt_span(stmt).start.offset)
+        .unwrap_or(body.span.start.offset)
+        .min(source.len());
+    let search_start = search_start.min(body_start);
+    source
+        .get(search_start..body_start)?
+        .rfind(opener)
+        .map(|offset| search_start + offset + opener.len())
+}
+
+fn block_close_offset_after_body(
+    body: &StmtSeq,
+    upper_bound: usize,
+    source: &str,
+    close: &str,
+) -> Option<usize> {
+    let body_end = body
+        .last()
+        .map(|stmt| stmt_span(stmt).end.offset)
+        .unwrap_or(body.span.end.offset)
+        .min(source.len());
+    let upper_bound = upper_bound.min(source.len()).max(body_end);
+    source
+        .get(body_end..upper_bound)?
+        .rfind(close)
+        .map(|offset| body_end + offset)
+}
+
+fn case_patterns_have_line_break(item: &CaseItem, source: &str) -> bool {
+    let (Some(first), Some(last)) = (item.patterns.first(), item.patterns.last()) else {
+        return false;
+    };
+    let start = first.span.start.offset.min(source.len());
+    let end = last.span.end.offset.min(source.len()).max(start);
+    source[start..end].contains('\n')
+}
+
+fn condition_source_has_leading_list_operator(source: &str) -> bool {
+    source.lines().skip(1).any(|line| {
+        let trimmed = line.trim_start();
+        trimmed.starts_with("&&") || trimmed.starts_with("||")
+    })
+}
+
+fn normalize_multiline_conditional_line(line: &str) -> String {
+    let line = line.trim().trim_end_matches('\\').trim_end();
+    let chars = line.chars().collect::<Vec<_>>();
+    let mut normalized = String::with_capacity(line.len());
+    let mut index = 0;
+    while index < chars.len() {
+        let ch = chars[index];
+        if ch == '(' {
+            normalized.push(ch);
+            index += 1;
+            while chars.get(index).is_some_and(|next| next.is_whitespace()) {
+                index += 1;
+            }
+            continue;
+        }
+        if ch.is_whitespace()
+            && chars
+                .get(index + 1..)
+                .and_then(|rest| rest.iter().position(|next| !next.is_whitespace()))
+                .is_some_and(|relative| chars[index + 1 + relative] == ')')
+        {
+            if normalized.ends_with('\\') {
+                normalized.push(' ');
+            }
+            index += 1;
+            while chars.get(index).is_some_and(|next| next.is_whitespace()) {
+                index += 1;
+            }
+            continue;
+        }
+        normalized.push(ch);
+        index += 1;
+    }
+    normalized
+}
+
+fn source_line_break_count_between(source: &str, start: usize, end: usize) -> usize {
+    let start = start.min(end).min(source.len());
+    let end = end.min(source.len());
+    source[start..end]
+        .bytes()
+        .filter(|byte| *byte == b'\n')
+        .count()
+}
+
+fn trim_trailing_whitespace_before_offset(source: &str, offset: usize) -> usize {
+    let mut end = offset.min(source.len());
+    while end > 0 {
+        let Some((start, ch)) = source[..end].char_indices().next_back() else {
+            break;
+        };
+        if !ch.is_whitespace() {
+            break;
+        }
+        end = start;
+    }
+    end
+}
+
+fn line_has_inline_comment_text(line: &str) -> bool {
+    let Some(comment_start) = line.find('#') else {
+        return false;
+    };
+    !line[..comment_start].trim().is_empty()
+}
+
+fn inline_comment_code_width(line: &str) -> Option<usize> {
+    let comment_start = line.find('#')?;
+    let code = line[..comment_start].trim_end();
+    (!code.trim().is_empty()).then_some(code.chars().count())
+}
+
+fn compound_assignment_closes_after_last_element(assignment: &Assignment, source: &str) -> bool {
+    let slice = assignment.span.slice(source);
+    let Some(close) = slice.rfind(')') else {
+        return false;
+    };
+    let before_close = &slice[..close];
+    let close_line = before_close
+        .rsplit_once('\n')
+        .map_or(before_close, |(_, line)| line);
+    !close_line.trim().is_empty()
+}
+
+fn compound_assignment_multiline_parts(
+    assignment: &Assignment,
+    source: &str,
+) -> Option<(Option<String>, Vec<String>)> {
+    let AssignmentValue::Compound(_) = &assignment.value else {
+        return None;
+    };
+
+    let slice = assignment.span.slice(source);
+    if !slice.contains('\n') {
+        return None;
+    }
+
+    let open = slice.find('(')?;
+    let close = slice.rfind(')')?;
+    if close <= open {
+        return None;
+    }
+
+    let mut lines = slice[open + 1..close].lines();
+    let first = lines
+        .next()
+        .map(str::trim)
+        .filter(|line| !line.is_empty())
+        .map(ToOwned::to_owned);
+    let remaining = lines
+        .map(str::trim)
+        .filter(|line| !line.is_empty())
+        .map(ToOwned::to_owned)
+        .collect::<Vec<_>>();
+
+    if first.is_none() && remaining.is_empty() {
+        None
+    } else {
+        Some((first, remaining))
+    }
 }
 
 fn collect_pipeline<'a>(
@@ -2064,6 +3870,76 @@ fn collect_command_list_first<'a>(
     first
 }
 
+fn source_has_newline_between(source: &str, start: usize, end: usize) -> bool {
+    start <= end
+        && source
+            .get(start..end)
+            .is_some_and(|between| between.contains('\n'))
+}
+
+fn source_line_indent_len_at(source: &str, offset: usize) -> usize {
+    let offset = offset.min(source.len());
+    let line_start = source[..offset]
+        .rfind(['\n', '\r'])
+        .map_or(0, |index| index + 1);
+    let line_end = source[offset..]
+        .find(['\n', '\r'])
+        .map_or(source.len(), |index| offset + index);
+    source[line_start..line_end]
+        .chars()
+        .take_while(|ch| *ch == ' ' || *ch == '\t')
+        .count()
+}
+
+fn command_gap_has_line_continuation(source: &str, previous_end: usize, next_start: usize) -> bool {
+    if previous_end <= next_start
+        && source
+            .get(previous_end.min(source.len())..next_start.min(source.len()))
+            .is_some_and(|between| between.contains('\n'))
+    {
+        return shfmt_keeps_source_continuation_before(source, next_start, previous_end)
+            .unwrap_or(true);
+    }
+
+    shfmt_keeps_source_continuation_before(source, next_start, previous_end).unwrap_or(false)
+}
+
+fn shfmt_keeps_source_continuation_before(
+    source: &str,
+    next_start: usize,
+    previous_end: usize,
+) -> Option<bool> {
+    let Some(before_next) = source.get(..next_start.min(source.len())) else {
+        return None;
+    };
+    let trimmed = before_next.trim_end_matches([' ', '\t']);
+    let Some(line_end) = trimmed.rfind(['\n', '\r']) else {
+        return None;
+    };
+    let continued_line = &trimmed[..line_end];
+    if !continued_line.ends_with('\\') {
+        return None;
+    }
+
+    let first_non_ws_after_continuation = source[line_end + 1..next_start.min(source.len())]
+        .find(|ch| ch != ' ' && ch != '\t' && ch != '\r' && ch != '\n')
+        .map_or(next_start.min(source.len()), |offset| line_end + 1 + offset);
+    let before_backslash = continued_line[..continued_line.len() - 1]
+        .chars()
+        .next_back();
+    let next_token = source
+        .get(next_start.min(source.len())..)
+        .and_then(|tail| tail.chars().next());
+    let shfmt_keeps_break = before_backslash.is_none_or(char::is_whitespace)
+        || matches!(next_token, Some('<' | '>'))
+        || (matches!(next_token, Some('-')) && matches!(before_backslash, Some('}' | '"' | '\'')));
+
+    Some(
+        shfmt_keeps_break
+            && (previous_end > next_start || previous_end <= first_non_ws_after_continuation),
+    )
+}
+
 fn list_item_inline_separator(operator: BinaryOp) -> &'static str {
     match operator {
         BinaryOp::And => " && ",
@@ -2082,29 +3958,87 @@ fn list_item_multiline_separator(operator: BinaryOp) -> &'static str {
 
 fn if_branch_upper_bound(command: &IfCommand, branch_index: usize, source: &str) -> usize {
     let current_branch_end = if branch_index == 0 {
-        command.then_branch.span.end.offset
+        stmt_seq_content_end(&command.then_branch, source)
     } else {
         command
             .elif_branches
             .get(branch_index - 1)
-            .map(|(_, body)| body.span.end.offset)
-            .unwrap_or(command.then_branch.span.end.offset)
+            .map(|(_, body)| stmt_seq_content_end(body, source))
+            .unwrap_or_else(|| stmt_seq_content_end(&command.then_branch, source))
     };
 
     if let Some((condition, _)) = command.elif_branches.get(branch_index) {
-        branch_keyword_offset(
+        let keyword_offset = branch_keyword_offset(
             source,
             current_branch_end,
             condition.span.start.offset,
             "elif",
         )
-        .unwrap_or(condition.span.start.offset)
+        .unwrap_or(condition.span.start.offset);
+        branch_leading_comment_start(source, current_branch_end, keyword_offset)
+            .unwrap_or(keyword_offset)
     } else if let Some(body) = &command.else_branch {
-        branch_keyword_offset(source, current_branch_end, body.span.start.offset, "else")
-            .unwrap_or(body.span.start.offset)
+        let keyword_offset =
+            branch_keyword_offset(source, current_branch_end, body.span.start.offset, "else")
+                .unwrap_or(body.span.start.offset);
+        branch_leading_comment_start(source, current_branch_end, keyword_offset)
+            .unwrap_or(keyword_offset)
     } else {
         command.span.end.offset
     }
+}
+
+fn elif_keyword_offset(command: &IfCommand, branch_index: usize, source: &str) -> Option<usize> {
+    let current_branch_end = if branch_index == 0 {
+        stmt_seq_content_end(&command.then_branch, source)
+    } else {
+        stmt_seq_content_end(&command.elif_branches.get(branch_index - 1)?.1, source)
+    };
+    let condition_start = command.elif_branches.get(branch_index)?.0.span.start.offset;
+    branch_keyword_offset(source, current_branch_end, condition_start, "elif")
+}
+
+fn else_keyword_offset(command: &IfCommand, source: &str) -> Option<usize> {
+    let body = command.else_branch.as_ref()?;
+    let current_branch_end = command
+        .elif_branches
+        .last()
+        .map(|(_, body)| stmt_seq_content_end(body, source))
+        .unwrap_or_else(|| stmt_seq_content_end(&command.then_branch, source));
+    branch_keyword_offset(source, current_branch_end, body.span.start.offset, "else")
+}
+
+fn stmt_seq_content_end(commands: &StmtSeq, source: &str) -> usize {
+    commands
+        .last()
+        .map(|stmt| stmt_verbatim_span(stmt, source).end.offset)
+        .unwrap_or(commands.span.end.offset)
+}
+
+fn branch_leading_comment_start(source: &str, start: usize, end: usize) -> Option<usize> {
+    let start = start.min(end).min(source.len());
+    let end = end.min(source.len());
+    let mut offset = start;
+    let mut first_comment = None;
+    while offset < end {
+        let relative_end = source[offset..end]
+            .find('\n')
+            .map_or(end - offset, |index| index);
+        let line_end = offset + relative_end;
+        let line = &source[offset..line_end];
+        let trimmed = line.trim();
+        if trimmed.is_empty() || trimmed == "\\" {
+            offset = (line_end + 1).min(end);
+            continue;
+        }
+        if trimmed.starts_with('#') {
+            first_comment.get_or_insert(offset);
+            offset = (line_end + 1).min(end);
+            continue;
+        }
+        return None;
+    }
+    first_comment
 }
 
 fn branch_keyword_offset(source: &str, start: usize, end: usize, keyword: &str) -> Option<usize> {

--- a/crates/shuck-formatter/src/streaming.rs
+++ b/crates/shuck-formatter/src/streaming.rs
@@ -1425,11 +1425,7 @@ impl<'source, 'facts> ShellStreamFormatter<'source, 'facts> {
             let multiline_condition = self
                 .condition_starts_after_keyword_continuation("elif", condition)
                 && !self.options().compact_layout();
-            if self.options().compact_layout() {
-                self.write_text("; elif ");
-                self.format_inline_stmts(condition)?;
-                self.write_text(self.then_separator(condition));
-            } else if elif_stays_on_previous_line {
+            if self.options().compact_layout() || elif_stays_on_previous_line {
                 self.write_text("; elif ");
                 self.format_inline_stmts(condition)?;
                 self.write_text(self.then_separator(condition));
@@ -1522,9 +1518,7 @@ impl<'source, 'facts> ShellStreamFormatter<'source, 'facts> {
                     source_breaks.clamp(1, 2)
                 };
             }
-            if self.options().compact_layout() {
-                self.write_text("; else");
-            } else if else_stays_on_then_line {
+            if self.options().compact_layout() || else_stays_on_then_line {
                 self.write_text("; else");
             } else if self.else_body_starts_on_else_line(command, body)
                 && self.can_keep_multiline_assignment_on_else_line(body)
@@ -1765,10 +1759,9 @@ impl<'source, 'facts> ShellStreamFormatter<'source, 'facts> {
             .rev()
             .find_map(Option::as_mut)
             .filter(|line| !line.is_empty())
+            && let Some(without_semicolon) = last.strip_suffix(';')
         {
-            if let Some(without_semicolon) = last.strip_suffix(';') {
-                *last = without_semicolon.trim_end().to_string();
-            }
+            *last = without_semicolon.trim_end().to_string();
         }
         while lines
             .last()
@@ -1776,10 +1769,10 @@ impl<'source, 'facts> ShellStreamFormatter<'source, 'facts> {
         {
             lines.pop();
         }
-        if let Some(last) = lines.iter_mut().rev().find_map(Option::as_mut) {
-            if let Some(without_continuation) = last.trim_end().strip_suffix('\\') {
-                *last = without_continuation.trim_end().to_string();
-            }
+        if let Some(last) = lines.iter_mut().rev().find_map(Option::as_mut)
+            && let Some(without_continuation) = last.trim_end().strip_suffix('\\')
+        {
+            *last = without_continuation.trim_end().to_string();
         }
 
         for (index, line) in lines.iter().enumerate() {
@@ -3909,13 +3902,9 @@ fn shfmt_keeps_source_continuation_before(
     next_start: usize,
     previous_end: usize,
 ) -> Option<bool> {
-    let Some(before_next) = source.get(..next_start.min(source.len())) else {
-        return None;
-    };
+    let before_next = source.get(..next_start.min(source.len()))?;
     let trimmed = before_next.trim_end_matches([' ', '\t']);
-    let Some(line_end) = trimmed.rfind(['\n', '\r']) else {
-        return None;
-    };
+    let line_end = trimmed.rfind(['\n', '\r'])?;
     let continued_line = &trimmed[..line_end];
     if !continued_line.ends_with('\\') {
         return None;

--- a/crates/shuck-formatter/src/word.rs
+++ b/crates/shuck-formatter/src/word.rs
@@ -214,7 +214,7 @@ fn format_parameter_default_arithmetic_in_raw_word(
         let end = start + "$((".len() + end + "))".len();
         formatted.push_str(&raw[index..start]);
         if let Some(arithmetic) = format_arithmetic_expansion_operand(&raw[start..end], options) {
-            changed |= arithmetic != &raw[start..end];
+            changed |= arithmetic != raw[start..end];
             formatted.push_str(&arithmetic);
         } else {
             formatted.push_str(&raw[start..end]);
@@ -1043,25 +1043,169 @@ fn pop_next_heredoc_delimiter(pending: &mut Vec<String>) -> Option<String> {
 
 pub(crate) fn heredoc_delimiters_in_rendered_line(line: &str) -> Vec<String> {
     let mut delimiters = Vec::new();
-    let mut rest = line;
-    while let Some(offset) = rest.find("<<") {
-        rest = &rest[offset + 2..];
+    let mut search_start = 0;
+    while let Some(offset) = line[search_start..].find("<<") {
+        let operator_start = search_start + offset;
+        let mut delimiter_start = operator_start + "<<".len();
+        let rest = &line[delimiter_start..];
         if rest.starts_with('<') {
+            search_start = delimiter_start + '<'.len_utf8();
             continue;
         }
-        rest = rest.strip_prefix('-').unwrap_or(rest).trim_start();
+        if heredoc_operator_is_in_non_redirection_context(line, operator_start) {
+            search_start = delimiter_start;
+            continue;
+        }
+
+        let mut rest = rest;
+        if rest.starts_with('-') {
+            delimiter_start += '-'.len_utf8();
+            rest = &line[delimiter_start..];
+        }
+        let trimmed = rest.trim_start();
+        delimiter_start += rest.len() - trimmed.len();
+        rest = trimmed;
         let token_end = rest
             .find(|ch: char| ch.is_whitespace() || matches!(ch, ';' | '&' | '|'))
             .unwrap_or(rest.len());
         if token_end == 0 {
+            search_start = delimiter_start;
             continue;
         }
 
         let token = &rest[..token_end];
         delimiters.push(unquote_heredoc_delimiter(token));
-        rest = &rest[token_end..];
+        search_start = delimiter_start + token_end;
     }
     delimiters
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum RenderedLineQuote {
+    Single,
+    Double,
+}
+
+fn heredoc_operator_is_in_non_redirection_context(line: &str, operator_start: usize) -> bool {
+    let mut index = 0;
+    let mut quote = None;
+    let mut escaped = false;
+    let mut arithmetic_depth = 0usize;
+    let mut conditional_depth = 0usize;
+    let mut double_quoted_command_substitution_depth = 0usize;
+
+    while index < operator_start {
+        let rest = &line[index..operator_start];
+        let Some(ch) = rest.chars().next() else {
+            break;
+        };
+        let ch_len = ch.len_utf8();
+
+        if escaped {
+            escaped = false;
+            index += ch_len;
+            continue;
+        }
+
+        match quote {
+            Some(RenderedLineQuote::Single) => {
+                if ch == '\'' {
+                    quote = None;
+                }
+                index += ch_len;
+                continue;
+            }
+            Some(RenderedLineQuote::Double) => {
+                if ch == '\\' {
+                    escaped = true;
+                    index += ch_len;
+                    continue;
+                }
+                if rest.starts_with("$((") {
+                    arithmetic_depth += 1;
+                    index += "$((".len();
+                    continue;
+                }
+                if arithmetic_depth > 0 && rest.starts_with("))") {
+                    arithmetic_depth -= 1;
+                    index += "))".len();
+                    continue;
+                }
+                if rest.starts_with("$(") {
+                    double_quoted_command_substitution_depth += 1;
+                    index += "$(".len();
+                    continue;
+                }
+                if double_quoted_command_substitution_depth > 0 && ch == ')' {
+                    double_quoted_command_substitution_depth -= 1;
+                    index += ch_len;
+                    continue;
+                }
+                if ch == '"' && double_quoted_command_substitution_depth == 0 {
+                    quote = None;
+                }
+                index += ch_len;
+                continue;
+            }
+            None => {}
+        }
+
+        if ch == '\\' {
+            escaped = true;
+            index += ch_len;
+            continue;
+        }
+        if ch == '\'' {
+            quote = Some(RenderedLineQuote::Single);
+            index += ch_len;
+            continue;
+        }
+        if ch == '"' {
+            quote = Some(RenderedLineQuote::Double);
+            index += ch_len;
+            continue;
+        }
+        if rest.starts_with("$((") {
+            arithmetic_depth += 1;
+            index += "$((".len();
+            continue;
+        }
+        if arithmetic_depth > 0 && rest.starts_with("))") {
+            arithmetic_depth -= 1;
+            index += "))".len();
+            continue;
+        }
+        if rest.starts_with("((") && shell_word_starts_at_boundary(line, index) {
+            arithmetic_depth += 1;
+            index += "((".len();
+            continue;
+        }
+        if rest.starts_with("[[") && shell_word_starts_at_boundary(line, index) {
+            conditional_depth += 1;
+            index += "[[".len();
+            continue;
+        }
+        if conditional_depth > 0 && rest.starts_with("]]") {
+            conditional_depth -= 1;
+            index += "]]".len();
+            continue;
+        }
+
+        index += ch_len;
+    }
+
+    escaped
+        || arithmetic_depth > 0
+        || conditional_depth > 0
+        || matches!(quote, Some(RenderedLineQuote::Single))
+        || matches!(quote, Some(RenderedLineQuote::Double))
+            && double_quoted_command_substitution_depth == 0
+}
+
+fn shell_word_starts_at_boundary(line: &str, index: usize) -> bool {
+    line[..index].chars().next_back().is_none_or(|ch| {
+        ch.is_whitespace() || matches!(ch, ';' | '&' | '|' | '(' | ')' | '{' | '}')
+    })
 }
 
 fn unquote_heredoc_delimiter(token: &str) -> String {
@@ -1960,4 +2104,36 @@ fn trim_unescaped_trailing_whitespace(text: &str) -> &str {
     }
 
     &text[..end]
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::ShellFormatOptions;
+
+    use super::*;
+
+    #[test]
+    fn indented_rendered_block_ignores_arithmetic_shift_as_heredoc() {
+        let options = ShellFormatOptions::default().resolve("", None);
+        let mut rendered = String::new();
+
+        push_indented_rendered_block(&mut rendered, "echo $((1 << 2))\necho done", &options, 1);
+
+        assert_eq!(rendered, "\techo $((1 << 2))\n\techo done");
+    }
+
+    #[test]
+    fn indented_rendered_block_keeps_heredoc_body_verbatim() {
+        let options = ShellFormatOptions::default().resolve("", None);
+        let mut rendered = String::new();
+
+        push_indented_rendered_block(
+            &mut rendered,
+            "cat <<EOF\nbody\nEOF\necho done",
+            &options,
+            1,
+        );
+
+        assert_eq!(rendered, "\tcat <<EOF\nbody\nEOF\n\techo done");
+    }
 }

--- a/crates/shuck-formatter/src/word.rs
+++ b/crates/shuck-formatter/src/word.rs
@@ -943,7 +943,8 @@ fn render_command_substitution(
         push_indented_rendered_block(rendered, trimmed, options, 1);
         rendered.push_str("\n)");
     } else {
-        let compacted_brace_group = compact_inline_brace_group_command_substitution(trimmed);
+        let compacted_brace_group =
+            compact_inline_brace_group_command_substitution(trimmed, options);
         let trimmed = compacted_brace_group.as_deref().unwrap_or(trimmed);
         rendered.push_str("$(");
         if trimmed.starts_with('(') {
@@ -956,7 +957,10 @@ fn render_command_substitution(
     Some(())
 }
 
-fn compact_inline_brace_group_command_substitution(rendered: &str) -> Option<String> {
+fn compact_inline_brace_group_command_substitution(
+    rendered: &str,
+    options: &ResolvedShellFormatOptions,
+) -> Option<String> {
     let body = rendered.strip_prefix("{\n")?;
     let close_offset = body.rfind("\n}")?;
     let group_body = &body[..close_offset];
@@ -971,9 +975,10 @@ fn compact_inline_brace_group_command_substitution(rendered: &str) -> Option<Str
     let mut compacted = String::new();
     compacted.push_str("{ ");
     compacted.push_str(first);
+    let indent = command_substitution_indent_prefix(options, 1);
     for line in rest {
         compacted.push('\n');
-        compacted.push('\t');
+        compacted.push_str(&indent);
         compacted.push_str(line);
     }
     if !compacted.trim_end().ends_with(';') {
@@ -1007,21 +1012,18 @@ fn push_indented_rendered_block(
     options: &ResolvedShellFormatOptions,
     levels: usize,
 ) {
-    let prefix = match options.indent_style() {
-        IndentStyle::Tab => "\t".repeat(levels),
-        IndentStyle::Space => " ".repeat(levels * usize::from(options.indent_width())),
-    };
+    let prefix = command_substitution_indent_prefix(options, levels);
     let mut pending_heredocs = Vec::new();
-    let mut active_heredoc = None;
+    let mut active_heredoc: Option<RenderedHeredocDelimiter> = None;
 
     for (index, line) in rendered.lines().enumerate() {
         if index > 0 {
             target.push('\n');
         }
 
-        if let Some(delimiter) = active_heredoc.as_deref() {
+        if let Some(delimiter) = active_heredoc.as_ref() {
             target.push_str(line);
-            if line == delimiter {
+            if delimiter.matches_line(line) {
                 active_heredoc = pop_next_heredoc_delimiter(&mut pending_heredocs);
             }
             continue;
@@ -1037,11 +1039,35 @@ fn push_indented_rendered_block(
     }
 }
 
-fn pop_next_heredoc_delimiter(pending: &mut Vec<String>) -> Option<String> {
+fn command_substitution_indent_prefix(
+    options: &ResolvedShellFormatOptions,
+    levels: usize,
+) -> String {
+    match options.indent_style() {
+        IndentStyle::Tab => "\t".repeat(levels),
+        IndentStyle::Space => " ".repeat(levels * usize::from(options.indent_width())),
+    }
+}
+
+fn pop_next_heredoc_delimiter(
+    pending: &mut Vec<RenderedHeredocDelimiter>,
+) -> Option<RenderedHeredocDelimiter> {
     (!pending.is_empty()).then(|| pending.remove(0))
 }
 
-pub(crate) fn heredoc_delimiters_in_rendered_line(line: &str) -> Vec<String> {
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct RenderedHeredocDelimiter {
+    pub(crate) delimiter: String,
+    pub(crate) strip_tabs: bool,
+}
+
+impl RenderedHeredocDelimiter {
+    pub(crate) fn matches_line(&self, line: &str) -> bool {
+        line == self.delimiter || self.strip_tabs && line.trim_start_matches('\t') == self.delimiter
+    }
+}
+
+pub(crate) fn heredoc_delimiters_in_rendered_line(line: &str) -> Vec<RenderedHeredocDelimiter> {
     let mut delimiters = Vec::new();
     let mut search_start = 0;
     while let Some(offset) = line[search_start..].find("<<") {
@@ -1058,6 +1084,7 @@ pub(crate) fn heredoc_delimiters_in_rendered_line(line: &str) -> Vec<String> {
         }
 
         let mut rest = rest;
+        let strip_tabs = rest.starts_with('-');
         if rest.starts_with('-') {
             delimiter_start += '-'.len_utf8();
             rest = &line[delimiter_start..];
@@ -1074,7 +1101,10 @@ pub(crate) fn heredoc_delimiters_in_rendered_line(line: &str) -> Vec<String> {
         }
 
         let token = &rest[..token_end];
-        delimiters.push(unquote_heredoc_delimiter(token));
+        delimiters.push(RenderedHeredocDelimiter {
+            delimiter: unquote_heredoc_delimiter(token),
+            strip_tabs,
+        });
         search_start = delimiter_start + token_end;
     }
     delimiters
@@ -2135,5 +2165,20 @@ mod tests {
         );
 
         assert_eq!(rendered, "\tcat <<EOF\nbody\nEOF\n\techo done");
+    }
+
+    #[test]
+    fn indented_rendered_block_closes_tab_stripped_heredocs() {
+        let options = ShellFormatOptions::default().resolve("", None);
+        let mut rendered = String::new();
+
+        push_indented_rendered_block(
+            &mut rendered,
+            "cat <<-EOF\n\tbody\n\tEOF\necho done",
+            &options,
+            1,
+        );
+
+        assert_eq!(rendered, "\tcat <<-EOF\n\tbody\n\tEOF\n\techo done");
     }
 }

--- a/crates/shuck-formatter/src/word.rs
+++ b/crates/shuck-formatter/src/word.rs
@@ -4,11 +4,12 @@ use shuck_ast::{
     ArithmeticAssignOp, ArithmeticBinaryOp, ArithmeticExpansionSyntax, ArithmeticExpr,
     ArithmeticExprNode, ArithmeticLvalue, ArithmeticPostfixOp, ArithmeticUnaryOp,
     BourneParameterExpansion, Command, CommandSubstitutionSyntax, CompoundCommand, HeredocBody,
-    HeredocBodyPart, ParameterOp, Pattern, Stmt, StmtSeq, SubscriptSelector, VarRef, Word,
-    WordPart,
+    HeredocBodyPart, ParameterOp, Pattern, Stmt, StmtSeq, Subscript, SubscriptSelector, VarRef,
+    Word, WordPart,
 };
 use shuck_format::IndentStyle;
 use shuck_format::{FormatResult, text, write};
+use shuck_parser::parser::Parser;
 
 use crate::FormatNodeRule;
 use crate::command::stmt_seq_has_heredoc;
@@ -100,7 +101,21 @@ fn render_word_syntax_internal(
         return;
     }
 
-    if word_needs_special_rendering(word) {
+    if let Some(raw) = raw_word_source_slice(word, source)
+        && let Some(without_continuation) = raw_simple_expansion_without_line_continuation(raw)
+    {
+        rendered.push_str(without_continuation);
+        return;
+    }
+
+    if let Some(raw) = raw_word_source_slice(word, source)
+        && let Some(formatted) = format_parameter_default_arithmetic_in_raw_word(raw, options)
+    {
+        rendered.push_str(&formatted);
+        return;
+    }
+
+    if word_needs_special_rendering(word, source) {
         if render_word_parts(
             word.parts.as_slice(),
             source,
@@ -120,6 +135,7 @@ fn render_word_syntax_internal(
         && !options.minify()
         && let Some(slice) = raw_word_source_slice(word, source)
         && could_need_preserve_raw_syntax(slice)
+        && !simple_expansion_word_has_line_continuation_suffix(word, slice)
     {
         let start = rendered.len();
         word.render_syntax_to_buf(source, rendered);
@@ -131,6 +147,99 @@ fn render_word_syntax_internal(
     }
 
     word.render_syntax_to_buf(source, rendered);
+}
+
+fn raw_simple_expansion_without_line_continuation(raw: &str) -> Option<&str> {
+    if !raw.contains('\n') {
+        return None;
+    }
+    let trimmed = raw.trim_end_matches([' ', '\t', '\r', '\n']);
+    let without_backslash = trimmed.strip_suffix('\\')?.trim_end();
+    if without_backslash.starts_with("${") && without_backslash.ends_with('}') {
+        Some(without_backslash)
+    } else {
+        None
+    }
+}
+
+fn simple_expansion_word_has_line_continuation_suffix(word: &Word, raw: &str) -> bool {
+    raw.contains('\n')
+        && raw
+            .trim_end_matches([' ', '\t', '\r', '\n'])
+            .ends_with('\\')
+        && word.parts.iter().all(|part| {
+            matches!(
+                part.kind,
+                WordPart::Parameter(_)
+                    | WordPart::ParameterExpansion { .. }
+                    | WordPart::ArrayAccess(_)
+                    | WordPart::ArrayLength(_)
+                    | WordPart::ArrayIndices(_)
+                    | WordPart::Length(_)
+                    | WordPart::Variable(_)
+            )
+        })
+}
+
+fn format_parameter_default_arithmetic_in_raw_word(
+    raw: &str,
+    options: &ResolvedShellFormatOptions,
+) -> Option<String> {
+    if !(raw.contains(":-$((")
+        || raw.contains(":=$((")
+        || raw.contains(":+$((")
+        || raw.contains(":?$((")
+        || raw.contains("-$((")
+        || raw.contains("=$((")
+        || raw.contains("+$((")
+        || raw.contains("?$(("))
+    {
+        return None;
+    }
+
+    let mut formatted = String::new();
+    let mut index = 0;
+    let mut changed = false;
+    while let Some(relative) = raw[index..].find("$((") {
+        let start = index + relative;
+        let operator_prefix = &raw[..start];
+        if !parameter_default_operator_precedes_operand(operator_prefix) {
+            formatted.push_str(&raw[index..start + "$(".len()]);
+            index = start + "$(".len();
+            continue;
+        }
+        let Some(end) = raw[start + "$((".len()..].find("))") else {
+            break;
+        };
+        let end = start + "$((".len() + end + "))".len();
+        formatted.push_str(&raw[index..start]);
+        if let Some(arithmetic) = format_arithmetic_expansion_operand(&raw[start..end], options) {
+            changed |= arithmetic != &raw[start..end];
+            formatted.push_str(&arithmetic);
+        } else {
+            formatted.push_str(&raw[start..end]);
+        }
+        index = end;
+    }
+    formatted.push_str(&raw[index..]);
+    changed.then_some(formatted)
+}
+
+fn parameter_default_operator_precedes_operand(prefix: &str) -> bool {
+    if [":-", ":=", ":+", ":?"]
+        .iter()
+        .any(|operator| prefix.ends_with(operator))
+    {
+        return true;
+    }
+
+    let Some((_, parameter_body_prefix)) = prefix.rsplit_once("${") else {
+        return false;
+    };
+    !parameter_body_prefix.contains(':')
+        && ["-", "=", "+", "?"]
+            .iter()
+            .any(|operator| parameter_body_prefix.ends_with(operator))
 }
 
 /// Returns `true` when a word contains a backtick command-substitution node
@@ -149,21 +258,39 @@ fn word_has_escaped_backtick_substitution(word: &Word, source: &str) -> bool {
     })
 }
 
-fn word_needs_special_rendering(word: &Word) -> bool {
+fn word_needs_special_rendering(word: &Word, source: &str) -> bool {
     word.parts
         .iter()
-        .any(|part| part_needs_special_rendering(&part.kind))
+        .any(|part| part_needs_special_rendering(&part.kind, source))
 }
 
-fn part_needs_special_rendering(part: &WordPart) -> bool {
+fn part_needs_special_rendering(part: &WordPart, source: &str) -> bool {
     match part {
         WordPart::DoubleQuoted { parts, .. } => parts
             .iter()
-            .any(|part| part_needs_special_rendering(&part.kind)),
+            .any(|part| part_needs_special_rendering(&part.kind, source)),
         WordPart::ArithmeticExpansion { expression_ast, .. } => expression_ast.is_some(),
-        WordPart::Parameter(parameter) => parameter_needs_special_rendering(parameter),
+        WordPart::Parameter(parameter) => parameter_needs_special_rendering(parameter, source),
+        WordPart::ParameterExpansion {
+            reference,
+            operator,
+            operand,
+            ..
+        } => {
+            var_ref_needs_special_rendering(reference, source)
+                || operand.as_ref().is_some_and(|operand| {
+                    parameter_default_operand_needs_special_rendering(
+                        operator.as_ref(),
+                        operand.slice(source),
+                    )
+                })
+        }
+        WordPart::ArrayAccess(_)
+        | WordPart::ArrayLength(_)
+        | WordPart::ArrayIndices(_)
+        | WordPart::Length(_) => true,
         WordPart::Substring { .. } | WordPart::ArraySlice { .. } => true,
-        WordPart::CommandSubstitution { .. } => true,
+        WordPart::CommandSubstitution { .. } | WordPart::ProcessSubstitution { .. } => true,
         _ => false,
     }
 }
@@ -184,6 +311,15 @@ fn render_word_parts(
     Ok(())
 }
 
+fn double_quoted_multiline_can_preserve_raw(parts: &[shuck_ast::WordPartNode]) -> bool {
+    !parts.iter().any(|part| {
+        matches!(
+            part.kind,
+            WordPart::CommandSubstitution { .. } | WordPart::ArithmeticExpansion { .. }
+        )
+    })
+}
+
 fn render_heredoc_body_part(
     rendered: &mut String,
     part: &HeredocBodyPart,
@@ -199,7 +335,9 @@ fn render_heredoc_body_part(
         }
         HeredocBodyPart::CommandSubstitution { body, syntax } => {
             let raw = raw_source_slice(span, source);
-            let multiline = raw.is_some_and(|raw| raw.contains('\n'))
+            let multiline = raw.is_some_and(command_substitution_opens_on_own_line)
+                || body.as_slice().len() > 1
+                || stmt_seq_has_heredoc(body)
                 || raw.is_none() && *syntax == CommandSubstitutionSyntax::DollarParen;
 
             if render_command_substitution(
@@ -310,14 +448,24 @@ fn render_word_part(
             rendered.push('\'');
         }
         WordPart::DoubleQuoted { parts, dollar } => {
+            if let Some(raw) = raw_source_slice(span, source)
+                && (raw.contains("\\\"")
+                    || raw.contains('\n') && double_quoted_multiline_can_preserve_raw(parts))
+            {
+                rendered.push_str(raw);
+                return Ok(());
+            }
             if *dollar {
                 rendered.push('$');
             }
             rendered.push('"');
             for part in parts {
                 match &part.kind {
+                    WordPart::Literal(text) if text.is_source_backed() => {
+                        rendered.push_str(text.syntax_str(source, part.span));
+                    }
                     WordPart::Literal(text) => {
-                        render_double_quoted_literal(rendered, text.as_str(source, part.span))
+                        render_double_quoted_literal(rendered, text.as_str(source, part.span));
                     }
                     other => render_word_part(
                         rendered, other, part.span, source, options, source_map, facts,
@@ -339,7 +487,11 @@ fn render_word_part(
                     span.end.offset,
                     source,
                     options,
-                    raw.contains('\n'),
+                    command_substitution_opens_on_own_line(raw)
+                        || command_substitution_has_line_continuation(raw)
+                            && !command_substitution_starts_with_inline_brace_group(raw)
+                        || body.as_slice().len() > 1
+                        || stmt_seq_has_heredoc(body),
                     source_map,
                     facts,
                 )
@@ -477,10 +629,16 @@ fn render_word_part(
             rendered.push_str("${");
             push_var_ref(rendered, reference, source, options);
             rendered.push(':');
-            push_arithmetic_source_text(rendered, offset, offset_ast.as_deref(), source, options);
+            push_parameter_slice_arithmetic(
+                rendered,
+                offset,
+                offset_ast.as_deref(),
+                source,
+                options,
+            );
             if let Some(length) = length {
                 rendered.push(':');
-                push_arithmetic_source_text(
+                push_parameter_slice_arithmetic(
                     rendered,
                     length,
                     length_ast.as_deref(),
@@ -513,9 +671,29 @@ fn render_word_part(
         WordPart::PrefixMatch { prefix, kind } => {
             std::write!(rendered, "${{!{}{}}}", prefix, kind.as_char())?;
         }
-        WordPart::ProcessSubstitution { .. }
-        | WordPart::Transformation { .. }
-        | WordPart::ZshQualifiedGlob(_) => {
+        WordPart::ProcessSubstitution { body, is_input } => {
+            if let Some(facts) = facts {
+                let mut body_rendered = String::new();
+                if format_stmt_sequence_streaming_to_buf(
+                    source,
+                    body,
+                    options,
+                    facts,
+                    None,
+                    &mut body_rendered,
+                )
+                .is_ok()
+                {
+                    rendered.push(if *is_input { '<' } else { '>' });
+                    rendered.push('(');
+                    rendered.push_str(body_rendered.trim_end());
+                    rendered.push(')');
+                    return Ok(());
+                }
+            }
+            rendered.push_str(span.slice(source));
+        }
+        WordPart::Transformation { .. } | WordPart::ZshQualifiedGlob(_) => {
             rendered.push_str(span.slice(source));
         }
     }
@@ -554,17 +732,65 @@ fn preferred_raw_word_part_source<'a>(
     }
 }
 
-fn parameter_needs_special_rendering(parameter: &shuck_ast::ParameterExpansion) -> bool {
+fn parameter_needs_special_rendering(
+    parameter: &shuck_ast::ParameterExpansion,
+    source: &str,
+) -> bool {
     parameter.bourne().is_some_and(|syntax| match syntax {
-        BourneParameterExpansion::Operation { operator, .. } => {
-            matches!(
-                operator.as_ref(),
-                ParameterOp::ReplaceFirst { .. } | ParameterOp::ReplaceAll { .. }
-            )
+        BourneParameterExpansion::Access { reference }
+        | BourneParameterExpansion::Length { reference }
+        | BourneParameterExpansion::Indices { reference } => {
+            var_ref_needs_special_rendering(reference, source)
+        }
+        BourneParameterExpansion::Operation {
+            reference,
+            operator,
+            operand,
+            ..
+        } => {
+            var_ref_needs_special_rendering(reference, source)
+                || matches!(
+                    operator.as_ref(),
+                    ParameterOp::ReplaceFirst { .. } | ParameterOp::ReplaceAll { .. }
+                )
+                || operand.as_ref().is_some_and(|operand| {
+                    parameter_default_operand_needs_special_rendering(
+                        operator.as_ref(),
+                        operand.slice(source),
+                    )
+                })
         }
         BourneParameterExpansion::Slice { .. } => true,
         _ => false,
     })
+}
+
+fn parameter_default_operand_needs_special_rendering(operator: &ParameterOp, raw: &str) -> bool {
+    matches!(
+        operator,
+        ParameterOp::UseDefault
+            | ParameterOp::AssignDefault
+            | ParameterOp::UseReplacement
+            | ParameterOp::Error
+    ) && raw.trim().starts_with("$((")
+        && raw.trim().ends_with("))")
+}
+
+fn var_ref_needs_special_rendering(reference: &VarRef, source: &str) -> bool {
+    reference.subscript.as_deref().is_some_and(|subscript| {
+        subscript.arithmetic_ast.is_some()
+            && subscript_prefers_structured_arithmetic(subscript, source)
+            || subscript
+                .word_ast()
+                .is_some_and(word_contains_structured_arithmetic_expansion)
+    })
+}
+
+fn subscript_prefers_structured_arithmetic(subscript: &Subscript, source: &str) -> bool {
+    subscript
+        .syntax_text(source)
+        .trim_start()
+        .starts_with("$((")
 }
 
 fn parameter_prefers_raw_source(
@@ -573,6 +799,18 @@ fn parameter_prefers_raw_source(
     source: &str,
 ) -> bool {
     parameter.bourne().is_none_or(|syntax| match syntax {
+        BourneParameterExpansion::Access { reference }
+        | BourneParameterExpansion::Length { reference }
+        | BourneParameterExpansion::Indices { reference }
+            if var_ref_needs_special_rendering(reference, source) =>
+        {
+            false
+        }
+        BourneParameterExpansion::Operation {
+            reference,
+            operator,
+            ..
+        } if var_ref_needs_special_rendering(reference, source) => false,
         BourneParameterExpansion::Operation { operator, .. } => match operator.as_ref() {
             ParameterOp::ReplaceFirst { replacement, .. }
             | ParameterOp::ReplaceAll { replacement, .. } => {
@@ -671,10 +909,6 @@ fn render_command_substitution(
     _source_map: Option<&SourceMap<'_>>,
     facts: Option<&FormatterFacts<'_>>,
 ) -> Option<()> {
-    if stmt_seq_has_heredoc(body) {
-        return None;
-    }
-
     let mut nested = String::new();
     let owned_facts;
     let facts = match facts {
@@ -709,7 +943,12 @@ fn render_command_substitution(
         push_indented_rendered_block(rendered, trimmed, options, 1);
         rendered.push_str("\n)");
     } else {
+        let compacted_brace_group = compact_inline_brace_group_command_substitution(trimmed);
+        let trimmed = compacted_brace_group.as_deref().unwrap_or(trimmed);
         rendered.push_str("$(");
+        if trimmed.starts_with('(') {
+            rendered.push(' ');
+        }
         rendered.push_str(trimmed);
         rendered.push(')');
     }
@@ -717,8 +956,49 @@ fn render_command_substitution(
     Some(())
 }
 
+fn compact_inline_brace_group_command_substitution(rendered: &str) -> Option<String> {
+    let body = rendered.strip_prefix("{\n")?;
+    let close_offset = body.rfind("\n}")?;
+    let group_body = &body[..close_offset];
+    let suffix = &body[close_offset + 2..];
+    let lines = group_body
+        .lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty())
+        .collect::<Vec<_>>();
+    let (first, rest) = lines.split_first()?;
+
+    let mut compacted = String::new();
+    compacted.push_str("{ ");
+    compacted.push_str(first);
+    for line in rest {
+        compacted.push('\n');
+        compacted.push('\t');
+        compacted.push_str(line);
+    }
+    if !compacted.trim_end().ends_with(';') {
+        compacted.push(';');
+    }
+    compacted.push_str(" }");
+    compacted.push_str(suffix);
+    Some(compacted)
+}
+
 fn trim_trailing_line_endings(rendered: &str) -> &str {
     rendered.trim_end_matches(&['\r', '\n'][..])
+}
+
+fn command_substitution_opens_on_own_line(raw: &str) -> bool {
+    raw.strip_prefix("$(")
+        .is_some_and(|body| body.starts_with(['\n', '\r']))
+}
+
+fn command_substitution_has_line_continuation(raw: &str) -> bool {
+    raw.contains("\\\n") || raw.contains("\\\r\n")
+}
+
+fn command_substitution_starts_with_inline_brace_group(raw: &str) -> bool {
+    raw.starts_with("$({")
 }
 
 fn push_indented_rendered_block(
@@ -731,16 +1011,76 @@ fn push_indented_rendered_block(
         IndentStyle::Tab => "\t".repeat(levels),
         IndentStyle::Space => " ".repeat(levels * usize::from(options.indent_width())),
     };
+    let mut pending_heredocs = Vec::new();
+    let mut active_heredoc = None;
 
     for (index, line) in rendered.lines().enumerate() {
         if index > 0 {
             target.push('\n');
         }
+
+        if let Some(delimiter) = active_heredoc.as_deref() {
+            target.push_str(line);
+            if line == delimiter {
+                active_heredoc = pop_next_heredoc_delimiter(&mut pending_heredocs);
+            }
+            continue;
+        }
+
         if line_needs_command_substitution_indent(line, options) {
             target.push_str(&prefix);
         }
         target.push_str(line);
+
+        pending_heredocs.extend(heredoc_delimiters_in_rendered_line(line));
+        active_heredoc = pop_next_heredoc_delimiter(&mut pending_heredocs);
     }
+}
+
+fn pop_next_heredoc_delimiter(pending: &mut Vec<String>) -> Option<String> {
+    (!pending.is_empty()).then(|| pending.remove(0))
+}
+
+pub(crate) fn heredoc_delimiters_in_rendered_line(line: &str) -> Vec<String> {
+    let mut delimiters = Vec::new();
+    let mut rest = line;
+    while let Some(offset) = rest.find("<<") {
+        rest = &rest[offset + 2..];
+        if rest.starts_with('<') {
+            continue;
+        }
+        rest = rest.strip_prefix('-').unwrap_or(rest).trim_start();
+        let token_end = rest
+            .find(|ch: char| ch.is_whitespace() || matches!(ch, ';' | '&' | '|'))
+            .unwrap_or(rest.len());
+        if token_end == 0 {
+            continue;
+        }
+
+        let token = &rest[..token_end];
+        delimiters.push(unquote_heredoc_delimiter(token));
+        rest = &rest[token_end..];
+    }
+    delimiters
+}
+
+fn unquote_heredoc_delimiter(token: &str) -> String {
+    let mut delimiter = String::with_capacity(token.len());
+    let mut chars = token.chars().peekable();
+    let mut quote = None;
+    while let Some(ch) = chars.next() {
+        match (quote, ch) {
+            (None, '\'' | '"') => quote = Some(ch),
+            (Some(active), current) if active == current => quote = None,
+            (_, '\\') => {
+                if let Some(next) = chars.next() {
+                    delimiter.push(next);
+                }
+            }
+            _ => delimiter.push(ch),
+        }
+    }
+    delimiter
 }
 
 fn line_needs_command_substitution_indent(
@@ -771,7 +1111,7 @@ fn render_double_quoted_literal(rendered: &mut String, text: &str) {
     }
 }
 
-fn render_arithmetic_expr_to_buf(
+pub(crate) fn render_arithmetic_expr_to_buf(
     rendered: &mut String,
     expr: &ArithmeticExprNode,
     source: &str,
@@ -849,9 +1189,13 @@ fn push_arithmetic_expr(
                 source,
                 options,
             );
-            rendered.push(' ');
-            rendered.push_str(arithmetic_binary_operator(*op));
-            rendered.push(' ');
+            if matches!(op, ArithmeticBinaryOp::Comma) {
+                rendered.push_str(", ");
+            } else {
+                rendered.push(' ');
+                rendered.push_str(arithmetic_binary_operator(*op));
+                rendered.push(' ');
+            }
             push_arithmetic_expr(
                 rendered,
                 right,
@@ -1108,27 +1452,73 @@ fn push_arithmetic_source_text(
     }
 }
 
+fn push_parameter_slice_arithmetic(
+    rendered: &mut String,
+    text: &shuck_ast::SourceText,
+    ast: Option<&ArithmeticExprNode>,
+    source: &str,
+    options: &ResolvedShellFormatOptions,
+) {
+    let start = rendered.len();
+    push_arithmetic_source_text(rendered, text, ast, source, options);
+    if text.slice(source).trim_start().starts_with('(') {
+        let trimmed = rendered[start..].trim_start().to_string();
+        rendered.truncate(start);
+        rendered.push_str(&trimmed);
+    }
+}
+
 fn render_arithmetic_slice_shell_word(
     word: &Word,
     source: &str,
     options: &ResolvedShellFormatOptions,
 ) -> String {
+    let trim_leading_parenthesized_offset = word.span.slice(source).trim_start().starts_with('(');
     let [part] = word.parts.as_slice() else {
-        return render_word_syntax(word, source, options);
+        let rendered = render_word_syntax(word, source, options);
+        return if trim_leading_parenthesized_offset {
+            rendered.trim_start().to_string()
+        } else {
+            rendered
+        };
     };
 
     match &part.kind {
         WordPart::ArithmeticExpansion {
-            expression, syntax, ..
+            expression,
+            expression_ast,
+            syntax,
+            ..
         } => match syntax {
             ArithmeticExpansionSyntax::DollarParenParen => {
-                format!("$(({}))", expression.slice(source).trim())
+                let mut rendered = String::from("$((");
+                if let Some(ast) = expression_ast.as_deref() {
+                    render_arithmetic_expr_to_buf(&mut rendered, ast, source, options);
+                } else {
+                    rendered.push_str(expression.slice(source).trim());
+                }
+                rendered.push_str("))");
+                rendered
             }
             ArithmeticExpansionSyntax::LegacyBracket => {
-                format!("$[{}]", expression.slice(source).trim())
+                let mut rendered = String::from("$[");
+                if let Some(ast) = expression_ast.as_deref() {
+                    render_arithmetic_expr_to_buf(&mut rendered, ast, source, options);
+                } else {
+                    rendered.push_str(expression.slice(source).trim());
+                }
+                rendered.push(']');
+                rendered
             }
         },
-        _ => render_word_syntax(word, source, options),
+        _ => {
+            let rendered = render_word_syntax(word, source, options);
+            if trim_leading_parenthesized_offset {
+                rendered.trim_start().to_string()
+            } else {
+                rendered
+            }
+        }
     }
 }
 
@@ -1165,12 +1555,37 @@ fn push_var_ref(
                 SubscriptSelector::At => '@',
                 SubscriptSelector::Star => '*',
             });
-        } else if let Some(ast) = subscript.arithmetic_ast.as_ref() {
+        } else if let Some(ast) = subscript.arithmetic_ast.as_ref()
+            && subscript_prefers_structured_arithmetic(subscript, source)
+        {
             render_arithmetic_expr_to_buf(rendered, ast, source, options);
+        } else if let Some(word) = subscript.word_ast()
+            && word_contains_structured_arithmetic_expansion(word)
+        {
+            render_word_syntax_to_buf(word, source, options, rendered);
         } else {
             rendered.push_str(subscript.syntax_text(source));
         }
         rendered.push(']');
+    }
+}
+
+fn word_contains_structured_arithmetic_expansion(word: &Word) -> bool {
+    word.parts
+        .iter()
+        .any(|part| part_contains_structured_arithmetic_expansion(&part.kind))
+}
+
+fn part_contains_structured_arithmetic_expansion(part: &WordPart) -> bool {
+    match part {
+        WordPart::DoubleQuoted { parts, .. } => parts
+            .iter()
+            .any(|part| part_contains_structured_arithmetic_expansion(&part.kind)),
+        WordPart::ArithmeticExpansion {
+            expression_ast: Some(_),
+            ..
+        } => true,
+        _ => false,
     }
 }
 
@@ -1241,10 +1656,16 @@ fn push_parameter_word(
             rendered.push_str("${");
             push_var_ref(rendered, reference, source, options);
             rendered.push(':');
-            push_arithmetic_source_text(rendered, offset, offset_ast.as_deref(), source, options);
+            push_parameter_slice_arithmetic(
+                rendered,
+                offset,
+                offset_ast.as_deref(),
+                source,
+                options,
+            );
             if let Some(length) = length {
                 rendered.push(':');
-                push_arithmetic_source_text(
+                push_parameter_slice_arithmetic(
                     rendered,
                     length,
                     length_ast.as_deref(),
@@ -1307,7 +1728,7 @@ fn render_parameter_expansion(
             }
             rendered.push_str(parameter_defaulting_operator(operator));
             if let Some(operand) = operand {
-                rendered.push_str(operand.slice(source));
+                push_parameter_default_operand(rendered, operand, source, options);
             }
         }
         ParameterOp::RemovePrefixShort { pattern } => {
@@ -1353,6 +1774,89 @@ fn render_parameter_expansion(
     }
     rendered.push('}');
     Ok(())
+}
+
+fn push_parameter_default_operand(
+    rendered: &mut String,
+    operand: &shuck_ast::SourceText,
+    source: &str,
+    options: &ResolvedShellFormatOptions,
+) {
+    let raw = operand.slice(source);
+    if let Some(formatted) = format_arithmetic_expansion_operand(raw, options) {
+        rendered.push_str(&formatted);
+    } else {
+        rendered.push_str(raw);
+    }
+}
+
+fn format_arithmetic_expansion_operand(
+    raw: &str,
+    options: &ResolvedShellFormatOptions,
+) -> Option<String> {
+    let trimmed = raw.trim();
+    let inner = trimmed.strip_prefix("$((")?.strip_suffix("))")?;
+    let spaced_inner = format_simple_arithmetic_operand_spacing(inner);
+    let synthetic = format!("(( {inner} ))");
+    let parsed = Parser::new(&synthetic).parse();
+    if parsed.is_err() {
+        return (spaced_inner != inner.trim()).then(|| format!("$(({spaced_inner}))"));
+    }
+    let statement = parsed.file.body.first()?;
+    let Command::Compound(CompoundCommand::Arithmetic(command)) = &statement.command else {
+        return None;
+    };
+    let expr = command.expr_ast.as_ref()?;
+    let mut formatted = String::from("$((");
+    render_arithmetic_expr_to_buf(&mut formatted, expr, &synthetic, options);
+    if formatted == "$((" && spaced_inner != inner.trim() {
+        formatted.push_str(&spaced_inner);
+        formatted.push_str("))");
+        return Some(formatted);
+    }
+    formatted.push_str("))");
+    if formatted == trimmed && spaced_inner != inner.trim() {
+        return Some(format!("$(({spaced_inner}))"));
+    }
+    Some(formatted)
+}
+
+fn format_simple_arithmetic_operand_spacing(inner: &str) -> String {
+    let mut formatted = String::new();
+    let chars = inner.trim().chars().collect::<Vec<_>>();
+    let mut index = 0;
+    let mut parameter_depth = 0usize;
+    while index < chars.len() {
+        let ch = chars[index];
+        if ch == '$' && chars.get(index + 1) == Some(&'{') {
+            parameter_depth += 1;
+            formatted.push(ch);
+            index += 1;
+            continue;
+        }
+        if ch == '}' && parameter_depth > 0 {
+            parameter_depth -= 1;
+            formatted.push(ch);
+            index += 1;
+            continue;
+        }
+        if parameter_depth == 0 && matches!(ch, '+' | '-' | '*' | '/' | '%') {
+            while formatted.ends_with(' ') {
+                formatted.pop();
+            }
+            formatted.push(' ');
+            formatted.push(ch);
+            formatted.push(' ');
+            index += 1;
+            while chars.get(index).is_some_and(|next| next.is_whitespace()) {
+                index += 1;
+            }
+            continue;
+        }
+        formatted.push(ch);
+        index += 1;
+    }
+    formatted
 }
 
 fn parameter_defaulting_operator(operator: &ParameterOp) -> &'static str {

--- a/crates/shuck-parser/src/parser/commands/lists.rs
+++ b/crates/shuck-parser/src/parser/commands/lists.rs
@@ -175,6 +175,12 @@ impl<'a> Parser<'a> {
                     .current_keyword()
                     .is_some_and(Self::is_non_command_keyword)
                 {
+                    if matches!(terminator, StmtTerminator::Background(_)) {
+                        current.terminator = Some(terminator);
+                        current.terminator_span = Some(operator_span);
+                        stmts.push(current);
+                        return Ok(Some(stmts));
+                    }
                     break;
                 }
                 if matches!(

--- a/crates/shuck-parser/src/parser/tests/commands/loops.rs
+++ b/crates/shuck-parser/src/parser/tests/commands/loops.rs
@@ -101,6 +101,23 @@ fn test_nonempty_while_body_accepted() {
     );
 }
 
+#[test]
+fn test_background_terminator_before_loop_done_is_preserved() {
+    let input = "for item in a; do\n  echo \"$item\" &\ndone\n";
+    let script = Parser::new(input).parse().unwrap().file;
+    let (compound, redirects) = expect_compound(&script.body[0]);
+    let AstCompoundCommand::For(command) = compound else {
+        panic!("expected for loop");
+    };
+
+    assert!(redirects.is_empty());
+    assert_eq!(
+        command.body[0].terminator,
+        Some(StmtTerminator::Background(BackgroundOperator::Plain))
+    );
+    assert_eq!(command.body[0].terminator_span.unwrap().slice(input), "&");
+}
+
 /// Issue #600: Subscript reader must handle nested ${...} containing brackets.
 
 #[test]


### PR DESCRIPTION
## Summary

- Wire `format_source` back through the real formatter pipeline instead of returning unchanged output.
- Restore shfmt parity across the formatter fixtures and benchmark corpus, including the larger benchmark scripts.
- Add focused regression coverage for formatter edge cases around case arms, branch comments, redirects, arithmetic parameter expansions, and block spacing.
- Remove the remaining benchmark-corpus shfmt divergence baseline.

## Validation

- `cargo fmt --all --check`
- `cargo test -p shuck-formatter`
- `cargo test -p shuck-parser test_background_terminator_before_loop_done_is_preserved`
- `cargo test -p shuck-benchmark formatter_source_and_ast_paths_match_benchmark_corpus`
- `nix develop --command bash -lc 'SHUCK_RUN_SHFMT_ORACLE=1 cargo test -p shuck-formatter --test oracle_shfmt -- --ignored --nocapture'`
- `nix develop --command bash -lc 'SHUCK_RUN_SHFMT_ORACLE=1 cargo test -p shuck-benchmark --test formatter_corpus -- --ignored --nocapture'`
- `make bench-macro-format`