### PR TITLE
test(formatter): add shfmt large-corpus oracle

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build test run check check-scripts setup-hooks setup-large-corpus ensure-cache test-large-corpus large-corpus-report large-corpus-report-from-log large-corpus-report-open test-oracle-shfmt test-oracle-shfmt-fixtures test-oracle-shfmt-benchmark test-oracle-shellcheck-cli fuzz-setup fuzz-list fuzz-smoke fuzz-run fuzz-cli bench bench-save bench-compare bench-parser bench-arithmetic bench-lexer bench-semantic bench-linter bench-formatter bench-large-corpus-hotspots bench-macro bench-macro-single bench-macro-format bench-macro-format-summary bench-macro-format-single bench-macro-site-local bench-repo-corpus profile-parser profile-parser-view profile-arithmetic profile-arithmetic-view profile-formatter profile-formatter-view profile-linter profile-linter-view profile-cli profile-cli-view profile-large-corpus profile-large-corpus-view flame-parser flame-arithmetic flame-formatter flame-linter flame-cli harden-release check-release-security
+.PHONY: build test run check check-scripts setup-hooks setup-large-corpus ensure-cache test-large-corpus large-corpus-report large-corpus-report-from-log large-corpus-report-open test-oracle-shfmt test-oracle-shfmt-fixtures test-oracle-shfmt-benchmark test-oracle-shfmt-large-corpus test-oracle-shellcheck-cli fuzz-setup fuzz-list fuzz-smoke fuzz-run fuzz-cli bench bench-save bench-compare bench-parser bench-arithmetic bench-lexer bench-semantic bench-linter bench-formatter bench-large-corpus-hotspots bench-macro bench-macro-single bench-macro-format bench-macro-format-summary bench-macro-format-single bench-macro-site-local bench-repo-corpus profile-parser profile-parser-view profile-arithmetic profile-arithmetic-view profile-formatter profile-formatter-view profile-linter profile-linter-view profile-cli profile-cli-view profile-large-corpus profile-large-corpus-view flame-parser flame-arithmetic flame-formatter flame-linter flame-cli harden-release check-release-security
 
 ARGS ?= --help
 BENCH_FILE ?=
@@ -147,6 +147,14 @@ test-oracle-shfmt-fixtures:
 test-oracle-shfmt-benchmark:
 	SHUCK_RUN_SHFMT_ORACLE=1 \
 	$(NIX_DEVELOP) cargo test -p shuck-benchmark --test formatter_corpus formatter_benchmark_corpus_matches_shfmt_baseline -- --ignored --exact --nocapture
+
+test-oracle-shfmt-large-corpus: ensure-cache
+	SHUCK_RUN_SHFMT_ORACLE=1 \
+	SHUCK_TEST_LARGE_CORPUS=1 \
+	SHUCK_LARGE_CORPUS_SAMPLE_PERCENT=$(SHUCK_LARGE_CORPUS_SAMPLE_PERCENT) \
+	TEST_SHARD_INDEX=$(TEST_SHARD_INDEX) \
+	TEST_TOTAL_SHARDS=$(TEST_TOTAL_SHARDS) \
+	$(NIX_DEVELOP) cargo test -p shuck-formatter --test oracle_shfmt large_corpus_matches_shfmt -- --ignored --exact --nocapture
 
 test-oracle-shellcheck-cli:
 	$(NIX_DEVELOP) cargo test -p shuck-cli --test oracle_shellcheck_cli -- --ignored --nocapture

--- a/crates/shuck-formatter/tests/oracle_shfmt.rs
+++ b/crates/shuck-formatter/tests/oracle_shfmt.rs
@@ -1,12 +1,35 @@
 use std::fs;
-use std::io::Write;
+use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
-use std::process::{Command, Stdio};
+use std::process::{Child, Command, Output, Stdio};
+use std::thread;
+use std::time::{Duration, Instant};
 
