### PR TITLE
fix(parser): handle corpus shell edge cases

### DIFF
--- a/crates/shuck-parser/src/parser/commands/conditionals.rs
+++ b/crates/shuck-parser/src/parser/commands/conditionals.rs
@@ -498,6 +498,9 @@ impl<'a> Parser<'a> {
                 Some(TokenKind::DoubleRightBracket) => break,
                 Some(TokenKind::And) | Some(TokenKind::Or) if paren_depth == 0 => break,
                 Some(TokenKind::RightParen) if stop_at_right_paren && paren_depth == 0 => break,
+                Some(TokenKind::DoubleRightParen) if stop_at_right_paren && paren_depth == 0 => {
+                    break;
+                }
                 None => break,
                 _ => {}
             }

--- a/crates/shuck-parser/src/parser/commands/conditionals.rs
+++ b/crates/shuck-parser/src/parser/commands/conditionals.rs
@@ -111,7 +111,7 @@ impl<'a> Parser<'a> {
                     let word = self.collect_conditional_context_word(stop_at_right_paren)?;
                     self.conditional_var_ref_expr(word)
                 } else {
-                    let word = self.parse_conditional_operand_word()?;
+                    let word = self.parse_conditional_operand_word(stop_at_right_paren)?;
                     ConditionalExpr::Word(word)
                 }
             };
@@ -162,7 +162,7 @@ impl<'a> Parser<'a> {
                 right_paren_span,
             })
         } else {
-            ConditionalExpr::Word(self.parse_conditional_operand_word()?)
+            ConditionalExpr::Word(self.parse_conditional_operand_word(stop_at_right_paren)?)
         };
 
         self.skip_conditional_newlines();
@@ -188,7 +188,7 @@ impl<'a> Parser<'a> {
                 let word = self.collect_conditional_context_word(stop_at_right_paren)?;
                 ConditionalExpr::Pattern(self.pattern_from_conditional_word(&word))
             }
-            _ => ConditionalExpr::Word(self.parse_conditional_operand_word()?),
+            _ => ConditionalExpr::Word(self.parse_conditional_operand_word(stop_at_right_paren)?),
         };
 
         Ok(ConditionalExpr::Binary(ConditionalBinaryExpr {
@@ -199,12 +199,15 @@ impl<'a> Parser<'a> {
         }))
     }
 
