### PR TITLE
fix(parser): preserve command substitution spans

### DIFF
--- a/crates/shuck-parser/src/parser/lexer/substitutions.rs
+++ b/crates/shuck-parser/src/parser/lexer/substitutions.rs
@@ -850,13 +850,9 @@ impl<'a> Lexer<'a> {
                                     escape_start,
                                 );
                                 if preserve_escape_width {
-                                    if let Some(text) = content.as_mut() {
-                                        text.push('\x00');
-                                        text.push(esc);
-                                    }
-                                } else {
-                                    Self::push_capture_char(content, esc);
+                                    Self::push_capture_char(content, '\x00');
                                 }
+                                Self::push_capture_char(content, esc);
                                 self.advance();
                             }
                             '}' => {

--- a/crates/shuck-parser/src/parser/source_tree.rs
+++ b/crates/shuck-parser/src/parser/source_tree.rs
@@ -320,6 +320,7 @@ impl<'a> Parser<'a> {
                 command.span = command.span.rebased(base);
                 for target in &mut command.targets {
                     target.span = target.span.rebased(base);
+                    Self::rebase_word(&mut target.word, base);
                 }
                 if let Some(words) = &mut command.words {
                     Self::rebase_words(words, base);

--- a/crates/shuck-parser/src/parser/tests/words/expansions.rs
+++ b/crates/shuck-parser/src/parser/tests/words/expansions.rs
@@ -320,6 +320,39 @@ fn test_parse_command_substitution_with_piped_tr_after_quoted_variable_keeps_nes
 }
 
 #[test]
+fn test_command_substitution_rebases_for_target_word() {
+    let input = r#"echo "$(for i in 1; do echo "$i"; done)""#;
+    let script = Parser::new(input).parse().unwrap().file;
+    let command = expect_simple(&script.body[0]);
+    let word = &command.args[0];
+
+    let [
+        WordPartNode {
+            kind: WordPart::DoubleQuoted { parts, .. },
+            ..
+        },
+    ] = word.parts.as_slice()
+    else {
+        panic!("expected double-quoted argument");
+    };
+    let body = parts
+        .iter()
+        .find_map(|part| match &part.kind {
+            WordPart::CommandSubstitution { body, .. } => Some(body),
+            _ => None,
+        })
+        .expect("expected command substitution");
+    let (compound, _) = expect_compound(&body[0]);
+    let AstCompoundCommand::For(command) = compound else {
+        panic!("expected for loop in command substitution");
+    };
+
+    assert_eq!(command.targets[0].name.as_deref(), Some("i"));
+    assert_eq!(command.targets[0].word.render_syntax(input), "i");
+    assert_eq!(command.targets[0].span.slice(input), "i");
+}
+
+#[test]
 fn test_parse_positional_parameters() {
     let parser = Parser::new("echo $@ $*");
     let script = parser.parse().unwrap().file;


### PR DESCRIPTION
## Summary
- rebase for-loop target words inside command substitutions so formatter output keeps the original target text
- keep escaped replacement spans source-backed while preserving escape-width padding
- add parser regression coverage for command substitution for-loop target spans

## Validation
- cargo test -p shuck-parser