### PR TITLE
refactor(formatter): reuse indexer facts

### DIFF
--- a/crates/shuck-formatter/src/command.rs
+++ b/crates/shuck-formatter/src/command.rs
@@ -2,10 +2,10 @@ use crate::comments::SourceMap;
 use crate::facts::FormatterFacts;
 use crate::options::ResolvedShellFormatOptions;
 use crate::scan::{
-    branch_keyword_offset, close_suffix_comment_offsets, common_nonempty_shell_indent,
-    last_shell_keyword_start, last_uncommented_shell_keyword_before, leading_shell_indent,
-    matching_done_close_start, matching_if_close_start, normalized_close_keyword_span,
-    refine_common_indent, shell_comment_can_start, skip_escaped_or_quoted,
+    branch_keyword_offset, common_nonempty_shell_indent, last_shell_keyword_start,
+    last_uncommented_shell_keyword_before, leading_shell_indent, matching_done_close_start,
+    matching_if_close_start, normalized_close_keyword_span, refine_common_indent,
+    shell_comment_can_start, skip_escaped_or_quoted,
 };
 use crate::word::{
     matching_raw_command_substitution_close, normalize_raw_pipeline_continuations,
@@ -1337,11 +1337,8 @@ pub(crate) fn group_open_suffix<'a>(
     let source = source_map.source();
     let first = commands.first()?;
     let first_start = stmt_group_attachment_start_offset(first, source_map);
-    let open_offset = find_group_open_offset_before_stmt(source, first_start, open)?;
-    let line_end = source[open_offset..]
-        .find('\n')
-        .map(|offset| open_offset + offset)
-        .unwrap_or(source.len());
+    let open_offset = find_group_open_offset_before_stmt(source_map, first_start, open)?;
+    let (_, line_end) = source_map.line_bounds_for_offset(open_offset)?;
     let suffix_start = open_offset + open.len_utf8();
     let suffix = source.get(suffix_start..line_end)?;
     suffix
@@ -1359,7 +1356,7 @@ pub(crate) fn group_attachment_span(
     let source = source_map.source();
     let first = commands.first()?;
     let open_offset = find_group_open_offset_before_stmt(
-        source,
+        source_map,
         stmt_group_attachment_start_offset(first, source_map),
         open,
     )?;
@@ -1460,19 +1457,23 @@ fn find_group_open_offset_between(
 }
 
 fn find_group_open_offset_before_stmt(
-    source: &str,
+    source_map: &SourceMap<'_>,
     search_end: usize,
     open: char,
 ) -> Option<usize> {
+    let source = source_map.source();
     let mut line_end = search_end.min(source.len());
 
     loop {
-        let line_start = source[..line_end]
-            .rfind('\n')
-            .map(|offset| offset + 1)
-            .unwrap_or(0);
+        let lookup_offset = if line_end == 0 {
+            0
+        } else {
+            line_end.saturating_sub(usize::from(line_end == source.len()))
+        };
+        let (line_start, indexed_line_end) = source_map.line_bounds_for_offset(lookup_offset)?;
+        let search_line_end = line_end.min(indexed_line_end);
         if let Some(open_offset) =
-            find_group_open_offset_on_line(source, line_start, line_end, open)
+            find_group_open_offset_on_line(source, line_start, search_line_end, open)
         {
             return Some(open_offset);
         }
@@ -1480,7 +1481,7 @@ fn find_group_open_offset_before_stmt(
         if line_start == 0 {
             break;
         }
-        line_end = line_start - 1;
+        line_end = line_start.saturating_sub(1);
     }
 
     None
@@ -1991,11 +1992,8 @@ fn extend_compound_close_suffix_attachment_span(
     let Some(close_span) = stmt_compound_close_span(stmt, source, source_map) else {
         return span;
     };
-    if let Some((comment_start, comment_end)) = close_suffix_comment_offsets(source, close_span) {
-        merge_non_empty_span(
-            span,
-            source_map.span_for_offsets(comment_start, comment_end),
-        )
+    if let Some(comment) = source_map.suffix_comment_after_span(close_span) {
+        merge_non_empty_span(span, comment.span())
     } else {
         span
     }

--- a/crates/shuck-formatter/src/comments.rs
+++ b/crates/shuck-formatter/src/comments.rs
@@ -168,6 +168,28 @@ impl<'a> SourceMap<'a> {
     }
 
     #[must_use]
+    pub(crate) fn suffix_comment_after_span(&self, span: Span) -> Option<SourceComment<'a>> {
+        if span.start.line != span.end.line {
+            return None;
+        }
+        let start = span.end.offset.min(self.source.len());
+        let (_, line_end) = self.line_bounds_for_offset(start)?;
+        let comment_start = self.first_comment_between(start, line_end)?;
+        let prefix = self.source.get(start..comment_start)?;
+        if !prefix.chars().all(|ch| matches!(ch, ' ' | '\t')) {
+            return None;
+        }
+
+        let comment_end = self
+            .source
+            .get(comment_start..line_end)?
+            .trim_end_matches([' ', '\t', '\r'])
+            .len()
+            + comment_start;
+        self.source_comment_for_offsets(comment_start, comment_end)
+    }
+
+    #[must_use]
     pub fn contains_comment_between(&self, start: usize, end: usize) -> bool {
         contains_offset_in_range(&self.data.hash_offsets, start, end)
     }
@@ -197,7 +219,92 @@ impl<'a> SourceMap<'a> {
         self.data
             .line_index
             .line_start(self.line_number_for_offset(start) + 1)
-            .is_some_and(|offset| usize::from(offset) < end)
+            .is_some_and(|offset| usize::from(offset) <= end)
+    }
+
+    #[must_use]
+    pub(crate) fn operator_starts_or_ends_line(&self, operator_span: Span) -> bool {
+        let start = operator_span.start.offset;
+        let end = operator_span.end.offset;
+        if start >= end || end > self.source.len() {
+            return false;
+        }
+
+        let Some((line_start, _)) = self.line_bounds_for_offset(start) else {
+            return false;
+        };
+        let Some((_, line_end)) = self.line_bounds_for_offset(end.saturating_sub(1)) else {
+            return false;
+        };
+        let Some(before) = self.source.get(line_start..start) else {
+            return false;
+        };
+        let Some(after) = self.source.get(end..line_end) else {
+            return false;
+        };
+
+        (line_start > 0 && line_edge_is_blank_or_continuation(before))
+            || (line_end < self.source.len() && line_edge_is_blank_or_continuation(after))
+    }
+
+    #[must_use]
+    pub(crate) fn line_indent_before_offset(&self, offset: usize) -> Option<&'a str> {
+        let offset = offset.min(self.source.len());
+        let (line_start, _) = self.line_bounds_for_offset(offset)?;
+        let prefix = self.source.get(line_start..offset)?;
+        let indent_end = prefix
+            .char_indices()
+            .find(|(_, ch)| !matches!(ch, ' ' | '\t'))
+            .map_or(prefix.len(), |(index, _)| index);
+        prefix.get(..indent_end)
+    }
+
+    #[must_use]
+    pub(crate) fn has_blank_line_immediately_before_offset(&self, offset: usize) -> bool {
+        let offset = offset.min(self.source.len());
+        let Some((line_start, _)) = self.line_bounds_for_offset(offset) else {
+            return false;
+        };
+        let Some(current_prefix) = self.source.get(line_start..offset) else {
+            return false;
+        };
+        if !line_is_blank(current_prefix) {
+            return false;
+        }
+
+        let Some((previous_start, previous_end)) = self.previous_line_bounds(line_start) else {
+            return false;
+        };
+        self.source
+            .get(previous_start..previous_end)
+            .is_some_and(line_is_blank)
+    }
+
+    #[must_use]
+    pub(crate) fn line_bounds_for_offset(&self, offset: usize) -> Option<(usize, usize)> {
+        if self.source.is_empty() {
+            return None;
+        }
+        let line = self.line_number_for_offset(offset);
+        self.line_bounds(line)
+    }
+
+    #[must_use]
+    pub(crate) fn previous_line_bounds(&self, line_start: usize) -> Option<(usize, usize)> {
+        if line_start == 0 || self.source.is_empty() {
+            return None;
+        }
+        let line = self.line_number_for_offset(line_start.saturating_sub(1));
+        self.line_bounds(line)
+    }
+
+    #[must_use]
+    pub(crate) fn next_line_bounds(&self, line_end: usize) -> Option<(usize, usize)> {
+        let next_start = line_end
+            .checked_add(1)
+            .filter(|offset| *offset < self.source.len())?;
+        let line = self.line_number_for_offset(next_start);
+        self.line_bounds(line)
     }
 
     #[must_use]
@@ -227,6 +334,11 @@ impl<'a> SourceMap<'a> {
         })
     }
 
+    fn line_bounds(&self, line: usize) -> Option<(usize, usize)> {
+        let range = self.data.line_index.line_range(line, self.source)?;
+        Some((usize::from(range.start()), usize::from(range.end())))
+    }
+
     fn clamped_offset(&self, offset: usize) -> usize {
         if self.source.is_empty() {
             0
@@ -234,6 +346,15 @@ impl<'a> SourceMap<'a> {
             offset.min(self.source.len().saturating_sub(1))
         }
     }
+}
+
+fn line_edge_is_blank_or_continuation(text: &str) -> bool {
+    let trimmed = text.trim_matches(|ch| matches!(ch, ' ' | '\t' | '\r'));
+    trimmed.is_empty() || trimmed == "\\"
+}
+
+fn line_is_blank(text: &str) -> bool {
+    text.trim_matches([' ', '\t', '\r']).is_empty()
 }
 
 fn slice_has_alignment_padding(slice: &str) -> bool {

--- a/crates/shuck-formatter/src/facts.rs
+++ b/crates/shuck-formatter/src/facts.rs
@@ -1,15 +1,16 @@
 use std::collections::{HashMap, HashSet};
 
-use shuck_ast::TextSize;
 use shuck_ast::{
     AnonymousFunctionCommand, ArithmeticExpr, ArithmeticExprNode, ArithmeticLvalue, Assignment,
     AssignmentValue, BinaryCommand, BinaryOp, BuiltinCommand, CaseCommand, CaseItem, Command,
     CommandSubstitutionSyntax, CompoundCommand, ConditionalCommand, ConditionalExpr, DeclClause,
-    DeclOperand, File, ForCommand, ForeachCommand, FunctionDef, HeredocBody, HeredocBodyPart,
-    IfCommand, Pattern, PatternPart, Redirect, RepeatCommand, SelectCommand, Span, Stmt, StmtSeq,
-    StmtTerminator, TimeCommand, UntilCommand, WhileCommand, Word, WordPart,
+    DeclOperand, File, ForCommand, ForeachCommand, FunctionDef, Heredoc, HeredocBody,
+    HeredocBodyPart, IfCommand, Pattern, PatternPart, Redirect, RepeatCommand, SelectCommand, Span,
+    Stmt, StmtSeq, StmtTerminator, TimeCommand, UntilCommand, WhileCommand, Word, WordPart,
 };
-use shuck_indexer::Indexer;
+use shuck_ast::{TextRange, TextSize};
+use shuck_format::LineEnding;
+use shuck_indexer::{CommentIndex, IndexedComment, Indexer, LineIndex};
 
 use crate::command::{
     array_elem_parts, branch_open_keyword_start, builtin_like_parts, case_item_body_upper_bound,
@@ -26,10 +27,7 @@ use crate::comments::{
     span_contains_comment,
 };
 use crate::options::ResolvedShellFormatOptions;
-use crate::scan::{
-    branch_prefix_first_comment_offset, has_newline_between_offsets as has_newline_between,
-    last_shell_keyword_start, operator_starts_or_ends_line,
-};
+use crate::scan::{BranchPrefixComment, last_shell_keyword_start};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 struct FactSpan {
@@ -234,6 +232,107 @@ impl<'source> FormatterFacts<'source> {
             .is_heredoc(TextSize::new(offset as u32))
     }
 
+    pub(crate) fn line_ending(&self) -> LineEnding {
+        match self.indexer.line_index().line_ending() {
+            shuck_indexer::LineEndingStyle::Lf => LineEnding::Lf,
+            shuck_indexer::LineEndingStyle::CrLf => LineEnding::CrLf,
+        }
+    }
+
+    pub(crate) fn contains_newline_between(&self, start: usize, end: usize) -> bool {
+        self.source_map.contains_newline_between(start, end)
+    }
+
+    pub(crate) fn has_continuation_line_start_between(&self, start: usize, end: usize) -> bool {
+        if start >= end {
+            return false;
+        }
+        let start = TextSize::new(start as u32);
+        let end = TextSize::new(end as u32);
+        self.indexer
+            .continuation_line_starts()
+            .iter()
+            .copied()
+            .any(|line_start| start < line_start && line_start <= end)
+    }
+
+    pub(crate) fn has_raw_continuation_backslash_between(&self, start: usize, end: usize) -> bool {
+        if start >= end {
+            return false;
+        }
+        let start = TextSize::new(start as u32);
+        let end = TextSize::new(end as u32);
+        self.indexer
+            .line_index()
+            .raw_continuation_backslashes()
+            .iter()
+            .copied()
+            .any(|backslash| start <= backslash && backslash < end)
+    }
+
+    pub(crate) fn line_end_for_offset(&self, offset: usize) -> Option<usize> {
+        let offset = TextSize::new(offset.min(self.source_map.source().len()) as u32);
+        let line = self.indexer.line_index().line_number(offset);
+        self.indexer
+            .line_index()
+            .line_range(line, self.source_map.source())
+            .map(|range| usize::from(range.end()))
+    }
+
+    pub(crate) fn branch_prefix_first_comment_offset(
+        &self,
+        start: usize,
+        end: usize,
+    ) -> Option<usize> {
+        self.branch_prefix_comments(start, end)
+            .first()
+            .map(|comment| comment.offset)
+    }
+
+    pub(crate) fn branch_prefix_comments(
+        &self,
+        start: usize,
+        end: usize,
+    ) -> Vec<BranchPrefixComment> {
+        branch_prefix_comments_from_index(
+            self.source_map.source(),
+            self.indexer.line_index(),
+            self.indexer.comment_index(),
+            start,
+            end,
+        )
+        .into_iter()
+        .filter(|comment| !self.offset_is_in_heredoc_body(comment.offset))
+        .collect()
+    }
+
+    pub(crate) fn own_line_comments_in_region(
+        &self,
+        start: usize,
+        end: usize,
+    ) -> Vec<BranchPrefixComment> {
+        own_line_comments_in_region_from_index(
+            self.source_map.source(),
+            self.indexer.line_index(),
+            self.indexer.comment_index(),
+            start,
+            end,
+        )
+        .into_iter()
+        .filter(|comment| !self.offset_is_in_heredoc_body(comment.offset))
+        .collect()
+    }
+
+    pub(crate) fn heredoc_closing_marker_bounds(
+        &self,
+        heredoc: &Heredoc,
+    ) -> Option<(usize, usize)> {
+        self.indexer
+            .region_index()
+            .heredoc_closing_marker_range(heredoc.body.span.to_range())
+            .map(|range| (usize::from(range.start()), usize::from(range.end())))
+    }
+
     #[cfg(feature = "benchmarking")]
     pub(crate) fn len(&self) -> usize {
         self.stmt_facts.len()
@@ -245,6 +344,146 @@ impl<'source> FormatterFacts<'source> {
             + self.inline_case_item_bodies.len()
             + self.indexer.region_index().heredoc_ranges().len()
     }
+}
+
+fn line_indent_before_offset<'source>(
+    source: &'source str,
+    line_index: &LineIndex,
+    offset: usize,
+) -> Option<&'source str> {
+    let offset = offset.min(source.len());
+    let line = line_index.line_number(TextSize::new(offset as u32));
+    let line_start = usize::from(line_index.line_start(line)?);
+    let prefix = source.get(line_start..offset)?;
+    let indent_end = prefix
+        .char_indices()
+        .find(|(_, ch)| !matches!(ch, ' ' | '\t'))
+        .map_or(prefix.len(), |(index, _)| index);
+    prefix.get(..indent_end)
+}
+
+fn branch_prefix_comments_from_index<'source>(
+    source: &'source str,
+    line_index: &LineIndex,
+    comment_index: &CommentIndex,
+    start: usize,
+    end: usize,
+) -> Vec<BranchPrefixComment> {
+    let start = start.min(end).min(source.len());
+    let end = end.min(source.len());
+    if start >= end {
+        return Vec::new();
+    }
+
+    let keyword_indent = line_indent_before_offset(source, line_index, end).unwrap_or("");
+    let mut comments = Vec::new();
+    let mut in_branch_prefix_run = false;
+    let first_line = line_index.line_number(TextSize::new(start as u32));
+    let last_line = line_index.line_number(TextSize::new(end.saturating_sub(1) as u32));
+
+    for line in first_line..=last_line {
+        let Some((line_start, line_end, text)) =
+            clamped_line_text(source, line_index, line, start, end)
+        else {
+            continue;
+        };
+        let trimmed = text.trim_start_matches([' ', '\t']);
+        let indent = text.len().saturating_sub(trimmed.len());
+        let own_line_comment =
+            own_line_comment_in_bounds(comment_index, line, line_start, line_end).is_some();
+        if own_line_comment
+            && trimmed.starts_with('#')
+            && (in_branch_prefix_run || text.get(..indent) == Some(keyword_indent))
+        {
+            comments.push(BranchPrefixComment {
+                offset: line_start + indent,
+                text: trimmed.trim_end_matches([' ', '\t', '\r']).to_string(),
+                source_indent: indent,
+            });
+            in_branch_prefix_run = true;
+        } else if !trimmed.is_empty() {
+            in_branch_prefix_run = false;
+        }
+    }
+
+    comments
+}
+
+fn own_line_comments_in_region_from_index<'source>(
+    source: &'source str,
+    line_index: &LineIndex,
+    comment_index: &CommentIndex,
+    start: usize,
+    end: usize,
+) -> Vec<BranchPrefixComment> {
+    let start = start.min(end).min(source.len());
+    let end = end.min(source.len());
+    let start_line = line_index.line_number(TextSize::new(start as u32));
+    let Some(next_line_start) = line_index.line_start(start_line + 1).map(usize::from) else {
+        return Vec::new();
+    };
+    if next_line_start >= end {
+        return Vec::new();
+    }
+
+    let mut comments = Vec::new();
+    let first_line = start_line + 1;
+    let last_line = line_index.line_number(TextSize::new(end.saturating_sub(1) as u32));
+    for line in first_line..=last_line {
+        let Some((line_start, line_end, text)) =
+            clamped_line_text(source, line_index, line, next_line_start, end)
+        else {
+            continue;
+        };
+        if own_line_comment_in_bounds(comment_index, line, line_start, line_end).is_none() {
+            continue;
+        }
+        let trimmed = text.trim_start_matches([' ', '\t']);
+        if !trimmed.starts_with('#') {
+            continue;
+        }
+        let indent = text.len().saturating_sub(trimmed.len());
+        comments.push(BranchPrefixComment {
+            offset: line_start + indent,
+            text: trimmed.trim_end_matches([' ', '\t', '\r']).to_string(),
+            source_indent: indent,
+        });
+    }
+
+    comments
+}
+
+fn clamped_line_text<'source>(
+    source: &'source str,
+    line_index: &LineIndex,
+    line: usize,
+    start: usize,
+    end: usize,
+) -> Option<(usize, usize, &'source str)> {
+    let range: TextRange = line_index.line_range(line, source)?;
+    let line_start = usize::from(range.start()).max(start);
+    let line_end = usize::from(range.end()).min(end);
+    (line_start <= line_end)
+        .then(|| {
+            source
+                .get(line_start..line_end)
+                .map(|text| (line_start, line_end, text))
+        })
+        .flatten()
+}
+
+fn own_line_comment_in_bounds(
+    comment_index: &CommentIndex,
+    line: usize,
+    line_start: usize,
+    line_end: usize,
+) -> Option<&IndexedComment> {
+    comment_index.comments_on_line(line).iter().find(|comment| {
+        comment.is_own_line && {
+            let start = usize::from(comment.range.start());
+            line_start <= start && start < line_end
+        }
+    })
 }
 
 struct FormatterFactsBuilder<'source, 'options> {
@@ -428,7 +667,7 @@ impl<'source, 'options> FormatterFactsBuilder<'source, 'options> {
                 .map(|span| span.end.offset)
                 .unwrap_or_else(|| stmt_span(current).end.offset);
             let next_start = self.facts.stmt(next).attachment_span().start.offset;
-            if has_newline_between(self.source, break_start, next_start) {
+            if self.facts.contains_newline_between(break_start, next_start) {
                 self.facts.background_breaks.insert(break_key);
             }
         }
@@ -568,8 +807,12 @@ impl<'source, 'options> FormatterFactsBuilder<'source, 'options> {
                 );
                 let next_start_line = self.source_map().line_number_for_offset(next_start);
                 let previous_span = stmt_span(previous);
-                if operator_starts_or_ends_line(self.source, item.operator_span)
-                    || has_newline_between(self.source, item.operator_span.end.offset, next_start)
+                if self
+                    .source_map()
+                    .operator_starts_or_ends_line(item.operator_span)
+                    || self
+                        .facts
+                        .contains_newline_between(item.operator_span.end.offset, next_start)
                     || (stmt_is_multiline_conditional(previous)
                         && previous_span.start.line < item.operator_span.start.line
                         && item.operator_span.end.line == next_start_line
@@ -680,6 +923,7 @@ impl<'source, 'options> FormatterFactsBuilder<'source, 'options> {
                 0,
                 self.source,
                 self.source_map(),
+                &self.facts,
             )),
             group_open_char,
             (!brace_syntax)
@@ -704,6 +948,7 @@ impl<'source, 'options> FormatterFactsBuilder<'source, 'options> {
                     index + 1,
                     self.source,
                     self.source_map(),
+                    &self.facts,
                 )),
                 group_open_char,
                 (!brace_syntax)
@@ -1104,8 +1349,8 @@ fn pipeline_has_explicit_line_break(
     for (statement, operator_span) in statements.iter().skip(1).zip(operators.iter()) {
         let next_start =
             stmt_start_after_operator(statement, operator_span.end.offset, source, source_map);
-        if operator_starts_or_ends_line(source, *operator_span)
-            || has_newline_between(source, operator_span.end.offset, next_start)
+        if source_map.operator_starts_or_ends_line(*operator_span)
+            || source_map.contains_newline_between(operator_span.end.offset, next_start)
         {
             return true;
         }
@@ -1121,10 +1366,7 @@ fn branch_open_suffix_span(
 ) -> Option<Span> {
     let source = source_map.source();
     let keyword_offset = branch_open_keyword_start(sequence, source, keyword)?;
-    let line_end = source[keyword_offset..]
-        .find('\n')
-        .map(|offset| keyword_offset + offset)
-        .unwrap_or(source.len());
+    let (_, line_end) = source_map.line_bounds_for_offset(keyword_offset)?;
     let suffix_start = keyword_offset + keyword.len();
     let suffix = source.get(suffix_start..line_end)?;
     suffix
@@ -1230,9 +1472,12 @@ fn if_branch_upper_bound(
     branch_index: usize,
     source: &str,
     source_map: &SourceMap<'_>,
+    facts: &FormatterFacts<'_>,
 ) -> usize {
     if let Some((start, end)) = if_next_branch_region(command, branch_index, source) {
-        branch_prefix_first_comment_offset(source, start, end).unwrap_or(end)
+        facts
+            .branch_prefix_first_comment_offset(start, end)
+            .unwrap_or(end)
     } else {
         if_close_start(command, source_map)
     }
@@ -1323,6 +1568,7 @@ mod tests {
                 1,
                 source,
                 facts.source_map(),
+                &facts,
             )),
         );
         assert_eq!(elif_facts.leading_for(0).len(), 1);
@@ -1373,6 +1619,7 @@ mod tests {
                 0,
                 source,
                 facts.source_map(),
+                &facts,
             )),
         );
         assert!(sequence.group_open_suffix_span().is_some());

--- a/crates/shuck-formatter/src/facts.rs
+++ b/crates/shuck-formatter/src/facts.rs
@@ -362,8 +362,8 @@ fn line_indent_before_offset<'source>(
     prefix.get(..indent_end)
 }
 