-    pub(super) fn parse_conditional_operand_word(&mut self) -> Result<Word> {
+    pub(super) fn parse_conditional_operand_word(
+        &mut self,
+        stop_at_right_paren: bool,
+    ) -> Result<Word> {
         self.skip_conditional_newlines();
 
-        if let Some(word) = self.current_conditional_source_word(false) {
+        if let Some(word) = self.current_conditional_source_word(stop_at_right_paren) {
             self.advance_past_word(&word);
-            self.restore_conditional_source_delimiter(word.span.end, false);
+            self.restore_conditional_source_delimiter(word.span.end, stop_at_right_paren);
             return Ok(word);
         }
 
@@ -365,6 +368,8 @@ impl<'a> Parser<'a> {
             (TokenKind::And, "&&")
         } else if rest.starts_with("||") {
             (TokenKind::Or, "||")
+        } else if stop_at_right_paren && rest.starts_with("))") {
+            (TokenKind::DoubleRightParen, "))")
         } else if stop_at_right_paren && rest.starts_with(')') {
             (TokenKind::RightParen, ")")
         } else {

--- a/crates/shuck-parser/src/parser/commands/lists.rs
+++ b/crates/shuck-parser/src/parser/commands/lists.rs
@@ -275,12 +275,7 @@ impl<'a> Parser<'a> {
             Some(Keyword::Function) => false,
             None => matches!(
                 self.current_token_kind,
-                Some(
-                    TokenKind::DoubleLeftBracket
-                        | TokenKind::DoubleLeftParen
-                        | TokenKind::LeftParen
-                        | TokenKind::LeftBrace
-                )
+                Some(TokenKind::DoubleLeftParen | TokenKind::LeftParen | TokenKind::LeftBrace)
             ),
             _ => false,
         }

--- a/crates/shuck-parser/src/parser/commands/simple.rs
+++ b/crates/shuck-parser/src/parser/commands/simple.rs
@@ -157,9 +157,7 @@ impl<'a> Parser<'a> {
                     self.advance();
                     words.push(word);
                 }
-                Some(TokenKind::DoubleRightBracket)
-                    if self.should_consume_double_right_bracket_as_literal_argument(&words) =>
-                {
+                Some(TokenKind::DoubleRightBracket) if !words.is_empty() => {
                     let span = self.current_span;
                     let word = self.word_from_raw_text(span.slice(self.input), span);
                     self.advance();
@@ -350,25 +348,5 @@ impl<'a> Parser<'a> {
         };
         words.pop();
         (Some(fd_var), Some(fd_var_span))
-    }
-
-    fn should_consume_double_right_bracket_as_literal_argument(&self, words: &[Word]) -> bool {
-        words
-            .first()
-            .and_then(|word| self.single_literal_word_text(word))
-            .is_some()
-            || words.iter().any(|word| word.span.slice(self.input) == "[[")
-            || words.first().is_some_and(|word| {
-                matches!(
-                    word.parts.as_slice(),
-                    [WordPartNode {
-                        kind: WordPart::ArithmeticExpansion {
-                            syntax: ArithmeticExpansionSyntax::DollarParenParen,
-                            ..
-                        },
-                        ..
-                    }]
-                )
-            })
     }
 }

--- a/crates/shuck-parser/src/parser/commands/simple.rs
+++ b/crates/shuck-parser/src/parser/commands/simple.rs
@@ -151,6 +151,17 @@ impl<'a> Parser<'a> {
                     };
                     words.push(word);
                 }
+                Some(TokenKind::DoubleLeftBracket | TokenKind::DoubleRightBracket)
+                    if words
+                        .first()
+                        .and_then(|word| self.single_literal_word_text(word))
+                        .is_some() =>
+                {
+                    let span = self.current_span;
+                    let word = self.word_from_raw_text(span.slice(self.input), span);
+                    self.advance();
+                    words.push(word);
+                }
                 Some(TokenKind::DoubleRightBracket)
                     if words.first().is_some_and(|word| {
                         matches!(

--- a/crates/shuck-parser/src/parser/commands/simple.rs
+++ b/crates/shuck-parser/src/parser/commands/simple.rs
@@ -151,30 +151,14 @@ impl<'a> Parser<'a> {
                     };
                     words.push(word);
                 }
-                Some(TokenKind::DoubleLeftBracket | TokenKind::DoubleRightBracket)
-                    if words
-                        .first()
-                        .and_then(|word| self.single_literal_word_text(word))
-                        .is_some() =>
-                {
+                Some(TokenKind::DoubleLeftBracket) if !words.is_empty() => {
                     let span = self.current_span;
                     let word = self.word_from_raw_text(span.slice(self.input), span);
                     self.advance();
                     words.push(word);
                 }
                 Some(TokenKind::DoubleRightBracket)
-                    if words.first().is_some_and(|word| {
-                        matches!(
-                            word.parts.as_slice(),
-                            [WordPartNode {
-                                kind: WordPart::ArithmeticExpansion {
-                                    syntax: ArithmeticExpansionSyntax::DollarParenParen,
-                                    ..
-                                },
-                                ..
-                            }]
-                        )
-                    }) =>
+                    if self.should_consume_double_right_bracket_as_literal_argument(&words) =>
                 {
                     let span = self.current_span;
                     let word = self.word_from_raw_text(span.slice(self.input), span);
@@ -366,5 +350,25 @@ impl<'a> Parser<'a> {
         };
         words.pop();
         (Some(fd_var), Some(fd_var_span))
+    }
+
+    fn should_consume_double_right_bracket_as_literal_argument(&self, words: &[Word]) -> bool {
+        words
+            .first()
+            .and_then(|word| self.single_literal_word_text(word))
+            .is_some()
+            || words.iter().any(|word| word.span.slice(self.input) == "[[")
+            || words.first().is_some_and(|word| {
+                matches!(
+                    word.parts.as_slice(),
+                    [WordPartNode {
+                        kind: WordPart::ArithmeticExpansion {
+                            syntax: ArithmeticExpansionSyntax::DollarParenParen,
+                            ..
+                        },
+                        ..
+                    }]
+                )
+            })
     }
 }

--- a/crates/shuck-parser/src/parser/commands/simple.rs
+++ b/crates/shuck-parser/src/parser/commands/simple.rs
@@ -159,7 +159,7 @@ impl<'a> Parser<'a> {
                     self.advance();
                     words.push(word);
                 }
-                Some(TokenKind::DoubleRightBracket) if !words.is_empty() => {
+                Some(TokenKind::DoubleRightBracket) if has_simple_command_prefix => {
                     let span = self.current_span;
                     let word = self.word_from_raw_text(span.slice(self.input), span);
                     self.advance();

--- a/crates/shuck-parser/src/parser/commands/simple.rs
+++ b/crates/shuck-parser/src/parser/commands/simple.rs
@@ -76,6 +76,8 @@ impl<'a> Parser<'a> {
             let right_brace_is_literal_argument = self.at(TokenKind::RightBrace)
                 && !words.is_empty()
                 && self.should_consume_right_brace_as_literal_argument(next_kind_after_right_brace);
+            let has_simple_command_prefix =
+                !words.is_empty() || !assignments.is_empty() || !redirects.is_empty();
             match self.current_token_kind {
                 Some(kind) if kind.is_word_like() => {
                     // Bail out before touching word text when the token is a
@@ -151,7 +153,7 @@ impl<'a> Parser<'a> {
                     };
                     words.push(word);
                 }
-                Some(TokenKind::DoubleLeftBracket) if !words.is_empty() => {
+                Some(TokenKind::DoubleLeftBracket) if has_simple_command_prefix => {
                     let span = self.current_span;
                     let word = self.word_from_raw_text(span.slice(self.input), span);
                     self.advance();

--- a/crates/shuck-parser/src/parser/lexer/quotes.rs
+++ b/crates/shuck-parser/src/parser/lexer/quotes.rs
@@ -429,7 +429,8 @@ impl<'a> Lexer<'a> {
                     } else if self.peek_char() == Some('{') {
                         Self::push_capture_char(&mut content, '{');
                         self.advance();
-                        borrowable &= self.read_param_expansion_into(&mut content, content_start);
+                        borrowable &=
+                            self.read_param_expansion_into(&mut content, content_start, true);
                     }
                     content_end = self.current_position();
                 }

--- a/crates/shuck-parser/src/parser/lexer/substitutions.rs
+++ b/crates/shuck-parser/src/parser/lexer/substitutions.rs
@@ -189,7 +189,7 @@ impl<'a> Lexer<'a> {
                     } else if self.peek_char() == Some('{') {
                         Self::push_capture_char(content, '{');
                         self.advance();
-                        if !self.read_param_expansion_into(content, segment_start) {
+                        if !self.read_param_expansion_into(content, segment_start, false) {
                             return false;
                         }
                     } else if self.peek_char() == Some('[') {
@@ -752,6 +752,7 @@ impl<'a> Lexer<'a> {
         &mut self,
         content: &mut Option<String>,
         segment_start: Position,
+        preserve_escape_width: bool,
     ) -> bool {
         let mut borrowable = true;
         let mut depth = 1;
@@ -848,7 +849,14 @@ impl<'a> Lexer<'a> {
                                     segment_start,
                                     escape_start,
                                 );
-                                Self::push_capture_char(content, esc);
+                                if preserve_escape_width {
+                                    if let Some(text) = content.as_mut() {
+                                        text.push('\x00');
+                                        text.push(esc);
+                                    }
+                                } else {
+                                    Self::push_capture_char(content, esc);
+                                }
                                 self.advance();
                             }
                             '}' => {
@@ -884,7 +892,11 @@ impl<'a> Lexer<'a> {
                     } else if self.peek_char() == Some('{') {
                         Self::push_capture_char(content, '{');
                         self.advance();
-                        borrowable &= self.read_param_expansion_into(content, segment_start);
+                        borrowable &= self.read_param_expansion_into(
+                            content,
+                            segment_start,
+                            preserve_escape_width,
+                        );
                     }
                 }
                 _ => {

--- a/crates/shuck-parser/src/parser/lexer/word.rs
+++ b/crates/shuck-parser/src/parser/lexer/word.rs
@@ -253,7 +253,7 @@ impl<'a> Lexer<'a> {
                     // doesn't stop at the inner }.
                     Self::push_capture_char(&mut word, '{');
                     self.advance();
-                    let _ = self.read_param_expansion_into(&mut word, start);
+                    let _ = self.read_param_expansion_into(&mut word, start, false);
                 } else {
                     // Check for special single-character variables ($?, $#, $@, $*, $!, $$, $-, $0-$9)
                     if let Some(c) = self.peek_char() {

--- a/crates/shuck-parser/src/parser/tests/commands/conditionals.rs
+++ b/crates/shuck-parser/src/parser/tests/commands/conditionals.rs
@@ -148,6 +148,23 @@ fn test_parse_conditional_accepts_adjacent_group_closes_after_rhs_words() {
 }
 
 #[test]
+fn test_parse_conditional_stops_quoted_rhs_before_adjacent_group_closes() {
+    for input in ["[[ (( x == \"foo\" )) ]]\n", "[[ (( x =~ \"foo\" )) ]]\n"] {
+        let script = Parser::new(input).parse().unwrap().file;
+
+        let (compound, _) = expect_compound(&script.body[0]);
+        let AstCompoundCommand::Conditional(command) = compound else {
+            panic!("expected conditional compound command for {input}");
+        };
+
+        assert!(matches!(
+            command.expression,
+            ConditionalExpr::Parenthesized(_)
+        ));
+    }
+}
+
+#[test]
 fn test_parse_conditional_pattern_rhs_preserves_structure() {
     let input = "[[ foo == @(bar|baz)* ]]\n";
     let script = Parser::new(input).parse().unwrap().file;

--- a/crates/shuck-parser/src/parser/tests/commands/conditionals.rs
+++ b/crates/shuck-parser/src/parser/tests/commands/conditionals.rs
@@ -128,6 +128,26 @@ fn test_parse_conditional_accepts_nested_grouping_with_double_parens() {
 }
 
 #[test]
+fn test_parse_conditional_accepts_adjacent_group_closes_after_rhs_words() {
+    let input = "[[ -n $brew_prefix && (($brew_prefix != \"/usr\" && $brew_prefix != \"/usr/local\") || (is_mac && osx_using_default_compiler && $CFLAGS =~ (^|\\ )-isysroot\\ )) ]]\n";
+    let script = Parser::new(input).parse().unwrap().file;
+
+    let (compound, _) = expect_compound(&script.body[0]);
+    let AstCompoundCommand::Conditional(command) = compound else {
+        panic!("expected conditional compound command");
+    };
+
+    let ConditionalExpr::Binary(binary) = &command.expression else {
+        panic!("expected binary conditional");
+    };
+    assert_eq!(binary.op, ConditionalBinaryOp::And);
+    assert!(matches!(
+        binary.right.as_ref(),
+        ConditionalExpr::Parenthesized(_)
+    ));
+}
+
+#[test]
 fn test_parse_conditional_pattern_rhs_preserves_structure() {
     let input = "[[ foo == @(bar|baz)* ]]\n";
     let script = Parser::new(input).parse().unwrap().file;

--- a/crates/shuck-parser/src/parser/tests/commands/simple.rs
+++ b/crates/shuck-parser/src/parser/tests/commands/simple.rs
@@ -89,6 +89,10 @@ fn test_simple_command_treats_conditional_brackets_as_arguments_after_name() {
         ),
         ("\"eval\" [[ 1 ]]", vec!["eval", "[[", "1", "]]"]),
         ("${cmd} [[ 1 ]]", vec!["${cmd}", "[[", "1", "]]"]),
+        (
+            "$dbracket foo == foo ]]",
+            vec!["$dbracket", "foo", "==", "foo", "]]"],
+        ),
     ];
 
     for (input, expected_words) in cases {
@@ -110,11 +114,25 @@ fn test_simple_command_treats_conditional_brackets_as_arguments_after_name() {
 }
 
 #[test]
-fn test_runtime_constructed_conditional_open_does_not_enable_close_token() {
+fn test_runtime_constructed_conditional_open_keeps_close_as_argument() {
     let input = "dbracket=[[\n$dbracket foo == foo ]]";
-    let parsed = Parser::new(input).parse();
+    let parsed = Parser::new(input).parse().unwrap();
 
-    assert!(parsed.is_err());
+    assert_eq!(parsed.status, ParseStatus::Clean);
+    assert_eq!(parsed.file.body.len(), 2);
+    let AstCommand::Simple(command) = &parsed.file.body[1].command else {
+        panic!("expected simple command");
+    };
+
+    assert_eq!(command.name.render(input), "$dbracket");
+    assert_eq!(
+        command
+            .args
+            .iter()
+            .map(|arg| arg.render(input))
+            .collect::<Vec<_>>(),
+        vec!["foo", "==", "foo", "]]"]
+    );
 }
 
 #[test]

--- a/crates/shuck-parser/src/parser/tests/commands/simple.rs
+++ b/crates/shuck-parser/src/parser/tests/commands/simple.rs
@@ -81,6 +81,36 @@ fn test_parse_multiple_args() {
 }
 
 #[test]
+fn test_simple_command_treats_conditional_brackets_as_arguments_after_name() {
+    let input = "eval ! [[ \"$env_var\" =~ ^[[:digit:]]+$ ]]";
+    let parsed = Parser::new(input).parse().unwrap();
+
+    assert_eq!(parsed.status, ParseStatus::Clean);
+    assert_eq!(parsed.file.body.len(), 1);
+    let AstCommand::Simple(command) = &parsed.file.body[0].command else {
+        panic!("expected simple command");
+    };
+
+    assert_eq!(command.name.render(input), "eval");
+    assert_eq!(
+        command
+            .args
+            .iter()
+            .map(|arg| arg.render(input))
+            .collect::<Vec<_>>(),
+        vec!["!", "[[", "$env_var", "=~", "^[[:digit:]]+$", "]]"]
+    );
+}
+
+#[test]
+fn test_dynamic_command_name_does_not_consume_conditional_close() {
+    let input = "dbracket=[[\n$dbracket foo == foo ]]";
+    let parsed = Parser::new(input).parse();
+
+    assert!(parsed.is_err());
+}
+
+#[test]
 fn test_simple_command_allows_nft_brace_literals_inside_and_block() {
     let input = "\
 start_nftables() {

--- a/crates/shuck-parser/src/parser/tests/commands/simple.rs
+++ b/crates/shuck-parser/src/parser/tests/commands/simple.rs
@@ -82,28 +82,35 @@ fn test_parse_multiple_args() {
 
 #[test]
 fn test_simple_command_treats_conditional_brackets_as_arguments_after_name() {
-    let input = "eval ! [[ \"$env_var\" =~ ^[[:digit:]]+$ ]]";
-    let parsed = Parser::new(input).parse().unwrap();
+    let cases = [
+        (
+            "eval ! [[ \"$env_var\" =~ ^[[:digit:]]+$ ]]",
+            vec!["eval", "!", "[[", "$env_var", "=~", "^[[:digit:]]+$", "]]"],
+        ),
+        ("\"eval\" [[ 1 ]]", vec!["eval", "[[", "1", "]]"]),
+        ("${cmd} [[ 1 ]]", vec!["${cmd}", "[[", "1", "]]"]),
+    ];
 
-    assert_eq!(parsed.status, ParseStatus::Clean);
-    assert_eq!(parsed.file.body.len(), 1);
-    let AstCommand::Simple(command) = &parsed.file.body[0].command else {
-        panic!("expected simple command");
-    };
+    for (input, expected_words) in cases {
+        let parsed = Parser::new(input).parse().unwrap();
 
-    assert_eq!(command.name.render(input), "eval");
-    assert_eq!(
-        command
-            .args
-            .iter()
+        assert_eq!(parsed.status, ParseStatus::Clean, "{input}");
+        assert_eq!(parsed.file.body.len(), 1, "{input}");
+        let AstCommand::Simple(command) = &parsed.file.body[0].command else {
+            panic!("expected simple command for {input}");
+        };
+
+        let words = std::iter::once(&command.name)
+            .chain(command.args.iter())
             .map(|arg| arg.render(input))
-            .collect::<Vec<_>>(),
-        vec!["!", "[[", "$env_var", "=~", "^[[:digit:]]+$", "]]"]
-    );
+            .collect::<Vec<_>>();
+
+        assert_eq!(words, expected_words, "{input}");
+    }
 }
 
 #[test]
-fn test_dynamic_command_name_does_not_consume_conditional_close() {
+fn test_runtime_constructed_conditional_open_does_not_enable_close_token() {
     let input = "dbracket=[[\n$dbracket foo == foo ]]";
     let parsed = Parser::new(input).parse();
 

--- a/crates/shuck-parser/src/parser/tests/commands/simple.rs
+++ b/crates/shuck-parser/src/parser/tests/commands/simple.rs
@@ -136,6 +136,35 @@ fn test_runtime_constructed_conditional_open_keeps_close_as_argument() {
 }
 
 #[test]
+fn test_simple_command_treats_conditional_open_as_name_after_prefixes() {
+    let cases = [("VAR=1 [[ 1 ]]", 1, 0), (">out [[ 1 ]]", 0, 1)];
+
+    for (input, expected_assignments, expected_redirects) in cases {
+        let parsed = Parser::new(input).parse().unwrap();
+
+        assert_eq!(parsed.status, ParseStatus::Clean, "{input}");
+        assert_eq!(parsed.file.body.len(), 1, "{input}");
+        let stmt = &parsed.file.body[0];
+        let AstCommand::Simple(command) = &stmt.command else {
+            panic!("expected simple command for {input}");
+        };
+
+        assert_eq!(command.assignments.len(), expected_assignments, "{input}");
+        assert_eq!(stmt.redirects.len(), expected_redirects, "{input}");
+        assert_eq!(command.name.render(input), "[[", "{input}");
+        assert_eq!(
+            command
+                .args
+                .iter()
+                .map(|arg| arg.render(input))
+                .collect::<Vec<_>>(),
+            vec!["1", "]]"],
+            "{input}"
+        );
+    }
+}
+
+#[test]
 fn test_simple_command_allows_nft_brace_literals_inside_and_block() {
     let input = "\
 start_nftables() {

--- a/crates/shuck-parser/src/parser/tests/commands/simple.rs
+++ b/crates/shuck-parser/src/parser/tests/commands/simple.rs
@@ -137,9 +137,14 @@ fn test_runtime_constructed_conditional_open_keeps_close_as_argument() {
 
 #[test]
 fn test_simple_command_treats_conditional_open_as_name_after_prefixes() {
-    let cases = [("VAR=1 [[ 1 ]]", 1, 0), (">out [[ 1 ]]", 0, 1)];
+    let cases = [
+        ("VAR=1 [[ 1 ]]", "[[", vec!["1", "]]"], 1, 0),
+        (">out [[ 1 ]]", "[[", vec!["1", "]]"], 0, 1),
+        ("VAR=1 ]]", "]]", Vec::new(), 1, 0),
+        (">out ]]", "]]", Vec::new(), 0, 1),
+    ];
 
-    for (input, expected_assignments, expected_redirects) in cases {
+    for (input, expected_name, expected_args, expected_assignments, expected_redirects) in cases {
         let parsed = Parser::new(input).parse().unwrap();
 
         assert_eq!(parsed.status, ParseStatus::Clean, "{input}");
@@ -151,14 +156,14 @@ fn test_simple_command_treats_conditional_open_as_name_after_prefixes() {
 
         assert_eq!(command.assignments.len(), expected_assignments, "{input}");
         assert_eq!(stmt.redirects.len(), expected_redirects, "{input}");
-        assert_eq!(command.name.render(input), "[[", "{input}");
+        assert_eq!(command.name.render(input), expected_name, "{input}");
         assert_eq!(
             command
                 .args
                 .iter()
                 .map(|arg| arg.render(input))
                 .collect::<Vec<_>>(),
-            vec!["1", "]]"],
+            expected_args,
             "{input}"
         );
     }

--- a/crates/shuck-parser/src/parser/tests/words/assignments.rs
+++ b/crates/shuck-parser/src/parser/tests/words/assignments.rs
@@ -647,6 +647,53 @@ fn test_assignment_replacement_expansion_span_keeps_escaped_backslashes() {
 }
 
 #[test]
+fn test_quoted_assignment_replacement_expansion_span_keeps_escaped_quotes() {
+    let input = r#"query="${query//\"/\\\"}""#;
+    assert_eq!(
+        Parser::scan_array_parameter_expansion_len(r#"query//\"/\\\"}""#),
+        Some(r#"query//\"/\\\"}"#.len())
+    );
+    let script = Parser::new(input).parse().unwrap().file;
+
+    let AstCommand::Simple(command) = &script.body[0].command else {
+        panic!("expected simple command");
+    };
+    let AssignmentValue::Scalar(word) = &command.assignments[0].value else {
+        panic!("expected scalar assignment");
+    };
+    let WordPart::DoubleQuoted { parts, .. } = &word.parts[0].kind else {
+        panic!("expected double quoted value");
+    };
+
+    assert_eq!(parts[0].span.slice(input), r#"${query//\"/\\\"}"#);
+    let (_, operator, _) = expect_parameter_operation_part(&parts[0].kind);
+    assert!(matches!(operator, ParameterOp::ReplaceAll { .. }));
+}
+
+#[test]
+fn test_quoted_assignment_replacement_expansion_span_keeps_escaped_slashes() {
+    let input = r#"url_path="${url_path//https:\\/\\/api.openai.com\/v1}""#;
+    let script = Parser::new(input).parse().unwrap().file;
+
+    let AstCommand::Simple(command) = &script.body[0].command else {
+        panic!("expected simple command");
+    };
+    let AssignmentValue::Scalar(word) = &command.assignments[0].value else {
+        panic!("expected scalar assignment");
+    };
+    let WordPart::DoubleQuoted { parts, .. } = &word.parts[0].kind else {
+        panic!("expected double quoted value");
+    };
+
+    assert_eq!(
+        parts[0].span.slice(input),
+        r#"${url_path//https:\\/\\/api.openai.com\/v1}"#
+    );
+    let (_, operator, _) = expect_parameter_operation_part(&parts[0].kind);
+    assert!(matches!(operator, ParameterOp::ReplaceAll { .. }));
+}
+
+#[test]
 fn test_parse_arithmetic_command_distinguishes_assignment_from_comparison() {
     let input = "(( a = b == c ))\n";
     let script = Parser::new(input).parse().unwrap().file;

--- a/crates/shuck-parser/tests/testdata/oils_expectations.json
+++ b/crates/shuck-parser/tests/testdata/oils_expectations.json
@@ -84,8 +84,8 @@
     "reason": "corpus case intentionally exercises a shell parse error"
   },
   "oils/dbracket.test.sh::[[ at runtime doesn't work": {
-    "expectation": "parse_err",
-    "reason": "corpus case intentionally exercises a shell parse error"
+    "expectation": "parse_ok",
+    "reason": "the shell parses this as a simple command and reports command-not-found at runtime"
   },
   "oils/dbracket.test.sh::[[ with op variable (compare with test-builtin.test.sh)": {
     "expectation": "parse_err",


### PR DESCRIPTION
## Summary
- preserve source spans for escaped replacement text inside quoted parameter expansions
- treat literal `[[` / `]]` tokens as simple-command arguments after a command name
- stop conditional source-word scans at adjacent `)` / `))` group closes when parsing nested conditional groups

## Validation
- `cargo fmt --check`
- `cargo test -p shuck-parser`
- `cargo test -p shuck-formatter --test oracle_shfmt --no-run`
- `git diff --check`

## Parser Criterion
Baseline: `env CARGO_TARGET_DIR=/private/tmp/shuck-parser-bench.HeBJnn/target cargo bench -p shuck-benchmark --bench parser -- --save-baseline=main --noplot`

Comparison: `env CARGO_TARGET_DIR=/private/tmp/shuck-parser-bench.HeBJnn/target cargo bench -p shuck-benchmark --bench parser -- --baseline=main --noplot`

Result: no broad parser regression detected. The full run marked `parser/all` as no change (-0.18% mean). A full-run `pyenv-python-build` sample initially flagged +3.63%, but an immediate targeted rerun for that fixture reported no change (-0.33% mean, p = 0.56).

## Edge Snippet Check
The benchmark corpus already covers the adjacent conditional-close shape via `pyenv-python-build`. I used a temporary out-of-tree parser timing harness for the two shapes not present in the corpus. It confirmed clean parsing for all three cases on this branch. The quoted-replacement snippet is a tiny concentrated case and measures slower locally, but the regular parser corpus stayed flat.