-use shuck_formatter::{FormattedSource, ShellDialect, ShellFormatOptions, format_source};
+use shuck_formatter::{FormattedSource, ShellDialect, ShellFormatOptions, format_file_ast};
+use shuck_parser::parser::Parser;
 use similar::TextDiff;
 
 const MAX_ORACLE_DIFF_LINES: usize = 200;
+const MAX_LARGE_CORPUS_FAILURES: usize = 25;
+const SHFMT_LARGE_CORPUS_TIMEOUT: Duration = Duration::from_secs(10);
+const LARGE_CORPUS_PROGRESS_INTERVAL: usize = 1_000;
+const LARGE_CORPUS_SLOW_FIXTURE: Duration = Duration::from_secs(3);
+const LARGE_CORPUS_ENV: &str = "SHUCK_TEST_LARGE_CORPUS";
+const LARGE_CORPUS_ROOT_ENV: &str = "SHUCK_LARGE_CORPUS_ROOT";
+const LARGE_CORPUS_SHARD_ENV: &str = "TEST_SHARD_INDEX";
+const LARGE_CORPUS_SHARDS_ENV: &str = "TEST_TOTAL_SHARDS";
+const LARGE_CORPUS_SAMPLE_PERCENT_ENV: &str = "SHUCK_LARGE_CORPUS_SAMPLE_PERCENT";
+const LARGE_CORPUS_CACHE_DIR_NAME: &str = ".cache/large-corpus";
+const LARGE_CORPUS_STATIC_IGNORE_SUFFIXES: &[&str] = &[
+    "super-linter__super-linter__test__linters__bash__shell_bad_1.sh",
+    "super-linter__super-linter__test__linters__bash_exec__shell_bad_1.sh",
+    "alpinelinux__aports__community__starship__starship.plugin.zsh",
+    "CISOfy__lynis__include__tests_ports_packages",
+    "google__oss-fuzz__infra__chronos__coverage_test_collection.py",
+    "moovweb__gvm__examples__native__configure",
+    "moovweb__gvm__examples__native__ltmain.sh",
+    "ohmyzsh__ohmyzsh__plugins__alias-finder__tests__test_run.sh",
+];
 
 struct OracleCase {
     name: &'static str,
@@ -18,6 +41,25 @@ struct OracleCase {
 
 struct ShfmtProbe {
     supported_flags: String,
+}
+
+#[derive(Debug, Clone)]
+struct LargeCorpusConfig {
+    corpus_dir: PathBuf,
+    shard_index: usize,
+    total_shards: usize,
+    sample_percent: usize,
+}
+
+#[derive(Debug, Clone)]
+struct LargeCorpusFixture {
+    path: PathBuf,
+    cache_rel_path: PathBuf,
+}
+
+struct FormatterOracleConfig {
+    shfmt_language: &'static str,
+    options: ShellFormatOptions,
 }
 
 #[test]
@@ -63,6 +105,124 @@ fn selected_fixtures_match_shfmt() {
     );
 }
 
+#[test]
+#[ignore = "requires SHUCK_RUN_SHFMT_ORACLE=1, SHUCK_TEST_LARGE_CORPUS=1, and shfmt on PATH"]
+fn large_corpus_matches_shfmt() {
+    if std::env::var_os("SHUCK_RUN_SHFMT_ORACLE").is_none() {
+        eprintln!("set SHUCK_RUN_SHFMT_ORACLE=1 to run the shfmt oracle");
+        return;
+    }
+    let Some(cfg) = resolve_large_corpus_config() else {
+        eprintln!("large corpus shfmt oracle skipped (set {LARGE_CORPUS_ENV}=1 to enable)");
+        return;
+    };
+
+    probe_shfmt().expect("shfmt not found on PATH; run under `nix develop`");
+
+    let all_fixtures = collect_large_corpus_fixtures(&cfg.corpus_dir);
+    assert!(
+        !all_fixtures.is_empty(),
+        "no large-corpus fixtures found in {}",
+        cfg.corpus_dir.join("scripts").display()
+    );
+
+    let fixtures = select_large_corpus_fixtures(all_fixtures, &cfg);
+    assert!(
+        !fixtures.is_empty(),
+        "no large-corpus fixtures selected from {}",
+        cfg.corpus_dir.join("scripts").display()
+    );
+
+    let mut compared = 0usize;
+    let mut matched = 0usize;
+    let mut unsupported_dialects = 0usize;
+    let mut non_utf8 = 0usize;
+    let mut shfmt_skips = 0usize;
+    let mut shuck_errors = Vec::new();
+    let mut mismatches = Vec::new();
+
+    for (fixture_index, fixture) in fixtures.iter().enumerate() {
+        let fixture_started = Instant::now();
+        let filename = fixture.cache_rel_path.to_string_lossy();
+        let processed = fixture_index + 1;
+        if processed % LARGE_CORPUS_PROGRESS_INTERVAL == 0 {
+            eprintln!(
+                "large corpus shfmt oracle progress: processed={processed}/{} compared={compared} matched={matched} mismatches={} shuck_errors={} shfmt_skips={} unsupported_dialects={} non_utf8={}",
+                fixtures.len(),
+                mismatches.len(),
+                shuck_errors.len(),
+                shfmt_skips,
+                unsupported_dialects,
+                non_utf8,
+            );
+        }
+
+        let source = match fs::read_to_string(&fixture.path) {
+            Ok(source) => source,
+            Err(_) => {
+                non_utf8 += 1;
+                continue;
+            }
+        };
+        let Some(format_config) = formatter_oracle_config(&source, &fixture.path) else {
+            unsupported_dialects += 1;
+            continue;
+        };
+
+        let shfmt = match try_run_shfmt(&source, &filename, format_config.shfmt_language) {
+            Ok(output) => output,
+            Err(_) => {
+                shfmt_skips += 1;
+                report_slow_large_corpus_fixture(&filename, fixture_started.elapsed());
+                continue;
+            }
+        };
+        compared += 1;
+
+        let shuck = match try_run_shuck_formatter(&source, &filename, &format_config.options) {
+            Ok(FormattedSource::Unchanged) => source.clone(),
+            Ok(FormattedSource::Formatted(formatted)) => formatted,
+            Err(error) => {
+                shuck_errors.push(format!(
+                    "{}: {error}",
+                    fixture.cache_rel_path.to_string_lossy()
+                ));
+                report_slow_large_corpus_fixture(&filename, fixture_started.elapsed());
+                continue;
+            }
+        };
+
+        if let Some(mismatch) = render_oracle_mismatch(&filename, &filename, &shfmt, &shuck) {
+            mismatches.push(mismatch);
+        } else {
+            matched += 1;
+        }
+
+        report_slow_large_corpus_fixture(&filename, fixture_started.elapsed());
+    }
+
+    eprintln!(
+        "large corpus shfmt oracle summary: fixtures={} compared={} matched={} mismatches={} shuck_errors={} shfmt_skips={} unsupported_dialects={} non_utf8={}",
+        fixtures.len(),
+        compared,
+        matched,
+        mismatches.len(),
+        shuck_errors.len(),
+        shfmt_skips,
+        unsupported_dialects,
+        non_utf8,
+    );
+
+    assert!(
+        shuck_errors.is_empty() && mismatches.is_empty(),
+        "large corpus shfmt oracle found {} shuck error(s) and {} mismatch(es):\n\n{}{}",
+        shuck_errors.len(),
+        mismatches.len(),
+        format_failure_list("shuck formatter errors", &shuck_errors),
+        format_failure_list("formatter mismatches", &mismatches),
+    );
+}
+
 impl OracleCase {
     fn is_supported(&self, shfmt: &ShfmtProbe) -> bool {
         self.shfmt_flags
@@ -103,10 +263,24 @@ fn probe_shfmt() -> Option<ShfmtProbe> {
 }
 
 fn run_shuck_formatter(source: &str, filename: &str, options: &ShellFormatOptions) -> String {
-    match format_source(source, Some(Path::new(filename)), options).unwrap() {
+    match try_run_shuck_formatter(source, filename, options).unwrap() {
         FormattedSource::Unchanged => source.to_string(),
         FormattedSource::Formatted(formatted) => formatted,
     }
+}
+
+fn try_run_shuck_formatter(
+    source: &str,
+    filename: &str,
+    options: &ShellFormatOptions,
+) -> Result<FormattedSource, String> {
+    let path = Path::new(filename);
+    let resolved = options.resolve(source, Some(path));
+    let parsed = Parser::with_dialect(source, resolved.dialect()).parse();
+    if parsed.is_err() {
+        return Err(parsed.strict_error().to_string());
+    }
+    format_file_ast(source, parsed.file, Some(path), options).map_err(|error| error.to_string())
 }
 
 fn run_shfmt(source: &str, filename: &str, flags: &[&str]) -> String {
@@ -133,6 +307,100 @@ fn run_shfmt(source: &str, filename: &str, flags: &[&str]) -> String {
         output.status
     );
     String::from_utf8(output.stdout).expect("utf8 shfmt output")
+}
+
+fn try_run_shfmt(source: &str, filename: &str, language: &str) -> Result<String, String> {
+    let mut command = Command::new("shfmt");
+    command
+        .arg("-filename")
+        .arg(filename)
+        .arg(format!("-ln={language}"))
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+
+    let mut child = command.spawn().map_err(|error| error.to_string())?;
+    child
+        .stdin
+        .as_mut()
+        .ok_or_else(|| "failed to open shfmt stdin".to_string())?
+        .write_all(source.as_bytes())
+        .map_err(|error| error.to_string())?;
+    let output = child
+        .wait_with_output_timeout(SHFMT_LARGE_CORPUS_TIMEOUT)
+        .map_err(|error| error.to_string())?;
+    if !output.status.success() {
+        return Err(String::from_utf8_lossy(&output.stderr).into_owned());
+    }
+    String::from_utf8(output.stdout).map_err(|error| error.to_string())
+}
+
+trait ChildTimeoutExt {
+    fn wait_with_output_timeout(self, timeout: Duration) -> Result<Output, String>;
+}
+
+impl ChildTimeoutExt for Child {
+    fn wait_with_output_timeout(mut self, timeout: Duration) -> Result<Output, String> {
+        drop(self.stdin.take());
+
+        let stdout_reader = self.stdout.take().map(spawn_reader);
+        let stderr_reader = self.stderr.take().map(spawn_reader);
+        let started = Instant::now();
+
+        let status = loop {
+            if let Some(status) = self.try_wait().map_err(|error| error.to_string())? {
+                break status;
+            }
+            if started.elapsed() >= timeout {
+                let _ = self.kill();
+                let _ = self.wait();
+                let _ = collect_reader(stdout_reader);
+                let _ = collect_reader(stderr_reader);
+                return Err(format!("shfmt timed out after {}s", timeout.as_secs()));
+            }
+            thread::sleep(Duration::from_millis(10));
+        };
+
+        Ok(Output {
+            status,
+            stdout: collect_reader(stdout_reader)?,
+            stderr: collect_reader(stderr_reader)?,
+        })
+    }
+}
+
+fn spawn_reader<R>(mut reader: R) -> thread::JoinHandle<Result<Vec<u8>, String>>
+where
+    R: Read + Send + 'static,
+{
+    thread::spawn(move || {
+        let mut output = Vec::new();
+        reader
+            .read_to_end(&mut output)
+            .map_err(|error| error.to_string())?;
+        Ok(output)
+    })
+}
+
+fn collect_reader(
+    reader: Option<thread::JoinHandle<Result<Vec<u8>, String>>>,
+) -> Result<Vec<u8>, String> {
+    match reader {
+        Some(reader) => reader
+            .join()
+            .map_err(|_| "failed to join shfmt pipe reader".to_string())?,
+        None => Ok(Vec::new()),
+    }
+}
+
+fn report_slow_large_corpus_fixture(filename: &str, elapsed: Duration) {
+    if elapsed >= LARGE_CORPUS_SLOW_FIXTURE {
+        eprintln!(
+            "large corpus shfmt oracle slow fixture: {} took {:.1}s",
+            filename,
+            elapsed.as_secs_f64(),
+        );
+    }
 }
 
 fn render_oracle_mismatch(
@@ -168,6 +436,292 @@ fn truncate_diff(diff: &str) -> String {
         "\n... diff truncated, omitted {omitted} additional lines ..."
     ));
     truncated
+}
+
+fn formatter_oracle_config(source: &str, path: &Path) -> Option<FormatterOracleConfig> {
+    match shuck_linter::ShellDialect::infer(source, Some(path)) {
+        shuck_linter::ShellDialect::Ksh | shuck_linter::ShellDialect::Mksh => {
+            Some(FormatterOracleConfig {
+                shfmt_language: "mksh",
+                options: ShellFormatOptions::default().with_dialect(ShellDialect::Mksh),
+            })
+        }
+        shuck_linter::ShellDialect::Unknown
+        | shuck_linter::ShellDialect::Sh
+        | shuck_linter::ShellDialect::Dash
+        | shuck_linter::ShellDialect::Bash => Some(FormatterOracleConfig {
+            shfmt_language: "bash",
+            options: ShellFormatOptions::default().with_dialect(ShellDialect::Bash),
+        }),
+        shuck_linter::ShellDialect::Zsh => None,
+    }
+}
+
+fn resolve_large_corpus_config() -> Option<LargeCorpusConfig> {
+    if !env_truthy(LARGE_CORPUS_ENV, false) {
+        return None;
+    }
+
+    let repo_root = repo_root();
+    let root_hint = std::env::var(LARGE_CORPUS_ROOT_ENV)
+        .ok()
+        .filter(|value| !value.is_empty());
+    let candidates = if let Some(root_hint) = root_hint {
+        vec![PathBuf::from(root_hint)]
+    } else {
+        vec![
+            repo_root.join(LARGE_CORPUS_CACHE_DIR_NAME),
+            repo_root.join("..").join("shell-checks"),
+        ]
+    };
+
+    for candidate in candidates {
+        if let Some(corpus_dir) = normalize_large_corpus_root(&candidate) {
+            let total_shards = positive_env_int(LARGE_CORPUS_SHARDS_ENV, 1);
+            let shard_index = non_negative_env_int(LARGE_CORPUS_SHARD_ENV, 0);
+            assert!(
+                shard_index < total_shards,
+                "{LARGE_CORPUS_SHARD_ENV}={shard_index}, want value in [0,{total_shards})"
+            );
+
+            return Some(LargeCorpusConfig {
+                corpus_dir,
+                shard_index,
+                total_shards,
+                sample_percent: percentage_env_int(LARGE_CORPUS_SAMPLE_PERCENT_ENV, 100),
+            });
+        }
+    }
+
+    panic!("large corpus not found; set {LARGE_CORPUS_ROOT_ENV} to an existing corpus directory");
+}
+
+fn normalize_large_corpus_root(root: &Path) -> Option<PathBuf> {
+    if !root.is_dir() {
+        return None;
+    }
+
+    let repo_corpus = root.join("corpus");
+    if corpus_dir_looks_valid(&repo_corpus) {
+        return Some(repo_corpus);
+    }
+    if corpus_dir_looks_valid(root) {
+        return Some(root.to_path_buf());
+    }
+    None
+}
+
+fn corpus_dir_looks_valid(dir: &Path) -> bool {
+    dir.join("scripts").is_dir() && dir.join("manifest.yaml").is_file()
+}
+
+fn repo_root() -> PathBuf {
+    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    manifest_dir
+        .parent()
+        .and_then(|path| path.parent())
+        .expect("failed to resolve repo root")
+        .to_path_buf()
+}
+
+fn collect_large_corpus_fixtures(corpus_dir: &Path) -> Vec<LargeCorpusFixture> {
+    let scripts_dir = corpus_dir.join("scripts");
+    let mut fixtures = Vec::new();
+    let mut pending = vec![scripts_dir.clone()];
+
+    while let Some(dir) = pending.pop() {
+        let entries = match fs::read_dir(&dir) {
+            Ok(entries) => entries,
+            Err(_) => continue,
+        };
+
+        for entry in entries.flatten() {
+            let path = entry.path();
+            let file_type = match entry.file_type() {
+                Ok(file_type) => file_type,
+                Err(_) => continue,
+            };
+            if file_type.is_dir() {
+                pending.push(path);
+            } else if file_type.is_file() && fixture_path_is_supported(&path) {
+                let cache_rel_path = path
+                    .strip_prefix(&scripts_dir)
+                    .unwrap_or(path.as_path())
+                    .to_path_buf();
+                fixtures.push(LargeCorpusFixture {
+                    path,
+                    cache_rel_path,
+                });
+            }
+        }
+    }
+
+    fixtures.sort_by(|a, b| a.cache_rel_path.cmp(&b.cache_rel_path));
+    fixtures
+}
+
+fn fixture_path_is_supported(path: &Path) -> bool {
+    !(path_is_statically_ignored_large_corpus_fixture(path)
+        || path_is_sample_file(path)
+        || path_is_fish_file(path)
+        || path_is_patch_file(path)
+        || path_is_appledouble_file(path)
+        || path_is_guess_file(path)
+        || path_is_config_sub_file(path)
+        || path_is_repo_git_entry(path))
+}
+
+fn path_matches_large_corpus_suffix(path: &Path, suffixes: &[&str]) -> bool {
+    let path = path.to_string_lossy();
+    suffixes.iter().any(|suffix| path.ends_with(suffix))
+}
+
+fn path_is_statically_ignored_large_corpus_fixture(path: &Path) -> bool {
+    path_matches_large_corpus_suffix(path, LARGE_CORPUS_STATIC_IGNORE_SUFFIXES)
+}
+
+fn path_is_sample_file(path: &Path) -> bool {
+    path.file_name()
+        .and_then(|name| name.to_str())
+        .is_some_and(|name| name.ends_with(".sample"))
+}
+
+fn path_is_patch_file(path: &Path) -> bool {
+    let path = path.to_string_lossy().to_lowercase();
+    path.ends_with(".patch") || path.ends_with(".diff") || path.ends_with(".dpatch")
+}
+
+fn path_is_fish_file(path: &Path) -> bool {
+    path.extension()
+        .and_then(|ext| ext.to_str())
+        .is_some_and(|ext| ext.eq_ignore_ascii_case("fish"))
+}
+
+fn path_is_appledouble_file(path: &Path) -> bool {
+    path.file_name()
+        .and_then(|name| name.to_str())
+        .is_some_and(|name| name.starts_with("._"))
+}
+
+fn path_is_guess_file(path: &Path) -> bool {
+    path.file_name()
+        .and_then(|name| name.to_str())
+        .is_some_and(|name| name.to_ascii_lowercase().ends_with(".guess"))
+}
+
+fn path_is_config_sub_file(path: &Path) -> bool {
+    path.file_name()
+        .and_then(|name| name.to_str())
+        .is_some_and(|name| name.to_ascii_lowercase().ends_with("config.sub"))
+}
+
+fn path_is_repo_git_entry(path: &Path) -> bool {
+    path.file_name()
+        .and_then(|name| name.to_str())
+        .is_some_and(|name| name.contains("__.git__"))
+}
+
+fn select_large_corpus_fixtures(
+    mut fixtures: Vec<LargeCorpusFixture>,
+    cfg: &LargeCorpusConfig,
+) -> Vec<LargeCorpusFixture> {
+    fixtures = shard_fixtures(fixtures, cfg.shard_index, cfg.total_shards);
+    fixtures = sample_fixtures(fixtures, cfg.sample_percent);
+    fixtures
+}
+
+fn shard_fixtures(
+    fixtures: Vec<LargeCorpusFixture>,
+    shard_index: usize,
+    total_shards: usize,
+) -> Vec<LargeCorpusFixture> {
+    if fixtures.is_empty() || total_shards <= 1 {
+        return fixtures;
+    }
+    let start = shard_index * fixtures.len() / total_shards;
+    let end = (shard_index + 1) * fixtures.len() / total_shards;
+    fixtures[start..end].to_vec()
+}
+
+fn sample_fixtures(
+    fixtures: Vec<LargeCorpusFixture>,
+    sample_percent: usize,
+) -> Vec<LargeCorpusFixture> {
+    if fixtures.is_empty() || sample_percent >= 100 {
+        return fixtures;
+    }
+
+    fixtures
+        .into_iter()
+        .filter(|fixture| fixture_selected_for_sample(fixture, sample_percent))
+        .collect()
+}
+
+fn fixture_selected_for_sample(fixture: &LargeCorpusFixture, sample_percent: usize) -> bool {
+    if sample_percent >= 100 {
+        return true;
+    }
+
+    let key = fixture.cache_rel_path.to_string_lossy();
+    stable_sample_hash(&key) % 100 < sample_percent as u64
+}
+
+fn stable_sample_hash(value: &str) -> u64 {
+    let mut hash = 0xcbf29ce484222325u64;
+    for byte in value.as_bytes() {
+        hash ^= u64::from(*byte);
+        hash = hash.wrapping_mul(0x100000001b3);
+    }
+    hash
+}
+
+fn format_failure_list(title: &str, failures: &[String]) -> String {
+    if failures.is_empty() {
+        return String::new();
+    }
+
+    let limit = failures.len().min(MAX_LARGE_CORPUS_FAILURES);
+    let mut report = format!("{title} (showing {limit}/{}):\n", failures.len());
+    for failure in failures.iter().take(limit) {
+        report.push_str(failure);
+        report.push_str("\n\n");
+    }
+    report
+}
+
+fn env_truthy(name: &str, default: bool) -> bool {
+    std::env::var(name)
+        .ok()
+        .map(|value| {
+            matches!(
+                value.as_str(),
+                "1" | "true" | "TRUE" | "yes" | "YES" | "on" | "ON"
+            )
+        })
+        .unwrap_or(default)
+}
+
+fn positive_env_int(name: &str, default: usize) -> usize {
+    std::env::var(name)
+        .ok()
+        .and_then(|value| value.parse::<usize>().ok())
+        .filter(|value| *value > 0)
+        .unwrap_or(default)
+}
+
+fn non_negative_env_int(name: &str, default: usize) -> usize {
+    std::env::var(name)
+        .ok()
+        .and_then(|value| value.parse::<usize>().ok())
+        .unwrap_or(default)
+}
+
+fn percentage_env_int(name: &str, default: usize) -> usize {
+    std::env::var(name)
+        .ok()
+        .and_then(|value| value.parse::<usize>().ok())
+        .filter(|value| (1..=100).contains(value))
+        .unwrap_or(default)
 }
 
 fn oracle_cases() -> Vec<OracleCase> {


### PR DESCRIPTION
## Summary
- add a `test-oracle-shfmt-large-corpus` Make target that runs through the nix dev environment
- add an ignored formatter oracle test that discovers large-corpus fixtures, supports sharding/sampling, reports progress, and times out slow `shfmt` invocations

## Validation
- `cargo fmt --check`
- `cargo test -p shuck-formatter --test oracle_shfmt --no-run`
- `cargo test -p shuck-formatter --test oracle_shfmt large_corpus_matches_shfmt -- --ignored --exact --nocapture`
- `make -n test-oracle-shfmt-large-corpus`