-fn branch_prefix_comments_from_index<'source>(
-    source: &'source str,
+fn branch_prefix_comments_from_index(
+    source: &str,
     line_index: &LineIndex,
     comment_index: &CommentIndex,
     start: usize,
@@ -409,8 +409,8 @@ fn branch_prefix_comments_from_index<'source>(
     comments
 }
 
-fn own_line_comments_in_region_from_index<'source>(
-    source: &'source str,
+fn own_line_comments_in_region_from_index(
+    source: &str,
     line_index: &LineIndex,
     comment_index: &CommentIndex,
     start: usize,

--- a/crates/shuck-formatter/src/facts.rs
+++ b/crates/shuck-formatter/src/facts.rs
@@ -10,7 +10,7 @@ use shuck_ast::{
 };
 use shuck_ast::{TextRange, TextSize};
 use shuck_format::LineEnding;
-use shuck_indexer::{CommentIndex, IndexedComment, Indexer, LineIndex};
+use shuck_indexer::{CommentIndex, IndexedComment, Indexer, IndexerOptions, LineIndex};
 
 use crate::command::{
     array_elem_parts, branch_open_keyword_start, builtin_like_parts, case_item_body_upper_bound,
@@ -163,7 +163,11 @@ impl<'source> FormatterFacts<'source> {
         file: &File,
         options: &ResolvedShellFormatOptions,
     ) -> Self {
-        let indexer = Indexer::for_file(source, file);
+        let indexer = Indexer::for_file_with_options(
+            source,
+            file,
+            IndexerOptions::new().with_source_layout_indexes(true),
+        );
         FormatterFactsBuilder::new(source, options, indexer).build(file)
     }
 

--- a/crates/shuck-formatter/src/lib.rs
+++ b/crates/shuck-formatter/src/lib.rs
@@ -33,7 +33,6 @@ use shuck_ast::File;
 use shuck_format::LineEnding;
 use shuck_parser::{Error as ParseError, parser::Parser};
 
-#[cfg(feature = "benchmarking")]
 use crate::facts::FormatterFacts;
 
 /// Formatter option types exposed by the shell formatter.
@@ -109,7 +108,7 @@ pub fn format_source(
     path: Option<&Path>,
     options: &ShellFormatOptions,
 ) -> Result<FormattedSource> {
-    let resolved = options.resolve(source, path);
+    let resolved = options.resolve_for_format(source, path);
 
     let dialect = resolved.dialect();
     let parsed = Parser::with_dialect(source, dialect).parse();
@@ -126,7 +125,7 @@ pub fn source_is_formatted(
     path: Option<&Path>,
     options: &ShellFormatOptions,
 ) -> Result<bool> {
-    let resolved = options.resolve(source, path);
+    let resolved = options.resolve_for_format(source, path);
 
     let dialect = resolved.dialect();
     let parsed = Parser::with_dialect(source, dialect).parse();
@@ -144,7 +143,7 @@ pub fn format_file_ast(
     path: Option<&Path>,
     options: &ShellFormatOptions,
 ) -> Result<FormattedSource> {
-    let resolved = options.resolve(source, path);
+    let resolved = options.resolve_for_format(source, path);
     let output = format_output(source, file, &resolved)?;
 
     Ok(formatted_source_from_output(source, output))
@@ -160,7 +159,9 @@ fn check_file(source: &str, mut file: File, resolved: ResolvedShellFormatOptions
         simplify::simplify_file(&mut file, source);
     }
 
-    streaming::format_file_streaming_matches_source(source, &file, &resolved)
+    let facts = FormatterFacts::build(source, &file, &resolved);
+    let resolved = resolved.with_line_ending(facts.line_ending());
+    streaming::format_file_streaming_matches_source_with_facts(source, &file, &resolved, &facts)
 }
 
 fn format_output(
@@ -172,7 +173,9 @@ fn format_output(
         simplify::simplify_file(&mut file, source);
     }
 
-    let mut output = streaming::format_file_streaming(source, &file, resolved)?;
+    let facts = FormatterFacts::build(source, &file, resolved);
+    let resolved = resolved.clone().with_line_ending(facts.line_ending());
+    let mut output = streaming::format_file_streaming_with_facts(source, &file, &resolved, &facts)?;
     if resolved.minify() {
         preserve_initial_shebang(source, &mut output, resolved.line_ending());
     }
@@ -193,7 +196,7 @@ fn formatted_source_from_output(source: &str, output: String) -> FormattedSource
 #[doc(hidden)]
 #[must_use]
 pub fn build_formatter_facts(source: &str, file: &File) -> usize {
-    let resolved = ShellFormatOptions::default().resolve(source, None);
+    let resolved = ShellFormatOptions::default().resolve_for_format(source, None);
     FormatterFacts::build(source, file, &resolved).len()
 }
 

--- a/crates/shuck-formatter/src/options.rs
+++ b/crates/shuck-formatter/src/options.rs
@@ -129,16 +129,22 @@ impl ShellFormatOptions {
 
     #[must_use]
     pub fn resolve(&self, source: &str, path: Option<&Path>) -> ResolvedShellFormatOptions {
+        let mut resolved = self.resolve_for_format(source, path);
+        resolved.line_ending = line_ending_from_source_index(source);
+        resolved
+    }
+
+    pub(crate) fn resolve_for_format(
+        &self,
+        source: &str,
+        path: Option<&Path>,
+    ) -> ResolvedShellFormatOptions {
         let mut options = self.clone();
         options.indent_width = options.indent_width.max(1);
         ResolvedShellFormatOptions {
             dialect: self.dialect.resolve(source, path),
             options,
-            line_ending: if source.contains("\r\n") {
-                LineEnding::CrLf
-            } else {
-                LineEnding::Lf
-            },
+            line_ending: LineEnding::Lf,
         }
     }
 }
@@ -208,6 +214,11 @@ impl ResolvedShellFormatOptions {
     option_getters! {
         line_ending: line_ending -> LineEnding;
     }
+
+    pub(crate) fn with_line_ending(mut self, line_ending: LineEnding) -> Self {
+        self.line_ending = line_ending;
+        self
+    }
 }
 
 impl FormatOptions for ResolvedShellFormatOptions {
@@ -218,6 +229,13 @@ impl FormatOptions for ResolvedShellFormatOptions {
             line_width: 80,
             line_ending: self.line_ending,
         }
+    }
+}
+
+fn line_ending_from_source_index(source: &str) -> LineEnding {
+    match shuck_indexer::LineIndex::new(source).line_ending() {
+        shuck_indexer::LineEndingStyle::Lf => LineEnding::Lf,
+        shuck_indexer::LineEndingStyle::CrLf => LineEnding::CrLf,
     }
 }
 

--- a/crates/shuck-formatter/src/scan.rs
+++ b/crates/shuck-formatter/src/scan.rs
@@ -76,33 +76,6 @@ pub(crate) fn line_without_continuation_backslash(line: &str) -> Option<&str> {
     Some(prefix.trim_end_matches([' ', '\t', '\r']))
 }
 
-pub(crate) fn operator_starts_or_ends_line(source: &str, operator_span: Span) -> bool {
-    let start = operator_span.start.offset;
-    let end = operator_span.end.offset;
-    if start >= end || end > source.len() {
-        return false;
-    }
-
-    let line_start = source[..start]
-        .rfind('\n')
-        .map_or(0, |offset| offset.saturating_add(1));
-    let line_end = source[end..]
-        .find('\n')
-        .map_or(source.len(), |offset| end.saturating_add(offset));
-    let has_previous_line = line_start > 0;
-    let has_next_line = line_end < source.len();
-    let before = &source[line_start..start];
-    let after = &source[end..line_end];
-
-    (has_previous_line && line_edge_is_blank_or_continuation(before))
-        || (has_next_line && line_edge_is_blank_or_continuation(after))
-}
-
-fn line_edge_is_blank_or_continuation(text: &str) -> bool {
-    let trimmed = text.trim_matches(|ch| matches!(ch, ' ' | '\t' | '\r'));
-    trimmed.is_empty() || trimmed == "\\"
-}
-
 pub(crate) fn line_has_shell_comment_before(source: &str, offset: usize) -> bool {
     let upper = offset.min(source.len());
     let line_start = source[..upper]
@@ -177,87 +150,6 @@ pub(crate) struct BranchPrefixComment {
     pub(crate) source_indent: usize,
 }
 
-pub(crate) fn branch_prefix_first_comment_offset(
-    source: &str,
-    start: usize,
-    end: usize,
-) -> Option<usize> {
-    branch_prefix_comments(source, start, end)
-        .first()
-        .map(|comment| comment.offset)
-}
-
-pub(crate) fn branch_prefix_comments(
-    source: &str,
-    start: usize,
-    end: usize,
-) -> Vec<BranchPrefixComment> {
-    let start = start.min(end).min(source.len());
-    let end = end.min(source.len());
-    let Some(slice) = source.get(start..end) else {
-        return Vec::new();
-    };
-    let keyword_indent = line_indent_before_offset(source, end).unwrap_or("");
-
-    let mut comments = Vec::new();
-    let mut in_branch_prefix_run = false;
-    let mut offset = start;
-    for line in slice.split_inclusive('\n') {
-        let text = line.trim_end_matches(['\n', '\r']);
-        let trimmed = text.trim_start_matches([' ', '\t']);
-        let indent = text.len().saturating_sub(trimmed.len());
-        if trimmed.starts_with('#')
-            && (in_branch_prefix_run || text.get(..indent) == Some(keyword_indent))
-        {
-            comments.push(BranchPrefixComment {
-                offset: offset + indent,
-                text: trimmed.trim_end_matches([' ', '\t', '\r']).to_string(),
-                source_indent: indent,
-            });
-            in_branch_prefix_run = true;
-        } else if !trimmed.is_empty() {
-            in_branch_prefix_run = false;
-        }
-        offset += line.len();
-    }
-    comments
-}
-
-pub(crate) fn own_line_comments_in_region(
-    source: &str,
-    start: usize,
-    end: usize,
-) -> Vec<BranchPrefixComment> {
-    let start = start.min(end).min(source.len());
-    let end = end.min(source.len());
-    let Some(next_line_start) = source
-        .get(start..end)
-        .and_then(|slice| slice.find('\n').map(|offset| start + offset + 1))
-    else {
-        return Vec::new();
-    };
-    let Some(slice) = source.get(next_line_start..end) else {
-        return Vec::new();
-    };
-
-    let mut comments = Vec::new();
-    let mut offset = next_line_start;
-    for line in slice.split_inclusive('\n') {
-        let text = line.trim_end_matches(['\n', '\r']);
-        let trimmed = text.trim_start_matches([' ', '\t']);
-        let indent = text.len().saturating_sub(trimmed.len());
-        if trimmed.starts_with('#') {
-            comments.push(BranchPrefixComment {
-                offset: offset + indent,
-                text: trimmed.trim_end_matches([' ', '\t', '\r']).to_string(),
-                source_indent: indent,
-            });
-        }
-        offset += line.len();
-    }
-    comments
-}
-
 pub(crate) fn last_uncommented_shell_keyword_before(
     source: &str,
     search_end: usize,
@@ -324,43 +216,6 @@ pub(crate) fn source_between_offsets(source: &str, start: usize, end: usize) -> 
     let lower = start.min(end).min(source.len());
     let upper = start.max(end).min(source.len());
     source.get(lower..upper)
-}
-
-pub(crate) fn has_newline_between_offsets(source: &str, start: usize, end: usize) -> bool {
-    source_between_offsets(source, start, end).is_some_and(|between| between.contains('\n'))
-}
-
-pub(crate) fn close_suffix_comment_offsets(
-    source: &str,
-    close_span: Span,
-) -> Option<(usize, usize)> {
-    if close_span.start.line != close_span.end.line {
-        return None;
-    }
-    let start = close_span.end.offset.min(source.len());
-    let suffix_source = source.get(start..)?;
-    let line_end = suffix_source
-        .find('\n')
-        .map_or(source.len(), |offset| start + offset);
-    let suffix = source.get(start..line_end)?;
-    let mut comment_start = None;
-    for (offset, ch) in suffix.char_indices() {
-        match ch {
-            ' ' | '\t' => {}
-            '#' => {
-                comment_start = Some(start + offset);
-                break;
-            }
-            _ => return None,
-        }
-    }
-    let comment_start = comment_start?;
-    let comment_end = source
-        .get(comment_start..line_end)?
-        .trim_end_matches([' ', '\t', '\r'])
-        .len()
-        + comment_start;
-    Some((comment_start, comment_end))
 }
 
 pub(crate) fn redirect_operator_end(bytes: &[u8], start: usize) -> Option<usize> {

--- a/crates/shuck-formatter/src/streaming.rs
+++ b/crates/shuck-formatter/src/streaming.rs
@@ -7,9 +7,9 @@ use shuck_ast::{
     Command, CompoundCommand, ConditionalBinaryExpr, ConditionalBinaryOp, ConditionalCommand,
     ConditionalExpr, ConditionalParenExpr, ConditionalUnaryExpr, ConditionalUnaryOp, CoprocCommand,
     DeclClause, DeclOperand, File, ForCommand, ForSyntax, ForeachCommand, ForeachSyntax,
-    FunctionDef, Heredoc, HeredocBody, HeredocBodyPart, IfCommand, IfSyntax, Pattern, PatternPart,
-    Redirect, RedirectKind, RepeatCommand, RepeatSyntax, SelectCommand, SimpleCommand, Span, Stmt,
-    StmtSeq, StmtTerminator, TimeCommand, UntilCommand, VarRef, WhileCommand, Word, WordPart,
+    FunctionDef, HeredocBody, HeredocBodyPart, IfCommand, IfSyntax, Pattern, PatternPart, Redirect,
+    RedirectKind, RepeatCommand, RepeatSyntax, SelectCommand, SimpleCommand, Span, Stmt, StmtSeq,
+    StmtTerminator, TimeCommand, UntilCommand, VarRef, WhileCommand, Word, WordPart,
 };
 use shuck_format::{IndentStyle, LineEnding};
 
@@ -34,12 +34,8 @@ use crate::comments::{SourceComment, SourceMap};
 use crate::facts::FormatterFacts;
 use crate::options::ResolvedShellFormatOptions;
 use crate::scan::{
-    BranchPrefixComment, branch_prefix_comments, branch_prefix_first_comment_offset,
-    close_suffix_comment_offsets, has_newline_between_offsets, heredoc_start,
-    last_shell_keyword_end, last_shell_keyword_start, last_shell_keyword_start_between,
-    line_indent_before_offset, line_without_continuation_backslash,
-    operator_starts_or_ends_line as pipeline_operator_starts_or_ends_line,
-    own_line_comments_in_region as scan_own_line_comments_in_region, redirect_operator_end,
+    BranchPrefixComment, heredoc_start, last_shell_keyword_end, last_shell_keyword_start,
+    last_shell_keyword_start_between, line_without_continuation_backslash, redirect_operator_end,
     shell_keyword_at, skip_double_quoted, skip_single_quoted, source_between_offsets,
 };
 use crate::word::{
@@ -221,25 +217,25 @@ impl<'source> CompareSink<'source> {
     }
 }
 
-pub(crate) fn format_file_streaming(
+pub(crate) fn format_file_streaming_with_facts(
     source: &str,
     file: &File,
     options: &ResolvedShellFormatOptions,
+    facts: &FormatterFacts<'_>,
 ) -> Result<String> {
-    let facts = FormatterFacts::build(source, file, options);
-    let mut formatter = ShellStreamFormatter::new(source, options, &facts);
+    let mut formatter = ShellStreamFormatter::new(source, options, facts);
     formatter.format_stmt_sequence(&file.body, None)?;
 
     Ok(formatter.finish_into_string())
 }
 
-pub(crate) fn format_file_streaming_matches_source(
+pub(crate) fn format_file_streaming_matches_source_with_facts(
     source: &str,
     file: &File,
     options: &ResolvedShellFormatOptions,
+    facts: &FormatterFacts<'_>,
 ) -> Result<bool> {
-    let facts = FormatterFacts::build(source, file, options);
-    let mut formatter = ShellStreamFormatter::new_compare(source, options, &facts);
+    let mut formatter = ShellStreamFormatter::new_compare(source, options, facts);
     formatter.format_stmt_sequence(&file.body, None)?;
 
     Ok(formatter.finish_matches_source())
@@ -945,7 +941,7 @@ impl<'source, 'facts> ShellStreamFormatter<'source, 'facts> {
     fn write_case_pattern(&mut self, item: &CaseItem, pattern: &Pattern) {
         let mut scratch = self.take_scratch_buffer();
         render_pattern_syntax_to_buf(pattern, self.source(), self.options(), &mut scratch);
-        if case_item_pattern_close_paren_on_own_line(item, self.source()) {
+        if case_item_pattern_close_paren_on_own_line(item, self.source(), self.source_map()) {
             trim_trailing_pattern_line_continuation(&mut scratch);
         }
         self.write_text(&scratch);
@@ -963,9 +959,11 @@ impl<'source, 'facts> ShellStreamFormatter<'source, 'facts> {
             self.write_rendered_shell_text(assignment.span.slice(self.source()));
             return;
         }
-        if let Some(normalized) =
-            normalize_scalar_assignment_unquoted_continuations(assignment, self.source())
-        {
+        if let Some(normalized) = normalize_scalar_assignment_unquoted_continuations(
+            assignment,
+            self.source(),
+            self.facts(),
+        ) {
             self.write_text(&normalized);
             return;
         }
@@ -1095,6 +1093,7 @@ impl<'source, 'facts> ShellStreamFormatter<'source, 'facts> {
             let current_code_column = self.column.saturating_sub(self.line_indent_column);
             let padding = trailing_comment_padding(
                 self.source(),
+                self.source_map(),
                 comment,
                 current_code_column,
                 self.line_indent_column,
@@ -1160,7 +1159,8 @@ impl<'source, 'facts> ShellStreamFormatter<'source, 'facts> {
         if !self.line_start {
             return;
         }
-        if comment_precedes_close_keyword_at_same_indent(self.source(), comment) {
+        if comment_precedes_close_keyword_at_same_indent(self.source(), self.source_map(), comment)
+        {
             let close_indent_column =
                 self.indent_column_for_level(self.indent_level.saturating_sub(1));
             if close_indent_column == 0 {
@@ -1353,7 +1353,11 @@ impl<'source, 'facts> ShellStreamFormatter<'source, 'facts> {
 
         if !stmt.redirects.is_empty() && !emit_redirects_first && !redirects_formatted_with_command
         {
-            if redirect_list_starts_on_continuation_line(command_span, &stmt.redirects, source) {
+            if redirect_list_starts_on_continuation_line(
+                command_span,
+                &stmt.redirects,
+                self.facts(),
+            ) {
                 self.line_continuation();
                 self.write_indent_units(1);
             } else if redirect_list_needs_leading_space(command_span, &stmt.redirects, source) {
@@ -1370,7 +1374,10 @@ impl<'source, 'facts> ShellStreamFormatter<'source, 'facts> {
                 self.write_text(render_background_operator(operator));
             }
             Some(StmtTerminator::Semicolon)
-                if stmt_semicolon_terminator_starts_on_continuation_line(stmt, source) =>
+                if stmt_semicolon_terminator_starts_on_continuation_line(
+                    stmt,
+                    self.source_map(),
+                ) =>
             {
                 self.line_continuation();
                 self.write_indent_units(1);
@@ -1494,7 +1501,8 @@ impl<'source, 'facts> ShellStreamFormatter<'source, 'facts> {
                     SimpleCommandPart::Assignment(_)
                 ) if keep_assignment_continuations_flush_left
             ) && previous_end.is_some_and(|previous_end| {
-                has_newline_between_offsets(source, previous_end, part.start_offset(command))
+                self.facts()
+                    .contains_newline_between(previous_end, part.start_offset(command))
             }) {
                 self.line_continuation();
             } else if let SimpleCommandPart::Redirect(redirect) = &part {
@@ -1739,7 +1747,8 @@ impl<'source, 'facts> ShellStreamFormatter<'source, 'facts> {
         )?;
         self.write_unmodeled_branch_background_terminator(body, body_upper_bound);
         if close_span.is_some_and(|span| {
-            source_has_blank_line_immediately_before_offset(self.source(), span.start.offset)
+            self.source_map()
+                .has_blank_line_immediately_before_offset(span.start.offset)
         }) || (close_span.is_none()
             && source_has_blank_line_before_last_keyword(
                 self.source(),
@@ -1769,10 +1778,12 @@ impl<'source, 'facts> ShellStreamFormatter<'source, 'facts> {
 
     fn source_line_before_offset_ends_with_do(&self, offset: usize) -> bool {
         let source = self.source();
-        let line_start = source[..offset]
-            .rfind('\n')
-            .map_or(0, |offset| offset.saturating_add(1));
-        source[line_start..offset]
+        let Some((line_start, _)) = self.source_map().line_bounds_for_offset(offset) else {
+            return false;
+        };
+        source
+            .get(line_start..offset.min(source.len()))
+            .unwrap_or("")
             .trim_end_matches([' ', '\t', '\r'])
             .ends_with("do")
     }
@@ -2117,10 +2128,7 @@ impl<'source, 'facts> ShellStreamFormatter<'source, 'facts> {
     }
 
     fn own_line_comments_in_region(&self, start: usize, end: usize) -> Vec<BranchPrefixComment> {
-        scan_own_line_comments_in_region(self.source(), start, end)
-            .into_iter()
-            .filter(|comment| !self.facts().offset_is_in_heredoc_body(comment.offset))
-            .collect()
+        self.facts().own_line_comments_in_region(start, end)
     }
 
     fn format_pipeline_stmt(&mut self, stmt: &Stmt) -> Result<()> {
@@ -2257,19 +2265,21 @@ impl<'source, 'facts> ShellStreamFormatter<'source, 'facts> {
                 source,
                 self.source_map(),
                 self.options(),
+                self.facts(),
             )
         {
             self.write_text("if");
             self.write_text(&raw_condition);
             self.write_text("then");
-            let then_upper_bound = if_branch_upper_bound(command, 0, source, self.source_map());
+            let then_upper_bound =
+                if_branch_upper_bound(command, 0, source, self.source_map(), self.facts());
             self.format_if_branch_body_after_open(
                 &command.then_branch,
                 then_upper_bound,
                 then_span.end.offset,
             )?;
             if let Some(body) = &command.else_branch {
-                if if_next_branch_has_blank_line_before_keyword(command, 0, source) {
+                if self.if_next_branch_has_blank_line_before_keyword(command, 0, source) {
                     self.newline();
                 }
                 self.newline();
@@ -2286,8 +2296,14 @@ impl<'source, 'facts> ShellStreamFormatter<'source, 'facts> {
             source,
             self.source_map(),
             self.options(),
-        ) || if_condition_has_explicit_statement_break(command, then_span, source)
-        {
+            self.facts(),
+        ) || if_condition_has_explicit_statement_break(
+            command,
+            then_span,
+            source,
+            self.source_map(),
+            self.facts(),
+        ) {
             self.write_text("if");
             self.newline();
             self.with_indent(|formatter| {
@@ -2295,7 +2311,8 @@ impl<'source, 'facts> ShellStreamFormatter<'source, 'facts> {
             })?;
             self.newline();
             self.write_text("then");
-            let then_upper_bound = if_branch_upper_bound(command, 0, source, self.source_map());
+            let then_upper_bound =
+                if_branch_upper_bound(command, 0, source, self.source_map(), self.facts());
             self.format_if_branch_body_after_open(
                 &command.then_branch,
                 then_upper_bound,
@@ -2304,8 +2321,13 @@ impl<'source, 'facts> ShellStreamFormatter<'source, 'facts> {
             for (index, (condition, body)) in command.elif_branches.iter().enumerate() {
                 self.write_if_branch_prefix(command, index, source);
                 self.write_elif_header(command, index, condition, body, source)?;
-                let body_upper_bound =
-                    if_branch_upper_bound(command, index + 1, source, self.source_map());
+                let body_upper_bound = if_branch_upper_bound(
+                    command,
+                    index + 1,
+                    source,
+                    self.source_map(),
+                    self.facts(),
+                );
                 self.format_if_branch_body_after_keyword(
                     body,
                     body_upper_bound,
@@ -2369,7 +2391,8 @@ impl<'source, 'facts> ShellStreamFormatter<'source, 'facts> {
             self.format_inline_stmts(&command.then_branch)?;
             self.write_text("; else");
             self.format_else_branch_body(command, else_branch, fi_upper_bound)?;
-            let then_upper_bound = if_branch_upper_bound(command, 0, source, self.source_map());
+            let then_upper_bound =
+                if_branch_upper_bound(command, 0, source, self.source_map(), self.facts());
             self.finish_multiline_if_close(command, then_upper_bound, fi_span);
             return Ok(());
         }
@@ -2403,7 +2426,8 @@ impl<'source, 'facts> ShellStreamFormatter<'source, 'facts> {
         }
 
         self.write_text(then_separator);
-        let then_upper_bound = if_branch_upper_bound(command, 0, source, self.source_map());
+        let then_upper_bound =
+            if_branch_upper_bound(command, 0, source, self.source_map(), self.facts());
         if !self.write_condition_separator_suffix_comment(&command.condition, then_span) {
             self.write_sequence_open_suffix(&command.then_branch, Some(then_upper_bound));
         }
@@ -2429,7 +2453,7 @@ impl<'source, 'facts> ShellStreamFormatter<'source, 'facts> {
                 self.write_elif_header(command, index, condition, body, source)?;
             }
             let body_upper_bound =
-                if_branch_upper_bound(command, index + 1, source, self.source_map());
+                if_branch_upper_bound(command, index + 1, source, self.source_map(), self.facts());
             self.format_if_branch_body_after_keyword(
                 body,
                 body_upper_bound,
@@ -2496,9 +2520,12 @@ impl<'source, 'facts> ShellStreamFormatter<'source, 'facts> {
         {
             return false;
         };
-        let Some((_, else_offset)) =
-            if_next_branch_region(command, command.elif_branches.len(), self.source())
-        else {
+        let Some((_, else_offset)) = if_next_branch_region(
+            command,
+            command.elif_branches.len(),
+            self.source(),
+            self.facts(),
+        ) else {
             return false;
         };
         let else_line = self.source_map().line_number_for_offset(else_offset);
@@ -2515,7 +2542,13 @@ impl<'source, 'facts> ShellStreamFormatter<'source, 'facts> {
         if !self.can_inline_body_with_upper_bound(
             &command.then_branch,
             command.span,
-            Some(if_branch_upper_bound(command, 0, source, self.source_map())),
+            Some(if_branch_upper_bound(
+                command,
+                0,
+                source,
+                self.source_map(),
+                self.facts(),
+            )),
         ) {
             return false;
         }
@@ -2529,6 +2562,7 @@ impl<'source, 'facts> ShellStreamFormatter<'source, 'facts> {
                     index + 1,
                     source,
                     self.source_map(),
+                    self.facts(),
                 )),
             ) {
                 return false;
@@ -2569,6 +2603,7 @@ impl<'source, 'facts> ShellStreamFormatter<'source, 'facts> {
                         0,
                         self.source(),
                         self.source_map(),
+                        self.facts(),
                     )),
                 )
                 .has_comments()
@@ -2588,18 +2623,22 @@ impl<'source, 'facts> ShellStreamFormatter<'source, 'facts> {
         !body.is_empty()
             && source_has_blank_line_before_last_keyword_after(
                 self.source(),
-                sequence_close_gap_start(body, self.source()),
+                sequence_close_gap_start(body, self.source(), self.facts()),
                 command.span,
                 "fi",
             )
     }
 
     fn write_if_branch_prefix(&mut self, command: &IfCommand, branch_index: usize, source: &str) {
-        if if_next_branch_has_blank_line_before_keyword(command, branch_index, source) {
+        if self.if_next_branch_has_blank_line_before_keyword(command, branch_index, source) {
             self.newline();
         }
-        let preserve_blank_after_prefix =
-            if_branch_prefix_comments_have_blank_line_before_keyword(command, branch_index, source);
+        let preserve_blank_after_prefix = self
+            .if_branch_prefix_comments_have_blank_line_before_keyword(
+                command,
+                branch_index,
+                source,
+            );
         self.emit_branch_prefix_comments(command, branch_index);
         self.newline();
         if preserve_blank_after_prefix {
@@ -2615,11 +2654,19 @@ impl<'source, 'facts> ShellStreamFormatter<'source, 'facts> {
         body: &StmtSeq,
         source: &str,
     ) -> Result<()> {
-        if condition_keyword_on_previous_non_empty_line(condition, source, "elif")
-            || elif_condition_has_explicit_statement_break(condition, body, source)
-            || !self
-                .elif_condition_prefix_comments(command, branch_index, condition)
-                .is_empty()
+        if condition_keyword_on_previous_non_empty_line(
+            condition,
+            source,
+            self.source_map(),
+            "elif",
+        ) || elif_condition_has_explicit_statement_break(
+            condition,
+            body,
+            source,
+            self.source_map(),
+        ) || !self
+            .elif_condition_prefix_comments(command, branch_index, condition)
+            .is_empty()
         {
             self.write_text("elif");
             self.newline();
@@ -2638,10 +2685,12 @@ impl<'source, 'facts> ShellStreamFormatter<'source, 'facts> {
     }
 
     fn emit_branch_prefix_comments(&mut self, command: &IfCommand, branch_index: usize) {
-        let Some((start, end)) = if_next_branch_region(command, branch_index, self.source()) else {
+        let Some((start, end)) =
+            if_next_branch_region(command, branch_index, self.source(), self.facts())
+        else {
             return;
         };
-        let comments = branch_prefix_comments(self.source(), start, end);
+        let comments = self.facts().branch_prefix_comments(start, end);
         if comments.is_empty() {
             return;
         }
@@ -2667,7 +2716,8 @@ impl<'source, 'facts> ShellStreamFormatter<'source, 'facts> {
         branch_index: usize,
         condition: &StmtSeq,
     ) -> Vec<BranchPrefixComment> {
-        let Some((_, keyword_offset)) = if_next_branch_region(command, branch_index, self.source())
+        let Some((_, keyword_offset)) =
+            if_next_branch_region(command, branch_index, self.source(), self.facts())
         else {
             return Vec::new();
         };
@@ -2680,6 +2730,47 @@ impl<'source, 'facts> ShellStreamFormatter<'source, 'facts> {
         }
 
         self.own_line_comments_in_region(keyword_offset, condition_start)
+    }
+
+    fn if_next_branch_has_blank_line_before_keyword(
+        &self,
+        command: &IfCommand,
+        branch_index: usize,
+        source: &str,
+    ) -> bool {
+        if_next_branch_region(command, branch_index, source, self.facts()).is_some_and(
+            |(start, end)| {
+                let first_prefix = self
+                    .facts()
+                    .branch_prefix_first_comment_offset(start, end)
+                    .unwrap_or(end);
+                gap_has_empty_physical_line(source, start, first_prefix)
+            },
+        )
+    }
+
+    fn if_branch_prefix_comments_have_blank_line_before_keyword(
+        &self,
+        command: &IfCommand,
+        branch_index: usize,
+        source: &str,
+    ) -> bool {
+        if_next_branch_region(command, branch_index, source, self.facts()).is_some_and(
+            |(start, end)| {
+                let comments = self.facts().branch_prefix_comments(start, end);
+                let Some(last) = comments.last() else {
+                    return false;
+                };
+                let Some(line_end) = self
+                    .facts()
+                    .line_end_for_offset(last.offset)
+                    .filter(|line_end| *line_end < end)
+                else {
+                    return false;
+                };
+                gap_has_empty_physical_line(source, line_end, end)
+            },
+        )
     }
 
     fn write_sequence_open_suffix(&mut self, commands: &StmtSeq, upper_bound: Option<usize>) {
@@ -2726,10 +2817,8 @@ impl<'source, 'facts> ShellStreamFormatter<'source, 'facts> {
             return None;
         }
         let comment_start = start + comment_rel;
-        let line_end = source
-            .get(comment_start..end)?
-            .find('\n')
-            .map_or(end, |offset| comment_start + offset);
+        let (_, indexed_line_end) = self.source_map().line_bounds_for_offset(comment_start)?;
+        let line_end = indexed_line_end.min(end);
         let comment = source
             .get(comment_start..line_end)?
             .trim_end_matches([' ', '\t', '\r']);
@@ -2811,7 +2900,13 @@ impl<'source, 'facts> ShellStreamFormatter<'source, 'facts> {
         self.write_space();
         self.format_brace_group(
             &command.then_branch,
-            Some(if_branch_upper_bound(command, 0, source, self.source_map())),
+            Some(if_branch_upper_bound(
+                command,
+                0,
+                source,
+                self.source_map(),
+                self.facts(),
+            )),
         )?;
         for (index, (condition, body)) in command.elif_branches.iter().enumerate() {
             self.write_text(" elif ");
@@ -2824,6 +2919,7 @@ impl<'source, 'facts> ShellStreamFormatter<'source, 'facts> {
                     index + 1,
                     source,
                     self.source_map(),
+                    self.facts(),
                 )),
             )?;
         }
@@ -3075,11 +3171,13 @@ impl<'source, 'facts> ShellStreamFormatter<'source, 'facts> {
         let source = self.source();
         let start = command.word.span.end.offset.min(source.len());
         let end = first_pattern.span.start.offset.min(source.len());
-        let Some(between) = source.get(start..end) else {
+        let Some((_, indexed_line_end)) = self.source_map().line_bounds_for_offset(start) else {
             return;
         };
-        let line_end = between.find('\n').unwrap_or(between.len());
-        let header = &between[..line_end];
+        let line_end = indexed_line_end.min(end);
+        let Some(header) = source.get(start..line_end) else {
+            return;
+        };
         let header = header.trim_start_matches([' ', '\t']);
         let Some(suffix) = header.strip_prefix("in") else {
             return;
@@ -3110,11 +3208,10 @@ impl<'source, 'facts> ShellStreamFormatter<'source, 'facts> {
         for (index, word) in item.patterns.iter().enumerate() {
             if index > 0 {
                 let previous = &item.patterns[index - 1];
-                if has_newline_between_offsets(
-                    self.source(),
-                    previous.span.end.offset,
-                    word.span.start.offset,
-                ) {
+                if self
+                    .facts()
+                    .contains_newline_between(previous.span.end.offset, word.span.start.offset)
+                {
                     self.write_text(" |");
                     self.line_continuation();
                     self.write_indent_units(1);
@@ -3130,12 +3227,18 @@ impl<'source, 'facts> ShellStreamFormatter<'source, 'facts> {
             let current_code_column = self.column.saturating_sub(self.line_indent_column);
             let mut padding = trailing_comment_padding(
                 self.source(),
+                self.source_map(),
                 comment,
                 current_code_column,
                 self.line_indent_column,
             );
-            if trailing_comment_alignment_column(self.source(), comment, self.line_indent_column)
-                .is_some()
+            if trailing_comment_alignment_column(
+                self.source(),
+                self.source_map(),
+                comment,
+                self.line_indent_column,
+            )
+            .is_some()
             {
                 padding += 1;
             }
@@ -3247,8 +3350,12 @@ impl<'source, 'facts> ShellStreamFormatter<'source, 'facts> {
                     stmt_render_start_line(stmt, self.source(), self.source_map(), self.options())
                 })
                 .unwrap_or(first_body_line);
-            if (case_item_pattern_close_paren_on_own_line(item, self.source())
-                && !case_item_close_paren_shares_line_with_body(item, self.source()))
+            if (case_item_pattern_close_paren_on_own_line(item, self.source(), self.source_map())
+                && !case_item_close_paren_shares_line_with_body(
+                    item,
+                    self.source(),
+                    self.source_map(),
+                ))
                 || case_item_has_blank_line_after_pattern(
                     item,
                     self.source(),
@@ -3265,7 +3372,7 @@ impl<'source, 'facts> ShellStreamFormatter<'source, 'facts> {
                     first_pattern_start,
                 )
             })?;
-            if case_item_has_blank_line_before_terminator(item, self.source()) {
+            if case_item_has_blank_line_before_terminator(item, self.source(), self.facts()) {
                 self.newline();
             }
             self.newline();
@@ -3349,22 +3456,7 @@ impl<'source, 'facts> ShellStreamFormatter<'source, 'facts> {
         if span.start.line != span.end.line {
             return None;
         }
-        let source = self.source();
-        let start = span.end.offset.min(source.len());
-        let suffix_source = source.get(start..)?;
-        let line_end = suffix_source
-            .find('\n')
-            .map_or(source.len(), |offset| start + offset);
-        let suffix = source.get(start..line_end)?;
-        let leading_padding = suffix.len() - suffix.trim_start_matches([' ', '\t']).len();
-        let comment = suffix[leading_padding..].trim_end_matches([' ', '\t', '\r']);
-        if !comment.starts_with('#') {
-            return None;
-        }
-        let absolute_start = start + leading_padding;
-        let absolute_end = absolute_start + comment.len();
-        self.source_map()
-            .source_comment_for_offsets(absolute_start, absolute_end)
+        self.source_map().suffix_comment_after_span(span)
     }
 
     fn case_item_prefix_comments(
@@ -3404,7 +3496,9 @@ impl<'source, 'facts> ShellStreamFormatter<'source, 'facts> {
         first_pattern_start: usize,
     ) -> Vec<SourceComment<'source>> {
         let source = self.source();
-        let Some((pattern_line_start, _)) = line_bounds_for_offset(source, first_pattern_start)
+        let Some((pattern_line_start, _)) = self
+            .source_map()
+            .line_bounds_for_offset(first_pattern_start)
         else {
             return Vec::new();
         };
@@ -3416,7 +3510,7 @@ impl<'source, 'facts> ShellStreamFormatter<'source, 'facts> {
         }
         let mut comments = Vec::new();
         let mut next_start = pattern_line_start;
-        while let Some((start, end)) = previous_line_bounds(source, next_start) {
+        while let Some((start, end)) = self.source_map().previous_line_bounds(next_start) {
             let Some(line) = source.get(start..end) else {
                 break;
             };
@@ -3500,6 +3594,7 @@ impl<'source, 'facts> ShellStreamFormatter<'source, 'facts> {
         for (index, comment) in comments.iter().enumerate() {
             let uses_body_indent = case_prefix_comment_uses_body_indent(
                 self.source(),
+                self.source_map(),
                 comment,
                 first_pattern.span.start.offset,
                 disabled_case_pattern_context,
@@ -3935,7 +4030,7 @@ impl<'source, 'facts> ShellStreamFormatter<'source, 'facts> {
         let first = commands.first()?;
         let source = self.source();
         let start = stmt_span(first).start.offset.min(source.len());
-        let (line_start, line_end) = line_bounds_for_offset(source, start)?;
+        let (line_start, line_end) = self.source_map().line_bounds_for_offset(start)?;
         let width = inline_comment_code_width(source, line_start, line_end, None)?;
         Some(width + 1)
     }
@@ -3952,10 +4047,8 @@ impl<'source, 'facts> ShellStreamFormatter<'source, 'facts> {
             return None;
         }
 
-        let line_end = source[header_end..body_start]
-            .find('\n')
-            .map(|offset| header_end + offset)
-            .unwrap_or(body_start);
+        let (_, indexed_line_end) = self.source_map().line_bounds_for_offset(header_end)?;
+        let line_end = indexed_line_end.min(body_start);
         let between = source.get(header_end..line_end)?;
         let comment_offset = between.find('#')?;
         if between[..comment_offset].contains('{') {
@@ -4197,11 +4290,12 @@ impl<'source, 'facts> ShellStreamFormatter<'source, 'facts> {
     fn write_comment_with_padding(
         &mut self,
         comment: &SourceComment<'_>,
-        padding_for: impl FnOnce(&str, &SourceComment<'_>, usize, usize) -> usize,
+        padding_for: impl FnOnce(&str, &SourceMap<'_>, &SourceComment<'_>, usize, usize) -> usize,
     ) {
         let current_code_column = self.column.saturating_sub(self.line_indent_column);
         let padding = padding_for(
             self.source(),
+            self.source_map(),
             comment,
             current_code_column,
             self.line_indent_column,
@@ -4219,13 +4313,19 @@ impl<'source, 'facts> ShellStreamFormatter<'source, 'facts> {
         let current_code_column = self.column.saturating_sub(self.line_indent_column);
         let mut padding = trailing_comment_padding(
             self.source(),
+            self.source_map(),
             &comment,
             current_code_column,
             self.line_indent_column,
         );
         if nudge_aligned
-            && trailing_comment_alignment_column(self.source(), &comment, self.line_indent_column)
-                .is_some()
+            && trailing_comment_alignment_column(
+                self.source(),
+                self.source_map(),
+                &comment,
+                self.line_indent_column,
+            )
+            .is_some()
         {
             padding += 1;
         }
@@ -4248,10 +4348,7 @@ impl<'source, 'facts> ShellStreamFormatter<'source, 'facts> {
     }
 
     fn close_suffix_comment_after_span(&self, close_span: Span) -> Option<SourceComment<'source>> {
-        let source = self.source();
-        let (comment_start, comment_end) = close_suffix_comment_offsets(source, close_span)?;
-        self.source_map()
-            .source_comment_for_offsets(comment_start, comment_end)
+        self.source_map().suffix_comment_after_span(close_span)
     }
 
     fn format_group_with_upper_bound(
@@ -4293,7 +4390,8 @@ impl<'source, 'facts> ShellStreamFormatter<'source, 'facts> {
         let preserve_close_blank = group_span.is_some_and(|span| {
             let close_offset =
                 group_close_offset(source, span, upper_bound, close_char, close.len());
-            source_has_blank_line_immediately_before_offset(source, close_offset)
+            self.source_map()
+                .has_blank_line_immediately_before_offset(close_offset)
         });
 
         self.format_body_with_upper_bound_open_blank_and_leading_filter(
@@ -4372,20 +4470,18 @@ impl<'source, 'facts> ShellStreamFormatter<'source, 'facts> {
             RedirectKind::OutputBoth => "&>",
         });
 
-        self.write_redirect_target(redirect, source, &options, true);
+        self.write_redirect_target(redirect, &options, true);
     }
 
     fn format_append_both_redirect(&mut self, redirect: &Redirect) {
-        let source = self.source();
         let options = self.options().clone();
         self.write_text("&>>");
-        self.write_redirect_target(redirect, source, &options, false);
+        self.write_redirect_target(redirect, &options, false);
     }
 
     fn write_redirect_target(
         &mut self,
         redirect: &Redirect,
-        source: &'source str,
         options: &ResolvedShellFormatOptions,
         preserve_here_string_indent: bool,
     ) {
@@ -4401,7 +4497,7 @@ impl<'source, 'facts> ShellStreamFormatter<'source, 'facts> {
             }
         }
         let normalized_target = normalized_redirect_target(redirect.kind, &target);
-        if redirect_target_starts_on_continuation_line(redirect, source) {
+        if redirect_target_starts_on_continuation_line(redirect, self.facts()) {
             self.line_continuation();
             self.write_indent_units(1);
         } else if needs_space_before_target(
@@ -4450,7 +4546,9 @@ impl<'source, 'facts> ShellStreamFormatter<'source, 'facts> {
             };
             // The opening redirection keeps delimiter quoting, but the closing
             // marker line uses the cooked delimiter text after quote removal.
-            let delimiter = heredoc_closing_marker_bounds(heredoc, source)
+            let delimiter = self
+                .facts()
+                .heredoc_closing_marker_bounds(heredoc)
                 .and_then(|(start, line_end)| source.get(start..line_end))
                 .map(str::to_owned)
                 .unwrap_or_else(|| heredoc.delimiter.cooked.to_string());
@@ -4492,15 +4590,22 @@ impl<'source, 'facts> ShellStreamFormatter<'source, 'facts> {
         Ok(())
     }
 
-    fn compound_assignment_source_has_line_continuations(raw: &str) -> bool {
-        raw.contains("\\\n") || raw.contains("\\\r\n")
+    fn compound_assignment_has_raw_line_continuations(&self, assignment: &Assignment) -> bool {
+        self.facts().has_raw_continuation_backslash_between(
+            assignment.span.start.offset,
+            assignment.span.end.offset,
+        )
     }
 
-    fn compound_assignment_source_has_escaped_multiline_double_quoted_item(raw: &str) -> bool {
-        if !Self::compound_assignment_source_has_line_continuations(raw) {
+    fn compound_assignment_source_has_escaped_multiline_double_quoted_item(
+        &self,
+        assignment: &Assignment,
+    ) -> bool {
+        if !self.compound_assignment_has_raw_line_continuations(assignment) {
             return false;
         }
 
+        let raw = assignment.span.slice(self.source());
         let Some(open) = raw.find('(') else {
             return false;
         };
@@ -4524,17 +4629,14 @@ impl<'source, 'facts> ShellStreamFormatter<'source, 'facts> {
             return false;
         }
 
-        let raw = assignment.span.slice(source);
-        !Self::compound_assignment_source_has_line_continuations(raw)
+        !self.compound_assignment_has_raw_line_continuations(assignment)
     }
 
     fn format_escaped_multiline_double_quoted_compound_assignment(
         &mut self,
         assignment: &Assignment,
     ) -> bool {
-        if !Self::compound_assignment_source_has_escaped_multiline_double_quoted_item(
-            assignment.span.slice(self.source()),
-        ) {
+        if !self.compound_assignment_source_has_escaped_multiline_double_quoted_item(assignment) {
             return false;
         }
 
@@ -4722,10 +4824,13 @@ impl<'source, 'facts> ShellStreamFormatter<'source, 'facts> {
         else {
             return false;
         };
-        let group_source = group_span.slice(self.source());
-        if !group_source.contains('\n')
-            || group_source.contains("\\\n")
-            || group_source.contains("\\\r\n")
+        if !self
+            .facts()
+            .contains_newline_between(group_span.start.offset, group_span.end.offset)
+            || self.facts().has_raw_continuation_backslash_between(
+                group_span.start.offset,
+                group_span.end.offset,
+            )
         {
             return false;
         }
@@ -4796,7 +4901,7 @@ impl<'source, 'facts> ShellStreamFormatter<'source, 'facts> {
         self.format_conditional_expr(&expression.left)?;
         self.write_space();
         self.write_text(expression.op.as_str());
-        if conditional_binary_has_explicit_rhs_break(expression, self.source()) {
+        if conditional_binary_has_explicit_rhs_break(expression, self.source_map()) {
             self.newline();
             if !conditional_expr_contains_command_substitution(&expression.left) {
                 self.write_indent_units(1);
@@ -5020,23 +5125,6 @@ fn normalize_rendered_heredoc_start_spacing(line: &str) -> Option<String> {
     Some(normalized)
 }
 
-fn heredoc_closing_marker_bounds(heredoc: &Heredoc, source: &str) -> Option<(usize, usize)> {
-    let mut start = heredoc.body.span.end.offset.min(source.len());
-    if source
-        .as_bytes()
-        .get(start)
-        .is_some_and(|byte| *byte == b'\n')
-    {
-        start += 1;
-    }
-    let line_end = source[start..]
-        .find(['\n', '\r'])
-        .map_or(source.len(), |offset| start + offset);
-    let line = source.get(start..line_end)?;
-    (line.trim_start_matches('\t') == heredoc.delimiter.cooked.as_str())
-        .then_some((start, line_end))
-}
-
 fn raw_redirect_source_slice<'a>(redirect: &Redirect, source: &'a str) -> Option<&'a str> {
     let span = redirect.span;
     (span.start.offset < span.end.offset && span.end.offset <= source.len())
@@ -5091,7 +5179,10 @@ fn append_both_redirect_pair_matches_source(
     false
 }
 
-fn redirect_target_starts_on_continuation_line(redirect: &Redirect, source: &str) -> bool {
+fn redirect_target_starts_on_continuation_line(
+    redirect: &Redirect,
+    facts: &FormatterFacts<'_>,
+) -> bool {
     let target_start = redirect
         .word_target()
         .map(|word| word.span.start.offset)
@@ -5103,9 +5194,7 @@ fn redirect_target_starts_on_continuation_line(redirect: &Redirect, source: &str
     let Some(target_start) = target_start else {
         return false;
     };
-    source
-        .get(redirect.span.start.offset.min(source.len())..target_start.min(source.len()))
-        .is_some_and(|between| between.contains("\\\n") || between.contains("\\\r\n"))
+    facts.has_continuation_line_start_between(redirect.span.start.offset, target_start)
 }
 
 fn should_render_explicit_fd(fd: i32, kind: RedirectKind) -> bool {
@@ -5212,7 +5301,7 @@ fn redirect_list_needs_leading_space(
 fn redirect_list_starts_on_continuation_line(
     command_span: Span,
     redirects: &[Redirect],
-    source: &str,
+    facts: &FormatterFacts<'_>,
 ) -> bool {
     let Some(redirect) = redirects.first() else {
         return false;
@@ -5220,11 +5309,7 @@ fn redirect_list_starts_on_continuation_line(
     if command_span == Span::new() || redirect.span.start.offset <= command_span.end.offset {
         return false;
     }
-    source
-        .get(
-            command_span.end.offset.min(source.len())..redirect.span.start.offset.min(source.len()),
-        )
-        .is_some_and(|between| between.contains("\\\n") || between.contains("\\\r\n"))
+    facts.has_continuation_line_start_between(command_span.end.offset, redirect.span.start.offset)
 }
 
 fn redirect_is_attached_process_substitution(
@@ -5336,6 +5421,7 @@ fn leading_list_operator_line_parts(line: &str) -> Option<(&'static str, &str)> 
 fn normalize_scalar_assignment_unquoted_continuations(
     assignment: &Assignment,
     source: &str,
+    facts: &FormatterFacts,
 ) -> Option<String> {
     if assignment_source_has_command_substitution(assignment, source) {
         return None;
@@ -5343,11 +5429,14 @@ fn normalize_scalar_assignment_unquoted_continuations(
     let AssignmentValue::Scalar(_) = &assignment.value else {
         return None;
     };
-    let raw = assignment.span.slice(source);
-    if !raw.contains("\\\n") && !raw.contains("\\\r\n") {
+    if !facts.has_raw_continuation_backslash_between(
+        assignment.span.start.offset,
+        assignment.span.end.offset,
+    ) {
         return None;
     }
 
+    let raw = assignment.span.slice(source);
     let mut head = String::new();
     render_assignment_head_to_buf(assignment, source, &mut head);
     let raw_value = raw.strip_prefix(&head)?;
@@ -5472,7 +5561,10 @@ fn assignment_value_is_quoted_command_substitution_only(assignment: &Assignment)
     }
 }
 
-fn stmt_semicolon_terminator_starts_on_continuation_line(stmt: &Stmt, source: &str) -> bool {
+fn stmt_semicolon_terminator_starts_on_continuation_line(
+    stmt: &Stmt,
+    source_map: &SourceMap<'_>,
+) -> bool {
     let Some(terminator_span) = stmt.terminator_span else {
         return false;
     };
@@ -5481,7 +5573,7 @@ fn stmt_semicolon_terminator_starts_on_continuation_line(stmt: &Stmt, source: &s
         .last()
         .map(|redirect| redirect.span.end.offset)
         .unwrap_or_else(|| command_format_span(&stmt.command).end.offset);
-    has_newline_between_offsets(source, render_end, terminator_span.start.offset)
+    source_map.contains_newline_between(render_end, terminator_span.start.offset)
 }
 
 fn stmt_rendered_end_line_after_format(
@@ -5491,7 +5583,7 @@ fn stmt_rendered_end_line_after_format(
     fallback: usize,
 ) -> usize {
     if matches!(stmt.terminator, Some(StmtTerminator::Semicolon))
-        && stmt_semicolon_terminator_starts_on_continuation_line(stmt, source)
+        && stmt_semicolon_terminator_starts_on_continuation_line(stmt, source_map)
         && let Some(terminator_span) = stmt.terminator_span
     {
         return terminator_span.start.line;
@@ -5536,8 +5628,9 @@ fn if_condition_starts_after_keyword(
     source: &str,
     source_map: &SourceMap<'_>,
     options: &ResolvedShellFormatOptions,
+    facts: &FormatterFacts,
 ) -> bool {
-    if raw_if_condition_starts_with_negation_continuation(command, then_span, source) {
+    if raw_if_condition_starts_with_negation_continuation(command, then_span, source, facts) {
         return false;
     }
     command.condition.first().is_some_and(|stmt| {
@@ -5549,14 +5642,17 @@ fn if_condition_has_explicit_statement_break(
     command: &IfCommand,
     then_span: Span,
     source: &str,
+    source_map: &SourceMap<'_>,
+    facts: &FormatterFacts,
 ) -> bool {
-    if raw_if_condition_starts_with_negation_continuation(command, then_span, source) {
+    if raw_if_condition_starts_with_negation_continuation(command, then_span, source, facts) {
         return false;
     }
     condition_sequence_has_explicit_statement_break(
         &command.condition,
         then_span.start.offset,
         source,
+        source_map,
     )
 }
 
@@ -5564,27 +5660,30 @@ fn raw_if_condition_starts_with_negation_continuation(
     command: &IfCommand,
     then_span: Span,
     source: &str,
+    facts: &FormatterFacts,
 ) -> bool {
     let condition_start = command.span.start.offset.saturating_add("if".len());
     let condition_end = then_span.start.offset.min(source.len());
-    source
-        .get(condition_start..condition_end)
-        .is_some_and(raw_condition_starts_with_negation_continuation)
-}
-
-fn raw_condition_starts_with_negation_continuation(raw: &str) -> bool {
+    let Some(raw) = source.get(condition_start..condition_end) else {
+        return false;
+    };
     let raw = raw.trim_start_matches([' ', '\t', '\r']);
     let Some(after_negation) = raw.strip_prefix('!') else {
         return false;
     };
     let after_negation = after_negation.trim_start_matches([' ', '\t', '\r']);
-    after_negation.starts_with("\\\n") || after_negation.starts_with("\\\r\n")
+    let continuation_offset = condition_end - after_negation.len();
+    facts.has_raw_continuation_backslash_between(
+        continuation_offset,
+        continuation_offset.saturating_add(1),
+    )
 }
 
 fn condition_sequence_has_explicit_statement_break(
     condition: &StmtSeq,
     upper_bound: usize,
     source: &str,
+    source_map: &SourceMap<'_>,
 ) -> bool {
     if condition.len() == 1 {
         let Some(stmt) = condition.first() else {
@@ -5603,7 +5702,7 @@ fn condition_sequence_has_explicit_statement_break(
     condition.as_slice().windows(2).any(|pair| {
         let previous_start = stmt_span(&pair[0]).start.offset;
         let next_start = stmt_span(&pair[1]).start.offset;
-        has_newline_between_offsets(source, previous_start, next_start)
+        source_map.contains_newline_between(previous_start, next_start)
     })
 }
 
@@ -5622,10 +5721,11 @@ fn elif_condition_has_explicit_statement_break(
     condition: &StmtSeq,
     body: &StmtSeq,
     source: &str,
+    source_map: &SourceMap<'_>,
 ) -> bool {
     let upper_bound =
         branch_open_keyword_start(body, source, "then").unwrap_or(body.span.start.offset);
-    condition_sequence_has_explicit_statement_break(condition, upper_bound, source)
+    condition_sequence_has_explicit_statement_break(condition, upper_bound, source, source_map)
 }
 
 fn has_unescaped_line_break(text: &str) -> bool {
@@ -5666,17 +5766,19 @@ fn loop_condition_starts_after_keyword(condition: &StmtSeq, span: Span) -> bool 
 fn condition_keyword_on_previous_non_empty_line(
     condition: &StmtSeq,
     source: &str,
+    source_map: &SourceMap<'_>,
     keyword: &str,
 ) -> bool {
     let Some(first) = condition.first() else {
         return false;
     };
-    let Some((mut line_start, _)) = line_bounds_for_offset(source, stmt_span(first).start.offset)
+    let Some((mut line_start, _)) =
+        source_map.line_bounds_for_offset(stmt_span(first).start.offset)
     else {
         return false;
     };
 
-    while let Some((start, end)) = previous_line_bounds(source, line_start) {
+    while let Some((start, end)) = source_map.previous_line_bounds(line_start) {
         let Some(line) = source.get(start..end) else {
             return false;
         };
@@ -5696,8 +5798,9 @@ fn raw_grouped_if_condition(
     source: &str,
     source_map: &SourceMap<'_>,
     options: &ResolvedShellFormatOptions,
+    facts: &FormatterFacts,
 ) -> Option<String> {
-    if !if_condition_starts_after_keyword(command, then_span, source, source_map, options) {
+    if !if_condition_starts_after_keyword(command, then_span, source, source_map, options, facts) {
         return None;
     }
     let start = command.span.start.offset.checked_add("if".len())?;
@@ -5709,7 +5812,9 @@ fn raw_grouped_if_condition(
     if !(raw.trim_start().starts_with('{') && raw.contains('}') && raw.contains('\n')) {
         return None;
     }
-    let outer_indent = line_indent_before_offset(source, command.span.start.offset).unwrap_or("");
+    let outer_indent = source_map
+        .line_indent_before_offset(command.span.start.offset)
+        .unwrap_or("");
     Some(strip_outer_indent_after_first_line(raw, outer_indent))
 }
 
@@ -5786,29 +5891,6 @@ fn body_has_blank_line_after_keyword(
     gap_has_blank_line(source, search_start + keyword_end, first_start)
 }
 
-fn source_has_blank_line_immediately_before_offset(source: &str, offset: usize) -> bool {
-    let offset = offset.min(source.len());
-    let close_line_start = source[..offset]
-        .rfind('\n')
-        .map_or(0, |index| index.saturating_add(1));
-    if !source[close_line_start..offset]
-        .trim_matches([' ', '\t', '\r'])
-        .is_empty()
-    {
-        return false;
-    }
-    if close_line_start == 0 {
-        return false;
-    }
-    let previous_line_end = close_line_start.saturating_sub(1);
-    let previous_line_start = source[..previous_line_end]
-        .rfind('\n')
-        .map_or(0, |index| index.saturating_add(1));
-    source[previous_line_start..previous_line_end]
-        .trim_matches([' ', '\t', '\r'])
-        .is_empty()
-}
-
 fn source_has_blank_line_before_last_keyword(
     source: &str,
     source_map: &SourceMap<'_>,
@@ -5816,7 +5898,7 @@ fn source_has_blank_line_before_last_keyword(
     keyword: &str,
 ) -> bool {
     last_shell_keyword_span(source, source_map, span, keyword).is_some_and(|keyword_span| {
-        source_has_blank_line_immediately_before_offset(source, keyword_span.start.offset)
+        source_map.has_blank_line_immediately_before_offset(keyword_span.start.offset)
     })
 }
 
@@ -6079,7 +6161,7 @@ fn case_item_single_body_stmt_can_inline(
     };
     if let Command::Compound(CompoundCommand::If(command)) = &stmt.command {
         return pattern_body_terminator_was_inline
-            && case_item_close_paren_shares_line_with_body(item, source)
+            && case_item_close_paren_shares_line_with_body(item, source, source_map)
             && case_item_if_close_shares_terminator(command, item, source, source_map);
     }
     if let Command::Compound(CompoundCommand::Case(command)) = &stmt.command {
@@ -6178,7 +6260,11 @@ fn case_item_pattern_starts_on_case_header(command: &CaseCommand, item: &CaseIte
         .is_some_and(|pattern| pattern.span.start.line == command.span.start.line)
 }
 
-fn case_item_pattern_close_paren_on_own_line(item: &CaseItem, source: &str) -> bool {
+fn case_item_pattern_close_paren_on_own_line(
+    item: &CaseItem,
+    source: &str,
+    source_map: &SourceMap<'_>,
+) -> bool {
     let Some(first_pattern) = item.patterns.first() else {
         return false;
     };
@@ -6195,15 +6281,22 @@ fn case_item_pattern_close_paren_on_own_line(item: &CaseItem, source: &str) -> b
     let Some(close_offset) = slice.rfind(')') else {
         return false;
     };
-    let line_start = slice[..close_offset]
-        .rfind('\n')
-        .map_or(0, |offset| offset + 1);
-    slice[line_start..close_offset]
+    let close_offset = first_pattern.span.start.offset + close_offset;
+    let Some((line_start, _)) = source_map.line_bounds_for_offset(close_offset) else {
+        return false;
+    };
+    source
+        .get(line_start..close_offset)
+        .unwrap_or("")
         .trim_matches([' ', '\t', '\r'])
         .is_empty()
 }
 
-fn case_item_close_paren_shares_line_with_body(item: &CaseItem, source: &str) -> bool {
+fn case_item_close_paren_shares_line_with_body(
+    item: &CaseItem,
+    source: &str,
+    source_map: &SourceMap<'_>,
+) -> bool {
     let Some(first_pattern) = item.patterns.first() else {
         return false;
     };
@@ -6217,7 +6310,8 @@ fn case_item_close_paren_shares_line_with_body(item: &CaseItem, source: &str) ->
     let Some(close_offset) = slice.rfind(')') else {
         return false;
     };
-    !slice[close_offset + 1..].contains(['\n', '\r'])
+    let close_offset = first_pattern.span.start.offset + close_offset;
+    !source_map.contains_newline_between(close_offset + 1, stmt_start)
 }
 
 fn trim_trailing_pattern_line_continuation(rendered: &mut String) {
@@ -6260,14 +6354,18 @@ fn case_item_has_blank_line_after_pattern(
     })
 }
 
-fn case_item_has_blank_line_before_terminator(item: &CaseItem, source: &str) -> bool {
+fn case_item_has_blank_line_before_terminator(
+    item: &CaseItem,
+    source: &str,
+    facts: &FormatterFacts<'_>,
+) -> bool {
     let Some(terminator_start) = item.terminator_span.map(|span| span.start.offset) else {
         return false;
     };
     if item.body.is_empty() {
         return false;
     }
-    let content_end = sequence_close_gap_start(&item.body, source);
+    let content_end = sequence_close_gap_start(&item.body, source, facts);
     gap_has_empty_physical_line(source, content_end, terminator_start)
 }
 
@@ -6282,13 +6380,13 @@ fn case_suffix_comment_start_line(item: &CaseItem) -> Option<usize> {
         .or_else(|| item.patterns.last().map(|pattern| pattern.span.end.line))
 }
 
-fn sequence_close_gap_start(commands: &StmtSeq, source: &str) -> usize {
+fn sequence_close_gap_start(commands: &StmtSeq, source: &str, facts: &FormatterFacts<'_>) -> usize {
     commands
         .trailing_comments
         .iter()
         .map(|comment| usize::from(comment.range.end()))
         .max()
-        .unwrap_or_else(|| branch_body_content_end(commands, source))
+        .unwrap_or_else(|| branch_body_content_end(commands, source, facts))
 }
 
 fn case_has_blank_line_before_esac(command: &CaseCommand, source: &str) -> bool {
@@ -6363,16 +6461,17 @@ fn group_close_offset(
 
 fn trailing_comment_padding(
     source: &str,
+    source_map: &SourceMap<'_>,
     comment: &SourceComment<'_>,
     current_code_column: usize,
     current_indent_column: usize,
 ) -> usize {
     let Some(target_column) =
-        trailing_comment_alignment_column(source, comment, current_indent_column)
+        trailing_comment_alignment_column(source, source_map, comment, current_indent_column)
     else {
         return 1;
     };
-    let indent_adjust = trailing_comment_tab_indent_adjust(source, comment);
+    let indent_adjust = trailing_comment_tab_indent_adjust(source, source_map, comment);
     target_column
         .saturating_sub(current_code_column.saturating_add(indent_adjust))
         .max(1)
@@ -6380,28 +6479,37 @@ fn trailing_comment_padding(
 
 fn close_suffix_comment_padding(
     source: &str,
+    source_map: &SourceMap<'_>,
     comment: &SourceComment<'_>,
     current_code_column: usize,
     current_indent_column: usize,
 ) -> usize {
     if let Some(padding) = aligned_close_suffix_comment_padding(
         source,
+        source_map,
         comment,
         current_code_column,
         current_indent_column,
     ) {
         return padding;
     }
-    trailing_comment_padding(source, comment, current_code_column, current_indent_column)
+    trailing_comment_padding(
+        source,
+        source_map,
+        comment,
+        current_code_column,
+        current_indent_column,
+    )
 }
 
 fn aligned_close_suffix_comment_padding(
     source: &str,
+    source_map: &SourceMap<'_>,
     comment: &SourceComment<'_>,
     current_code_column: usize,
     current_indent_column: usize,
 ) -> Option<usize> {
-    let entries = close_suffix_comment_alignment_entries(source, comment)?;
+    let entries = close_suffix_comment_alignment_entries(source, source_map, comment)?;
     if entries.len() <= 1 {
         return None;
     }
@@ -6443,9 +6551,10 @@ struct CloseSuffixAlignmentEntry {
 
 fn close_suffix_comment_alignment_entries(
     source: &str,
+    source_map: &SourceMap<'_>,
     comment: &SourceComment<'_>,
 ) -> Option<Vec<CloseSuffixAlignmentEntry>> {
-    let (line_start, line_end) = line_bounds_for_offset(source, comment.span().start.offset)?;
+    let (line_start, line_end) = source_map.line_bounds_for_offset(comment.span().start.offset)?;
     let mut entries = vec![close_suffix_alignment_entry(
         source,
         line_start,
@@ -6454,7 +6563,7 @@ fn close_suffix_comment_alignment_entries(
     )?];
 
     let mut previous_start = line_start;
-    while let Some((start, end)) = previous_line_bounds(source, previous_start) {
+    while let Some((start, end)) = source_map.previous_line_bounds(previous_start) {
         let Some(entry) = close_suffix_alignment_entry(source, start, end, None) else {
             break;
         };
@@ -6462,13 +6571,13 @@ fn close_suffix_comment_alignment_entries(
         previous_start = start;
     }
 
-    let mut next_line = next_line_bounds(source, line_end);
+    let mut next_line = source_map.next_line_bounds(line_end);
     while let Some((start, end)) = next_line {
         let Some(entry) = close_suffix_alignment_entry(source, start, end, None) else {
             break;
         };
         entries.push(entry);
-        next_line = next_line_bounds(source, end);
+        next_line = source_map.next_line_bounds(end);
     }
 
     Some(entries)
@@ -6523,16 +6632,17 @@ fn leading_indent_and_code_start(text: &str) -> Option<(usize, usize)> {
 
 fn trailing_comment_alignment_column(
     source: &str,
+    source_map: &SourceMap<'_>,
     comment: &SourceComment<'_>,
     current_indent_column: usize,
 ) -> Option<usize> {
-    let (line_start, line_end) = line_bounds_for_offset(source, comment.span().start.offset)?;
+    let (line_start, line_end) = source_map.line_bounds_for_offset(comment.span().start.offset)?;
     let mut widths = vec![trimmed_line_width(
         source.get(line_start..comment.span().start.offset)?,
     )?];
 
     let mut previous_start = line_start;
-    while let Some((start, end)) = previous_line_bounds(source, previous_start) {
+    while let Some((start, end)) = source_map.previous_line_bounds(previous_start) {
         let Some(width) = inline_comment_code_width(source, start, end, None) else {
             if source
                 .get(start..end)
@@ -6547,31 +6657,37 @@ fn trailing_comment_alignment_column(
         previous_start = start;
     }
 
-    let mut next_line = next_line_bounds(source, line_end);
+    let mut next_line = source_map.next_line_bounds(line_end);
     while let Some((start, end)) = next_line {
         let Some(width) = inline_comment_code_width(source, start, end, None) else {
             if let Some((width, suffix_end)) = multiline_header_suffix_comment_width(
                 source,
+                source_map,
                 line_start,
                 start,
                 end,
                 current_indent_column,
             ) {
                 widths.push(width);
-                next_line = next_line_bounds(source, suffix_end);
+                next_line = source_map.next_line_bounds(suffix_end);
                 continue;
             }
             break;
         };
         widths.push(width);
-        next_line = next_line_bounds(source, end);
+        next_line = source_map.next_line_bounds(end);
     }
 
     (widths.len() > 1).then(|| widths.into_iter().max().unwrap_or(0) + 1)
 }
 
-fn trailing_comment_tab_indent_adjust(source: &str, comment: &SourceComment<'_>) -> usize {
-    let Some((line_start, line_end)) = line_bounds_for_offset(source, comment.span().start.offset)
+fn trailing_comment_tab_indent_adjust(
+    source: &str,
+    source_map: &SourceMap<'_>,
+    comment: &SourceComment<'_>,
+) -> usize {
+    let Some((line_start, line_end)) =
+        source_map.line_bounds_for_offset(comment.span().start.offset)
     else {
         return 0;
     };
@@ -6584,7 +6700,7 @@ fn trailing_comment_tab_indent_adjust(source: &str, comment: &SourceComment<'_>)
     }
 
     let mut previous_start = line_start;
-    while let Some((start, end)) = previous_line_bounds(source, previous_start) {
+    while let Some((start, end)) = source_map.previous_line_bounds(previous_start) {
         if inline_comment_code_width(source, start, end, None).is_some() {
             return source
                 .get(start..end)
@@ -6607,7 +6723,7 @@ fn trailing_comment_tab_indent_adjust(source: &str, comment: &SourceComment<'_>)
         break;
     }
 
-    let mut next_line = next_line_bounds(source, line_end);
+    let mut next_line = source_map.next_line_bounds(line_end);
     while let Some((start, end)) = next_line {
         if inline_comment_code_width(source, start, end, None).is_some() {
             return source
@@ -6625,7 +6741,7 @@ fn trailing_comment_tab_indent_adjust(source: &str, comment: &SourceComment<'_>)
             .get(start..end)
             .is_some_and(line_is_skippable_alignment_opener)
         {
-            next_line = next_line_bounds(source, end);
+            next_line = source_map.next_line_bounds(end);
             continue;
         }
         break;
@@ -6645,41 +6761,6 @@ fn leading_tabs_only_indent_width(line: &str) -> usize {
     tabs
 }
 
-fn line_bounds_for_offset(source: &str, offset: usize) -> Option<(usize, usize)> {
-    if source.is_empty() {
-        return None;
-    }
-    let offset = offset.min(source.len().saturating_sub(1));
-    let start = source[..offset]
-        .rfind('\n')
-        .map_or(0, |index| index.saturating_add(1));
-    let end = source[offset..]
-        .find('\n')
-        .map_or(source.len(), |index| offset + index);
-    Some((start, end))
-}
-
-fn previous_line_bounds(source: &str, line_start: usize) -> Option<(usize, usize)> {
-    if line_start == 0 {
-        return None;
-    }
-    let end = line_start.saturating_sub(1);
-    let start = source[..end]
-        .rfind('\n')
-        .map_or(0, |index| index.saturating_add(1));
-    Some((start, end))
-}
-
-fn next_line_bounds(source: &str, line_end: usize) -> Option<(usize, usize)> {
-    let start = line_end
-        .checked_add(1)
-        .filter(|offset| *offset < source.len())?;
-    let end = source[start..]
-        .find('\n')
-        .map_or(source.len(), |offset| start + offset);
-    Some((start, end))
-}
-
 fn inline_comment_code_width(
     source: &str,
     line_start: usize,
@@ -6697,6 +6778,7 @@ fn inline_comment_code_width(
 
 fn multiline_header_suffix_comment_width(
     source: &str,
+    source_map: &SourceMap<'_>,
     current_line_start: usize,
     header_start: usize,
     header_end: usize,
@@ -6709,7 +6791,7 @@ fn multiline_header_suffix_comment_width(
     let header = header_line.trim_matches([' ', '\t', '\r']);
     let suffix = multiline_header_suffix_keyword(header)?;
 
-    let (suffix_start, suffix_end) = next_line_bounds(source, header_end)?;
+    let (suffix_start, suffix_end) = source_map.next_line_bounds(header_end)?;
     let suffix_line = source.get(suffix_start..suffix_end)?;
     let comment_offset = find_inline_comment_start(suffix_line, suffix_start)?;
     let suffix_prefix = source.get(suffix_start..comment_offset)?;
@@ -6722,6 +6804,7 @@ fn multiline_header_suffix_comment_width(
     Some((
         alignment_width_relative_to_current_indent(
             source,
+            source_map,
             current_line_start,
             header_start,
             normalized_comment_alignment_width(&rendered),
@@ -6741,15 +6824,16 @@ fn multiline_header_suffix_keyword(header: &str) -> Option<&'static str> {
 
 fn alignment_width_relative_to_current_indent(
     source: &str,
+    source_map: &SourceMap<'_>,
     current_line_start: usize,
     target_line_start: usize,
     width: usize,
     current_indent_column: usize,
 ) -> usize {
-    let Some((_, current_line_end)) = line_bounds_for_offset(source, current_line_start) else {
+    let Some((_, current_line_end)) = source_map.line_bounds_for_offset(current_line_start) else {
         return width;
     };
-    let Some((_, target_line_end)) = line_bounds_for_offset(source, target_line_start) else {
+    let Some((_, target_line_end)) = source_map.line_bounds_for_offset(target_line_start) else {
         return width;
     };
     let current_indent = line_indent_info(source, current_line_start, current_line_end);
@@ -6769,6 +6853,7 @@ fn alignment_width_relative_to_current_indent(
     }
     let delta = rendered_indent_delta_between_lines(
         source,
+        source_map,
         current_line_start,
         target_line_start,
         current_indent_column,
@@ -6782,14 +6867,15 @@ fn alignment_width_relative_to_current_indent(
 
 fn rendered_indent_delta_between_lines(
     source: &str,
+    source_map: &SourceMap<'_>,
     current_line_start: usize,
     target_line_start: usize,
     current_rendered_indent: usize,
 ) -> isize {
-    let Some((_, current_line_end)) = line_bounds_for_offset(source, current_line_start) else {
+    let Some((_, current_line_end)) = source_map.line_bounds_for_offset(current_line_start) else {
         return 0;
     };
-    let Some((_, target_line_end)) = line_bounds_for_offset(source, target_line_start) else {
+    let Some((_, target_line_end)) = source_map.line_bounds_for_offset(target_line_start) else {
         return 0;
     };
     let current_indent = line_indent_info(source, current_line_start, current_line_end);
@@ -7206,16 +7292,17 @@ fn multiline_compound_assignment_line_extra_indent(
 
 fn case_prefix_comment_uses_body_indent(
     source: &str,
+    source_map: &SourceMap<'_>,
     comment: &SourceComment<'_>,
     pattern_start: usize,
     disabled_case_pattern_context: bool,
     body_indent_context: bool,
 ) -> bool {
-    let Some(comment_indent) = line_indent_before_offset(source, comment.span().start.offset)
+    let Some(comment_indent) = source_map.line_indent_before_offset(comment.span().start.offset)
     else {
         return false;
     };
-    let Some(pattern_indent) = line_indent_before_offset(source, pattern_start) else {
+    let Some(pattern_indent) = source_map.line_indent_before_offset(pattern_start) else {
         return false;
     };
     let comment_width = shell_indent_width(comment_indent);
@@ -7224,23 +7311,31 @@ fn case_prefix_comment_uses_body_indent(
         if body_indent_context {
             return true;
         }
-        if comment_width != pattern_width && case_prefix_comment_follows_terminator(source, comment)
+        if comment_width != pattern_width
+            && case_prefix_comment_follows_terminator(source, source_map, comment)
         {
             return true;
         }
         return comment_text_after_hash_starts_with_tab(comment) && comment_width < pattern_width;
     }
-    if comment_width < pattern_width && case_prefix_comment_follows_terminator(source, comment) {
+    if comment_width < pattern_width
+        && case_prefix_comment_follows_terminator(source, source_map, comment)
+    {
         return true;
     }
     comment_width > pattern_width || (comment_width == 0 && pattern_width > 0)
 }
 
-fn case_prefix_comment_follows_terminator(source: &str, comment: &SourceComment<'_>) -> bool {
-    let Some((line_start, _)) = line_bounds_for_offset(source, comment.span().start.offset) else {
+fn case_prefix_comment_follows_terminator(
+    source: &str,
+    source_map: &SourceMap<'_>,
+    comment: &SourceComment<'_>,
+) -> bool {
+    let Some((line_start, _)) = source_map.line_bounds_for_offset(comment.span().start.offset)
+    else {
         return false;
     };
-    let Some((previous_start, previous_end)) = previous_line_bounds(source, line_start) else {
+    let Some((previous_start, previous_end)) = source_map.previous_line_bounds(line_start) else {
         return false;
     };
     source
@@ -7273,31 +7368,26 @@ fn shell_indent_width(indent: &str) -> usize {
 
 fn comment_precedes_close_keyword_at_same_indent(
     source: &str,
+    source_map: &SourceMap<'_>,
     comment: &SourceComment<'_>,
 ) -> bool {
-    let Some(comment_indent) = line_indent_before_offset(source, comment.span().start.offset)
+    let Some(comment_indent) = source_map.line_indent_before_offset(comment.span().start.offset)
     else {
         return false;
     };
-    let mut offset = source
-        .get(comment.span().end.offset..)
-        .and_then(|suffix| {
-            suffix
-                .find('\n')
-                .map(|line_end| comment.span().end.offset + line_end + 1)
-        })
-        .unwrap_or(source.len());
+    let Some((_, comment_line_end)) = source_map.line_bounds_for_offset(comment.span().end.offset)
+    else {
+        return false;
+    };
+    let mut next_line = source_map.next_line_bounds(comment_line_end);
 
-    while offset < source.len() {
-        let line_end = source[offset..]
-            .find('\n')
-            .map_or(source.len(), |line_end| offset + line_end);
-        let Some(line) = source.get(offset..line_end) else {
+    while let Some((line_start, line_end)) = next_line {
+        let Some(line) = source.get(line_start..line_end) else {
             return false;
         };
         let trimmed = line.trim_start_matches([' ', '\t']);
         if trimmed.trim().is_empty() {
-            offset = line_end.saturating_add(1);
+            next_line = source_map.next_line_bounds(line_end);
             continue;
         }
         let indent_len = line.len() - trimmed.len();
@@ -7306,7 +7396,7 @@ fn comment_precedes_close_keyword_at_same_indent(
                 return true;
             }
             if trimmed.starts_with('#') {
-                offset = line_end.saturating_add(1);
+                next_line = source_map.next_line_bounds(line_end);
                 continue;
             }
         }
@@ -7408,8 +7498,8 @@ fn pipeline_operator_breaks(
         let next_start =
             interstitial_comment_end(statement, operator_span.end.offset, source, source_map);
         breaks.push(
-            pipeline_operator_starts_or_ends_line(source, *operator_span)
-                || has_newline_between_offsets(source, operator_span.end.offset, next_start),
+            source_map.operator_starts_or_ends_line(*operator_span)
+                || source_map.contains_newline_between(operator_span.end.offset, next_start),
         );
     }
 
@@ -7788,7 +7878,7 @@ fn final_pipe_operator_is_unquoted(text: &str) -> bool {
 
 fn conditional_binary_has_explicit_rhs_break(
     expression: &ConditionalBinaryExpr,
-    source: &str,
+    source_map: &SourceMap<'_>,
 ) -> bool {
     if !matches!(
         expression.op,
@@ -7796,14 +7886,12 @@ fn conditional_binary_has_explicit_rhs_break(
     ) {
         return false;
     }
-    pipeline_operator_starts_or_ends_line(source, expression.op_span)
-        || has_newline_between_offsets(
-            source,
+    source_map.operator_starts_or_ends_line(expression.op_span)
+        || source_map.contains_newline_between(
             expression.left.span().end.offset,
             expression.op_span.start.offset,
         )
-        || has_newline_between_offsets(
-            source,
+        || source_map.contains_newline_between(
             expression.op_span.end.offset,
             expression.right.span().start.offset,
         )
@@ -7959,9 +8047,12 @@ fn if_branch_upper_bound(
     branch_index: usize,
     source: &str,
     source_map: &SourceMap<'_>,
+    facts: &FormatterFacts<'_>,
 ) -> usize {
-    if let Some((start, end)) = if_next_branch_region(command, branch_index, source) {
-        branch_prefix_first_comment_offset(source, start, end).unwrap_or(end)
+    if let Some((start, end)) = if_next_branch_region(command, branch_index, source, facts) {
+        facts
+            .branch_prefix_first_comment_offset(start, end)
+            .unwrap_or(end)
     } else {
         command_if_close_span(command, source, source_map)
             .start
@@ -7969,45 +8060,18 @@ fn if_branch_upper_bound(
     }
 }
 
-fn if_next_branch_has_blank_line_before_keyword(
-    command: &IfCommand,
-    branch_index: usize,
-    source: &str,
-) -> bool {
-    if_next_branch_region(command, branch_index, source).is_some_and(|(start, end)| {
-        let first_prefix = branch_prefix_first_comment_offset(source, start, end).unwrap_or(end);
-        gap_has_empty_physical_line(source, start, first_prefix)
-    })
-}
-
-fn if_branch_prefix_comments_have_blank_line_before_keyword(
-    command: &IfCommand,
-    branch_index: usize,
-    source: &str,
-) -> bool {
-    if_next_branch_region(command, branch_index, source).is_some_and(|(start, end)| {
-        let comments = branch_prefix_comments(source, start, end);
-        let Some(last) = comments.last() else {
-            return false;
-        };
-        let Some(line_end) = source[last.offset..end].find('\n') else {
-            return false;
-        };
-        gap_has_empty_physical_line(source, last.offset + line_end, end)
-    })
-}
-
 fn if_next_branch_region(
     command: &IfCommand,
     branch_index: usize,
     source: &str,
+    facts: &FormatterFacts<'_>,
 ) -> Option<(usize, usize)> {
     if_next_branch_region_with_body_end(command, branch_index, source, |body| {
-        branch_body_content_end(body, source)
+        branch_body_content_end(body, source, facts)
     })
 }
 
-fn branch_body_content_end(body: &StmtSeq, source: &str) -> usize {
+fn branch_body_content_end(body: &StmtSeq, source: &str, facts: &FormatterFacts<'_>) -> usize {
     let mut end = body
         .last()
         .map(|stmt| stmt_span(stmt).end.offset)
@@ -8017,7 +8081,8 @@ fn branch_body_content_end(body: &StmtSeq, source: &str) -> usize {
             let Some(heredoc) = redirect.heredoc() else {
                 continue;
             };
-            let heredoc_end = heredoc_closing_marker_bounds(heredoc, source)
+            let heredoc_end = facts
+                .heredoc_closing_marker_bounds(heredoc)
                 .map(|(_, line_end)| line_end)
                 .unwrap_or(heredoc.body.span.end.offset);
             end = end.max(heredoc_end);

--- a/crates/shuck-indexer/src/lib.rs
+++ b/crates/shuck-indexer/src/lib.rs
@@ -25,9 +25,9 @@ mod region_index;
 /// Comment lookup types derived from parser output.
 pub use comment_index::{CommentIndex, IndexedComment};
 /// Line-based offset lookup utilities.
-pub use line_index::LineIndex;
+pub use line_index::{LineEndingStyle, LineIndex};
 /// Structural region indexes over parsed shell source.
-pub use region_index::{RegionIndex, RegionKind};
+pub use region_index::{IndexedHeredoc, RegionIndex, RegionKind};
 
 use shuck_ast::{File, TextSize};
 use shuck_parser::parser::ParseResult;
@@ -137,11 +137,14 @@ fn collect_continuation_lines(
 ) -> Vec<TextSize> {
     let mut continuation_lines = Vec::new();
 
-    for line_start in line_index.raw_continuation_line_starts() {
-        let backslash_offset = TextSize::new(line_start.to_u32() - 2);
-        if comment_index.is_comment(backslash_offset)
-            || region_index.is_heredoc(backslash_offset)
-            || region_index.is_quoted(backslash_offset)
+    for (line_start, backslash_offset) in line_index
+        .raw_continuation_line_starts()
+        .iter()
+        .zip(line_index.raw_continuation_backslashes())
+    {
+        if comment_index.is_comment(*backslash_offset)
+            || region_index.is_heredoc(*backslash_offset)
+            || region_index.is_quoted(*backslash_offset)
         {
             continue;
         }

--- a/crates/shuck-indexer/src/lib.rs
+++ b/crates/shuck-indexer/src/lib.rs
@@ -29,8 +29,43 @@ pub use line_index::{LineEndingStyle, LineIndex};
 /// Structural region indexes over parsed shell source.
 pub use region_index::{IndexedHeredoc, RegionIndex, RegionKind};
 
+use line_index::{RawContinuationCandidate, RawContinuationMode};
 use shuck_ast::{File, TextSize};
 use shuck_parser::parser::ParseResult;
+
+/// Optional index families that are not needed by every consumer.
+///
+/// The default options build the indexes used by linting and semantic analysis.
+/// Source-layout indexes retain formatter-oriented lookup tables such as raw
+/// continuation backslash offsets and heredoc closing-marker ranges.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct IndexerOptions {
+    source_layout_indexes: bool,
+}
+
+impl IndexerOptions {
+    /// Return default indexer options.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Enable or disable formatter-oriented source-layout indexes.
+    ///
+    /// When enabled, [`LineIndex::raw_continuation_line_starts`],
+    /// [`LineIndex::raw_continuation_backslashes`], and
+    /// [`RegionIndex::heredoc_closing_marker_range`] retain their lookup data.
+    /// The default keeps those retained indexes disabled while still computing
+    /// semantic continuation lines for [`Indexer::continuation_line_starts`].
+    pub fn with_source_layout_indexes(mut self, enabled: bool) -> Self {
+        self.source_layout_indexes = enabled;
+        self
+    }
+
+    /// Return whether formatter-oriented source-layout indexes are enabled.
+    pub fn source_layout_indexes(self) -> bool {
+        self.source_layout_indexes
+    }
+}
 
 /// Pre-computed positional and structural index over a parsed shell script.
 ///
@@ -61,16 +96,41 @@ impl Indexer {
         Self::for_file(source, &output.file)
     }
 
+    /// Build indexes from parser output using explicit options.
+    ///
+    /// `source` must be the exact text used to produce `output`; ranges in the
+    /// parse result are interpreted as byte offsets into that string.
+    pub fn new_with_options(source: &str, output: &ParseResult, options: IndexerOptions) -> Self {
+        Self::for_file_with_options(source, &output.file, options)
+    }
+
     /// Build all indexes from an already parsed file and the original source text.
     ///
     /// `source` must be the exact text used to produce `file`; ranges in the
     /// AST are interpreted as byte offsets into that string.
     pub fn for_file(source: &str, file: &File) -> Self {
-        let line_index = LineIndex::new(source);
+        Self::for_file_with_options(source, file, IndexerOptions::default())
+    }
+
+    /// Build indexes from an already parsed file using explicit options.
+    ///
+    /// `source` must be the exact text used to produce `file`; ranges in the
+    /// AST are interpreted as byte offsets into that string.
+    pub fn for_file_with_options(source: &str, file: &File, options: IndexerOptions) -> Self {
+        let raw_mode = if options.source_layout_indexes() {
+            RawContinuationMode::StoreAndReturn
+        } else {
+            RawContinuationMode::ReturnOnly
+        };
+        let (line_index, raw_continuations) = LineIndex::build(source, raw_mode);
         let comment_index = CommentIndex::new(source, &line_index, file);
-        let region_index = RegionIndex::new(source, file);
+        let region_index = RegionIndex::new_with_source_layout_indexes(
+            source,
+            file,
+            options.source_layout_indexes(),
+        );
         let continuation_lines =
-            collect_continuation_lines(&line_index, &comment_index, &region_index);
+            collect_continuation_lines(&raw_continuations, &comment_index, &region_index);
 
         Self {
             line_index,
@@ -131,25 +191,21 @@ impl Indexer {
 }
 
 fn collect_continuation_lines(
-    line_index: &LineIndex,
+    raw_continuations: &[RawContinuationCandidate],
     comment_index: &CommentIndex,
     region_index: &RegionIndex,
 ) -> Vec<TextSize> {
     let mut continuation_lines = Vec::new();
 
-    for (line_start, backslash_offset) in line_index
-        .raw_continuation_line_starts()
-        .iter()
-        .zip(line_index.raw_continuation_backslashes())
-    {
-        if comment_index.is_comment(*backslash_offset)
-            || region_index.is_heredoc(*backslash_offset)
-            || region_index.is_quoted(*backslash_offset)
+    for continuation in raw_continuations {
+        if comment_index.is_comment(continuation.backslash)
+            || region_index.is_heredoc(continuation.backslash)
+            || region_index.is_quoted(continuation.backslash)
         {
             continue;
         }
 
-        continuation_lines.push(*line_start);
+        continuation_lines.push(continuation.line_start);
     }
 
     continuation_lines
@@ -177,6 +233,30 @@ mod tests {
         assert_eq!(indexer.continuation_line_starts().len(), 1);
         assert!(indexer.is_continuation(TextSize::new(11)));
         assert!(!indexer.is_continuation(TextSize::new(28)));
+        assert!(
+            indexer
+                .line_index()
+                .raw_continuation_backslashes()
+                .is_empty()
+        );
+        assert!(indexer.region_index().heredocs().is_empty());
+    }
+
+    #[test]
+    fn retains_source_layout_indexes_only_when_requested() {
+        let source = "echo foo \\\n  bar\ncat <<EOF\nbody\nEOF\n";
+        let output = Parser::new(source).parse().unwrap();
+        let indexer = Indexer::new_with_options(
+            source,
+            &output,
+            IndexerOptions::new().with_source_layout_indexes(true),
+        );
+
+        assert_eq!(
+            indexer.line_index().raw_continuation_backslashes(),
+            &[TextSize::new(source.find('\\').unwrap() as u32)]
+        );
+        assert_eq!(indexer.region_index().heredocs().len(), 1);
     }
 
     #[test]

--- a/crates/shuck-indexer/src/line_index.rs
+++ b/crates/shuck-indexer/src/line_index.rs
@@ -1,5 +1,15 @@
 use shuck_ast::{TextRange, TextSize};
 
+/// Source line-ending style inferred while indexing physical lines.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum LineEndingStyle {
+    /// Unix-style `\n` line endings.
+    #[default]
+    Lf,
+    /// Windows-style `\r\n` line endings.
+    CrLf,
+}
+
 /// Maps between byte offsets and 1-based source lines.
 ///
 /// `LineIndex` stores the byte offset of each physical line start in the source
@@ -9,6 +19,8 @@ use shuck_ast::{TextRange, TextSize};
 pub struct LineIndex {
     line_starts: Vec<TextSize>,
     raw_continuation_line_starts: Vec<TextSize>,
+    raw_continuation_backslashes: Vec<TextSize>,
+    line_ending: LineEndingStyle,
 }
 
 impl LineIndex {
@@ -25,14 +37,27 @@ impl LineIndex {
         let bytes = source.as_bytes();
         let mut line_starts = Vec::new();
         let mut raw_continuation_line_starts = Vec::new();
+        let mut raw_continuation_backslashes = Vec::new();
+        let mut line_ending = LineEndingStyle::Lf;
         line_starts.push(TextSize::new(0));
 
         for (index, byte) in bytes.iter().copied().enumerate() {
             if byte == b'\n' {
                 let next_line_start = TextSize::new((index + 1) as u32);
                 line_starts.push(next_line_start);
-                if index > 0 && bytes[index - 1] == b'\\' {
+                if index > 0 && bytes[index - 1] == b'\r' {
+                    line_ending = LineEndingStyle::CrLf;
+                }
+                let backslash_index = if index > 0 && bytes[index - 1] == b'\r' {
+                    index.checked_sub(2)
+                } else {
+                    index.checked_sub(1)
+                };
+                if let Some(backslash_index) = backslash_index
+                    && bytes[backslash_index] == b'\\'
+                {
                     raw_continuation_line_starts.push(next_line_start);
+                    raw_continuation_backslashes.push(TextSize::new(backslash_index as u32));
                 }
             }
         }
@@ -40,6 +65,8 @@ impl LineIndex {
         Self {
             line_starts,
             raw_continuation_line_starts,
+            raw_continuation_backslashes,
+            line_ending,
         }
     }
 
@@ -123,8 +150,31 @@ impl LineIndex {
         self.line_starts.len()
     }
 
-    pub(crate) fn raw_continuation_line_starts(&self) -> &[TextSize] {
+    /// Return the source line-ending style observed while indexing lines.
+    ///
+    /// A file with any `\r\n` line ending is treated as CRLF, matching the
+    /// formatter's existing preservation behavior.
+    pub fn line_ending(&self) -> LineEndingStyle {
+        self.line_ending
+    }
+
+    /// Return byte offsets for physical line starts after a raw backslash-newline.
+    ///
+    /// These are unfiltered lexical candidates. Use
+    /// [`Indexer::continuation_line_starts`](crate::Indexer::continuation_line_starts)
+    /// when comments, quoted regions, and heredoc bodies should be ignored.
+    pub fn raw_continuation_line_starts(&self) -> &[TextSize] {
         &self.raw_continuation_line_starts
+    }
+
+    /// Return byte offsets for the backslashes that introduce raw line continuations.
+    ///
+    /// These are unfiltered lexical candidates paired with
+    /// [`Self::raw_continuation_line_starts`]. The offset points at the
+    /// backslash immediately before the physical line ending, including CRLF
+    /// input where the carriage return sits between the backslash and newline.
+    pub fn raw_continuation_backslashes(&self) -> &[TextSize] {
+        &self.raw_continuation_backslashes
     }
 }
 
@@ -162,6 +212,15 @@ mod tests {
             index.raw_continuation_line_starts(),
             &[TextSize::new(11), TextSize::new(28)]
         );
+    }
+
+    #[test]
+    fn detects_crlf_line_endings_during_line_indexing() {
+        let index = LineIndex::new("one \\\r\ntwo\n");
+
+        assert_eq!(index.line_ending(), LineEndingStyle::CrLf);
+        assert_eq!(index.raw_continuation_line_starts(), &[TextSize::new(7)]);
+        assert_eq!(index.raw_continuation_backslashes(), &[TextSize::new(4)]);
     }
 
     #[test]

--- a/crates/shuck-indexer/src/line_index.rs
+++ b/crates/shuck-indexer/src/line_index.rs
@@ -1,5 +1,18 @@
 use shuck_ast::{TextRange, TextSize};
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct RawContinuationCandidate {
+    pub(crate) line_start: TextSize,
+    pub(crate) backslash: TextSize,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum RawContinuationMode {
+    Ignore,
+    ReturnOnly,
+    StoreAndReturn,
+}
+
 /// Source line-ending style inferred while indexing physical lines.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum LineEndingStyle {
@@ -30,14 +43,30 @@ impl LineIndex {
     /// Every byte immediately after `\n` is recorded as the start of the next
     /// line, including a trailing empty line when the source ends in a newline.
     ///
-    /// This constructor also records raw backslash-newline candidates for
-    /// [`crate::Indexer`]. Those raw candidates are filtered later against
-    /// comments, quotes, and heredocs before becoming semantic continuations.
     pub fn new(source: &str) -> Self {
+        Self::build(source, RawContinuationMode::Ignore).0
+    }
+
+    /// Build a line index that also stores raw backslash-newline candidates.
+    ///
+    /// Most callers should use [`Self::new`], which records line starts and
+    /// line-ending style only. Formatter-style source-preserving consumers can
+    /// use this constructor when they also need
+    /// [`Self::raw_continuation_line_starts`] or
+    /// [`Self::raw_continuation_backslashes`].
+    pub fn with_raw_continuations(source: &str) -> Self {
+        Self::build(source, RawContinuationMode::StoreAndReturn).0
+    }
+
+    pub(crate) fn build(
+        source: &str,
+        raw_continuation_mode: RawContinuationMode,
+    ) -> (Self, Vec<RawContinuationCandidate>) {
         let bytes = source.as_bytes();
         let mut line_starts = Vec::new();
         let mut raw_continuation_line_starts = Vec::new();
         let mut raw_continuation_backslashes = Vec::new();
+        let mut raw_continuations = Vec::new();
         let mut line_ending = LineEndingStyle::Lf;
         line_starts.push(TextSize::new(0));
 
@@ -56,18 +85,37 @@ impl LineIndex {
                 if let Some(backslash_index) = backslash_index
                     && bytes[backslash_index] == b'\\'
                 {
-                    raw_continuation_line_starts.push(next_line_start);
-                    raw_continuation_backslashes.push(TextSize::new(backslash_index as u32));
+                    let backslash = TextSize::new(backslash_index as u32);
+                    match raw_continuation_mode {
+                        RawContinuationMode::Ignore => {}
+                        RawContinuationMode::ReturnOnly => {
+                            raw_continuations.push(RawContinuationCandidate {
+                                line_start: next_line_start,
+                                backslash,
+                            });
+                        }
+                        RawContinuationMode::StoreAndReturn => {
+                            raw_continuations.push(RawContinuationCandidate {
+                                line_start: next_line_start,
+                                backslash,
+                            });
+                            raw_continuation_line_starts.push(next_line_start);
+                            raw_continuation_backslashes.push(backslash);
+                        }
+                    }
                 }
             }
         }
 
-        Self {
-            line_starts,
-            raw_continuation_line_starts,
-            raw_continuation_backslashes,
-            line_ending,
-        }
+        (
+            Self {
+                line_starts,
+                raw_continuation_line_starts,
+                raw_continuation_backslashes,
+                line_ending,
+            },
+            raw_continuations,
+        )
     }
 
     /// Return the 1-based line number containing `offset`.
@@ -160,7 +208,9 @@ impl LineIndex {
 
     /// Return byte offsets for physical line starts after a raw backslash-newline.
     ///
-    /// These are unfiltered lexical candidates. Use
+    /// These are unfiltered lexical candidates and are only retained when the
+    /// line index is built with [`Self::with_raw_continuations`], or through an
+    /// [`crate::Indexer`] with source-layout indexes enabled. Use
     /// [`Indexer::continuation_line_starts`](crate::Indexer::continuation_line_starts)
     /// when comments, quoted regions, and heredoc bodies should be ignored.
     pub fn raw_continuation_line_starts(&self) -> &[TextSize] {
@@ -170,9 +220,10 @@ impl LineIndex {
     /// Return byte offsets for the backslashes that introduce raw line continuations.
     ///
     /// These are unfiltered lexical candidates paired with
-    /// [`Self::raw_continuation_line_starts`]. The offset points at the
-    /// backslash immediately before the physical line ending, including CRLF
-    /// input where the carriage return sits between the backslash and newline.
+    /// [`Self::raw_continuation_line_starts`] and are only retained when raw
+    /// continuation storage is requested. The offset points at the backslash
+    /// immediately before the physical line ending, including CRLF input where
+    /// the carriage return sits between the backslash and newline.
     pub fn raw_continuation_backslashes(&self) -> &[TextSize] {
         &self.raw_continuation_backslashes
     }
@@ -206,7 +257,7 @@ mod tests {
     #[test]
     fn tracks_raw_continuation_candidates_while_collecting_lines() {
         let source = "echo foo \\\n  bar\necho \"foo\\\nbar\"\n";
-        let index = LineIndex::new(source);
+        let index = LineIndex::with_raw_continuations(source);
 
         assert_eq!(
             index.raw_continuation_line_starts(),
@@ -215,8 +266,16 @@ mod tests {
     }
 
     #[test]
+    fn skips_raw_continuation_storage_by_default() {
+        let index = LineIndex::new("echo foo \\\n  bar\n");
+
+        assert!(index.raw_continuation_line_starts().is_empty());
+        assert!(index.raw_continuation_backslashes().is_empty());
+    }
+
+    #[test]
     fn detects_crlf_line_endings_during_line_indexing() {
-        let index = LineIndex::new("one \\\r\ntwo\n");
+        let index = LineIndex::with_raw_continuations("one \\\r\ntwo\n");
 
         assert_eq!(index.line_ending(), LineEndingStyle::CrLf);
         assert_eq!(index.raw_continuation_line_starts(), &[TextSize::new(7)]);

--- a/crates/shuck-indexer/src/region_index.rs
+++ b/crates/shuck-indexer/src/region_index.rs
@@ -1,10 +1,11 @@
 use shuck_ast::{
     ArithmeticForCommand, Assignment, AssignmentValue, BourneParameterExpansion, BuiltinCommand,
     Command, CommandSubstitutionSyntax, CompoundCommand, ConditionalExpr, DeclClause, DeclOperand,
-    File, FunctionDef, HeredocBody, HeredocBodyPart, HeredocBodyPartNode, ParameterExpansion,
-    ParameterExpansionSyntax, ParameterOp, Pattern, PatternPart, PatternPartNode, Redirect,
-    RedirectKind, Stmt, StmtSeq, Subscript, TextRange, TextSize, VarRef, Word, WordPart,
-    WordPartNode, ZshExpansionOperation, ZshExpansionTarget, ZshGlobSegment, ZshParameterExpansion,
+    File, FunctionDef, Heredoc, HeredocBody, HeredocBodyPart, HeredocBodyPartNode,
+    ParameterExpansion, ParameterExpansionSyntax, ParameterOp, Pattern, PatternPart,
+    PatternPartNode, Redirect, RedirectKind, Stmt, StmtSeq, Subscript, TextRange, TextSize, VarRef,
+    Word, WordPart, WordPartNode, ZshExpansionOperation, ZshExpansionTarget, ZshGlobSegment,
+    ZshParameterExpansion,
 };
 /// A syntactic region that affects source interpretation.
 ///
@@ -34,6 +35,15 @@ struct IndexedRegion {
     range: TextRange,
 }
 
+/// Indexed metadata for one heredoc body and its source closer.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IndexedHeredoc {
+    /// Byte range of the parsed heredoc body.
+    pub body_range: TextRange,
+    /// Byte range of the original closing marker line, excluding the line ending.
+    pub closing_marker_range: Option<TextRange>,
+}
+
 /// Byte ranges of syntactic regions where special rules apply.
 ///
 /// `RegionIndex` stores one sorted range list per commonly queried region type
@@ -55,6 +65,7 @@ pub struct RegionIndex {
     arithmetic: Vec<TextRange>,
     conditionals: Vec<TextRange>,
     quoted_heredocs: Vec<TextRange>,
+    indexed_heredocs: Vec<IndexedHeredoc>,
     regions: Vec<IndexedRegion>,
     expansion_brace_edges: Vec<TextSize>,
     dollar_brace_pairs: Vec<TextRange>,
@@ -166,6 +177,23 @@ impl RegionIndex {
         &self.heredocs
     }
 
+    /// Return indexed heredoc metadata in source order.
+    pub fn heredocs(&self) -> &[IndexedHeredoc] {
+        &self.indexed_heredocs
+    }
+
+    /// Return the original closing marker range for a heredoc body range.
+    pub fn heredoc_closing_marker_range(&self, body_range: TextRange) -> Option<TextRange> {
+        let index = self.indexed_heredocs.partition_point(|heredoc| {
+            (heredoc.body_range.start(), heredoc.body_range.end())
+                < (body_range.start(), body_range.end())
+        });
+        self.indexed_heredocs
+            .get(index)
+            .filter(|heredoc| heredoc.body_range == body_range)
+            .and_then(|heredoc| heredoc.closing_marker_range)
+    }
+
     /// Return whether `offset` is the byte position of an `{` or `}` that the
     /// parser classified as part of an expansion construct.
     ///
@@ -205,6 +233,7 @@ struct RegionCollector<'a> {
     arithmetic: Vec<TextRange>,
     conditionals: Vec<TextRange>,
     quoted_heredocs: Vec<TextRange>,
+    indexed_heredocs: Vec<IndexedHeredoc>,
     expansion_brace_edges: Vec<TextSize>,
     dollar_brace_pairs: Vec<TextRange>,
 }
@@ -221,6 +250,7 @@ impl<'a> RegionCollector<'a> {
             arithmetic: Vec::new(),
             conditionals: Vec::new(),
             quoted_heredocs: Vec::new(),
+            indexed_heredocs: Vec::new(),
             expansion_brace_edges: Vec::new(),
             dollar_brace_pairs: Vec::new(),
         }
@@ -235,6 +265,12 @@ impl<'a> RegionCollector<'a> {
         sort_ranges(&mut self.arithmetic);
         sort_ranges(&mut self.conditionals);
         sort_ranges(&mut self.quoted_heredocs);
+        self.indexed_heredocs.sort_unstable_by_key(|heredoc| {
+            (
+                heredoc.body_range.start().to_u32(),
+                heredoc.body_range.end().to_u32(),
+            )
+        });
         self.expansion_brace_edges.sort_unstable();
         self.expansion_brace_edges.dedup();
         self.dollar_brace_pairs
@@ -307,6 +343,7 @@ impl<'a> RegionCollector<'a> {
             arithmetic: self.arithmetic,
             conditionals: self.conditionals,
             quoted_heredocs: self.quoted_heredocs,
+            indexed_heredocs: self.indexed_heredocs,
             regions,
             expansion_brace_edges: self.expansion_brace_edges,
             dollar_brace_pairs: self.dollar_brace_pairs,
@@ -616,6 +653,10 @@ impl<'a> RegionCollector<'a> {
                 };
                 let range = heredoc.body.span.to_range();
                 push_range(&mut self.heredocs, range);
+                self.indexed_heredocs.push(IndexedHeredoc {
+                    body_range: range,
+                    closing_marker_range: heredoc_closing_marker_range(heredoc, self._source),
+                });
                 if heredoc.delimiter.quoted {
                     push_range(&mut self.quoted_heredocs, range);
                 }
@@ -1043,6 +1084,25 @@ fn push_range(ranges: &mut Vec<TextRange>, range: TextRange) {
     }
 }
 
+fn heredoc_closing_marker_range(heredoc: &Heredoc, source: &str) -> Option<TextRange> {
+    let mut start = heredoc.body.span.end.offset.min(source.len());
+    if source
+        .as_bytes()
+        .get(start)
+        .is_some_and(|byte| *byte == b'\n')
+    {
+        start += 1;
+    }
+    let line_end = source[start..]
+        .find(['\n', '\r'])
+        .map_or(source.len(), |offset| start + offset);
+    let line = source.get(start..line_end)?;
+    (line.trim_start_matches('\t') == heredoc.delimiter.cooked.as_str()).then_some(TextRange::new(
+        TextSize::new(start as u32),
+        TextSize::new(line_end as u32),
+    ))
+}
+
 fn contains(range: TextRange, offset: TextSize) -> bool {
     range.start() <= offset && offset < range.end()
 }
@@ -1341,6 +1401,32 @@ mod tests {
                 TextSize::new(start as u32),
                 TextSize::new(end as u32),
             )]
+        );
+    }
+
+    #[test]
+    fn tracks_heredoc_closing_marker_ranges() {
+        let source = "cat <<-EOF\n\tbody\n\tEOF\n";
+        let regions = regions(source);
+        let body_start = source.find("body").unwrap();
+        let body_range = regions
+            .heredocs()
+            .iter()
+            .find(|heredoc| {
+                heredoc.body_range.start() <= TextSize::new(body_start as u32)
+                    && TextSize::new(body_start as u32) < heredoc.body_range.end()
+            })
+            .unwrap()
+            .body_range;
+        let close_start = source.rfind("\tEOF").unwrap();
+        let close_range = TextRange::new(
+            TextSize::new(close_start as u32),
+            TextSize::new((close_start + "\tEOF".len()) as u32),
+        );
+
+        assert_eq!(
+            regions.heredoc_closing_marker_range(body_range),
+            Some(close_range)
         );
     }
 

--- a/crates/shuck-indexer/src/region_index.rs
+++ b/crates/shuck-indexer/src/region_index.rs
@@ -79,7 +79,25 @@ impl RegionIndex {
     /// driven by AST spans from `file`. `source` and `file` should describe the
     /// same parsed text.
     pub fn new(source: &str, file: &File) -> Self {
-        let mut collector = RegionCollector::new(source);
+        Self::new_with_source_layout_indexes(source, file, false)
+    }
+
+    /// Build a region index that also retains source-layout metadata.
+    ///
+    /// Most callers should use [`Self::new`]. Formatter-style consumers that
+    /// need heredoc closing marker ranges can use this constructor directly, or
+    /// build an [`crate::Indexer`] with
+    /// [`crate::IndexerOptions::with_source_layout_indexes`].
+    pub fn with_source_layout_indexes(source: &str, file: &File) -> Self {
+        Self::new_with_source_layout_indexes(source, file, true)
+    }
+
+    pub(crate) fn new_with_source_layout_indexes(
+        source: &str,
+        file: &File,
+        source_layout_indexes: bool,
+    ) -> Self {
+        let mut collector = RegionCollector::new(source, source_layout_indexes);
         collector.visit_file(file);
         collector.finish()
     }
@@ -178,11 +196,17 @@ impl RegionIndex {
     }
 
     /// Return indexed heredoc metadata in source order.
+    ///
+    /// This formatter-oriented metadata is only retained when source-layout
+    /// indexes are enabled.
     pub fn heredocs(&self) -> &[IndexedHeredoc] {
         &self.indexed_heredocs
     }
 
     /// Return the original closing marker range for a heredoc body range.
+    ///
+    /// Returns `None` unless source-layout indexes were enabled during
+    /// construction.
     pub fn heredoc_closing_marker_range(&self, body_range: TextRange) -> Option<TextRange> {
         let index = self.indexed_heredocs.partition_point(|heredoc| {
             (heredoc.body_range.start(), heredoc.body_range.end())
@@ -225,6 +249,7 @@ impl RegionIndex {
 
 struct RegionCollector<'a> {
     _source: &'a str,
+    source_layout_indexes: bool,
     single_quoted: Vec<TextRange>,
     double_quoted: Vec<TextRange>,
     heredocs: Vec<TextRange>,
@@ -239,9 +264,10 @@ struct RegionCollector<'a> {
 }
 
 impl<'a> RegionCollector<'a> {
-    fn new(source: &'a str) -> Self {
+    fn new(source: &'a str, source_layout_indexes: bool) -> Self {
         Self {
             _source: source,
+            source_layout_indexes,
             single_quoted: Vec::new(),
             double_quoted: Vec::new(),
             heredocs: Vec::new(),
@@ -653,10 +679,12 @@ impl<'a> RegionCollector<'a> {
                 };
                 let range = heredoc.body.span.to_range();
                 push_range(&mut self.heredocs, range);
-                self.indexed_heredocs.push(IndexedHeredoc {
-                    body_range: range,
-                    closing_marker_range: heredoc_closing_marker_range(heredoc, self._source),
-                });
+                if self.source_layout_indexes {
+                    self.indexed_heredocs.push(IndexedHeredoc {
+                        body_range: range,
+                        closing_marker_range: heredoc_closing_marker_range(heredoc, self._source),
+                    });
+                }
                 if heredoc.delimiter.quoted {
                     push_range(&mut self.quoted_heredocs, range);
                 }
@@ -1343,6 +1371,11 @@ mod tests {
         RegionIndex::new(source, &output.file)
     }
 
+    fn regions_with_source_layout_indexes(source: &str) -> RegionIndex {
+        let output = Parser::new(source).parse().unwrap();
+        RegionIndex::with_source_layout_indexes(source, &output.file)
+    }
+
     #[test]
     fn finds_single_and_double_quoted_regions() {
         let source = "echo 'hello' \"world $name\"\n";
@@ -1407,7 +1440,7 @@ mod tests {
     #[test]
     fn tracks_heredoc_closing_marker_ranges() {
         let source = "cat <<-EOF\n\tbody\n\tEOF\n";
-        let regions = regions(source);
+        let regions = regions_with_source_layout_indexes(source);
         let body_start = source.find("body").unwrap();
         let body_range = regions
             .heredocs()
@@ -1427,6 +1460,19 @@ mod tests {
         assert_eq!(
             regions.heredoc_closing_marker_range(body_range),
             Some(close_range)
+        );
+    }
+
+    #[test]
+    fn skips_heredoc_closing_marker_ranges_by_default() {
+        let source = "cat <<-EOF\n\tbody\n\tEOF\n";
+        let regions = regions(source);
+
+        assert!(regions.heredocs().is_empty());
+        assert!(
+            regions
+                .heredoc_closing_marker_range(regions.heredoc_ranges()[0])
+                .is_none()
         );
     }
 


### PR DESCRIPTION
## Summary

- extend shuck-indexer with reusable line-ending, raw continuation, and heredoc closer facts
- route formatter comment, line-bound, suffix-comment, heredoc, and continuation decisions through indexer-backed FormatterFacts/SourceMap APIs
- remove duplicated formatter scans for branch comments, own-line comments, close suffix comments, CRLF detection, and heredoc closer bounds

## Validation

- `cargo fmt --check`
- `cargo test -p shuck-indexer`
- `cargo test -p shuck-formatter`
- `make test-oracle-shfmt-fixtures`
- `make test-oracle-shfmt-large-corpus` exited nonzero as expected with `385` mismatches and `0` shuck errors, below the known `394` mismatch baseline
