### PR TITLE
feat(formatter): expose format command by default

### DIFF
--- a/crates/shuck-cli/src/args.rs
+++ b/crates/shuck-cli/src/args.rs
@@ -5,7 +5,6 @@ use std::path::PathBuf;
 
 use clap::builder::Styles;
 use clap::builder::styling::{AnsiColor, Effects};
-use clap::error::ErrorKind;
 use clap::{
     Args as ClapArgs, ColorChoice, CommandFactory, FromArgMatches, Parser, Subcommand, ValueEnum,
 };
@@ -20,7 +19,6 @@ const STYLES: Styles = Styles::styled()
     .usage(AnsiColor::Green.on_default().effects(Effects::BOLD))
     .literal(AnsiColor::Cyan.on_default().effects(Effects::BOLD))
     .placeholder(AnsiColor::Cyan.on_default());
-const EXPERIMENTAL_ENV_VAR: &str = "SHUCK_EXPERIMENTAL";
 
 /// Shell dialect override accepted by `shuck format`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
@@ -148,18 +146,6 @@ struct StableCli {
     command: StableCommand,
 }
 
-#[derive(Debug, Parser)]
-#[command(name = "shuck")]
-#[command(about = "Shell checker CLI for shuck")]
-#[command(version = env!("CARGO_PKG_VERSION"))]
-#[command(styles = STYLES)]
-struct ExperimentalCli {
-    #[command(flatten)]
-    global: GlobalArgs,
-    #[command(subcommand)]
-    command: ExperimentalCommand,
-}
-
 #[derive(Debug, Clone, ClapArgs)]
 struct GlobalArgs {
     /// Either a path to a TOML configuration file (`shuck.toml`), or a TOML
@@ -212,24 +198,6 @@ enum StableCommand {
     Install(InstallCommand),
     /// Spawn a shell session using a managed interpreter.
     Shell(ShellCommand),
-    #[command(hide = true)]
-    Format(FormatCommand),
-    /// Remove shuck cache entries for the provided paths' projects.
-    Clean(CleanCommand),
-}
-
-#[derive(Debug, Subcommand)]
-enum ExperimentalCommand {
-    /// Lint shell files and supported embedded shell scripts.
-    Check(Box<CheckCommand>),
-    /// Start the language server over stdio.
-    Server(ServerCommand),
-    /// Run a shell script with a managed interpreter.
-    Run(RunCommand),
-    /// Pre-install a managed shell interpreter or list available versions.
-    Install(InstallCommand),
-    /// Spawn a shell session using a managed interpreter.
-    Shell(ShellCommand),
     /// Format shell files.
     Format(FormatCommand),
     /// Remove shuck cache entries for the provided paths' projects.
@@ -264,13 +232,8 @@ impl Args {
         I: IntoIterator<Item = T>,
         T: Into<OsString> + Clone,
     {
-        if experimental_enabled() {
-            let parsed = parse_with_color::<ExperimentalCli, _, _>(itr)?;
-            Self::from_experimental(parsed)
-        } else {
-            let parsed = parse_with_color::<StableCli, _, _>(itr)?;
-            Self::from_stable(parsed)
-        }
+        let parsed = parse_with_color::<StableCli, _, _>(itr)?;
+        Self::from_stable(parsed)
     }
 }
 
@@ -289,41 +252,8 @@ impl Args {
             StableCommand::Run(command) => Command::Run(command),
             StableCommand::Install(command) => Command::Install(command),
             StableCommand::Shell(command) => Command::Shell(command),
-            StableCommand::Format(_) => {
-                return Err(clap::Error::raw(
-                    ErrorKind::InvalidSubcommand,
-                    format!(
-                        "the `format` subcommand is experimental; set {EXPERIMENTAL_ENV_VAR}=1 to enable it"
-                    ),
-                ));
-            }
+            StableCommand::Format(command) => Command::Format(command),
             StableCommand::Clean(command) => Command::Clean(command),
-        };
-
-        Ok(Self {
-            cache_dir,
-            config: ConfigArguments::from_cli(config, isolated)?,
-            color,
-            command,
-        })
-    }
-
-    fn from_experimental(value: ExperimentalCli) -> Result<Self, clap::Error> {
-        let ExperimentalCli { global, command } = value;
-        let GlobalArgs {
-            cache_dir,
-            config,
-            isolated,
-            color,
-        } = global;
-        let command = match command {
-            ExperimentalCommand::Check(command) => Command::Check(command),
-            ExperimentalCommand::Server(command) => Command::Server(command),
-            ExperimentalCommand::Run(command) => Command::Run(command),
-            ExperimentalCommand::Install(command) => Command::Install(command),
-            ExperimentalCommand::Shell(command) => Command::Shell(command),
-            ExperimentalCommand::Format(command) => Command::Format(command),
-            ExperimentalCommand::Clean(command) => Command::Clean(command),
         };
 
         Ok(Self {
@@ -352,15 +282,6 @@ pub enum Command {
     Format(FormatCommand),
     /// Remove shuck cache entries for the provided paths' projects.
     Clean(CleanCommand),
-}
-
-fn experimental_enabled() -> bool {
-    std::env::var_os(EXPERIMENTAL_ENV_VAR).is_some_and(|value| {
-        !matches!(
-            value.to_string_lossy().trim().to_ascii_lowercase().as_str(),
-            "" | "0" | "false" | "no" | "off"
-        )
-    })
 }
 
 /// Arguments for `shuck server`.
@@ -1166,6 +1087,7 @@ pub struct CleanCommand {
 mod tests {
     use super::*;
     use clap::builder::TypedValueParser;
+    use clap::error::ErrorKind;
     use shuck_linter::Rule;
 
     #[test]

--- a/crates/shuck-cli/src/config_docs.rs
+++ b/crates/shuck-cli/src/config_docs.rs
@@ -65,9 +65,10 @@ mod tests {
         let reference = generate_settings_reference();
 
         assert!(reference.contains("## `[check]`"));
+        assert!(reference.contains("## `[format]`"));
         assert!(reference.contains("## `[lint]`"));
         assert!(reference.contains("### `[lint.rule-options.c001]`"));
         assert!(reference.contains("#### `embedded`"));
-        assert!(!reference.contains("## `[format]`"));
+        assert!(reference.contains("#### `indent-style`"));
     }
 }

--- a/crates/shuck-cli/src/config_docs.rs
+++ b/crates/shuck-cli/src/config_docs.rs
@@ -27,7 +27,7 @@ fn emit_section(output: &mut String, section: &ConfigSectionMetadata, parents: &
     let path = parents.join(".");
     let heading = if parents.len() == 1 { "##" } else { "###" };
 
-    let _ = writeln!(output, "{heading} `[{path}]`\n");
+    let _ = writeln!(output, "{heading} `{}`\n", section_heading(&path));
     output.push_str(section.docs);
     output.push_str("\n\n");
 
@@ -50,10 +50,29 @@ fn emit_field(output: &mut String, field: &ConfigFieldMetadata, section_path: &s
     let _ = writeln!(output, "**Type**: `{}`\n", field.value_type);
     output.push_str("**Example usage**:\n\n");
     output.push_str("```toml\n");
-    let _ = writeln!(output, "[{section_path}]");
+    emit_example_headers(output, section_path);
     output.push_str(field.example);
     output.push_str("\n```\n\n");
     output.push_str("---\n\n");
+}
+
+fn section_heading(path: &str) -> String {
+    if path == "lint.contracts.custom" {
+        format!("[[{path}]]")
+    } else {
+        format!("[{path}]")
+    }
+}
+
+fn emit_example_headers(output: &mut String, section_path: &str) {
+    if section_path == "lint.contracts.custom" {
+        let _ = writeln!(output, "[[lint.contracts.custom]]");
+    } else if let Some(nested) = section_path.strip_prefix("lint.contracts.custom.") {
+        let _ = writeln!(output, "[[lint.contracts.custom]]");
+        let _ = writeln!(output, "[lint.contracts.custom.{nested}]");
+    } else {
+        let _ = writeln!(output, "[{section_path}]");
+    }
 }
 
 #[cfg(test)]
@@ -68,6 +87,12 @@ mod tests {
         assert!(reference.contains("## `[format]`"));
         assert!(reference.contains("## `[lint]`"));
         assert!(reference.contains("### `[lint.rule-options.c001]`"));
+        assert!(reference.contains("### `[[lint.contracts.custom]]`"));
+        assert!(reference.contains("[[lint.contracts.custom]]\nid ="));
+        assert!(
+            reference
+                .contains("[[lint.contracts.custom]]\n[lint.contracts.custom.consumes]\nnames =")
+        );
         assert!(reference.contains("#### `embedded`"));
         assert!(reference.contains("#### `indent-style`"));
     }

--- a/crates/shuck-cli/tests/integration_test.rs
+++ b/crates/shuck-cli/tests/integration_test.rs
@@ -34,10 +34,6 @@ fn configure_default_cache_env(cmd: &mut Command, root: &Path) {
     cmd.env("LOCALAPPDATA", local_appdata);
 }
 
-fn enable_experimental(cmd: &mut Command) {
-    cmd.env("SHUCK_EXPERIMENTAL", "1");
-}
-
 fn run_check_output(root: &Path, args: &[&str]) -> std::process::Output {
     let mut cmd = Command::cargo_bin("shuck").unwrap();
     configure_env_cache(&mut cmd, root);
@@ -152,18 +148,6 @@ fn help_shows_commands() {
         .stdout(predicate::str::contains("--config <CONFIG_OPTION>"))
         .stdout(predicate::str::contains("--isolated"))
         .stdout(predicate::str::contains("--color <WHEN>"))
-        .stdout(predicate::str::contains("Format shell files").not())
-        .stdout(predicate::str::contains("clean"));
-}
-
-#[test]
-fn help_shows_format_when_experimental_enabled() {
-    let mut cmd = Command::cargo_bin("shuck").unwrap();
-    enable_experimental(&mut cmd);
-    cmd.arg("--help");
-    cmd.assert()
-        .success()
-        .stdout(predicate::str::contains("check"))
         .stdout(predicate::str::contains("Format shell files"))
         .stdout(predicate::str::contains("clean"));
 }
@@ -225,7 +209,6 @@ fn check_help_shows_rule_selection_options() {
 #[test]
 fn format_help_shows_file_selection_options() {
     let mut cmd = Command::cargo_bin("shuck").unwrap();
-    enable_experimental(&mut cmd);
     cmd.args(["format", "--help"]);
     cmd.assert()
         .success()
@@ -265,12 +248,12 @@ fn config_file_and_isolated_conflict() {
 }
 
 #[test]
-fn format_subcommand_requires_experimental_env() {
+fn format_subcommand_is_available_without_env() {
+    let tempdir = tempdir().unwrap();
     let mut cmd = Command::cargo_bin("shuck").unwrap();
-    cmd.arg("format");
-    cmd.assert().code(2).stderr(predicate::str::contains(
-        "the `format` subcommand is experimental; set SHUCK_EXPERIMENTAL=1 to enable it",
-    ));
+    configure_env_cache(&mut cmd, tempdir.path());
+    cmd.current_dir(tempdir.path()).arg("format");
+    cmd.assert().success().stdout("");
 }
 
 #[test]
@@ -1618,7 +1601,6 @@ fn format_good_file_succeeds_and_preserves_contents() {
 
     let mut cmd = Command::cargo_bin("shuck").unwrap();
     configure_env_cache(&mut cmd, tempdir.path());
-    enable_experimental(&mut cmd);
     cmd.current_dir(tempdir.path()).arg("format");
     cmd.assert().success().stdout("");
 
@@ -1632,7 +1614,6 @@ fn format_check_and_diff_are_clean_for_valid_input() {
 
     let mut check = Command::cargo_bin("shuck").unwrap();
     configure_env_cache(&mut check, tempdir.path());
-    enable_experimental(&mut check);
     check
         .current_dir(tempdir.path())
         .args(["format", "--check"]);
@@ -1640,7 +1621,6 @@ fn format_check_and_diff_are_clean_for_valid_input() {
 
     let mut diff = Command::cargo_bin("shuck").unwrap();
     configure_env_cache(&mut diff, tempdir.path());
-    enable_experimental(&mut diff);
     diff.current_dir(tempdir.path()).args(["format", "--diff"]);
     diff.assert().success().stdout("");
 }
@@ -1652,7 +1632,6 @@ fn format_check_and_diff_report_noncanonical_input() {
 
     let mut check = Command::cargo_bin("shuck").unwrap();
     configure_env_cache(&mut check, tempdir.path());
-    enable_experimental(&mut check);
     check
         .current_dir(tempdir.path())
         .args(["format", "--check", "--function-next-line"]);
@@ -1660,7 +1639,6 @@ fn format_check_and_diff_report_noncanonical_input() {
 
     let mut diff = Command::cargo_bin("shuck").unwrap();
     configure_env_cache(&mut diff, tempdir.path());
-    enable_experimental(&mut diff);
     diff.current_dir(tempdir.path())
         .args(["format", "--diff", "--function-next-line"]);
     diff.assert()
@@ -1675,7 +1653,6 @@ fn format_broken_file_reports_parse_error() {
 
     let mut cmd = Command::cargo_bin("shuck").unwrap();
     configure_env_cache(&mut cmd, tempdir.path());
-    enable_experimental(&mut cmd);
     cmd.current_dir(tempdir.path()).arg("format");
     cmd.assert()
         .code(2)
@@ -1687,7 +1664,6 @@ fn format_stdin_round_trips_valid_input() {
     let source = "#!/bin/bash\necho ok\n";
 
     let mut cmd = Command::cargo_bin("shuck").unwrap();
-    enable_experimental(&mut cmd);
     cmd.args(["format", "-"]).write_stdin(source);
     cmd.assert().success().stdout(source);
 }
@@ -1695,7 +1671,6 @@ fn format_stdin_round_trips_valid_input() {
 #[test]
 fn format_stdin_filename_reports_parse_errors() {
     let mut cmd = Command::cargo_bin("shuck").unwrap();
-    enable_experimental(&mut cmd);
     cmd.args(["format", "--stdin-filename", "foo.sh"])
         .write_stdin("#!/bin/bash\nif true\n");
     cmd.assert()
@@ -1713,7 +1688,6 @@ fn format_stdin_uses_current_project_config() {
     .unwrap();
 
     let mut cmd = Command::cargo_bin("shuck").unwrap();
-    enable_experimental(&mut cmd);
     cmd.current_dir(tempdir.path())
         .args(["format", "-"])
         .write_stdin("foo(){\necho hi\n}\n");
@@ -1723,7 +1697,6 @@ fn format_stdin_uses_current_project_config() {
 #[test]
 fn format_stdin_filename_enforces_inferred_posix_dialect() {
     let mut cmd = Command::cargo_bin("shuck").unwrap();
-    enable_experimental(&mut cmd);
     cmd.args(["format", "--stdin-filename", "script.sh"])
         .write_stdin("[[ foo == bar ]]\n");
     cmd.assert()
@@ -1735,7 +1708,6 @@ fn format_stdin_filename_enforces_inferred_posix_dialect() {
 fn format_stdin_filename_accepts_common_shell_extensions() {
     for path in ["script.bash", "script.mksh", "script.ksh", "script.dash"] {
         let mut cmd = Command::cargo_bin("shuck").unwrap();
-        enable_experimental(&mut cmd);
         cmd.args(["format", "--stdin-filename", path])
             .write_stdin("echo ok\n");
         cmd.assert().success().stdout("echo ok\n");
@@ -1745,7 +1717,6 @@ fn format_stdin_filename_accepts_common_shell_extensions() {
 #[test]
 fn format_stdin_filename_infers_zsh_dialect() {
     let mut cmd = Command::cargo_bin("shuck").unwrap();
-    enable_experimental(&mut cmd);
     cmd.args(["format", "--stdin-filename", "script.zsh"])
         .write_stdin("print ${(m)foo}\n");
     cmd.assert().success().stdout("print ${(m)foo}\n");
@@ -1761,7 +1732,6 @@ fn format_stdin_rejects_configured_dialect() {
     .unwrap();
 
     let mut cmd = Command::cargo_bin("shuck").unwrap();
-    enable_experimental(&mut cmd);
     cmd.current_dir(tempdir.path())
         .args(["format", "-"])
         .write_stdin("print ${(m)foo}\n");
@@ -1774,7 +1744,6 @@ fn format_stdin_rejects_configured_dialect() {
 #[test]
 fn format_stdin_uses_cli_zsh_dialect_override() {
     let mut cmd = Command::cargo_bin("shuck").unwrap();
-    enable_experimental(&mut cmd);
     cmd.args(["format", "--dialect", "zsh", "-"])
         .write_stdin("print ${(m)foo}\n");
     cmd.assert().success().stdout("print ${(m)foo}\n");
@@ -1992,7 +1961,6 @@ fn format_exclude_skips_walked_files_but_not_explicit_files_without_force_exclud
 
     let mut walked = Command::cargo_bin("shuck").unwrap();
     configure_env_cache(&mut walked, tempdir.path());
-    enable_experimental(&mut walked);
     walked
         .current_dir(tempdir.path())
         .args(["format", "--exclude", "ignored.sh"]);
@@ -2001,7 +1969,6 @@ fn format_exclude_skips_walked_files_but_not_explicit_files_without_force_exclud
 
     let mut explicit = Command::cargo_bin("shuck").unwrap();
     configure_env_cache(&mut explicit, tempdir.path());
-    enable_experimental(&mut explicit);
     explicit
         .current_dir(tempdir.path())
         .args(["format", "--exclude", "ignored.sh", "ignored.sh"]);
@@ -2012,7 +1979,6 @@ fn format_exclude_skips_walked_files_but_not_explicit_files_without_force_exclud
 
     let mut forced = Command::cargo_bin("shuck").unwrap();
     configure_env_cache(&mut forced, tempdir.path());
-    enable_experimental(&mut forced);
     forced.current_dir(tempdir.path()).args([
         "format",
         "--exclude",
@@ -2035,14 +2001,12 @@ fn format_gitignore_and_force_exclude_flags_control_explicit_files() {
 
     let mut default_walk = Command::cargo_bin("shuck").unwrap();
     configure_env_cache(&mut default_walk, tempdir.path());
-    enable_experimental(&mut default_walk);
     default_walk.current_dir(tempdir.path()).arg("format");
     default_walk.assert().success().stdout("");
     assert_eq!(fs::read_to_string(&ignored).unwrap(), unformatted);
 
     let mut no_respect = Command::cargo_bin("shuck").unwrap();
     configure_env_cache(&mut no_respect, tempdir.path());
-    enable_experimental(&mut no_respect);
     no_respect
         .current_dir(tempdir.path())
         .args(["format", "--no-respect-gitignore"]);
@@ -2053,7 +2017,6 @@ fn format_gitignore_and_force_exclude_flags_control_explicit_files() {
 
     let mut explicit = Command::cargo_bin("shuck").unwrap();
     configure_env_cache(&mut explicit, tempdir.path());
-    enable_experimental(&mut explicit);
     explicit
         .current_dir(tempdir.path())
         .args(["format", "ignored.sh"]);
@@ -2064,7 +2027,6 @@ fn format_gitignore_and_force_exclude_flags_control_explicit_files() {
 
     let mut forced = Command::cargo_bin("shuck").unwrap();
     configure_env_cache(&mut forced, tempdir.path());
-    enable_experimental(&mut forced);
     forced
         .current_dir(tempdir.path())
         .args(["format", "--force-exclude", "ignored.sh"]);
@@ -2085,7 +2047,6 @@ fn format_honors_project_config_and_cli_overrides_it() {
 
     let mut cmd = Command::cargo_bin("shuck").unwrap();
     configure_env_cache(&mut cmd, tempdir.path());
-    enable_experimental(&mut cmd);
     cmd.current_dir(tempdir.path())
         .args(["format", "--function-next-line"]);
     cmd.assert().success().stdout("");
@@ -2106,7 +2067,6 @@ fn format_honors_explicit_global_config_file() {
 
     let mut cmd = Command::cargo_bin("shuck").unwrap();
     configure_env_cache(&mut cmd, tempdir.path());
-    enable_experimental(&mut cmd);
     cmd.current_dir(tempdir.path())
         .arg("--config")
         .arg(&config_path)
@@ -2129,7 +2089,6 @@ fn format_inline_global_config_override_beats_global_config_file() {
 
     let mut cmd = Command::cargo_bin("shuck").unwrap();
     configure_env_cache(&mut cmd, tempdir.path());
-    enable_experimental(&mut cmd);
     cmd.current_dir(tempdir.path())
         .arg("--config")
         .arg(&config_path)
@@ -2157,7 +2116,6 @@ fn format_isolated_ignores_discovered_project_config() {
 
     let mut cmd = Command::cargo_bin("shuck").unwrap();
     configure_env_cache(&mut cmd, tempdir.path());
-    enable_experimental(&mut cmd);
     cmd.current_dir(tempdir.path())
         .arg("--isolated")
         .arg("format");
@@ -2189,7 +2147,6 @@ fn format_prefers_nested_project_config_for_explicit_files() {
 
     let mut cmd = Command::cargo_bin("shuck").unwrap();
     configure_env_cache(&mut cmd, tempdir.path());
-    enable_experimental(&mut cmd);
     cmd.current_dir(tempdir.path())
         .args(["format", "nested/fn.sh"]);
     cmd.assert().success().stdout("");
@@ -2207,13 +2164,11 @@ fn format_cache_invalidates_when_formatter_options_change() {
 
     let mut initial = Command::cargo_bin("shuck").unwrap();
     configure_env_cache(&mut initial, tempdir.path());
-    enable_experimental(&mut initial);
     initial.current_dir(tempdir.path()).arg("format");
     initial.assert().success().stdout("");
 
     let mut check = Command::cargo_bin("shuck").unwrap();
     configure_env_cache(&mut check, tempdir.path());
-    enable_experimental(&mut check);
     check
         .current_dir(tempdir.path())
         .args(["format", "--check", "--function-next-line"]);

--- a/crates/shuck-config/src/lib.rs
+++ b/crates/shuck-config/src/lib.rs
@@ -777,7 +777,7 @@ pub fn configuration_metadata() -> &'static [ConfigSectionMetadata] {
     &CONFIGURATION_METADATA
 }
 
-const CONFIGURATION_METADATA: [ConfigSectionMetadata; 3] = [
+const CONFIGURATION_METADATA: [ConfigSectionMetadata; 4] = [
     ConfigSectionMetadata {
         key: "check",
         docs: "File-level analysis behavior for `shuck check`.",
@@ -788,6 +788,69 @@ const CONFIGURATION_METADATA: [ConfigSectionMetadata; 3] = [
             value_type: "bool",
             example: "embedded = false",
         }],
+        sections: &[],
+    },
+    ConfigSectionMetadata {
+        key: "format",
+        docs: "Formatter style options for `shuck format`.",
+        fields: &[
+            ConfigFieldMetadata {
+                key: "binary-next-line",
+                docs: "Place binary list and pipeline operators at the start of continuation lines when a command is split.",
+                default: "false",
+                value_type: "bool",
+                example: "binary-next-line = true",
+            },
+            ConfigFieldMetadata {
+                key: "function-next-line",
+                docs: "Place function opening braces on the line after the function name.",
+                default: "false",
+                value_type: "bool",
+                example: "function-next-line = true",
+            },
+            ConfigFieldMetadata {
+                key: "indent-style",
+                docs: "Indent with tabs or spaces. Supported values are `tab` and `space`.",
+                default: r#""tab""#,
+                value_type: "string",
+                example: r#"indent-style = "space""#,
+            },
+            ConfigFieldMetadata {
+                key: "indent-width",
+                docs: "Number of spaces to use for each indentation level when `indent-style = \"space\"`.",
+                default: "8",
+                value_type: "integer",
+                example: "indent-width = 2",
+            },
+            ConfigFieldMetadata {
+                key: "keep-padding",
+                docs: "Preserve existing horizontal padding in source regions where the formatter can do so safely.",
+                default: "false",
+                value_type: "bool",
+                example: "keep-padding = true",
+            },
+            ConfigFieldMetadata {
+                key: "never-split",
+                docs: "Prefer compact layouts and avoid optional line splitting.",
+                default: "false",
+                value_type: "bool",
+                example: "never-split = true",
+            },
+            ConfigFieldMetadata {
+                key: "space-redirects",
+                docs: "Insert spaces between redirection operators and their targets where the shell grammar allows it.",
+                default: "false",
+                value_type: "bool",
+                example: "space-redirects = true",
+            },
+            ConfigFieldMetadata {
+                key: "switch-case-indent",
+                docs: "Indent `case` branch bodies one level deeper than the branch pattern.",
+                default: "false",
+                value_type: "bool",
+                example: "switch-case-indent = true",
+            },
+        ],
         sections: &[],
     },
     ConfigSectionMetadata {

--- a/crates/shuck-formatter/README.md
+++ b/crates/shuck-formatter/README.md
@@ -3,4 +3,4 @@
 `shuck-formatter` formats shell scripts using the parser and AST from the Shuck workspace.
 
 It exposes formatting options, source-level formatting helpers, and AST-based formatting entry
-points. The crate powers the experimental `shuck format` command and remains pre-1.0.
+points. The crate powers the `shuck format` command and remains pre-1.0.

--- a/website/app/components/docs/DocsSidebar.tsx
+++ b/website/app/components/docs/DocsSidebar.tsx
@@ -1,20 +1,124 @@
 "use client";
 
 import Link from "next/link";
-import { usePathname } from "next/navigation";
-import { useState } from "react";
+import { usePathname, useSearchParams } from "next/navigation";
+import { useEffect, useState } from "react";
 import { ChevronDown, Menu, X } from "lucide-react";
 import { docsNavigation, type NavItem } from "@/app/lib/docs-navigation";
 
+function hrefIsActive(href: string, pathname: string, currentHref: string) {
+  if (href.includes("?")) {
+    return currentHref === href;
+  }
+  if (pathname === href) {
+    return currentHref === href;
+  }
+  return pathname.startsWith(`${href}/`);
+}
+
+function navItemIsActive(item: NavItem, pathname: string, currentHref: string): boolean {
+  if (item.href && hrefIsActive(item.href, pathname, currentHref)) {
+    return true;
+  }
+  return item.items?.some((child) => navItemIsActive(child, pathname, currentHref)) ?? false;
+}
+
+function NavListItem({
+  item,
+  pathname,
+  currentHref,
+  depth = 0,
+}: {
+  item: NavItem;
+  pathname: string;
+  currentHref: string;
+  depth?: number;
+}) {
+  const hasChildren = Boolean(item.items?.length);
+  const isActive = navItemIsActive(item, pathname, currentHref);
+  const [open, setOpen] = useState(isActive);
+
+  useEffect(() => {
+    if (isActive) setOpen(true);
+  }, [isActive]);
+
+  if (hasChildren) {
+    return (
+      <li>
+        <button
+          onClick={() => setOpen(!open)}
+          aria-expanded={open}
+          className={`flex w-full items-center justify-between rounded-md py-1.5 pr-2 text-sm transition-colors ${
+            depth > 0 ? "pl-4" : "pl-2"
+          } ${
+            isActive
+              ? "text-accent font-medium"
+              : "text-fg-secondary hover:text-fg-primary hover:bg-bg-card"
+          }`}
+        >
+          <span>{item.title}</span>
+          <ChevronDown
+            className={`h-3.5 w-3.5 transition-transform ${open ? "" : "-rotate-90"}`}
+          />
+        </button>
+        {open && (
+          <ul className="ml-3 mt-0.5 space-y-0.5 border-l border-fg-dim/20 pl-2">
+            {item.items!.map((child) => (
+              <NavListItem
+                key={`${child.title}-${child.href ?? "group"}`}
+                item={child}
+                pathname={pathname}
+                currentHref={currentHref}
+                depth={depth + 1}
+              />
+            ))}
+          </ul>
+        )}
+      </li>
+    );
+  }
+
+  if (!item.href) {
+    return null;
+  }
+
+  const isLinkActive = hrefIsActive(item.href, pathname, currentHref);
+
+  return (
+    <li>
+      <Link
+        href={item.href}
+        className={`block rounded-md py-1.5 pr-2 text-sm transition-colors ${
+          depth > 0 ? "pl-4" : "pl-2"
+        } ${
+          isLinkActive
+            ? "bg-accent/10 text-accent font-medium"
+            : "text-fg-secondary hover:text-fg-primary hover:bg-bg-card"
+        }`}
+      >
+        {item.title}
+      </Link>
+    </li>
+  );
+}
+
 function NavSection({ item }: { item: NavItem }) {
   const pathname = usePathname();
-  const isActive = item.items?.some((child) => child.href === pathname);
+  const searchParams = useSearchParams();
+  const query = searchParams.toString();
+  const currentHref = query ? `${pathname}?${query}` : pathname;
+  const isActive = navItemIsActive(item, pathname, currentHref);
   const [open, setOpen] = useState(true);
+
+  useEffect(() => {
+    if (isActive) setOpen(true);
+  }, [isActive]);
 
   return (
     <div className="mb-4">
       <button
         onClick={() => setOpen(!open)}
+        aria-expanded={open}
         className="flex w-full items-center justify-between text-xs font-semibold uppercase tracking-wider text-fg-dim hover:text-fg-secondary transition-colors mb-1.5 px-2"
       >
         <span className={isActive ? "text-accent" : ""}>{item.title}</span>
@@ -25,18 +129,12 @@ function NavSection({ item }: { item: NavItem }) {
       {open && item.items && (
         <ul className="space-y-0.5">
           {item.items.map((child) => (
-            <li key={child.href}>
-              <Link
-                href={child.href!}
-                className={`block rounded-md px-2 py-1.5 text-sm transition-colors ${
-                  pathname === child.href
-                    ? "bg-accent/10 text-accent font-medium"
-                    : "text-fg-secondary hover:text-fg-primary hover:bg-bg-card"
-                }`}
-              >
-                {child.title}
-              </Link>
-            </li>
+            <NavListItem
+              key={`${child.title}-${child.href ?? "group"}`}
+              item={child}
+              pathname={pathname}
+              currentHref={currentHref}
+            />
           ))}
         </ul>
       )}

--- a/website/app/docs/[[...slug]]/page.tsx
+++ b/website/app/docs/[[...slug]]/page.tsx
@@ -5,6 +5,9 @@ import { flattenNav, docsNavigation } from "@/app/lib/docs-navigation";
 // Map of slug paths to their MDX imports
 const pages: Record<string, () => Promise<{ default: React.ComponentType; metadata?: { title?: string; description?: string } }>> = {
   "getting-started": () => import("@/content/getting-started/index.mdx"),
+  "linting": () => import("@/content/linting/index.mdx"),
+  "formatting": () => import("@/content/formatting/index.mdx"),
+  "lsp": () => import("@/content/editors/index.mdx"),
   "editors": () => import("@/content/editors/index.mdx"),
   "run": () => import("@/content/run/index.mdx"),
   "embedded-scripts": () => import("@/content/embedded-scripts/index.mdx"),

--- a/website/app/docs/layout.tsx
+++ b/website/app/docs/layout.tsx
@@ -1,6 +1,7 @@
 import Header from "@/app/components/Header";
 import Footer from "@/app/components/Footer";
 import DocsSidebar from "@/app/components/docs/DocsSidebar";
+import { Suspense } from "react";
 
 export default function DocsLayout({
   children,
@@ -11,7 +12,9 @@ export default function DocsLayout({
     <>
       <Header />
       <div className="mx-auto flex max-w-6xl">
-        <DocsSidebar />
+        <Suspense>
+          <DocsSidebar />
+        </Suspense>
         <main className="min-w-0 flex-1 px-4 sm:px-8 py-8 lg:py-10">
           {children}
         </main>

--- a/website/app/lib/docs-navigation.ts
+++ b/website/app/lib/docs-navigation.ts
@@ -10,31 +10,53 @@ export const docsNavigation: NavItem[] = [
     items: [
       { title: "Overview", href: "/docs/getting-started" },
       { title: "Configuration", href: "/docs/configuration" },
+      { title: "Settings Reference", href: "/docs/settings" },
+    ],
+  },
+  {
+    title: "Linting",
+    items: [
+      { title: "Linting", href: "/docs/linting" },
+      { title: "Suppression", href: "/docs/suppression" },
+      { title: "Embedded Scripts", href: "/docs/embedded-scripts" },
       { title: "Zsh Support", href: "/docs/zsh-support" },
       { title: "Contracts", href: "/docs/contracts" },
-      { title: "Managed Runtime", href: "/docs/run" },
-      { title: "Editor Integration", href: "/docs/editors" },
-      { title: "Suppression", href: "/docs/suppression" },
-      { title: "Settings Reference", href: "/docs/settings" },
       { title: "ShellCheck Compatibility", href: "/docs/shellcheck-compat" },
-      { title: "Embedded Scripts", href: "/docs/embedded-scripts" },
+      {
+        title: "Rules",
+        items: [
+          { title: "All Rules", href: "/docs/rules" },
+          { title: "Correctness (C)", href: "/docs/rules?category=Correctness" },
+          { title: "Style (S)", href: "/docs/rules?category=Style" },
+          { title: "Portability (X)", href: "/docs/rules?category=Portability" },
+          { title: "Performance (P)", href: "/docs/rules?category=Performance" },
+          { title: "Security (K)", href: "/docs/rules?category=Security" },
+        ],
+      },
+    ],
+  },
+  {
+    title: "Formatting",
+    items: [
+      { title: "Formatting", href: "/docs/formatting" },
+    ],
+  },
+  {
+    title: "LSP",
+    items: [
+      { title: "LSP Server", href: "/docs/lsp" },
+    ],
+  },
+  {
+    title: "Runtime",
+    items: [
+      { title: "Managed Runtime", href: "/docs/run" },
     ],
   },
   {
     title: "Performance",
     items: [
       { title: "Benchmarks", href: "/docs/performance/benchmarks" },
-    ],
-  },
-  {
-    title: "Rules",
-    items: [
-      { title: "All Rules", href: "/docs/rules" },
-      { title: "Correctness (C)", href: "/docs/rules?category=Correctness" },
-      { title: "Style (S)", href: "/docs/rules?category=Style" },
-      { title: "Portability (X)", href: "/docs/rules?category=Portability" },
-      { title: "Performance (P)", href: "/docs/rules?category=Performance" },
-      { title: "Security (K)", href: "/docs/rules?category=Security" },
     ],
   },
 ];

--- a/website/app/page.tsx
+++ b/website/app/page.tsx
@@ -42,7 +42,7 @@ export default function Home() {
                 </pre>
               </div>
               <div>
-                <p className="text-xs text-fg-dim mb-1 font-medium">Editor LSP</p>
+                <p className="text-xs text-fg-dim mb-1 font-medium">LSP Server</p>
                 <pre className="rounded-md bg-bg-secondary border border-fg-dim/20 px-3 py-2 text-sm font-mono text-fg-primary overflow-x-auto">
                   shuck server
                 </pre>
@@ -58,10 +58,10 @@ export default function Home() {
                 Docs
               </Link>
               <Link
-                href="/docs/editors"
+                href="/docs/lsp"
                 className="text-accent hover:underline"
               >
-                Editor Setup
+                LSP Server
               </Link>
               <Link
                 href="/docs/performance/benchmarks"

--- a/website/content/configuration/index.mdx
+++ b/website/content/configuration/index.mdx
@@ -2,7 +2,7 @@
 
 Shuck can be configured through a `shuck.toml` or `.shuck.toml` file.
 
-This page covers Shuck's stable native configuration for `shuck check`, `shuck run`, and related native commands. ShellCheck compatibility mode uses `.shellcheckrc` instead; see the [ShellCheck compatibility guide](/docs/shellcheck-compat).
+This page covers Shuck's native configuration for `shuck check`, `shuck format`, `shuck run`, and related native commands. ShellCheck compatibility mode uses `.shellcheckrc` instead; see the [ShellCheck compatibility guide](/docs/shellcheck-compat).
 
 ## Default behavior
 
@@ -204,6 +204,28 @@ See the dedicated [Contracts guide](/docs/contracts) for the discovery boundary,
 examples, and when to prefer Contracts over more source resolution. The
 [Settings Reference](/docs/settings) includes the exact `[lint.contracts]`
 syntax.
+
+## Format settings
+
+The formatter reads style options from `[format]`.
+
+```toml
+[format]
+indent-style = "space"
+indent-width = 2
+binary-next-line = true
+switch-case-indent = true
+space-redirects = true
+keep-padding = true
+function-next-line = false
+never-split = false
+```
+
+Formatter config follows the same discovery and override rules as the rest of Shuck config. CLI flags passed to `shuck format` override `[format]` for that invocation.
+
+Dialect is the exception: `[format].dialect` is rejected so projects do not accidentally force one parser mode for every file. Use file names, shebangs, or `shuck format --dialect ...` for a one-off override.
+
+See the dedicated [Formatting guide](/docs/formatting) for command examples, stdin behavior, `--check`, `--diff`, `--simplify`, and `--minify`.
 
 ## Runtime settings
 

--- a/website/content/editors/index.mdx
+++ b/website/content/editors/index.mdx
@@ -1,4 +1,4 @@
-# Editor Integration
+# LSP Server
 
 Shuck ships with a first-party Language Server Protocol server in the main CLI. Start it with `shuck server` and point your editor at that command over stdio.
 
@@ -13,8 +13,9 @@ The current server already covers the core editor feedback loop:
 - Dialect inference from the buffer `languageId`, shebang, and file path
 - Quick fixes, disable-this-line actions, and `source.fixAll.shuck` code actions
 - Hover help for suppression codes in `# shuck:` and `# shellcheck` directives
+- Whole-document and selected-range formatting through LSP
 
-Formatting is not advertised to editors yet, so it is still best to keep your existing shell formatter setup alongside Shuck for now.
+Editor formatting uses the same parser-backed formatter as [`shuck format`](/docs/formatting). Once `shuck server` is attached, use your editor's normal LSP format command or format-on-save integration.
 
 ## Before you start
 

--- a/website/content/formatting/index.mdx
+++ b/website/content/formatting/index.mdx
@@ -1,0 +1,120 @@
+# Formatting
+
+`shuck format` rewrites shell scripts using Shuck's parser and formatter. It is useful for project-wide formatting, CI checks, and one-off cleanup before reviewing script changes.
+
+## Basic usage
+
+```bash
+# Format the current project in place
+shuck format .
+
+# Format specific files
+shuck format scripts/deploy.sh scripts/build.sh
+
+# Check whether files are already formatted
+shuck format --check .
+
+# Print a unified diff without changing files
+shuck format --diff .
+```
+
+When no path is passed, `shuck format` formats the current directory. It only formats standalone shell files; embedded shell snippets inside YAML or other host files are skipped.
+
+## Standard input
+
+Pass `-` to read from stdin and write the formatted result to stdout:
+
+```bash
+printf 'if true; then echo ok; fi\n' | shuck format -
+```
+
+Use `--stdin-filename` when the file name matters for dialect inference or project config discovery:
+
+```bash
+printf 'print $ZSH_VERSION\n' | shuck format --stdin-filename .zshrc -
+```
+
+In `--check` mode, stdin exits successfully if the input is already formatted and exits non-zero if it would change. In `--diff` mode, stdin prints a unified diff.
+
+## Project settings
+
+Formatter settings live in the `[format]` section of `shuck.toml` or `.shuck.toml`:
+
+```toml
+[format]
+indent-style = "space"
+indent-width = 2
+binary-next-line = true
+switch-case-indent = true
+space-redirects = true
+keep-padding = true
+function-next-line = false
+never-split = false
+```
+
+The defaults are tab indentation with width `8`, compact inline function braces, unspaced redirection targets, and ordinary formatter-controlled splitting.
+
+CLI flags override config values for that run:
+
+```bash
+shuck format --indent-style space --indent-width 2 .
+shuck format --function-next-line --space-redirects script.sh
+```
+
+Boolean formatter flags also have hidden `--no-...` forms for overriding config values from the command line:
+
+```bash
+shuck format --no-function-next-line .
+```
+
+## Dialect selection
+
+By default, the formatter infers dialect from the source text, shebang, and file path. Use `--dialect` for a one-off override:
+
+```bash
+shuck format --dialect bash script
+shuck format --dialect zsh .zshrc
+```
+
+Accepted values are `bash`, `posix`, `mksh`, and `zsh`.
+
+`[format].dialect` is intentionally not supported in config files. Use file names, shebangs, or the per-run `--dialect` flag instead.
+
+## Simplify and minify
+
+`--simplify` applies safe syntax simplifications before formatting:
+
+```bash
+shuck format --simplify script.sh
+```
+
+`--minify` emits a compact form and drops ordinary comments while preserving meaningful shell structure:
+
+```bash
+shuck format --minify script.sh
+```
+
+Both options are CLI-only today.
+
+## Caching and file selection
+
+Formatting uses Shuck's project discovery and cache plumbing. Use `--no-cache` when debugging formatter behavior:
+
+```bash
+shuck format --no-cache .
+```
+
+The standard file-selection flags are available:
+
+```bash
+shuck format --exclude vendor --extend-exclude testdata .
+shuck format --force-exclude scripts vendor/script.sh
+```
+
+Formatting respects ignore files by default, matching `shuck check`.
+
+## Editor status
+
+The LSP server advertises whole-document and selected-range formatting. Once `shuck server` is attached, use your editor's normal LSP format command or format-on-save integration.
+
+Use `shuck format` directly for CI, pre-commit, project-wide rewrites, and one-off command-line formatting. See [LSP Server](/docs/lsp) for editor setup.

--- a/website/content/getting-started/index.mdx
+++ b/website/content/getting-started/index.mdx
@@ -1,18 +1,17 @@
 # Getting Started
 
-An extremely fast shell script linter, written in Rust.
+Shuck is a Rust toolkit for working with shell scripts: linting, formatting, editor feedback, and managed shell execution from one CLI.
 
-- ⚡ 20x faster than ShellCheck, with built-in caching for incremental runs
-- 🐚 Multi-dialect support for bash, sh/POSIX, dash, ksh, mksh, and zsh
-- 🤝 ShellCheck suppression compatibility (`# shellcheck disable=SC2086` just works)
-- 🔄 ShellCheck CLI compatibility mode for existing editor, CI, and local workflows
-- 🧩 Embedded shell extraction for GitHub Actions workflows and composite actions
-- 🔧 Fix support, for automatic error correction (`--fix` and `--unsafe-fixes`)
-- 📏 Rules across correctness, style, performance, and portability categories
-- 💾 Per-file caching to avoid re-analyzing unchanged files
-- 📦 Single binary, zero dependencies
+- ⚡ Lint 20-100x faster than ShellCheck in benchmarked runs, with per-file caching for incremental checks.
+- 🐚 Work across bash, sh/POSIX, dash, ksh, mksh, and zsh from the same binary.
+- 🧩 Check shell scripts and embedded GitHub Actions `run:` blocks with parser-backed diagnostics.
+- 🪄 Format shell files from the command line, CI, or an editor through LSP formatting.
+- 🖥️ Use the LSP server for live diagnostics, quick fixes, hover help, navigation, and format-on-save.
+- 🧪 Run scripts with managed shell interpreters when you need reproducible local or CI behavior.
+- 🤝 Keep ShellCheck-compatible suppressions and CLI migration paths for existing workflows.
+- 📦 Install one dependency-free executable for local development, editors, and CI.
 
-Shuck aims to be orders of magnitude faster than ShellCheck while expanding coverage to dialects that ShellCheck does not support, like zsh.
+Shuck is built around one shared shell parser, so the CLI, formatter, linter, and language server agree on how each script is understood.
 
 ## Installation
 
@@ -35,7 +34,7 @@ cargo install shuck-cli
 
 Pre-built binaries are available for macOS (aarch64) and Linux (x86_64) from the [releases page](https://github.com/ewhauser/shuck/releases).
 
-## Usage
+## Linting
 
 ```bash
 # Check files and directories
@@ -53,6 +52,25 @@ echo 'echo $foo' | shuck check -
 # Apply safe fixes automatically
 shuck check --fix .
 ```
+
+See the dedicated [Linting guide](/docs/linting) for rule selection, fixes, output formats, watch mode, per-file shell overrides, and CI behavior.
+
+## Formatting
+
+Shuck includes a formatter for standalone shell files:
+
+```bash
+# Format the current project in place
+shuck format .
+
+# Check formatting in CI
+shuck format --check .
+
+# Print a diff without changing files
+shuck format --diff .
+```
+
+See the dedicated [Formatting guide](/docs/formatting) for formatter config, stdin usage, dialect overrides, and LSP formatting support.
 
 ## Pre-commit
 
@@ -83,7 +101,7 @@ repos:
 The `shuck-src` hook requires a working Rust toolchain because it runs
 `cargo run -p shuck-cli -- check ...` from the cloned hook repository.
 
-## Editor integration
+## LSP server
 
 Shuck also ships with a first-party LSP server over stdio:
 
@@ -91,7 +109,7 @@ Shuck also ships with a first-party LSP server over stdio:
 shuck server
 ```
 
-See the dedicated [Editor Integration guide](/docs/editors) for setup examples in Neovim, Vim, Emacs, and Zed.
+See the dedicated [LSP Server guide](/docs/lsp) for setup examples in Neovim, Vim, Emacs, and Zed.
 
 ## Managed runtime
 

--- a/website/content/linting/index.mdx
+++ b/website/content/linting/index.mdx
@@ -1,0 +1,146 @@
+# Linting
+
+`shuck check` lints shell scripts, supported embedded shell snippets, and whole project trees. It is the command to use in CI, pre-commit hooks, editor save hooks, and local review before a script lands.
+
+## Basic usage
+
+```bash
+# Check one script
+shuck check script.sh
+
+# Check the current project
+shuck check .
+
+# Check multiple roots in one run
+shuck check scripts/ .github/workflows/ci.yml
+
+# Read a script from stdin
+printf 'echo $name\n' | shuck check -
+```
+
+When no path is passed, `shuck check` checks the current directory.
+
+## What gets checked
+
+Shuck discovers shell files by extension, shebang, and supported host-file extraction.
+
+Standalone shell files include common Bash, POSIX shell, Dash, Korn shell, mksh, and zsh script paths. Embedded extraction is enabled by default for supported GitHub Actions workflow and composite-action `run:` blocks.
+
+```toml
+[check]
+embedded = true
+```
+
+Set `[check].embedded = false` when you only want standalone shell files. See [Embedded Scripts](/docs/embedded-scripts) for the extraction and remapping details.
+
+## Rule selection
+
+By default, Shuck enables implemented non-style rules:
+
+- Correctness rules (`C`)
+- Performance rules (`P`)
+- Portability rules (`X`)
+- Security rules (`K`)
+
+Style rules (`S`) are opt-in. Selectors can name a category prefix, a narrower prefix, an exact rule code, a named group such as `google`, or `ALL`.
+
+```bash
+# Add all style rules to the default set
+shuck check --extend-select S .
+
+# Run one rule
+shuck check --select C001 script.sh
+
+# Run everything except a noisy rule
+shuck check --select ALL --ignore S074 .
+```
+
+The same model is available in config:
+
+```toml
+[lint]
+extend-select = ["S"]
+ignore = ["S074"]
+per-file-ignores = { "vendor/**" = ["ALL"] }
+```
+
+Use [Rules](/docs/rules) to browse the rule catalog and [Configuration](/docs/configuration) for the full selection model.
+
+## Fixes and ignore comments
+
+Run safe fixes with `--fix`:
+
+```bash
+shuck check --fix .
+```
+
+Unsafe fixes require an explicit opt-in:
+
+```bash
+shuck check --fix --unsafe-fixes .
+```
+
+You can narrow which rules are eligible for fixes:
+
+```bash
+shuck check --fix --fixable C,S074 --unfixable C001 .
+```
+
+When a warning is intentional, `--add-ignore` writes native Shuck ignore comments on the affected lines:
+
+```bash
+shuck check --add-ignore="legacy input shape" .
+```
+
+See [Suppression](/docs/suppression) for native `# shuck:` directives and ShellCheck-compatible suppression comments.
+
+## Output and CI
+
+The default output format is human-readable. Use `--output-format` for tools that need structured or compact output:
+
+```bash
+shuck check --output-format concise .
+shuck check --output-format json-lines .
+shuck check --output-format github .
+shuck check --output-format sarif .
+```
+
+`shuck check` exits with:
+
+- `0` when there are no diagnostics;
+- `1` when diagnostics are reported;
+- `2` for parse errors, file errors, or runtime errors.
+
+Use `--exit-zero` for exploratory runs where diagnostics should not fail the command. Use `--exit-non-zero-on-fix` when CI should fail if a fix changed files.
+
+## Watch mode
+
+Use `--watch` during local editing:
+
+```bash
+shuck check --watch .
+```
+
+Watch mode reruns when requested files, relevant config files, or discovered source dependencies change.
+
+## Dialect overrides
+
+Shuck infers a script's dialect from the file path, shebang, and parser context. Override unusual layouts with per-file shell mappings:
+
+```bash
+shuck check --per-file-shell "scripts/**/*.bash:bash" --extend-per-file-shell "zsh/**:zsh" .
+```
+
+```toml
+[lint]
+per-file-shell = { "scripts/**/*.bash" = "bash" }
+extend-per-file-shell = { "zsh/**" = "zsh" }
+```
+
+For zsh projects, [Zsh Support](/docs/zsh-support) covers plugin resolution and dotfile-specific setup.
+
+## Related workflows
+
+- Use [Formatting](/docs/formatting) for `shuck format`.
+- Use [LSP Server](/docs/lsp) for live editor diagnostics and code actions.
+- Use [ShellCheck Compatibility](/docs/shellcheck-compat) when an existing tool expects a ShellCheck-shaped command line.

--- a/website/content/settings/index.mdx
+++ b/website/content/settings/index.mdx
@@ -27,6 +27,146 @@ embedded = false
 
 ---
 
+## `[format]`
+
+Formatter style options for `shuck format`.
+
+#### `binary-next-line`
+
+Place binary list and pipeline operators at the start of continuation lines when a command is split.
+
+**Default value**: `false`
+
+**Type**: `bool`
+
+**Example usage**:
+
+```toml
+[format]
+binary-next-line = true
+```
+
+---
+
+#### `function-next-line`
+
+Place function opening braces on the line after the function name.
+
+**Default value**: `false`
+
+**Type**: `bool`
+
+**Example usage**:
+
+```toml
+[format]
+function-next-line = true
+```
+
+---
+
+#### `indent-style`
+
+Indent with tabs or spaces. Supported values are `tab` and `space`.
+
+**Default value**: `"tab"`
+
+**Type**: `string`
+
+**Example usage**:
+
+```toml
+[format]
+indent-style = "space"
+```
+
+---
+
+#### `indent-width`
+
+Number of spaces to use for each indentation level when `indent-style = "space"`.
+
+**Default value**: `8`
+
+**Type**: `integer`
+
+**Example usage**:
+
+```toml
+[format]
+indent-width = 2
+```
+
+---
+
+#### `keep-padding`
+
+Preserve existing horizontal padding in source regions where the formatter can do so safely.
+
+**Default value**: `false`
+
+**Type**: `bool`
+
+**Example usage**:
+
+```toml
+[format]
+keep-padding = true
+```
+
+---
+
+#### `never-split`
+
+Prefer compact layouts and avoid optional line splitting.
+
+**Default value**: `false`
+
+**Type**: `bool`
+
+**Example usage**:
+
+```toml
+[format]
+never-split = true
+```
+
+---
+
+#### `space-redirects`
+
+Insert spaces between redirection operators and their targets where the shell grammar allows it.
+
+**Default value**: `false`
+
+**Type**: `bool`
+
+**Example usage**:
+
+```toml
+[format]
+space-redirects = true
+```
+
+---
+
+#### `switch-case-indent`
+
+Indent `case` branch bodies one level deeper than the branch pattern.
+
+**Default value**: `false`
+
+**Type**: `bool`
+
+**Example usage**:
+
+```toml
+[format]
+switch-case-indent = true
+```
+
+---
+
 ## `[lint]`
 
 Rule selection, per-file ignores, fix eligibility, and rule-specific behavior for `shuck check`.
@@ -205,7 +345,7 @@ disabled = ["zsh/oh-my-zsh", "runtime/github-actions/env"]
 
 ---
 
-### `[[lint.contracts.custom]]`
+### `[lint.contracts.custom]`
 
 User-authored ambient contracts layered on top of, or in place of, the built-in registry.
 
@@ -220,7 +360,7 @@ Stable identifier for the custom contract.
 **Example usage**:
 
 ```toml
-[[lint.contracts.custom]]
+[lint.contracts.custom]
 id = "github-actions-env"
 ```
 
@@ -237,7 +377,7 @@ Built-in contract selectors that this custom contract replaces.
 **Example usage**:
 
 ```toml
-[[lint.contracts.custom]]
+[lint.contracts.custom]
 replaces = ["zsh/oh-my-zsh/plugin/tmux"]
 ```
 
@@ -254,7 +394,7 @@ Activation for the contract, either `"always"` or an object such as `{ type = "z
 **Example usage**:
 
 ```toml
-[[lint.contracts.custom]]
+[lint.contracts.custom]
 when = { type = "zsh_plugin", framework = "oh-my-zsh", plugin = "tmux" }
 ```
 
@@ -271,7 +411,7 @@ Optional file globs that limit where the contract applies.
 **Example usage**:
 
 ```toml
-[[lint.contracts.custom]]
+[lint.contracts.custom]
 files = ["**/.zshrc"]
 ```
 
@@ -288,7 +428,7 @@ Ambient names the activated runtime reads from the caller environment.
 **Example usage**:
 
 ```toml
-[[lint.contracts.custom]]
+[lint.contracts.custom]
 reads = ["GITHUB_ENV", "GITHUB_OUTPUT"]
 ```
 
@@ -305,7 +445,7 @@ Provided function contracts with caller reads and caller-visible sets.
 **Example usage**:
 
 ```toml
-[[lint.contracts.custom]]
+[lint.contracts.custom]
 functions = [{ name = "helper", reads = ["CALLER_VALUE"], sets = ["REPLY"] }]
 ```
 
@@ -446,6 +586,445 @@ Report nested function definitions when no reachable direct call reaches the enc
 ```toml
 [lint.rule-options.c063]
 report-unreached-nested-definitions = true
+```
+
+---
+
+### `[lint.rule-options.s078]`
+
+Behavior overrides for `S078` shebang shell policy.
+
+#### `allowed-shells`
+
+Interpreter names accepted in shebangs for this project.
+
+**Default value**: `["bash"]`
+
+**Type**: `list[string]`
+
+**Example usage**:
+
+```toml
+[lint.rule-options.s078]
+allowed-shells = ["bash", "zsh"]
+```
+
+---
+
+### `[lint.rule-options.s079]`
+
+Behavior overrides for `S079` shebang invocation form policy.
+
+#### `allowed-forms`
+
+Shebang invocation forms accepted for this project. Supported values are `absolute-path` and `env-lookup`.
+
+**Default value**: `["env-lookup"]`
+
+**Type**: `list[string]`
+
+**Example usage**:
+
+```toml
+[lint.rule-options.s079]
+allowed-forms = ["env-lookup"]
+```
+
+---
+
+#### `allowed-paths`
+
+Exact shebang invocation strings accepted regardless of invocation form.
+
+**Default value**: `["/bin/bash", "/usr/bin/env bash"]`
+
+**Type**: `list[string]`
+
+**Example usage**:
+
+```toml
+[lint.rule-options.s079]
+allowed-paths = ["/usr/bin/env bash"]
+```
+
+---
+
+### `[lint.rule-options.s080]`
+
+Behavior overrides for `S080` script size policy.
+
+#### `max-lines`
+
+Maximum accepted line count for one script.
+
+**Default value**: `100`
+
+**Type**: `integer`
+
+**Example usage**:
+
+```toml
+[lint.rule-options.s080]
+max-lines = 100
+```
+
+---
+
+#### `count`
+
+Line-counting mode. Supported values are `physical` and `non-comment-non-blank`.
+
+**Default value**: `"physical"`
+
+**Type**: `string`
+
+**Example usage**:
+
+```toml
+[lint.rule-options.s080]
+count = "non-comment-non-blank"
+```
+
+---
+
+### `[lint.rule-options.s081]`
+
+Behavior overrides for `S081` file description comments.
+
+#### `ignore-shebang-only-files`
+
+Do not report scripts whose only content is a shebang line.
+
+**Default value**: `false`
+
+**Type**: `bool`
+
+**Example usage**:
+
+```toml
+[lint.rule-options.s081]
+ignore-shebang-only-files = true
+```
+
+---
+
+### `[lint.rule-options.s082]`
+
+Behavior overrides for `S082` action comment formatting.
+
+#### `kinds`
+
+Comment markers checked at the start of a comment.
+
+**Default value**: `["TODO", "FIXME", "XXX"]`
+
+**Type**: `list[string]`
+
+**Example usage**:
+
+```toml
+[lint.rule-options.s082]
+kinds = ["TODO", "FIXME"]
+```
+
+---
+
+#### `require-owner`
+
+Require a checked marker to be followed immediately by a parenthesized owner.
+
+**Default value**: `true`
+
+**Type**: `bool`
+
+**Example usage**:
+
+```toml
+[lint.rule-options.s082]
+require-owner = false
+```
+
+---
+
+#### `require-message`
+
+Require a checked marker to include non-empty explanatory text.
+
+**Default value**: `true`
+
+**Type**: `bool`
+
+**Example usage**:
+
+```toml
+[lint.rule-options.s082]
+require-message = false
+```
+
+---
+
+### `[lint.rule-options.s083]`
+
+Behavior overrides for `S083` missing function documentation.
+
+#### `require-for`
+
+Choose which functions require a leading documentation comment: all, exported, long, or parameterized.
+
+**Default value**: `long`
+
+**Type**: `string`
+
+**Example usage**:
+
+```toml
+[lint.rule-options.s083]
+require-for = "exported"
+```
+
+---
+
+#### `long-function-line-threshold`
+
+Minimum body line count for `require-for = "long"`.
+
+**Default value**: `10`
+
+**Type**: `integer`
+
+**Example usage**:
+
+```toml
+[lint.rule-options.s083]
+long-function-line-threshold = 20
+```
+
+---
+
+### `[lint.rule-options.s084]`
+
+Behavior overrides for `S084` function documentation content.
+
+#### `require-globals`
+
+Require a Globals section when a documented function reads or writes non-local variables.
+
+**Default value**: `true`
+
+**Type**: `bool`
+
+**Example usage**:
+
+```toml
+[lint.rule-options.s084]
+require-globals = false
+```
+
+---
+
+#### `require-arguments`
+
+Require an Arguments section when a documented function uses positional parameters.
+
+**Default value**: `true`
+
+**Type**: `bool`
+
+**Example usage**:
+
+```toml
+[lint.rule-options.s084]
+require-arguments = false
+```
+
+---
+
+#### `require-outputs`
+
+Require an Outputs section when a documented function writes with echo or printf.
+
+**Default value**: `true`
+
+**Type**: `bool`
+
+**Example usage**:
+
+```toml
+[lint.rule-options.s084]
+require-outputs = false
+```
+
+---
+
+#### `require-returns`
+
+Require a Returns section when a documented function has an explicit return code.
+
+**Default value**: `true`
+
+**Type**: `bool`
+
+**Example usage**:
+
+```toml
+[lint.rule-options.s084]
+require-returns = false
+```
+
+---
+
+### `[lint.rule-options.s085]`
+
+Behavior overrides for `S085` missing main entrypoint analysis.
+
+#### `non-trivial-line-threshold`
+
+Minimum source line count before the script is checked.
+
+**Default value**: `30`
+
+**Type**: `int`
+
+**Example usage**:
+
+```toml
+[lint.rule-options.s085]
+non-trivial-line-threshold = 20
+```
+
+---
+
+#### `non-trivial-function-count`
+
+Minimum function definition count before the script is checked.
+
+**Default value**: `2`
+
+**Type**: `int`
+
+**Example usage**:
+
+```toml
+[lint.rule-options.s085]
+non-trivial-function-count = 3
+```
+
+---
+
+#### `main-name`
+
+Function name expected as the final top-level call in non-trivial scripts.
+
+**Default value**: `"main"`
+
+**Type**: `string`
+
+**Example usage**:
+
+```toml
+[lint.rule-options.s085]
+main-name = "run"
+```
+
+---
+
+### `[lint.rule-options.c158]`
+
+Behavior overrides for `C158` implicit global assignment analysis.
+
+#### `treat-readonly-as-documented`
+
+Treat top-level readonly declarations as documented intentional globals.
+
+**Default value**: `true`
+
+**Type**: `bool`
+
+**Example usage**:
+
+```toml
+[lint.rule-options.c158]
+treat-readonly-as-documented = false
+```
+
+---
+
+#### `treat-export-as-intentional`
+
+Treat top-level exported bindings as intentional globals.
+
+**Default value**: `true`
+
+**Type**: `bool`
+
+**Example usage**:
+
+```toml
+[lint.rule-options.c158]
+treat-export-as-intentional = false
+```
+
+---
+
+### `[lint.rule-options.c159]`
+
+Behavior overrides for `C159` mutable global analysis.
+
+#### `allow-conditional-init`
+
+Allow self-referential default initializers such as `name=${name:-value}` without treating them as global mutations.
+
+**Default value**: `true`
+
+**Type**: `bool`
+
+**Example usage**:
+
+```toml
+[lint.rule-options.c159]
+allow-conditional-init = false
+```
+
+---
+
+### `[lint.rule-options.c160]`
+
+Behavior overrides for `C160` unanchored source path analysis.
+
+#### `allowed-anchors`
+
+Path prefix expressions accepted as script-directory anchors for source or dot commands.
+
+**Default value**: `["${BASH_SOURCE[0]%/*}", "$(dirname \"$0\")", "$(dirname \"${BASH_SOURCE[0]}\")"]`
+
+**Type**: `list[string]`
+
+**Example usage**:
+
+```toml
+[lint.rule-options.c160]
+allowed-anchors = ["$SCRIPT_DIR"]
+```
+
+---
+
+### `[lint.rule-options.c161]`
+
+Behavior overrides for `C161` function call ordering analysis.
+
+#### `ignore-after-source`
+
+Ignore later calls after a source command because the sourced file may define functions.
+
+**Default value**: `true`
+
+**Type**: `bool`
+
+**Example usage**:
+
+```toml
+[lint.rule-options.c161]
+ignore-after-source = false
 ```
 
 ---

--- a/website/content/settings/index.mdx
+++ b/website/content/settings/index.mdx
@@ -345,7 +345,7 @@ disabled = ["zsh/oh-my-zsh", "runtime/github-actions/env"]
 
 ---
 
-### `[lint.contracts.custom]`
+### `[[lint.contracts.custom]]`
 
 User-authored ambient contracts layered on top of, or in place of, the built-in registry.
 
@@ -360,7 +360,7 @@ Stable identifier for the custom contract.
 **Example usage**:
 
 ```toml
-[lint.contracts.custom]
+[[lint.contracts.custom]]
 id = "github-actions-env"
 ```
 
@@ -377,7 +377,7 @@ Built-in contract selectors that this custom contract replaces.
 **Example usage**:
 
 ```toml
-[lint.contracts.custom]
+[[lint.contracts.custom]]
 replaces = ["zsh/oh-my-zsh/plugin/tmux"]
 ```
 
@@ -394,7 +394,7 @@ Activation for the contract, either `"always"` or an object such as `{ type = "z
 **Example usage**:
 
 ```toml
-[lint.contracts.custom]
+[[lint.contracts.custom]]
 when = { type = "zsh_plugin", framework = "oh-my-zsh", plugin = "tmux" }
 ```
 
@@ -411,7 +411,7 @@ Optional file globs that limit where the contract applies.
 **Example usage**:
 
 ```toml
-[lint.contracts.custom]
+[[lint.contracts.custom]]
 files = ["**/.zshrc"]
 ```
 
@@ -428,7 +428,7 @@ Ambient names the activated runtime reads from the caller environment.
 **Example usage**:
 
 ```toml
-[lint.contracts.custom]
+[[lint.contracts.custom]]
 reads = ["GITHUB_ENV", "GITHUB_OUTPUT"]
 ```
 
@@ -445,7 +445,7 @@ Provided function contracts with caller reads and caller-visible sets.
 **Example usage**:
 
 ```toml
-[lint.contracts.custom]
+[[lint.contracts.custom]]
 functions = [{ name = "helper", reads = ["CALLER_VALUE"], sets = ["REPLY"] }]
 ```
 
@@ -466,6 +466,7 @@ Exact names consumed by external runtime behavior.
 **Example usage**:
 
 ```toml
+[[lint.contracts.custom]]
 [lint.contracts.custom.consumes]
 names = ["HISTFILE", "SAVEHIST"]
 ```
@@ -483,6 +484,7 @@ Name prefixes consumed by external runtime behavior.
 **Example usage**:
 
 ```toml
+[[lint.contracts.custom]]
 [lint.contracts.custom.consumes]
 prefixes = ["ZSH_TMUX_"]
 ```
@@ -500,6 +502,7 @@ Treat every assignment in the file as externally consumed.
 **Example usage**:
 
 ```toml
+[[lint.contracts.custom]]
 [lint.contracts.custom.consumes]
 all = true
 ```
@@ -521,6 +524,7 @@ Variables provided by the contract.
 **Example usage**:
 
 ```toml
+[[lint.contracts.custom]]
 [lint.contracts.custom.provides]
 variables = ["reply", "REPLY"]
 ```
@@ -538,6 +542,7 @@ Callable function names provided by the contract.
 **Example usage**:
 
 ```toml
+[[lint.contracts.custom]]
 [lint.contracts.custom.provides]
 functions = ["helper"]
 ```

--- a/website/content/shellcheck-compat/index.mdx
+++ b/website/content/shellcheck-compat/index.mdx
@@ -158,7 +158,7 @@ That keeps your existing `rules_lint` entry point, target names, and `.shellchec
 - Exit status follows the usual ShellCheck shape: `0` for no diagnostics, `1` when diagnostics are reported, and `2` for file or runtime errors.
 - Diagnostic codes, suppressions, and filters use `SCxxxx` identifiers, so existing `# shellcheck disable=...` comments continue to work.
 - `--list-optional` is available, but not every named optional check is implemented yet. Treat that catalog as a compatibility target rather than a guarantee that every check can already be enabled.
-- If you want Shuck-only features such as the native multi-dialect workflow or automatic fixes, use the regular [`shuck check` docs](/docs/getting-started) instead of the compatibility surface.
+- If you want Shuck-only features such as the native multi-dialect workflow or automatic fixes, use the regular [`shuck check` docs](/docs/linting) instead of the compatibility surface.
 
 ## Repository conformance
 


### PR DESCRIPTION
## Summary

- Make `shuck format` available without `SHUCK_EXPERIMENTAL` and update the related CLI tests.
- Add dedicated website docs for linting and formatting, plus clearer LSP wording for advertised formatting support.
- Restructure the docs sidebar into Linting, Formatting, LSP, Runtime, and Performance sections, with Rules nested at the end of Linting.
- Regenerate the settings reference so formatter options are documented.

## Validation

- `cargo fmt`
- `git diff --check`
- `cargo test -p shuck-cli format`
- `./node_modules/.bin/tsx --test scripts/*.test.ts app/lib/*.test.ts`
- `npx --yes pnpm@10.33.0 --dir website build`
- Browser-verified `/docs/getting-started`, `/docs/formatting`, and `/docs/lsp`

## Note

A broader earlier `cargo test -p shuck-cli` run reproduced an existing watch-mode test failure in `check_watch_reruns_when_files_change`, where the watch test did not observe a rerun after file changes. The formatter-focused CLI tests pass.