### PR TITLE
perf(formatter): parallelize file formatting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1873,6 +1873,7 @@ dependencies = [
 name = "shuck-formatter"
 version = "0.0.40"
 dependencies = [
+ "rayon",
  "shuck-ast",
  "shuck-format",
  "shuck-linter",

--- a/crates/shuck-cli/src/commands/format.rs
+++ b/crates/shuck-cli/src/commands/format.rs
@@ -198,13 +198,22 @@ fn run_format_with_cwd(
             Ok(())
         })?;
 
-        let results = pending
-            .into_par_iter()
-            .map(|pending| format_pending_file(pending, &settings, mode))
-            .collect::<Vec<_>>();
+        let batch_size = pending_format_batch_size();
+        let mut pending = pending.into_iter();
+        loop {
+            let batch = pending.by_ref().take(batch_size).collect::<Vec<_>>();
+            if batch.is_empty() {
+                break;
+            }
 
-        for result in results {
-            handle_format_outcome(result?, &mut run.cache, &mut report)?;
+            let results = batch
+                .into_par_iter()
+                .map(|pending| format_pending_file(pending, &settings, mode))
+                .collect::<Vec<_>>();
+
+            for result in results {
+                handle_format_outcome(result?, &mut run.cache, &mut report)?;
+            }
         }
 
         run.persist_cache()?;
@@ -219,6 +228,10 @@ fn run_format_with_cwd(
     });
 
     Ok(report)
+}
+
+fn pending_format_batch_size() -> usize {
+    rayon::current_num_threads().max(1)
 }
 
 fn format_pending_file(

--- a/crates/shuck-cli/src/commands/format.rs
+++ b/crates/shuck-cli/src/commands/format.rs
@@ -3,6 +3,7 @@ use std::io::{self, BufWriter, Write};
 use std::path::{Path, PathBuf};
 
 use anyhow::{Result, anyhow};
+use rayon::prelude::*;
 use serde::{Deserialize, Serialize};
 use shuck_cache::{FileCacheKey, PackageCache};
 use shuck_config::ConfigArguments;
@@ -84,6 +85,16 @@ struct ParseCacheFailure {
     column: usize,
 }
 
+#[derive(Debug)]
+struct PendingFormatOutcome {
+    relative_path: PathBuf,
+    cached_key: FileCacheKey,
+    cached_result: Option<FormatCacheData>,
+    error: Option<DisplayedFormatError>,
+    changed_path: Option<PathBuf>,
+    diff: Option<String>,
+}
+
 pub(crate) fn format(
     args: FormatCommand,
     config_arguments: &ConfigArguments,
@@ -150,7 +161,7 @@ fn run_format_with_cwd(
         extend_exclude_patterns: args.file_selection.extend_exclude.clone(),
         respect_gitignore: args.respect_gitignore(),
         force_exclude: args.force_exclude(),
-        parallel: false,
+        parallel: true,
         cache_root: Some(cache_root.to_path_buf()),
         use_config_roots: config_arguments.use_config_roots(),
     };
@@ -187,8 +198,13 @@ fn run_format_with_cwd(
             Ok(())
         })?;
 
-        for pending in pending {
-            handle_pending_file(pending, &settings, mode, &mut run.cache, &mut report)?;
+        let results = pending
+            .into_par_iter()
+            .map(|pending| format_pending_file(pending, &settings, mode))
+            .collect::<Vec<_>>();
+
+        for result in results {
+            handle_format_outcome(result?, &mut run.cache, &mut report)?;
         }
 
         run.persist_cache()?;
@@ -205,100 +221,116 @@ fn run_format_with_cwd(
     Ok(report)
 }
 
-fn handle_pending_file(
+fn format_pending_file(
     pending: PendingProjectFile,
     settings: &ShellFormatOptions,
     mode: FormatMode,
-    cache: &mut Option<PackageCache<FormatCacheData>>,
-    report: &mut FormatReport,
-) -> Result<()> {
+) -> Result<PendingFormatOutcome> {
     let PendingProjectFile { file, file_key } = pending;
     let source = fs::read_to_string(&file.absolute_path)?;
-    let (cached_result, cached_key) = if matches!(mode, FormatMode::Check) {
+
+    let mut outcome = PendingFormatOutcome {
+        relative_path: file.relative_path,
+        cached_key: file_key.clone(),
+        cached_result: None,
+        error: None,
+        changed_path: None,
+        diff: None,
+    };
+
+    if matches!(mode, FormatMode::Check) {
         match source_is_formatted(&source, Some(&file.absolute_path), settings) {
-            Ok(true) => (Some(FormatCacheData::Unchanged), file_key.clone()),
+            Ok(true) => {
+                outcome.cached_result = Some(FormatCacheData::Unchanged);
+            }
             Ok(false) => {
-                report.changed_files.push(file.display_path.clone());
-                (None, file_key.clone())
+                outcome.changed_path = Some(file.display_path);
             }
             Err(FormatError::Parse {
                 message,
                 line,
                 column,
             }) => {
-                report.errors.push(DisplayedFormatError {
+                outcome.error = Some(DisplayedFormatError {
                     path: file.display_path.clone(),
                     line,
                     column,
                     message: message.clone(),
                 });
 
-                (
-                    Some(FormatCacheData::ParseError(ParseCacheFailure {
-                        message,
-                        line,
-                        column,
-                    })),
-                    file_key.clone(),
-                )
+                outcome.cached_result = Some(FormatCacheData::ParseError(ParseCacheFailure {
+                    message,
+                    line,
+                    column,
+                }));
             }
             Err(FormatError::Internal(message)) => return Err(anyhow!(message)),
         }
     } else {
         match format_source(&source, Some(&file.absolute_path), settings) {
-            Ok(FormattedSource::Unchanged) => (Some(FormatCacheData::Unchanged), file_key.clone()),
+            Ok(FormattedSource::Unchanged) => {
+                outcome.cached_result = Some(FormatCacheData::Unchanged);
+            }
             Ok(FormattedSource::Formatted(formatted)) => {
-                report.changed_files.push(file.display_path.clone());
+                outcome.changed_path = Some(file.display_path.clone());
                 match mode {
                     FormatMode::Write => fs::write(&file.absolute_path, formatted.as_bytes())?,
                     FormatMode::Check => {}
                     FormatMode::Diff => {
-                        let mut stdout = io::stdout().lock();
-                        write!(
-                            &mut stdout,
-                            "{}",
-                            unified_diff(&file.display_path, &source, &formatted)
-                        )?;
+                        outcome.diff = Some(unified_diff(&file.display_path, &source, &formatted));
                     }
                 }
 
-                let cache_key = if mode.is_write() {
-                    FileCacheKey::from_path(&file.absolute_path)?
-                } else {
-                    file_key.clone()
-                };
-                let cache_result = mode.is_write().then_some(FormatCacheData::Unchanged);
-                (cache_result, cache_key)
+                if mode.is_write() {
+                    outcome.cached_key = FileCacheKey::from_path(&file.absolute_path)?;
+                    outcome.cached_result = Some(FormatCacheData::Unchanged);
+                }
             }
             Err(FormatError::Parse {
                 message,
                 line,
                 column,
             }) => {
-                report.errors.push(DisplayedFormatError {
+                outcome.error = Some(DisplayedFormatError {
                     path: file.display_path.clone(),
                     line,
                     column,
                     message: message.clone(),
                 });
 
-                (
-                    Some(FormatCacheData::ParseError(ParseCacheFailure {
-                        message,
-                        line,
-                        column,
-                    })),
-                    file_key.clone(),
-                )
+                outcome.cached_result = Some(FormatCacheData::ParseError(ParseCacheFailure {
+                    message,
+                    line,
+                    column,
+                }));
             }
             Err(FormatError::Internal(message)) => return Err(anyhow!(message)),
         }
     };
 
+    Ok(outcome)
+}
+
+fn handle_format_outcome(
+    outcome: PendingFormatOutcome,
+    cache: &mut Option<PackageCache<FormatCacheData>>,
+    report: &mut FormatReport,
+) -> Result<()> {
+    if let Some(error) = outcome.error {
+        report.errors.push(error);
+    }
+    if let Some(path) = outcome.changed_path {
+        report.changed_files.push(path);
+    }
+    if let Some(diff) = outcome.diff {
+        let mut stdout = io::stdout().lock();
+        write!(&mut stdout, "{diff}")?;
+    }
+
     if let Some(cache) = cache.as_mut()
-        && let Some(cached_result) = cached_result
+        && let Some(cached_result) = outcome.cached_result
     {
-        cache.insert(file.relative_path, cached_key, cached_result);
+        cache.insert(outcome.relative_path, outcome.cached_key, cached_result);
     }
     report.cache_misses += 1;
     Ok(())

--- a/crates/shuck-formatter/Cargo.toml
+++ b/crates/shuck-formatter/Cargo.toml
@@ -20,5 +20,6 @@ shuck-format = { workspace = true }
 shuck-parser = { workspace = true }
 
 [dev-dependencies]
+rayon = { workspace = true }
 shuck-linter = { workspace = true }
 similar = { workspace = true }

--- a/crates/shuck-formatter/tests/oracle_shfmt.rs
+++ b/crates/shuck-formatter/tests/oracle_shfmt.rs
@@ -2,9 +2,11 @@ use std::fs;
 use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
 use std::process::{Child, Command, Output, Stdio};
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::thread;
 use std::time::{Duration, Instant};
 
+use rayon::prelude::*;
 use shuck_formatter::{FormattedSource, ShellDialect, ShellFormatOptions, format_file_ast};
 use shuck_parser::parser::Parser;
 use similar::TextDiff;
@@ -60,6 +62,35 @@ struct LargeCorpusFixture {
 struct FormatterOracleConfig {
     shfmt_language: &'static str,
     options: ShellFormatOptions,
+}
+
+#[derive(Debug)]
+struct LargeCorpusFixtureResult {
+    filename: String,
+    elapsed: Duration,
+    comparison: LargeCorpusComparison,
+}
+
+#[derive(Debug)]
+enum LargeCorpusComparison {
+    Matched,
+    Mismatch(String),
+    ShuckError(String),
+    ShfmtSkip,
+    UnsupportedDialect,
+    NonUtf8,
+}
+
+#[derive(Default)]
+struct LargeCorpusProgress {
+    processed: AtomicUsize,
+    compared: AtomicUsize,
+    matched: AtomicUsize,
+    mismatches: AtomicUsize,
+    shuck_errors: AtomicUsize,
+    shfmt_skips: AtomicUsize,
+    unsupported_dialects: AtomicUsize,
+    non_utf8: AtomicUsize,
 }
 
 #[test]
@@ -132,6 +163,21 @@ fn large_corpus_matches_shfmt() {
         "no large-corpus fixtures selected from {}",
         cfg.corpus_dir.join("scripts").display()
     );
+    eprintln!(
+        "large corpus shfmt oracle using Rayon: fixtures={} workers={}",
+        fixtures.len(),
+        rayon::current_num_threads()
+    );
+
+    let progress = LargeCorpusProgress::default();
+    let results = fixtures
+        .par_iter()
+        .map(|fixture| {
+            let result = compare_large_corpus_fixture(fixture);
+            progress.observe(&result, fixtures.len());
+            result
+        })
+        .collect::<Vec<_>>();
 
     let mut compared = 0usize;
     let mut matched = 0usize;
@@ -141,64 +187,31 @@ fn large_corpus_matches_shfmt() {
     let mut shuck_errors = Vec::new();
     let mut mismatches = Vec::new();
 
-    for (fixture_index, fixture) in fixtures.iter().enumerate() {
-        let fixture_started = Instant::now();
-        let filename = fixture.cache_rel_path.to_string_lossy();
-        let processed = fixture_index + 1;
-        if processed % LARGE_CORPUS_PROGRESS_INTERVAL == 0 {
-            eprintln!(
-                "large corpus shfmt oracle progress: processed={processed}/{} compared={compared} matched={matched} mismatches={} shuck_errors={} shfmt_skips={} unsupported_dialects={} non_utf8={}",
-                fixtures.len(),
-                mismatches.len(),
-                shuck_errors.len(),
-                shfmt_skips,
-                unsupported_dialects,
-                non_utf8,
-            );
-        }
-
-        let source = match fs::read_to_string(&fixture.path) {
-            Ok(source) => source,
-            Err(_) => {
-                non_utf8 += 1;
-                continue;
+    for result in results {
+        report_slow_large_corpus_fixture(&result.filename, result.elapsed);
+        match result.comparison {
+            LargeCorpusComparison::Matched => {
+                compared += 1;
+                matched += 1;
             }
-        };
-        let Some(format_config) = formatter_oracle_config(&source, &fixture.path) else {
-            unsupported_dialects += 1;
-            continue;
-        };
-
-        let shfmt = match try_run_shfmt(&source, &filename, format_config.shfmt_language) {
-            Ok(output) => output,
-            Err(_) => {
+            LargeCorpusComparison::Mismatch(mismatch) => {
+                compared += 1;
+                mismatches.push(mismatch);
+            }
+            LargeCorpusComparison::ShuckError(error) => {
+                compared += 1;
+                shuck_errors.push(error);
+            }
+            LargeCorpusComparison::ShfmtSkip => {
                 shfmt_skips += 1;
-                report_slow_large_corpus_fixture(&filename, fixture_started.elapsed());
-                continue;
             }
-        };
-        compared += 1;
-
-        let shuck = match try_run_shuck_formatter(&source, &filename, &format_config.options) {
-            Ok(FormattedSource::Unchanged) => source.clone(),
-            Ok(FormattedSource::Formatted(formatted)) => formatted,
-            Err(error) => {
-                shuck_errors.push(format!(
-                    "{}: {error}",
-                    fixture.cache_rel_path.to_string_lossy()
-                ));
-                report_slow_large_corpus_fixture(&filename, fixture_started.elapsed());
-                continue;
+            LargeCorpusComparison::UnsupportedDialect => {
+                unsupported_dialects += 1;
             }
-        };
-
-        if let Some(mismatch) = render_oracle_mismatch(&filename, &filename, &shfmt, &shuck) {
-            mismatches.push(mismatch);
-        } else {
-            matched += 1;
+            LargeCorpusComparison::NonUtf8 => {
+                non_utf8 += 1;
+            }
         }
-
-        report_slow_large_corpus_fixture(&filename, fixture_started.elapsed());
     }
 
     eprintln!(
@@ -221,6 +234,104 @@ fn large_corpus_matches_shfmt() {
         format_failure_list("shuck formatter errors", &shuck_errors),
         format_failure_list("formatter mismatches", &mismatches),
     );
+}
+
+impl LargeCorpusProgress {
+    fn observe(&self, result: &LargeCorpusFixtureResult, total: usize) {
+        match &result.comparison {
+            LargeCorpusComparison::Matched => {
+                self.compared.fetch_add(1, Ordering::Relaxed);
+                self.matched.fetch_add(1, Ordering::Relaxed);
+            }
+            LargeCorpusComparison::Mismatch(_) => {
+                self.compared.fetch_add(1, Ordering::Relaxed);
+                self.mismatches.fetch_add(1, Ordering::Relaxed);
+            }
+            LargeCorpusComparison::ShuckError(_) => {
+                self.compared.fetch_add(1, Ordering::Relaxed);
+                self.shuck_errors.fetch_add(1, Ordering::Relaxed);
+            }
+            LargeCorpusComparison::ShfmtSkip => {
+                self.shfmt_skips.fetch_add(1, Ordering::Relaxed);
+            }
+            LargeCorpusComparison::UnsupportedDialect => {
+                self.unsupported_dialects.fetch_add(1, Ordering::Relaxed);
+            }
+            LargeCorpusComparison::NonUtf8 => {
+                self.non_utf8.fetch_add(1, Ordering::Relaxed);
+            }
+        }
+
+        let processed = self.processed.fetch_add(1, Ordering::Relaxed) + 1;
+        if processed.is_multiple_of(LARGE_CORPUS_PROGRESS_INTERVAL) {
+            eprintln!(
+                "large corpus shfmt oracle progress: processed={processed}/{total} compared={} matched={} mismatches={} shuck_errors={} shfmt_skips={} unsupported_dialects={} non_utf8={}",
+                self.compared.load(Ordering::Relaxed),
+                self.matched.load(Ordering::Relaxed),
+                self.mismatches.load(Ordering::Relaxed),
+                self.shuck_errors.load(Ordering::Relaxed),
+                self.shfmt_skips.load(Ordering::Relaxed),
+                self.unsupported_dialects.load(Ordering::Relaxed),
+                self.non_utf8.load(Ordering::Relaxed),
+            );
+        }
+    }
+}
+
+fn compare_large_corpus_fixture(fixture: &LargeCorpusFixture) -> LargeCorpusFixtureResult {
+    let fixture_started = Instant::now();
+    let filename = fixture.cache_rel_path.to_string_lossy().into_owned();
+
+    let source = match fs::read_to_string(&fixture.path) {
+        Ok(source) => source,
+        Err(_) => {
+            return LargeCorpusFixtureResult {
+                filename,
+                elapsed: fixture_started.elapsed(),
+                comparison: LargeCorpusComparison::NonUtf8,
+            };
+        }
+    };
+    let Some(format_config) = formatter_oracle_config(&source, &fixture.path) else {
+        return LargeCorpusFixtureResult {
+            filename,
+            elapsed: fixture_started.elapsed(),
+            comparison: LargeCorpusComparison::UnsupportedDialect,
+        };
+    };
+
+    let shfmt = match try_run_shfmt(&source, &filename, format_config.shfmt_language) {
+        Ok(output) => output,
+        Err(_) => {
+            return LargeCorpusFixtureResult {
+                filename,
+                elapsed: fixture_started.elapsed(),
+                comparison: LargeCorpusComparison::ShfmtSkip,
+            };
+        }
+    };
+
+    let shuck = match try_run_shuck_formatter(&source, &filename, &format_config.options) {
+        Ok(FormattedSource::Unchanged) => source.clone(),
+        Ok(FormattedSource::Formatted(formatted)) => formatted,
+        Err(error) => {
+            return LargeCorpusFixtureResult {
+                filename: filename.clone(),
+                elapsed: fixture_started.elapsed(),
+                comparison: LargeCorpusComparison::ShuckError(format!("{filename}: {error}")),
+            };
+        }
+    };
+
+    let comparison = render_oracle_mismatch(&filename, &filename, &shfmt, &shuck)
+        .map(LargeCorpusComparison::Mismatch)
+        .unwrap_or(LargeCorpusComparison::Matched);
+
+    LargeCorpusFixtureResult {
+        filename,
+        elapsed: fixture_started.elapsed(),
+        comparison,
+    }
 }
 
 impl OracleCase {


### PR DESCRIPTION
## Summary

- Run `shuck format` file discovery and pending-file formatting through Rayon so independent files format in parallel.
- Keep cache writes, report aggregation, and diff output serialized after per-file work completes.
- Run the shfmt large-corpus oracle over selected fixtures with Rayon, including a worker-count line in the corpus output.

## Validation

- `cargo fmt --check`
- `cargo test -p shuck-cli format`
- `cargo test -p shuck-cli commands::format`
- `cargo test -p shuck-formatter`
- `cargo clippy -p shuck-cli -p shuck-formatter --all-targets -- -D warnings`

Also ran `make test-oracle-shfmt-large-corpus SHUCK_LARGE_CORPUS_SAMPLE_PERCENT=1` to exercise the parallel corpus path. It printed `fixtures=330 workers=18` and failed on the current shfmt conformance backlog with `33` mismatches and `0` shuck errors.