### PR TITLE
refactor(formatter): consolidate AST walking

### DIFF
--- a/crates/shuck-formatter/src/command.rs
+++ b/crates/shuck-formatter/src/command.rs
@@ -7,6 +7,7 @@ use crate::scan::{
     matching_if_close_start, normalized_close_keyword_span, refine_common_indent,
     shell_comment_can_start, skip_escaped_or_quoted,
 };
+use crate::visit::{self, AstVisitor};
 use crate::word::{
     matching_raw_command_substitution_close, normalize_raw_pipeline_continuations,
     render_arithmetic_expr_to_buf, render_word_syntax_to_buf, render_word_syntax_with_facts_to_buf,
@@ -15,7 +16,7 @@ use shuck_ast::{
     AnonymousFunctionCommand, ArithmeticExprNode, ArrayElem, Assignment, AssignmentValue,
     BackgroundOperator, BinaryCommand, BinaryOp, BuiltinCommand, CaseItem, CaseTerminator, Command,
     CompoundCommand, DeclClause, DeclOperand, ForSyntax, ForeachSyntax, FunctionDef, IfCommand,
-    IfSyntax, RedirectKind, RepeatSyntax, SimpleCommand, SourceText, Span, Stmt, StmtSeq,
+    IfSyntax, Redirect, RedirectKind, RepeatSyntax, SimpleCommand, SourceText, Span, Stmt, StmtSeq,
     StmtTerminator, Subscript, VarRef, Word, WordPart,
 };
 
@@ -873,38 +874,47 @@ pub(crate) fn render_source_text_to_buf(text: &SourceText, source: &str, rendere
 }
 
 pub(crate) fn has_heredoc(stmt: &Stmt) -> bool {
-    stmt.redirects.iter().any(|redirect| {
-        matches!(
-            redirect.kind,
-            RedirectKind::HereDoc | RedirectKind::HereDocStrip
-        )
-    }) || match &stmt.command {
-        Command::Simple(_) | Command::Builtin(_) | Command::Decl(_) => false,
-        Command::Binary(command) => has_heredoc(&command.left) || has_heredoc(&command.right),
-        Command::Compound(command) => {
-            compound_contains_child(command, has_heredoc, stmt_seq_has_heredoc)
-        }
-        Command::Function(function) => has_heredoc(&function.body),
-        Command::AnonymousFunction(function) => has_heredoc(&function.body),
-    }
+    let mut visitor = HeredocFinder::default();
+    visitor.visit_stmt(stmt);
+    visitor.found
 }
 
-pub(crate) fn compound_contains_child(
-    command: &CompoundCommand,
-    mut stmt_predicate: impl FnMut(&Stmt) -> bool,
-    mut seq_predicate: impl FnMut(&StmtSeq) -> bool,
-) -> bool {
-    let mut found = false;
-    for_each_compound_child(command, |child| {
-        if found {
-            return;
+pub(crate) fn stmt_seq_has_heredoc(commands: &StmtSeq) -> bool {
+    let mut visitor = HeredocFinder::default();
+    visitor.visit_stmt_seq(commands);
+    visitor.found
+}
+
+#[derive(Default)]
+struct HeredocFinder {
+    found: bool,
+}
+
+impl AstVisitor for HeredocFinder {
+    fn visit_stmt(&mut self, stmt: &Stmt) {
+        if !self.found {
+            visit::walk_stmt(self, stmt);
         }
-        found = match child {
-            CompoundChild::Stmt(stmt) => stmt_predicate(stmt),
-            CompoundChild::Sequence(sequence) => seq_predicate(sequence),
-        };
-    });
-    found
+    }
+
+    fn visit_stmt_seq(&mut self, sequence: &StmtSeq) {
+        if !self.found {
+            visit::walk_stmt_seq(self, sequence);
+        }
+    }
+
+    fn visit_redirect(&mut self, redirect: &Redirect) {
+        if matches!(
+            redirect.kind,
+            RedirectKind::HereDoc | RedirectKind::HereDocStrip
+        ) {
+            self.found = true;
+        } else {
+            visit::walk_redirect(self, redirect);
+        }
+    }
+
+    fn visit_word(&mut self, _word: &Word) {}
 }
 
 enum CompoundChild<'a> {
@@ -958,10 +968,6 @@ fn for_each_compound_child(command: &CompoundCommand, mut visitor: impl FnMut(Co
             visitor(CompoundChild::Sequence(&command.always_body));
         }
     }
-}
-
-pub(crate) fn stmt_seq_has_heredoc(commands: &StmtSeq) -> bool {
-    commands.iter().any(has_heredoc)
 }
 
 pub(crate) fn stmt_verbatim_span_with_source_map(stmt: &Stmt, source_map: &SourceMap<'_>) -> Span {
@@ -1703,6 +1709,33 @@ pub(crate) fn builtin_like_parts(
             &command.assignments,
             command.code.as_ref(),
             &command.extra_args,
+        ),
+    }
+}
+
+pub(crate) fn builtin_like_parts_mut(
+    command: &mut BuiltinCommand,
+) -> (&mut [Assignment], Option<&mut Word>, &mut [Word]) {
+    match command {
+        BuiltinCommand::Break(command) => (
+            &mut command.assignments,
+            command.depth.as_mut(),
+            &mut command.extra_args,
+        ),
+        BuiltinCommand::Continue(command) => (
+            &mut command.assignments,
+            command.depth.as_mut(),
+            &mut command.extra_args,
+        ),
+        BuiltinCommand::Return(command) => (
+            &mut command.assignments,
+            command.code.as_mut(),
+            &mut command.extra_args,
+        ),
+        BuiltinCommand::Exit(command) => (
+            &mut command.assignments,
+            command.code.as_mut(),
+            &mut command.extra_args,
         ),
     }
 }

--- a/crates/shuck-formatter/src/facts.rs
+++ b/crates/shuck-formatter/src/facts.rs
@@ -1,18 +1,18 @@
 use std::collections::{HashMap, HashSet};
 
 use shuck_ast::{
-    AnonymousFunctionCommand, ArithmeticExpr, ArithmeticExprNode, ArithmeticLvalue, Assignment,
-    AssignmentValue, BinaryCommand, BinaryOp, BuiltinCommand, CaseCommand, CaseItem, Command,
-    CommandSubstitutionSyntax, CompoundCommand, ConditionalCommand, ConditionalExpr, DeclClause,
-    DeclOperand, File, ForCommand, ForeachCommand, FunctionDef, Heredoc, HeredocBody,
-    HeredocBodyPart, IfCommand, Pattern, PatternPart, Redirect, RepeatCommand, SelectCommand, Span,
-    Stmt, StmtSeq, StmtTerminator, TimeCommand, UntilCommand, WhileCommand, Word, WordPart,
+    AnonymousFunctionCommand, ArithmeticExprNode, Assignment, AssignmentValue, BinaryCommand,
+    BinaryOp, CaseCommand, CaseItem, Command, CommandSubstitutionSyntax, CompoundCommand,
+    ConditionalCommand, ConditionalExpr, File, ForCommand, ForeachCommand, FunctionDef, Heredoc,
+    HeredocBody, HeredocBodyPart, HeredocBodyPartNode, IfCommand, Pattern, Redirect, RepeatCommand,
+    SelectCommand, Span, Stmt, StmtSeq, StmtTerminator, TimeCommand, UntilCommand, WhileCommand,
+    Word, WordPart, WordPartNode,
 };
 use shuck_ast::{TextRange, TextSize};
 use shuck_indexer::{CommentIndex, IndexedComment, Indexer, IndexerOptions, LineIndex};
 
 use crate::command::{
-    array_elem_parts, branch_open_keyword_start, builtin_like_parts, case_item_body_upper_bound,
+    array_elem_parts, branch_open_keyword_start, case_item_body_upper_bound,
     case_item_was_inline_in_source, collect_binary_list_first as collect_binary_list_first_with,
     collect_pipeline_parts, command_group_commands, done_close_span, group_attachment_span,
     group_open_suffix, group_was_inline_in_source, if_close_span,
@@ -27,6 +27,7 @@ use crate::comments::{
 };
 use crate::options::{LineEnding, ResolvedShellFormatOptions};
 use crate::scan::{BranchPrefixComment, last_shell_keyword_start};
+use crate::visit::{self, AstVisitor};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 struct FactSpan {
@@ -741,48 +742,10 @@ impl<'source, 'options> FormatterFactsBuilder<'source, 'options> {
     }
 
     fn visit_command(&mut self, command: &Command) {
-        match command {
-            Command::Simple(command) => {
-                for assignment in &command.assignments {
-                    self.visit_assignment(assignment);
-                }
-                self.visit_word(&command.name);
-                for word in &command.args {
-                    self.visit_word(word);
-                }
-            }
-            Command::Builtin(command) => self.visit_builtin_command(command),
-            Command::Decl(command) => self.visit_decl_clause(command),
-            Command::Binary(command) => self.visit_binary_command(command),
-            Command::Compound(command) => self.visit_compound_command(command),
-            Command::Function(function) => self.visit_function(function),
-            Command::AnonymousFunction(function) => self.visit_anonymous_function(function),
-        }
-    }
-
-    fn visit_builtin_command(&mut self, command: &BuiltinCommand) {
-        let (_, _, assignments, primary, extra_args) = builtin_like_parts(command);
-        for assignment in assignments {
-            self.visit_assignment(assignment);
-        }
-        if let Some(primary) = primary {
-            self.visit_word(primary);
-        }
-        for word in extra_args {
-            self.visit_word(word);
-        }
-    }
-
-    fn visit_decl_clause(&mut self, command: &DeclClause) {
-        for assignment in &command.assignments {
-            self.visit_assignment(assignment);
-        }
-        for operand in &command.operands {
-            match operand {
-                DeclOperand::Flag(word) | DeclOperand::Dynamic(word) => self.visit_word(word),
-                DeclOperand::Name(_) => {}
-                DeclOperand::Assignment(assignment) => self.visit_assignment(assignment),
-            }
+        if let Command::Binary(command) = command {
+            self.visit_binary_command(command);
+        } else {
+            visit::walk_command(self, command);
         }
     }
 
@@ -1155,40 +1118,15 @@ impl<'source, 'options> FormatterFactsBuilder<'source, 'options> {
     }
 
     fn visit_conditional_expr(&mut self, expression: &ConditionalExpr) {
-        match expression {
-            ConditionalExpr::Binary(expr) => {
-                self.visit_conditional_expr(expr.left.as_ref());
-                self.visit_conditional_expr(expr.right.as_ref());
-            }
-            ConditionalExpr::Unary(expr) => self.visit_conditional_expr(expr.expr.as_ref()),
-            ConditionalExpr::Parenthesized(expr) => self.visit_conditional_expr(expr.expr.as_ref()),
-            ConditionalExpr::Word(word) | ConditionalExpr::Regex(word) => self.visit_word(word),
-            ConditionalExpr::Pattern(pattern) => self.visit_pattern(pattern),
-            ConditionalExpr::VarRef(_) => {}
-        }
+        visit::walk_conditional_expr(self, expression);
     }
 
     fn visit_pattern(&mut self, pattern: &Pattern) {
-        for part in &pattern.parts {
-            match &part.kind {
-                PatternPart::Group { patterns, .. } => {
-                    for pattern in patterns {
-                        self.visit_pattern(pattern);
-                    }
-                }
-                PatternPart::Word(word) => self.visit_word(word),
-                PatternPart::Literal(_)
-                | PatternPart::AnyString
-                | PatternPart::AnyChar
-                | PatternPart::CharClass(_) => {}
-            }
-        }
+        visit::walk_pattern(self, pattern);
     }
 
     fn visit_word(&mut self, word: &Word) {
-        for part in &word.parts {
-            self.visit_word_part(&part.kind, part.span);
-        }
+        visit::walk_word(self, word);
     }
 
     fn visit_word_part(&mut self, part: &WordPart, span: Span) {
@@ -1266,43 +1204,53 @@ impl<'source, 'options> FormatterFactsBuilder<'source, 'options> {
     }
 
     fn visit_arithmetic_expr(&mut self, expr: &ArithmeticExprNode) {
-        match &expr.kind {
-            ArithmeticExpr::ShellWord(word) => self.visit_word(word),
-            ArithmeticExpr::Indexed { index, .. } => self.visit_arithmetic_expr(index),
-            ArithmeticExpr::Parenthesized { expression } => self.visit_arithmetic_expr(expression),
-            ArithmeticExpr::Unary { expr, .. } | ArithmeticExpr::Postfix { expr, .. } => {
-                self.visit_arithmetic_expr(expr);
-            }
-            ArithmeticExpr::Binary { left, right, .. } => {
-                self.visit_arithmetic_expr(left);
-                self.visit_arithmetic_expr(right);
-            }
-            ArithmeticExpr::Conditional {
-                condition,
-                then_expr,
-                else_expr,
-            } => {
-                self.visit_arithmetic_expr(condition);
-                self.visit_arithmetic_expr(then_expr);
-                self.visit_arithmetic_expr(else_expr);
-            }
-            ArithmeticExpr::Assignment { target, value, .. } => {
-                self.visit_arithmetic_lvalue(target);
-                self.visit_arithmetic_expr(value);
-            }
-            ArithmeticExpr::Number(_) | ArithmeticExpr::Variable(_) => {}
-        }
-    }
-
-    fn visit_arithmetic_lvalue(&mut self, target: &ArithmeticLvalue) {
-        match target {
-            ArithmeticLvalue::Indexed { index, .. } => self.visit_arithmetic_expr(index),
-            ArithmeticLvalue::Variable(_) => {}
-        }
+        visit::walk_arithmetic_expr(self, expr);
     }
 
     fn source_map(&self) -> &SourceMap<'source> {
         &self.facts.source_map
+    }
+}
+
+impl<'source, 'options> AstVisitor for FormatterFactsBuilder<'source, 'options> {
+    fn visit_stmt_seq(&mut self, sequence: &StmtSeq) {
+        self.visit_sequence(sequence, None, None);
+    }
+
+    fn visit_stmt(&mut self, stmt: &Stmt) {
+        FormatterFactsBuilder::visit_stmt(self, stmt);
+    }
+
+    fn visit_command(&mut self, command: &Command) {
+        FormatterFactsBuilder::visit_command(self, command);
+    }
+
+    fn visit_compound_command(&mut self, command: &CompoundCommand) {
+        FormatterFactsBuilder::visit_compound_command(self, command);
+    }
+
+    fn visit_function(&mut self, function: &FunctionDef) {
+        FormatterFactsBuilder::visit_function(self, function);
+    }
+
+    fn visit_anonymous_function(&mut self, function: &AnonymousFunctionCommand) {
+        FormatterFactsBuilder::visit_anonymous_function(self, function);
+    }
+
+    fn visit_redirect(&mut self, redirect: &Redirect) {
+        FormatterFactsBuilder::visit_redirect(self, redirect);
+    }
+
+    fn visit_assignment(&mut self, assignment: &Assignment) {
+        FormatterFactsBuilder::visit_assignment(self, assignment);
+    }
+
+    fn visit_word_part(&mut self, part: &WordPartNode) {
+        FormatterFactsBuilder::visit_word_part(self, &part.kind, part.span);
+    }
+
+    fn visit_heredoc_body_part(&mut self, part: &HeredocBodyPartNode) {
+        FormatterFactsBuilder::visit_heredoc_body_part(self, &part.kind, part.span);
     }
 }
 

--- a/crates/shuck-formatter/src/lib.rs
+++ b/crates/shuck-formatter/src/lib.rs
@@ -22,6 +22,8 @@ mod simplify;
 #[allow(missing_docs)]
 mod streaming;
 #[allow(missing_docs)]
+mod visit;
+#[allow(missing_docs)]
 mod word;
 
 use std::path::Path;

--- a/crates/shuck-formatter/src/simplify.rs
+++ b/crates/shuck-formatter/src/simplify.rs
@@ -1,13 +1,12 @@
 use shuck_ast::{
-    ArrayElem, Assignment, AssignmentValue, BourneParameterExpansion, BuiltinCommand, Command,
-    CompoundCommand, ConditionalBinaryExpr, ConditionalBinaryOp, ConditionalExpr,
-    ConditionalParenExpr, ConditionalUnaryExpr, ConditionalUnaryOp, DeclClause, DeclOperand, File,
-    FunctionDef, HeredocBody, HeredocBodyPart, ParameterExpansion, ParameterExpansionSyntax,
-    ParameterOp, Pattern, PatternPart, Redirect, RedirectTarget, SourceText, Stmt, StmtSeq, VarRef,
+    BourneParameterExpansion, Command, CompoundCommand, ConditionalBinaryExpr, ConditionalBinaryOp,
+    ConditionalExpr, ConditionalUnaryExpr, ConditionalUnaryOp, File, HeredocBody, HeredocBodyPart,
+    ParameterExpansion, ParameterExpansionSyntax, ParameterOp, SourceText, Stmt, StmtSeq, VarRef,
     Word, WordPart, WordPartNode, ZshExpansionOperation, ZshExpansionTarget,
 };
 
-use crate::command::{array_elem_value_word_mut, render_var_ref_to_buf};
+use crate::command::render_var_ref_to_buf;
+use crate::visit::{self, AstVisitorMut};
 use crate::word::parameter_defaulting_operator;
 
 const PAREN_CLEANUP: &str = "paren-cleanup";
@@ -79,17 +78,54 @@ impl RewriteCounts {
 
 pub fn simplify_file(file: &mut File, source: &str) -> SimplifyReport {
     let counts = RewriteCounts::default();
-    simplify_stmt_seq(&mut file.body, source, &counts);
+    {
+        let mut visitor = SimplifyVisitor {
+            source,
+            counts: &counts,
+            mode: SimplifyTraversalMode::Full,
+        };
+        visitor.visit_file(file);
+    }
     counts.into_report()
 }
 
-fn simplify_stmt_seq(commands: &mut StmtSeq, source: &str, counts: &RewriteCounts) -> usize {
-    let mut stmt_visitor = |stmt: &mut Stmt, source: &str| {
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SimplifyTraversalMode {
+    Full,
+    HeredocCommandSubstitution,
+}
+
+struct SimplifyVisitor<'source, 'counts> {
+    source: &'source str,
+    counts: &'counts RewriteCounts,
+    mode: SimplifyTraversalMode,
+}
+
+impl SimplifyVisitor<'_, '_> {
+    fn with_mode(
+        &mut self,
+        mode: SimplifyTraversalMode,
+        visit: impl FnOnce(&mut Self) -> usize,
+    ) -> usize {
+        let previous = self.mode;
+        self.mode = mode;
+        let changes = visit(self);
+        self.mode = previous;
+        changes
+    }
+}
+
+impl AstVisitorMut for SimplifyVisitor<'_, '_> {
+    fn enter_stmt(&mut self, stmt: &mut Stmt) -> usize {
+        if self.mode == SimplifyTraversalMode::HeredocCommandSubstitution {
+            return 0;
+        }
+
         let mut changes = 0;
 
         if let Command::Compound(CompoundCommand::Conditional(conditional)) = &mut stmt.command {
-            let count = simplify_conditional_expr(&mut conditional.expression, source);
-            counts.add_conditionals(count);
+            let count = simplify_conditional_expr(&mut conditional.expression, self.source);
+            self.counts.add_conditionals(count);
             changes += count;
         }
 
@@ -99,41 +135,82 @@ fn simplify_stmt_seq(commands: &mut StmtSeq, source: &str, counts: &RewriteCount
             && stmt.terminator.is_none()
         {
             let count = collapse_nested_subshell_sequence(commands);
-            counts.add_nested_subshells(count);
+            self.counts.add_nested_subshells(count);
             changes += count;
         }
 
         changes
-    };
+    }
 
-    let mut word_visitor = |word: &mut Word| {
+    fn visit_word(&mut self, word: &mut Word) -> usize {
+        let mut changes = if self.mode == SimplifyTraversalMode::Full {
+            visit::walk_word_surface_source_texts_mut(self, word)
+        } else {
+            0
+        };
+
         let nested_subshells = collapse_nested_subshells_in_word(word);
-        counts.add_nested_subshells(nested_subshells);
+        self.counts.add_nested_subshells(nested_subshells);
+        changes += nested_subshells;
 
-        let quote_tightening = tighten_literal_quotes(word, source);
-        counts.add_quote_tightening(quote_tightening);
+        let quote_tightening = tighten_literal_quotes(word, self.source);
+        self.counts.add_quote_tightening(quote_tightening);
+        changes += quote_tightening;
 
-        nested_subshells + quote_tightening
-    };
+        changes
+    }
 
-    let mut source_text_visitor = |text: &mut SourceText, source: &str| {
-        let paren_cleanup = transform_source_text(text, source, strip_single_outer_parens);
-        counts.add_paren_cleanup(paren_cleanup);
+    fn visit_heredoc_body(&mut self, body: &mut HeredocBody) -> usize {
+        let mut count = 0;
+
+        for part in &mut body.parts {
+            count += match &mut part.kind {
+                HeredocBodyPart::CommandSubstitution {
+                    body: command_body, ..
+                } => self.with_mode(
+                    SimplifyTraversalMode::HeredocCommandSubstitution,
+                    |visitor| visitor.visit_stmt_seq(command_body),
+                ),
+                HeredocBodyPart::ArithmeticExpansion { expression, .. } => {
+                    self.visit_source_text(expression)
+                }
+                HeredocBodyPart::Parameter(parameter) => self.visit_parameter_expansion(parameter),
+                HeredocBodyPart::Literal(_) | HeredocBodyPart::Variable(_) => 0,
+            };
+        }
+
+        if count > 0 {
+            body.source_backed = false;
+        }
+
+        count
+    }
+
+    fn visit_parameter_expansion(&mut self, parameter: &mut ParameterExpansion) -> usize {
+        let count = visit::walk_parameter_expansion_surface_source_texts_mut(self, parameter);
+        if count > 0 {
+            parameter.raw_body = SourceText::cooked(
+                parameter.raw_body.span(),
+                render_parameter_raw_body(parameter, self.source),
+            );
+        }
+        count
+    }
+
+    fn visit_source_text(&mut self, text: &mut SourceText) -> usize {
+        if self.mode == SimplifyTraversalMode::HeredocCommandSubstitution {
+            return 0;
+        }
+
+        let paren_cleanup = transform_source_text(text, self.source, strip_single_outer_parens);
+        self.counts.add_paren_cleanup(paren_cleanup);
 
         let arithmetic_vars =
-            transform_source_text(text, source, simplify_arithmetic_variables_text);
-        counts.add_arithmetic_vars(arithmetic_vars);
+            transform_source_text(text, self.source, simplify_arithmetic_variables_text);
+        self.counts.add_arithmetic_vars(arithmetic_vars);
 
         paren_cleanup + arithmetic_vars
-    };
-
-    walk_stmt_seq(
-        commands,
-        source,
-        &mut stmt_visitor,
-        &mut word_visitor,
-        &mut source_text_visitor,
-    )
+    }
 }
 
 fn collapse_nested_subshell_sequence(commands: &mut StmtSeq) -> usize {
@@ -172,857 +249,6 @@ fn collapse_nested_subshells_in_word(word: &mut Word) -> usize {
             _ => 0,
         })
         .sum()
-}
-
-fn walk_stmt_seq(
-    commands: &mut StmtSeq,
-    source: &str,
-    stmt_visitor: &mut dyn FnMut(&mut Stmt, &str) -> usize,
-    word_visitor: &mut dyn FnMut(&mut Word) -> usize,
-    source_text_visitor: &mut dyn FnMut(&mut SourceText, &str) -> usize,
-) -> usize {
-    commands
-        .iter_mut()
-        .map(|command| {
-            walk_stmt(
-                command,
-                source,
-                stmt_visitor,
-                word_visitor,
-                source_text_visitor,
-            )
-        })
-        .sum()
-}
-
-fn walk_stmt(
-    stmt: &mut Stmt,
-    source: &str,
-    stmt_visitor: &mut dyn FnMut(&mut Stmt, &str) -> usize,
-    word_visitor: &mut dyn FnMut(&mut Word) -> usize,
-    source_text_visitor: &mut dyn FnMut(&mut SourceText, &str) -> usize,
-) -> usize {
-    let mut changes = stmt_visitor(stmt, source);
-    changes += match &mut stmt.command {
-        Command::Simple(command) => {
-            let mut count = 0;
-            for assignment in &mut command.assignments {
-                count += walk_assignment(assignment, source, source_text_visitor, word_visitor);
-            }
-            count += walk_word(&mut command.name, source, word_visitor, source_text_visitor);
-            count += walk_words(&mut command.args, source, word_visitor, source_text_visitor);
-            count
-        }
-        Command::Builtin(command) => {
-            walk_builtin(command, source, word_visitor, source_text_visitor)
-        }
-        Command::Decl(command) => {
-            walk_decl_clause(command, source, word_visitor, source_text_visitor)
-        }
-        Command::Binary(command) => {
-            walk_stmt(
-                &mut command.left,
-                source,
-                stmt_visitor,
-                word_visitor,
-                source_text_visitor,
-            ) + walk_stmt(
-                &mut command.right,
-                source,
-                stmt_visitor,
-                word_visitor,
-                source_text_visitor,
-            )
-        }
-        Command::Compound(compound) => walk_compound(
-            compound,
-            source,
-            stmt_visitor,
-            word_visitor,
-            source_text_visitor,
-        ),
-        Command::Function(function) => walk_function(
-            function,
-            source,
-            stmt_visitor,
-            word_visitor,
-            source_text_visitor,
-        ),
-        Command::AnonymousFunction(function) => walk_anonymous_function(
-            function,
-            source,
-            stmt_visitor,
-            word_visitor,
-            source_text_visitor,
-        ),
-    };
-    for redirect in &mut stmt.redirects {
-        changes += walk_redirect(redirect, source, word_visitor, source_text_visitor);
-    }
-    changes
-}
-
-fn walk_builtin(
-    command: &mut BuiltinCommand,
-    source: &str,
-    word_visitor: &mut dyn FnMut(&mut Word) -> usize,
-    source_text_visitor: &mut dyn FnMut(&mut SourceText, &str) -> usize,
-) -> usize {
-    let (assignments, primary, extra_args) = builtin_like_parts_mut(command);
-    walk_builtin_like(
-        assignments,
-        primary,
-        extra_args,
-        source,
-        word_visitor,
-        source_text_visitor,
-    )
-}
-
-fn walk_builtin_like(
-    assignments: &mut [Assignment],
-    primary: Option<&mut Word>,
-    extra_args: &mut [Word],
-    source: &str,
-    word_visitor: &mut dyn FnMut(&mut Word) -> usize,
-    source_text_visitor: &mut dyn FnMut(&mut SourceText, &str) -> usize,
-) -> usize {
-    let mut count = 0;
-    for assignment in assignments {
-        count += walk_assignment(assignment, source, source_text_visitor, word_visitor);
-    }
-    if let Some(primary) = primary {
-        count += walk_word(primary, source, word_visitor, source_text_visitor);
-    }
-    count += walk_words(extra_args, source, word_visitor, source_text_visitor);
-    count
-}
-
-fn builtin_like_parts_mut(
-    command: &mut BuiltinCommand,
-) -> (&mut [Assignment], Option<&mut Word>, &mut [Word]) {
-    match command {
-        BuiltinCommand::Break(command) => (
-            &mut command.assignments,
-            command.depth.as_mut(),
-            &mut command.extra_args,
-        ),
-        BuiltinCommand::Continue(command) => (
-            &mut command.assignments,
-            command.depth.as_mut(),
-            &mut command.extra_args,
-        ),
-        BuiltinCommand::Return(command) => (
-            &mut command.assignments,
-            command.code.as_mut(),
-            &mut command.extra_args,
-        ),
-        BuiltinCommand::Exit(command) => (
-            &mut command.assignments,
-            command.code.as_mut(),
-            &mut command.extra_args,
-        ),
-    }
-}
-
-fn walk_decl_clause(
-    command: &mut DeclClause,
-    source: &str,
-    word_visitor: &mut dyn FnMut(&mut Word) -> usize,
-    source_text_visitor: &mut dyn FnMut(&mut SourceText, &str) -> usize,
-) -> usize {
-    let mut count = 0;
-    for assignment in &mut command.assignments {
-        count += walk_assignment(assignment, source, source_text_visitor, word_visitor);
-    }
-    for operand in &mut command.operands {
-        count += match operand {
-            DeclOperand::Flag(word) | DeclOperand::Dynamic(word) => {
-                walk_word(word, source, word_visitor, source_text_visitor)
-            }
-            DeclOperand::Name(name) => walk_var_ref(name, source, source_text_visitor),
-            DeclOperand::Assignment(assignment) => {
-                walk_assignment(assignment, source, source_text_visitor, word_visitor)
-            }
-        };
-    }
-    count
-}
-
-fn walk_function(
-    function: &mut FunctionDef,
-    source: &str,
-    stmt_visitor: &mut dyn FnMut(&mut Stmt, &str) -> usize,
-    word_visitor: &mut dyn FnMut(&mut Word) -> usize,
-    source_text_visitor: &mut dyn FnMut(&mut SourceText, &str) -> usize,
-) -> usize {
-    let mut count = 0;
-    for entry in &mut function.header.entries {
-        count += walk_word(&mut entry.word, source, word_visitor, source_text_visitor);
-    }
-    count
-        + walk_stmt(
-            function.body.as_mut(),
-            source,
-            stmt_visitor,
-            word_visitor,
-            source_text_visitor,
-        )
-}
-
-fn walk_anonymous_function(
-    function: &mut shuck_ast::AnonymousFunctionCommand,
-    source: &str,
-    stmt_visitor: &mut dyn FnMut(&mut Stmt, &str) -> usize,
-    word_visitor: &mut dyn FnMut(&mut Word) -> usize,
-    source_text_visitor: &mut dyn FnMut(&mut SourceText, &str) -> usize,
-) -> usize {
-    let mut count = walk_stmt(
-        function.body.as_mut(),
-        source,
-        stmt_visitor,
-        word_visitor,
-        source_text_visitor,
-    );
-    count += walk_words(
-        &mut function.args,
-        source,
-        word_visitor,
-        source_text_visitor,
-    );
-    count
-}
-
-fn walk_compound(
-    command: &mut CompoundCommand,
-    source: &str,
-    stmt_visitor: &mut dyn FnMut(&mut Stmt, &str) -> usize,
-    word_visitor: &mut dyn FnMut(&mut Word) -> usize,
-    source_text_visitor: &mut dyn FnMut(&mut SourceText, &str) -> usize,
-) -> usize {
-    match command {
-        CompoundCommand::If(command) => {
-            let mut count = 0;
-            count += walk_stmt_seq(
-                &mut command.condition,
-                source,
-                stmt_visitor,
-                word_visitor,
-                source_text_visitor,
-            );
-            count += walk_stmt_seq(
-                &mut command.then_branch,
-                source,
-                stmt_visitor,
-                word_visitor,
-                source_text_visitor,
-            );
-            for (condition, body) in &mut command.elif_branches {
-                count += walk_stmt_seq(
-                    condition,
-                    source,
-                    stmt_visitor,
-                    word_visitor,
-                    source_text_visitor,
-                );
-                count += walk_stmt_seq(
-                    body,
-                    source,
-                    stmt_visitor,
-                    word_visitor,
-                    source_text_visitor,
-                );
-            }
-            if let Some(body) = &mut command.else_branch {
-                count += walk_stmt_seq(
-                    body,
-                    source,
-                    stmt_visitor,
-                    word_visitor,
-                    source_text_visitor,
-                );
-            }
-            count
-        }
-        CompoundCommand::For(command) => {
-            command.words.as_deref_mut().map_or(0, |words| {
-                walk_words(words, source, word_visitor, source_text_visitor)
-            }) + walk_stmt_seq(
-                &mut command.body,
-                source,
-                stmt_visitor,
-                word_visitor,
-                source_text_visitor,
-            )
-        }
-        CompoundCommand::Repeat(command) => {
-            walk_word(
-                &mut command.count,
-                source,
-                word_visitor,
-                source_text_visitor,
-            ) + walk_stmt_seq(
-                &mut command.body,
-                source,
-                stmt_visitor,
-                word_visitor,
-                source_text_visitor,
-            )
-        }
-        CompoundCommand::Foreach(command) => {
-            walk_words(
-                &mut command.words,
-                source,
-                word_visitor,
-                source_text_visitor,
-            ) + walk_stmt_seq(
-                &mut command.body,
-                source,
-                stmt_visitor,
-                word_visitor,
-                source_text_visitor,
-            )
-        }
-        CompoundCommand::ArithmeticFor(command) => walk_stmt_seq(
-            &mut command.body,
-            source,
-            stmt_visitor,
-            word_visitor,
-            source_text_visitor,
-        ),
-        CompoundCommand::While(command) => {
-            walk_stmt_seq(
-                &mut command.condition,
-                source,
-                stmt_visitor,
-                word_visitor,
-                source_text_visitor,
-            ) + walk_stmt_seq(
-                &mut command.body,
-                source,
-                stmt_visitor,
-                word_visitor,
-                source_text_visitor,
-            )
-        }
-        CompoundCommand::Until(command) => {
-            walk_stmt_seq(
-                &mut command.condition,
-                source,
-                stmt_visitor,
-                word_visitor,
-                source_text_visitor,
-            ) + walk_stmt_seq(
-                &mut command.body,
-                source,
-                stmt_visitor,
-                word_visitor,
-                source_text_visitor,
-            )
-        }
-        CompoundCommand::Case(command) => {
-            let mut count = walk_word(&mut command.word, source, word_visitor, source_text_visitor);
-            for item in &mut command.cases {
-                for pattern in &mut item.patterns {
-                    count += walk_pattern(pattern, source, word_visitor, source_text_visitor);
-                }
-                count += walk_stmt_seq(
-                    &mut item.body,
-                    source,
-                    stmt_visitor,
-                    word_visitor,
-                    source_text_visitor,
-                );
-            }
-            count
-        }
-        CompoundCommand::Select(command) => {
-            walk_words(
-                &mut command.words,
-                source,
-                word_visitor,
-                source_text_visitor,
-            ) + walk_stmt_seq(
-                &mut command.body,
-                source,
-                stmt_visitor,
-                word_visitor,
-                source_text_visitor,
-            )
-        }
-        CompoundCommand::Subshell(commands) | CompoundCommand::BraceGroup(commands) => {
-            walk_stmt_seq(
-                commands,
-                source,
-                stmt_visitor,
-                word_visitor,
-                source_text_visitor,
-            )
-        }
-        CompoundCommand::Arithmetic(_) => 0,
-        CompoundCommand::Time(command) => command.command.as_mut().map_or(0, |command| {
-            walk_stmt(
-                command,
-                source,
-                stmt_visitor,
-                word_visitor,
-                source_text_visitor,
-            )
-        }),
-        CompoundCommand::Conditional(command) => {
-            let mut count = 0;
-            count += walk_conditional_words(
-                &mut command.expression,
-                source,
-                word_visitor,
-                source_text_visitor,
-            );
-            count
-        }
-        CompoundCommand::Coproc(command) => walk_stmt(
-            command.body.as_mut(),
-            source,
-            stmt_visitor,
-            word_visitor,
-            source_text_visitor,
-        ),
-        CompoundCommand::Always(command) => {
-            walk_stmt_seq(
-                &mut command.body,
-                source,
-                stmt_visitor,
-                word_visitor,
-                source_text_visitor,
-            ) + walk_stmt_seq(
-                &mut command.always_body,
-                source,
-                stmt_visitor,
-                word_visitor,
-                source_text_visitor,
-            )
-        }
-    }
-}
-
-fn walk_redirect(
-    redirect: &mut Redirect,
-    source: &str,
-    word_visitor: &mut dyn FnMut(&mut Word) -> usize,
-    source_text_visitor: &mut dyn FnMut(&mut SourceText, &str) -> usize,
-) -> usize {
-    match &mut redirect.target {
-        RedirectTarget::Word(word) => walk_word(word, source, word_visitor, source_text_visitor),
-        RedirectTarget::Heredoc(heredoc) => {
-            walk_word(
-                &mut heredoc.delimiter.raw,
-                source,
-                word_visitor,
-                source_text_visitor,
-            ) + walk_heredoc_body(&mut heredoc.body, source, word_visitor, source_text_visitor)
-        }
-    }
-}
-
-fn walk_var_ref(
-    name: &mut VarRef,
-    source: &str,
-    visitor: &mut dyn FnMut(&mut SourceText, &str) -> usize,
-) -> usize {
-    name.subscript.as_mut().map_or(0, |subscript| {
-        let mut count = visitor(&mut subscript.text, source);
-        if let Some(raw) = &mut subscript.raw {
-            count += visitor(raw, source);
-        }
-        count
-    })
-}
-
-fn walk_assignment(
-    assignment: &mut Assignment,
-    source: &str,
-    source_text_visitor: &mut dyn FnMut(&mut SourceText, &str) -> usize,
-    word_visitor: &mut dyn FnMut(&mut Word) -> usize,
-) -> usize {
-    let mut count = walk_var_ref(&mut assignment.target, source, source_text_visitor);
-    count += match &mut assignment.value {
-        AssignmentValue::Scalar(word) => walk_word(word, source, word_visitor, source_text_visitor),
-        AssignmentValue::Compound(array) => {
-            let mut inner = 0;
-            for element in &mut array.elements {
-                match element {
-                    ArrayElem::Sequential(_) => {}
-                    ArrayElem::Keyed { key, .. } | ArrayElem::KeyedAppend { key, .. } => {
-                        inner += walk_subscript(key, source, source_text_visitor);
-                    }
-                }
-                inner += walk_word(
-                    array_elem_value_word_mut(element),
-                    source,
-                    word_visitor,
-                    source_text_visitor,
-                );
-            }
-            inner
-        }
-    };
-    count
-}
-
-fn walk_subscript(
-    subscript: &mut shuck_ast::Subscript,
-    source: &str,
-    visitor: &mut dyn FnMut(&mut SourceText, &str) -> usize,
-) -> usize {
-    let mut count = visitor(&mut subscript.text, source);
-    if let Some(raw) = &mut subscript.raw {
-        count += visitor(raw, source);
-    }
-    count
-}
-
-fn walk_word(
-    word: &mut Word,
-    source: &str,
-    word_visitor: &mut dyn FnMut(&mut Word) -> usize,
-    source_text_visitor: &mut dyn FnMut(&mut SourceText, &str) -> usize,
-) -> usize {
-    let mut count = rewrite_word_source_texts(word, source, source_text_visitor);
-    count += word_visitor(word);
-    count
-}
-
-fn walk_words(
-    words: &mut [Word],
-    source: &str,
-    word_visitor: &mut dyn FnMut(&mut Word) -> usize,
-    source_text_visitor: &mut dyn FnMut(&mut SourceText, &str) -> usize,
-) -> usize {
-    words
-        .iter_mut()
-        .map(|word| walk_word(word, source, word_visitor, source_text_visitor))
-        .sum()
-}
-
-fn walk_heredoc_body(
-    body: &mut HeredocBody,
-    source: &str,
-    word_visitor: &mut dyn FnMut(&mut Word) -> usize,
-    source_text_visitor: &mut dyn FnMut(&mut SourceText, &str) -> usize,
-) -> usize {
-    let mut count = 0;
-
-    for part in &mut body.parts {
-        count += match &mut part.kind {
-            HeredocBodyPart::CommandSubstitution {
-                body: command_body, ..
-            } => walk_stmt_seq(
-                command_body,
-                source,
-                &mut |_: &mut Stmt, _: &str| 0,
-                word_visitor,
-                &mut |_, _| 0,
-            ),
-            HeredocBodyPart::ArithmeticExpansion { expression, .. } => {
-                source_text_visitor(expression, source)
-            }
-            HeredocBodyPart::Parameter(parameter) => {
-                rewrite_parameter_source_texts(parameter, source, source_text_visitor)
-            }
-            HeredocBodyPart::Literal(_) | HeredocBodyPart::Variable(_) => 0,
-        };
-    }
-
-    if count > 0 {
-        body.source_backed = false;
-    }
-
-    count
-}
-
-fn walk_pattern(
-    pattern: &mut Pattern,
-    source: &str,
-    word_visitor: &mut dyn FnMut(&mut Word) -> usize,
-    source_text_visitor: &mut dyn FnMut(&mut SourceText, &str) -> usize,
-) -> usize {
-    let mut count = 0;
-
-    for part in &mut pattern.parts {
-        count += match &mut part.kind {
-            PatternPart::Group { patterns, .. } => {
-                let mut inner = 0;
-                for pattern in patterns {
-                    inner += walk_pattern(pattern, source, word_visitor, source_text_visitor);
-                }
-                inner
-            }
-            PatternPart::Word(word) => walk_word(word, source, word_visitor, source_text_visitor),
-            PatternPart::CharClass(text) => source_text_visitor(text, source),
-            PatternPart::Literal(_) | PatternPart::AnyString | PatternPart::AnyChar => 0,
-        };
-    }
-
-    count
-}
-
-fn walk_conditional_words(
-    expression: &mut ConditionalExpr,
-    source: &str,
-    word_visitor: &mut dyn FnMut(&mut Word) -> usize,
-    source_text_visitor: &mut dyn FnMut(&mut SourceText, &str) -> usize,
-) -> usize {
-    match expression {
-        ConditionalExpr::Binary(ConditionalBinaryExpr { left, right, .. }) => {
-            walk_conditional_words(left, source, word_visitor, source_text_visitor)
-                + walk_conditional_words(right, source, word_visitor, source_text_visitor)
-        }
-        ConditionalExpr::Unary(ConditionalUnaryExpr { expr, .. })
-        | ConditionalExpr::Parenthesized(ConditionalParenExpr { expr, .. }) => {
-            walk_conditional_words(expr, source, word_visitor, source_text_visitor)
-        }
-        ConditionalExpr::Word(word) | ConditionalExpr::Regex(word) => {
-            walk_word(word, source, word_visitor, source_text_visitor)
-        }
-        ConditionalExpr::Pattern(pattern) => {
-            walk_pattern(pattern, source, word_visitor, source_text_visitor)
-        }
-        ConditionalExpr::VarRef(reference) => walk_var_ref(reference, source, source_text_visitor),
-    }
-}
-
-fn rewrite_var_ref_source_texts(
-    reference: &mut VarRef,
-    source: &str,
-    visitor: &mut (impl FnMut(&mut SourceText, &str) -> usize + ?Sized),
-) -> usize {
-    reference.subscript.as_mut().map_or(0, |subscript| {
-        rewrite_subscript_source_texts(subscript, source, visitor)
-    })
-}
-
-fn rewrite_subscript_source_texts(
-    subscript: &mut shuck_ast::Subscript,
-    source: &str,
-    visitor: &mut (impl FnMut(&mut SourceText, &str) -> usize + ?Sized),
-) -> usize {
-    let mut count = visitor(&mut subscript.text, source);
-    if let Some(raw) = &mut subscript.raw {
-        count += visitor(raw, source);
-    }
-    count
-}
-
-fn rewrite_optional<T>(value: &mut Option<T>, f: impl FnOnce(&mut T) -> usize) -> usize {
-    value.as_mut().map_or(0, f)
-}
-
-fn rewrite_pattern_source_texts(
-    pattern: &mut Pattern,
-    source: &str,
-    visitor: &mut (impl FnMut(&mut SourceText, &str) -> usize + ?Sized),
-) -> usize {
-    pattern
-        .parts
-        .iter_mut()
-        .map(|part| match &mut part.kind {
-            PatternPart::CharClass(text) => visitor(text, source),
-            PatternPart::Group { patterns, .. } => patterns
-                .iter_mut()
-                .map(|pattern| rewrite_pattern_source_texts(pattern, source, visitor))
-                .sum(),
-            PatternPart::Word(word) => rewrite_word_source_texts(word, source, visitor),
-            PatternPart::Literal(_) | PatternPart::AnyString | PatternPart::AnyChar => 0,
-        })
-        .sum()
-}
-
-fn rewrite_word_source_texts(
-    word: &mut Word,
-    source: &str,
-    visitor: &mut (impl FnMut(&mut SourceText, &str) -> usize + ?Sized),
-) -> usize {
-    word.parts
-        .iter_mut()
-        .map(|part| rewrite_word_part_source_texts(part, source, visitor))
-        .sum()
-}
-
-fn rewrite_word_part_source_texts(
-    part: &mut WordPartNode,
-    source: &str,
-    visitor: &mut (impl FnMut(&mut SourceText, &str) -> usize + ?Sized),
-) -> usize {
-    match &mut part.kind {
-        WordPart::ZshQualifiedGlob(glob) => {
-            glob.segments
-                .iter_mut()
-                .map(|segment| rewrite_zsh_glob_segment_source_texts(segment, source, visitor))
-                .sum::<usize>()
-                + glob.qualifiers.as_mut().map_or(0, |group| {
-                    rewrite_zsh_glob_qualifier_group_source_texts(group, source, visitor)
-                })
-        }
-        WordPart::SingleQuoted { value, .. } => visitor(value, source),
-        WordPart::DoubleQuoted { parts, .. } => parts
-            .iter_mut()
-            .map(|part| rewrite_word_part_source_texts(part, source, visitor))
-            .sum(),
-        WordPart::ArithmeticExpansion { expression, .. } => visitor(expression, source),
-        WordPart::Parameter(parameter) => {
-            rewrite_parameter_source_texts(parameter, source, visitor)
-        }
-        WordPart::ParameterExpansion {
-            reference,
-            operator,
-            operand,
-            ..
-        } => {
-            rewrite_var_ref_source_texts(reference, source, visitor)
-                + rewrite_optional(operand, |operand| visitor(operand, source))
-                + rewrite_parameter_op_source_texts(operator, source, visitor)
-        }
-        WordPart::Length(reference)
-        | WordPart::ArrayAccess(reference)
-        | WordPart::ArrayLength(reference)
-        | WordPart::ArrayIndices(reference)
-        | WordPart::Transformation { reference, .. } => {
-            rewrite_var_ref_source_texts(reference, source, visitor)
-        }
-        WordPart::Substring {
-            reference,
-            offset,
-            length,
-            ..
-        }
-        | WordPart::ArraySlice {
-            reference,
-            offset,
-            length,
-            ..
-        } => {
-            rewrite_var_ref_source_texts(reference, source, visitor)
-                + visitor(offset, source)
-                + rewrite_optional(length, |length| visitor(length, source))
-        }
-        WordPart::IndirectExpansion {
-            reference,
-            operand,
-            operator,
-            ..
-        } => {
-            rewrite_var_ref_source_texts(reference, source, visitor)
-                + rewrite_optional(operand, |operand| visitor(operand, source))
-                + rewrite_optional(operator, |operator| {
-                    rewrite_parameter_op_source_texts(operator, source, visitor)
-                })
-        }
-        WordPart::Literal(_)
-        | WordPart::Variable(_)
-        | WordPart::CommandSubstitution { .. }
-        | WordPart::ProcessSubstitution { .. }
-        | WordPart::PrefixMatch { .. } => 0,
-    }
-}
-
-fn rewrite_zsh_glob_segment_source_texts(
-    segment: &mut shuck_ast::ZshGlobSegment,
-    source: &str,
-    visitor: &mut (impl FnMut(&mut SourceText, &str) -> usize + ?Sized),
-) -> usize {
-    match segment {
-        shuck_ast::ZshGlobSegment::Pattern(pattern) => {
-            rewrite_pattern_source_texts(pattern, source, visitor)
-        }
-        shuck_ast::ZshGlobSegment::InlineControl(_) => 0,
-    }
-}
-
-fn rewrite_zsh_glob_qualifier_group_source_texts(
-    group: &mut shuck_ast::ZshGlobQualifierGroup,
-    source: &str,
-    visitor: &mut (impl FnMut(&mut SourceText, &str) -> usize + ?Sized),
-) -> usize {
-    group
-        .fragments
-        .iter_mut()
-        .map(|fragment| match fragment {
-            shuck_ast::ZshGlobQualifier::Negation { .. }
-            | shuck_ast::ZshGlobQualifier::Flag { .. } => 0,
-            shuck_ast::ZshGlobQualifier::LetterSequence { text, .. } => visitor(text, source),
-            shuck_ast::ZshGlobQualifier::NumericArgument { start, end, .. } => {
-                visitor(start, source) + rewrite_optional(end, |end| visitor(end, source))
-            }
-        })
-        .sum()
-}
-
-fn rewrite_parameter_source_texts(
-    parameter: &mut ParameterExpansion,
-    source: &str,
-    visitor: &mut (impl FnMut(&mut SourceText, &str) -> usize + ?Sized),
-) -> usize {
-    let count = match &mut parameter.syntax {
-        ParameterExpansionSyntax::Bourne(syntax) => match syntax {
-            BourneParameterExpansion::Access { reference }
-            | BourneParameterExpansion::Length { reference }
-            | BourneParameterExpansion::Indices { reference }
-            | BourneParameterExpansion::Transformation { reference, .. } => {
-                rewrite_var_ref_source_texts(reference, source, visitor)
-            }
-            BourneParameterExpansion::Indirect {
-                reference,
-                operator,
-                operand,
-                ..
-            } => {
-                rewrite_var_ref_source_texts(reference, source, visitor)
-                    + rewrite_optional(operand, |operand| visitor(operand, source))
-                    + rewrite_optional(operator, |operator| {
-                        rewrite_parameter_op_source_texts(operator, source, visitor)
-                    })
-            }
-            BourneParameterExpansion::PrefixMatch { .. } => 0,
-            BourneParameterExpansion::Slice {
-                reference,
-                offset,
-                length,
-                ..
-            } => {
-                rewrite_var_ref_source_texts(reference, source, visitor)
-                    + visitor(offset, source)
-                    + rewrite_optional(length, |length| visitor(length, source))
-            }
-            BourneParameterExpansion::Operation {
-                reference,
-                operator,
-                operand,
-                ..
-            } => {
-                rewrite_var_ref_source_texts(reference, source, visitor)
-                    + rewrite_optional(operand, |operand| visitor(operand, source))
-                    + rewrite_parameter_op_source_texts(operator, source, visitor)
-            }
-        },
-        ParameterExpansionSyntax::Zsh(syntax) => match &mut syntax.target {
-            ZshExpansionTarget::Reference(reference) => {
-                rewrite_var_ref_source_texts(reference, source, visitor)
-            }
-            ZshExpansionTarget::Word(word) => rewrite_word_source_texts(word, source, visitor),
-            ZshExpansionTarget::Nested(parameter) => {
-                rewrite_parameter_source_texts(parameter, source, visitor)
-            }
-            ZshExpansionTarget::Empty => 0,
-        },
-    };
-
-    if count > 0 {
-        parameter.raw_body = SourceText::cooked(
-            parameter.raw_body.span(),
-            render_parameter_raw_body(parameter, source),
-        );
-    }
-
-    count
 }
 
 fn render_parameter_raw_body(parameter: &ParameterExpansion, source: &str) -> String {
@@ -1264,32 +490,6 @@ fn render_var_ref_syntax(reference: &VarRef, source: &str) -> String {
     let mut rendered = String::new();
     render_var_ref_to_buf(reference, source, &mut rendered);
     rendered
-}
-
-fn rewrite_parameter_op_source_texts(
-    operator: &mut ParameterOp,
-    source: &str,
-    visitor: &mut (impl FnMut(&mut SourceText, &str) -> usize + ?Sized),
-) -> usize {
-    match operator {
-        ParameterOp::RemovePrefixShort { pattern }
-        | ParameterOp::RemovePrefixLong { pattern }
-        | ParameterOp::RemoveSuffixShort { pattern }
-        | ParameterOp::RemoveSuffixLong { pattern } => {
-            rewrite_pattern_source_texts(pattern, source, visitor)
-        }
-        ParameterOp::ReplaceFirst {
-            pattern,
-            replacement,
-            ..
-        }
-        | ParameterOp::ReplaceAll {
-            pattern,
-            replacement,
-            ..
-        } => rewrite_pattern_source_texts(pattern, source, visitor) + visitor(replacement, source),
-        _ => 0,
-    }
 }
 
 fn transform_source_text(

--- a/crates/shuck-formatter/src/visit.rs
+++ b/crates/shuck-formatter/src/visit.rs
@@ -1,0 +1,1876 @@
+use shuck_ast::{
+    AnonymousFunctionCommand, ArithmeticExpr, ArithmeticExprNode, ArithmeticLvalue, Assignment,
+    AssignmentValue, BourneParameterExpansion, Command, CompoundCommand, ConditionalExpr,
+    DeclClause, DeclOperand, File, FunctionDef, Heredoc, HeredocBody, HeredocBodyPart,
+    HeredocBodyPartNode, ParameterExpansion, ParameterExpansionSyntax, ParameterOp, Pattern,
+    PatternPart, PatternPartNode, Redirect, RedirectTarget, SourceText, Stmt, StmtSeq, Subscript,
+    VarRef, Word, WordPart, WordPartNode, ZshExpansionOperation, ZshExpansionTarget,
+    ZshGlobQualifier, ZshGlobQualifierGroup, ZshGlobSegment, ZshParameterExpansion,
+};
+
+use crate::command::{
+    array_elem_parts, array_elem_value_word_mut, builtin_like_parts, builtin_like_parts_mut,
+};
+
+pub(crate) trait AstVisitor {
+    fn visit_stmt_seq(&mut self, sequence: &StmtSeq) {
+        walk_stmt_seq(self, sequence);
+    }
+
+    fn visit_stmt(&mut self, stmt: &Stmt) {
+        walk_stmt(self, stmt);
+    }
+
+    fn visit_command(&mut self, command: &Command) {
+        walk_command(self, command);
+    }
+
+    fn visit_compound_command(&mut self, command: &CompoundCommand) {
+        walk_compound_command(self, command);
+    }
+
+    fn visit_function(&mut self, function: &FunctionDef) {
+        walk_function(self, function);
+    }
+
+    fn visit_anonymous_function(&mut self, function: &AnonymousFunctionCommand) {
+        walk_anonymous_function(self, function);
+    }
+
+    fn visit_redirect(&mut self, redirect: &Redirect) {
+        walk_redirect(self, redirect);
+    }
+
+    fn visit_assignment(&mut self, assignment: &Assignment) {
+        walk_assignment(self, assignment);
+    }
+
+    fn visit_var_ref(&mut self, reference: &VarRef) {
+        walk_var_ref(self, reference);
+    }
+
+    fn visit_subscript(&mut self, subscript: &Subscript) {
+        walk_subscript(self, subscript);
+    }
+
+    fn visit_conditional_expr(&mut self, expression: &ConditionalExpr) {
+        walk_conditional_expr(self, expression);
+    }
+
+    fn visit_pattern(&mut self, pattern: &Pattern) {
+        walk_pattern(self, pattern);
+    }
+
+    fn visit_pattern_part(&mut self, part: &PatternPartNode) {
+        walk_pattern_part(self, part);
+    }
+
+    fn visit_word(&mut self, word: &Word) {
+        walk_word(self, word);
+    }
+
+    fn visit_word_part(&mut self, part: &WordPartNode) {
+        walk_word_part(self, part);
+    }
+
+    fn visit_heredoc(&mut self, heredoc: &Heredoc) {
+        walk_heredoc(self, heredoc);
+    }
+
+    fn visit_heredoc_body(&mut self, body: &HeredocBody) {
+        walk_heredoc_body(self, body);
+    }
+
+    fn visit_heredoc_body_part(&mut self, part: &HeredocBodyPartNode) {
+        walk_heredoc_body_part(self, part);
+    }
+
+    fn visit_arithmetic_expr(&mut self, expression: &ArithmeticExprNode) {
+        walk_arithmetic_expr(self, expression);
+    }
+
+    fn visit_arithmetic_lvalue(&mut self, target: &ArithmeticLvalue) {
+        walk_arithmetic_lvalue(self, target);
+    }
+
+    fn visit_parameter_expansion(&mut self, parameter: &ParameterExpansion) {
+        walk_parameter_expansion(self, parameter);
+    }
+
+    fn visit_parameter_op(&mut self, operator: &ParameterOp) {
+        walk_parameter_op(self, operator);
+    }
+
+    fn visit_source_text(&mut self, _text: &SourceText) {}
+}
+
+pub(crate) trait AstVisitorMut {
+    fn visit_file(&mut self, file: &mut File) -> usize {
+        walk_file_mut(self, file)
+    }
+
+    fn visit_stmt_seq(&mut self, sequence: &mut StmtSeq) -> usize {
+        walk_stmt_seq_mut(self, sequence)
+    }
+
+    fn visit_stmt(&mut self, stmt: &mut Stmt) -> usize {
+        self.enter_stmt(stmt) + walk_stmt_mut(self, stmt)
+    }
+
+    fn enter_stmt(&mut self, _stmt: &mut Stmt) -> usize {
+        0
+    }
+
+    fn visit_command(&mut self, command: &mut Command) -> usize {
+        walk_command_mut(self, command)
+    }
+
+    fn visit_compound_command(&mut self, command: &mut CompoundCommand) -> usize {
+        walk_compound_command_mut(self, command)
+    }
+
+    fn visit_function(&mut self, function: &mut FunctionDef) -> usize {
+        walk_function_mut(self, function)
+    }
+
+    fn visit_anonymous_function(&mut self, function: &mut AnonymousFunctionCommand) -> usize {
+        walk_anonymous_function_mut(self, function)
+    }
+
+    fn visit_redirect(&mut self, redirect: &mut Redirect) -> usize {
+        walk_redirect_mut(self, redirect)
+    }
+
+    fn visit_assignment(&mut self, assignment: &mut Assignment) -> usize {
+        walk_assignment_mut(self, assignment)
+    }
+
+    fn visit_var_ref(&mut self, reference: &mut VarRef) -> usize {
+        walk_var_ref_mut(self, reference)
+    }
+
+    fn visit_subscript(&mut self, subscript: &mut Subscript) -> usize {
+        walk_subscript_mut(self, subscript)
+    }
+
+    fn visit_conditional_expr(&mut self, expression: &mut ConditionalExpr) -> usize {
+        walk_conditional_expr_mut(self, expression)
+    }
+
+    fn visit_pattern(&mut self, pattern: &mut Pattern) -> usize {
+        walk_pattern_mut(self, pattern)
+    }
+
+    fn visit_pattern_part(&mut self, part: &mut PatternPartNode) -> usize {
+        walk_pattern_part_mut(self, part)
+    }
+
+    fn visit_word(&mut self, word: &mut Word) -> usize {
+        let changes = walk_word_mut(self, word);
+        changes + self.leave_word(word)
+    }
+
+    fn leave_word(&mut self, _word: &mut Word) -> usize {
+        0
+    }
+
+    fn visit_word_part(&mut self, part: &mut WordPartNode) -> usize {
+        walk_word_part_mut(self, part)
+    }
+
+    fn visit_heredoc(&mut self, heredoc: &mut Heredoc) -> usize {
+        walk_heredoc_mut(self, heredoc)
+    }
+
+    fn visit_heredoc_body(&mut self, body: &mut HeredocBody) -> usize {
+        walk_heredoc_body_mut(self, body)
+    }
+
+    fn visit_heredoc_body_part(&mut self, part: &mut HeredocBodyPartNode) -> usize {
+        walk_heredoc_body_part_mut(self, part)
+    }
+
+    fn visit_arithmetic_expr(&mut self, expression: &mut ArithmeticExprNode) -> usize {
+        walk_arithmetic_expr_mut(self, expression)
+    }
+
+    fn visit_arithmetic_lvalue(&mut self, target: &mut ArithmeticLvalue) -> usize {
+        walk_arithmetic_lvalue_mut(self, target)
+    }
+
+    fn visit_parameter_expansion(&mut self, parameter: &mut ParameterExpansion) -> usize {
+        walk_parameter_expansion_mut(self, parameter)
+    }
+
+    fn visit_parameter_op(&mut self, operator: &mut ParameterOp) -> usize {
+        walk_parameter_op_mut(self, operator)
+    }
+
+    fn visit_source_text(&mut self, _text: &mut SourceText) -> usize {
+        0
+    }
+}
+
+pub(crate) fn walk_stmt_seq<V: AstVisitor + ?Sized>(visitor: &mut V, sequence: &StmtSeq) {
+    for stmt in sequence.iter() {
+        visitor.visit_stmt(stmt);
+    }
+}
+
+pub(crate) fn walk_stmt<V: AstVisitor + ?Sized>(visitor: &mut V, stmt: &Stmt) {
+    visitor.visit_command(&stmt.command);
+    for redirect in &stmt.redirects {
+        visitor.visit_redirect(redirect);
+    }
+}
+
+pub(crate) fn walk_command<V: AstVisitor + ?Sized>(visitor: &mut V, command: &Command) {
+    match command {
+        Command::Simple(command) => {
+            for assignment in &command.assignments {
+                visitor.visit_assignment(assignment);
+            }
+            visitor.visit_word(&command.name);
+            for word in &command.args {
+                visitor.visit_word(word);
+            }
+        }
+        Command::Builtin(command) => {
+            let (_, _, assignments, primary, extra_args) = builtin_like_parts(command);
+            for assignment in assignments {
+                visitor.visit_assignment(assignment);
+            }
+            if let Some(primary) = primary {
+                visitor.visit_word(primary);
+            }
+            for word in extra_args {
+                visitor.visit_word(word);
+            }
+        }
+        Command::Decl(command) => walk_decl_clause(visitor, command),
+        Command::Binary(command) => {
+            visitor.visit_stmt(&command.left);
+            visitor.visit_stmt(&command.right);
+        }
+        Command::Compound(command) => visitor.visit_compound_command(command),
+        Command::Function(function) => visitor.visit_function(function),
+        Command::AnonymousFunction(function) => visitor.visit_anonymous_function(function),
+    }
+}
+
+fn walk_decl_clause<V: AstVisitor + ?Sized>(visitor: &mut V, command: &DeclClause) {
+    for assignment in &command.assignments {
+        visitor.visit_assignment(assignment);
+    }
+    for operand in &command.operands {
+        match operand {
+            DeclOperand::Flag(word) | DeclOperand::Dynamic(word) => visitor.visit_word(word),
+            DeclOperand::Name(reference) => visitor.visit_var_ref(reference),
+            DeclOperand::Assignment(assignment) => visitor.visit_assignment(assignment),
+        }
+    }
+}
+
+pub(crate) fn walk_compound_command<V: AstVisitor + ?Sized>(
+    visitor: &mut V,
+    command: &CompoundCommand,
+) {
+    match command {
+        CompoundCommand::If(command) => {
+            visitor.visit_stmt_seq(&command.condition);
+            visitor.visit_stmt_seq(&command.then_branch);
+            for (condition, body) in &command.elif_branches {
+                visitor.visit_stmt_seq(condition);
+                visitor.visit_stmt_seq(body);
+            }
+            if let Some(body) = &command.else_branch {
+                visitor.visit_stmt_seq(body);
+            }
+        }
+        CompoundCommand::For(command) => {
+            for target in &command.targets {
+                visitor.visit_word(&target.word);
+            }
+            if let Some(words) = &command.words {
+                for word in words {
+                    visitor.visit_word(word);
+                }
+            }
+            visitor.visit_stmt_seq(&command.body);
+        }
+        CompoundCommand::Repeat(command) => {
+            visitor.visit_word(&command.count);
+            visitor.visit_stmt_seq(&command.body);
+        }
+        CompoundCommand::Foreach(command) => {
+            for word in &command.words {
+                visitor.visit_word(word);
+            }
+            visitor.visit_stmt_seq(&command.body);
+        }
+        CompoundCommand::ArithmeticFor(command) => {
+            if let Some(expression) = &command.init_ast {
+                visitor.visit_arithmetic_expr(expression);
+            }
+            if let Some(expression) = &command.condition_ast {
+                visitor.visit_arithmetic_expr(expression);
+            }
+            if let Some(expression) = &command.step_ast {
+                visitor.visit_arithmetic_expr(expression);
+            }
+            visitor.visit_stmt_seq(&command.body);
+        }
+        CompoundCommand::While(command) => {
+            visitor.visit_stmt_seq(&command.condition);
+            visitor.visit_stmt_seq(&command.body);
+        }
+        CompoundCommand::Until(command) => {
+            visitor.visit_stmt_seq(&command.condition);
+            visitor.visit_stmt_seq(&command.body);
+        }
+        CompoundCommand::Case(command) => {
+            visitor.visit_word(&command.word);
+            for item in &command.cases {
+                for pattern in &item.patterns {
+                    visitor.visit_pattern(pattern);
+                }
+                visitor.visit_stmt_seq(&item.body);
+            }
+        }
+        CompoundCommand::Select(command) => {
+            for word in &command.words {
+                visitor.visit_word(word);
+            }
+            visitor.visit_stmt_seq(&command.body);
+        }
+        CompoundCommand::Subshell(commands) | CompoundCommand::BraceGroup(commands) => {
+            visitor.visit_stmt_seq(commands);
+        }
+        CompoundCommand::Arithmetic(command) => {
+            if let Some(expression) = &command.expr_ast {
+                visitor.visit_arithmetic_expr(expression);
+            }
+        }
+        CompoundCommand::Time(command) => {
+            if let Some(command) = &command.command {
+                visitor.visit_stmt(command);
+            }
+        }
+        CompoundCommand::Conditional(command) => {
+            visitor.visit_conditional_expr(&command.expression)
+        }
+        CompoundCommand::Coproc(command) => visitor.visit_stmt(&command.body),
+        CompoundCommand::Always(command) => {
+            visitor.visit_stmt_seq(&command.body);
+            visitor.visit_stmt_seq(&command.always_body);
+        }
+    }
+}
+
+pub(crate) fn walk_function<V: AstVisitor + ?Sized>(visitor: &mut V, function: &FunctionDef) {
+    for entry in &function.header.entries {
+        visitor.visit_word(&entry.word);
+    }
+    visitor.visit_stmt(&function.body);
+}
+
+pub(crate) fn walk_anonymous_function<V: AstVisitor + ?Sized>(
+    visitor: &mut V,
+    function: &AnonymousFunctionCommand,
+) {
+    visitor.visit_stmt(&function.body);
+    for argument in &function.args {
+        visitor.visit_word(argument);
+    }
+}
+
+pub(crate) fn walk_redirect<V: AstVisitor + ?Sized>(visitor: &mut V, redirect: &Redirect) {
+    match &redirect.target {
+        RedirectTarget::Word(word) => visitor.visit_word(word),
+        RedirectTarget::Heredoc(heredoc) => visitor.visit_heredoc(heredoc),
+    }
+}
+
+pub(crate) fn walk_heredoc<V: AstVisitor + ?Sized>(visitor: &mut V, heredoc: &Heredoc) {
+    visitor.visit_word(&heredoc.delimiter.raw);
+    visitor.visit_heredoc_body(&heredoc.body);
+}
+
+pub(crate) fn walk_assignment<V: AstVisitor + ?Sized>(visitor: &mut V, assignment: &Assignment) {
+    visitor.visit_var_ref(&assignment.target);
+    match &assignment.value {
+        AssignmentValue::Scalar(word) => visitor.visit_word(word),
+        AssignmentValue::Compound(array) => {
+            for element in &array.elements {
+                if let Some(key) = array_elem_parts(element).0 {
+                    visitor.visit_subscript(key);
+                }
+                visitor.visit_word(array_elem_parts(element).1);
+            }
+        }
+    }
+}
+
+pub(crate) fn walk_var_ref<V: AstVisitor + ?Sized>(visitor: &mut V, reference: &VarRef) {
+    if let Some(subscript) = &reference.subscript {
+        visitor.visit_subscript(subscript);
+    }
+}
+
+pub(crate) fn walk_subscript<V: AstVisitor + ?Sized>(visitor: &mut V, subscript: &Subscript) {
+    visitor.visit_source_text(&subscript.text);
+    if let Some(raw) = &subscript.raw {
+        visitor.visit_source_text(raw);
+    }
+    if let Some(word) = &subscript.word_ast {
+        visitor.visit_word(word);
+    }
+    if let Some(expression) = &subscript.arithmetic_ast {
+        visitor.visit_arithmetic_expr(expression);
+    }
+}
+
+pub(crate) fn walk_conditional_expr<V: AstVisitor + ?Sized>(
+    visitor: &mut V,
+    expression: &ConditionalExpr,
+) {
+    match expression {
+        ConditionalExpr::Binary(expression) => {
+            visitor.visit_conditional_expr(&expression.left);
+            visitor.visit_conditional_expr(&expression.right);
+        }
+        ConditionalExpr::Unary(expression) => visitor.visit_conditional_expr(&expression.expr),
+        ConditionalExpr::Parenthesized(expression) => {
+            visitor.visit_conditional_expr(&expression.expr);
+        }
+        ConditionalExpr::Word(word) | ConditionalExpr::Regex(word) => visitor.visit_word(word),
+        ConditionalExpr::Pattern(pattern) => visitor.visit_pattern(pattern),
+        ConditionalExpr::VarRef(reference) => visitor.visit_var_ref(reference),
+    }
+}
+
+pub(crate) fn walk_pattern<V: AstVisitor + ?Sized>(visitor: &mut V, pattern: &Pattern) {
+    for part in &pattern.parts {
+        visitor.visit_pattern_part(part);
+    }
+}
+
+pub(crate) fn walk_pattern_part<V: AstVisitor + ?Sized>(visitor: &mut V, part: &PatternPartNode) {
+    match &part.kind {
+        PatternPart::CharClass(text) => visitor.visit_source_text(text),
+        PatternPart::Group { patterns, .. } => {
+            for pattern in patterns {
+                visitor.visit_pattern(pattern);
+            }
+        }
+        PatternPart::Word(word) => visitor.visit_word(word),
+        PatternPart::Literal(_) | PatternPart::AnyString | PatternPart::AnyChar => {}
+    }
+}
+
+pub(crate) fn walk_word<V: AstVisitor + ?Sized>(visitor: &mut V, word: &Word) {
+    for part in &word.parts {
+        visitor.visit_word_part(part);
+    }
+}
+
+pub(crate) fn walk_word_part<V: AstVisitor + ?Sized>(visitor: &mut V, part: &WordPartNode) {
+    match &part.kind {
+        WordPart::Literal(_) | WordPart::Variable(_) | WordPart::PrefixMatch { .. } => {}
+        WordPart::ZshQualifiedGlob(glob) => walk_zsh_qualified_glob(visitor, glob),
+        WordPart::SingleQuoted { value, .. } => visitor.visit_source_text(value),
+        WordPart::DoubleQuoted { parts, .. } => {
+            for part in parts {
+                visitor.visit_word_part(part);
+            }
+        }
+        WordPart::CommandSubstitution { body, .. } | WordPart::ProcessSubstitution { body, .. } => {
+            visitor.visit_stmt_seq(body);
+        }
+        WordPart::ArithmeticExpansion {
+            expression,
+            expression_ast,
+            expression_word_ast,
+            ..
+        } => {
+            visitor.visit_source_text(expression);
+            if let Some(expression) = expression_ast {
+                visitor.visit_arithmetic_expr(expression);
+            } else {
+                visitor.visit_word(expression_word_ast);
+            }
+        }
+        WordPart::Parameter(parameter) => visitor.visit_parameter_expansion(parameter),
+        WordPart::ParameterExpansion {
+            reference,
+            operator,
+            operand,
+            operand_word_ast,
+            ..
+        } => {
+            visitor.visit_var_ref(reference);
+            visitor.visit_parameter_op(operator);
+            if let Some(operand) = operand {
+                visitor.visit_source_text(operand);
+            }
+            if let Some(operand) = operand_word_ast {
+                visitor.visit_word(operand);
+            }
+        }
+        WordPart::Length(reference)
+        | WordPart::ArrayAccess(reference)
+        | WordPart::ArrayLength(reference)
+        | WordPart::ArrayIndices(reference)
+        | WordPart::Transformation { reference, .. } => visitor.visit_var_ref(reference),
+        WordPart::Substring {
+            reference,
+            offset,
+            offset_ast,
+            offset_word_ast,
+            length,
+            length_ast,
+            length_word_ast,
+            ..
+        }
+        | WordPart::ArraySlice {
+            reference,
+            offset,
+            offset_ast,
+            offset_word_ast,
+            length,
+            length_ast,
+            length_word_ast,
+            ..
+        } => {
+            visitor.visit_var_ref(reference);
+            visitor.visit_source_text(offset);
+            if let Some(expression) = offset_ast {
+                visitor.visit_arithmetic_expr(expression);
+            } else {
+                visitor.visit_word(offset_word_ast);
+            }
+            if let Some(length) = length {
+                visitor.visit_source_text(length);
+            }
+            if let Some(expression) = length_ast {
+                visitor.visit_arithmetic_expr(expression);
+            } else if let Some(word) = length_word_ast {
+                visitor.visit_word(word);
+            }
+        }
+        WordPart::IndirectExpansion {
+            reference,
+            operator,
+            operand,
+            operand_word_ast,
+            ..
+        } => {
+            visitor.visit_var_ref(reference);
+            if let Some(operator) = operator {
+                visitor.visit_parameter_op(operator);
+            }
+            if let Some(operand) = operand {
+                visitor.visit_source_text(operand);
+            }
+            if let Some(operand) = operand_word_ast {
+                visitor.visit_word(operand);
+            }
+        }
+    }
+}
+
+pub(crate) fn walk_heredoc_body<V: AstVisitor + ?Sized>(visitor: &mut V, body: &HeredocBody) {
+    for part in &body.parts {
+        visitor.visit_heredoc_body_part(part);
+    }
+}
+
+pub(crate) fn walk_heredoc_body_part<V: AstVisitor + ?Sized>(
+    visitor: &mut V,
+    part: &HeredocBodyPartNode,
+) {
+    match &part.kind {
+        HeredocBodyPart::Literal(_) | HeredocBodyPart::Variable(_) => {}
+        HeredocBodyPart::CommandSubstitution { body, .. } => visitor.visit_stmt_seq(body),
+        HeredocBodyPart::ArithmeticExpansion {
+            expression,
+            expression_ast,
+            expression_word_ast,
+            ..
+        } => {
+            visitor.visit_source_text(expression);
+            if let Some(expression) = expression_ast {
+                visitor.visit_arithmetic_expr(expression);
+            } else {
+                visitor.visit_word(expression_word_ast);
+            }
+        }
+        HeredocBodyPart::Parameter(parameter) => visitor.visit_parameter_expansion(parameter),
+    }
+}
+
+pub(crate) fn walk_arithmetic_expr<V: AstVisitor + ?Sized>(
+    visitor: &mut V,
+    expression: &ArithmeticExprNode,
+) {
+    match &expression.kind {
+        ArithmeticExpr::Number(text) => visitor.visit_source_text(text),
+        ArithmeticExpr::Variable(_) => {}
+        ArithmeticExpr::Indexed { index, .. } => visitor.visit_arithmetic_expr(index),
+        ArithmeticExpr::ShellWord(word) => visitor.visit_word(word),
+        ArithmeticExpr::Parenthesized { expression } => visitor.visit_arithmetic_expr(expression),
+        ArithmeticExpr::Unary { expr, .. } | ArithmeticExpr::Postfix { expr, .. } => {
+            visitor.visit_arithmetic_expr(expr);
+        }
+        ArithmeticExpr::Binary { left, right, .. } => {
+            visitor.visit_arithmetic_expr(left);
+            visitor.visit_arithmetic_expr(right);
+        }
+        ArithmeticExpr::Conditional {
+            condition,
+            then_expr,
+            else_expr,
+        } => {
+            visitor.visit_arithmetic_expr(condition);
+            visitor.visit_arithmetic_expr(then_expr);
+            visitor.visit_arithmetic_expr(else_expr);
+        }
+        ArithmeticExpr::Assignment { target, value, .. } => {
+            visitor.visit_arithmetic_lvalue(target);
+            visitor.visit_arithmetic_expr(value);
+        }
+    }
+}
+
+pub(crate) fn walk_arithmetic_lvalue<V: AstVisitor + ?Sized>(
+    visitor: &mut V,
+    target: &ArithmeticLvalue,
+) {
+    match target {
+        ArithmeticLvalue::Variable(_) => {}
+        ArithmeticLvalue::Indexed { index, .. } => visitor.visit_arithmetic_expr(index),
+    }
+}
+
+pub(crate) fn walk_parameter_expansion<V: AstVisitor + ?Sized>(
+    visitor: &mut V,
+    parameter: &ParameterExpansion,
+) {
+    match &parameter.syntax {
+        ParameterExpansionSyntax::Bourne(syntax) => match syntax {
+            BourneParameterExpansion::Access { reference }
+            | BourneParameterExpansion::Length { reference }
+            | BourneParameterExpansion::Indices { reference }
+            | BourneParameterExpansion::Transformation { reference, .. } => {
+                visitor.visit_var_ref(reference);
+            }
+            BourneParameterExpansion::Indirect {
+                reference,
+                operator,
+                operand,
+                operand_word_ast,
+                ..
+            } => {
+                visitor.visit_var_ref(reference);
+                if let Some(operator) = operator {
+                    visitor.visit_parameter_op(operator);
+                }
+                if let Some(operand) = operand {
+                    visitor.visit_source_text(operand);
+                }
+                if let Some(operand) = operand_word_ast {
+                    visitor.visit_word(operand);
+                }
+            }
+            BourneParameterExpansion::Operation {
+                reference,
+                operator,
+                operand,
+                operand_word_ast,
+                ..
+            } => {
+                visitor.visit_var_ref(reference);
+                visitor.visit_parameter_op(operator);
+                if let Some(operand) = operand {
+                    visitor.visit_source_text(operand);
+                }
+                if let Some(operand) = operand_word_ast {
+                    visitor.visit_word(operand);
+                }
+            }
+            BourneParameterExpansion::PrefixMatch { .. } => {}
+            BourneParameterExpansion::Slice {
+                reference,
+                offset,
+                offset_ast,
+                offset_word_ast,
+                length,
+                length_ast,
+                length_word_ast,
+                ..
+            } => {
+                visitor.visit_var_ref(reference);
+                visitor.visit_source_text(offset);
+                if let Some(expression) = offset_ast {
+                    visitor.visit_arithmetic_expr(expression);
+                } else {
+                    visitor.visit_word(offset_word_ast);
+                }
+                if let Some(length) = length {
+                    visitor.visit_source_text(length);
+                }
+                if let Some(expression) = length_ast {
+                    visitor.visit_arithmetic_expr(expression);
+                } else if let Some(word) = length_word_ast {
+                    visitor.visit_word(word);
+                }
+            }
+        },
+        ParameterExpansionSyntax::Zsh(syntax) => walk_zsh_parameter_expansion(visitor, syntax),
+    }
+}
+
+fn walk_zsh_parameter_expansion<V: AstVisitor + ?Sized>(
+    visitor: &mut V,
+    syntax: &ZshParameterExpansion,
+) {
+    match &syntax.target {
+        ZshExpansionTarget::Reference(reference) => visitor.visit_var_ref(reference),
+        ZshExpansionTarget::Nested(parameter) => visitor.visit_parameter_expansion(parameter),
+        ZshExpansionTarget::Word(word) => visitor.visit_word(word),
+        ZshExpansionTarget::Empty => {}
+    }
+    for modifier in &syntax.modifiers {
+        if let Some(argument) = &modifier.argument {
+            visitor.visit_source_text(argument);
+        }
+        if let Some(word) = &modifier.argument_word_ast {
+            visitor.visit_word(word);
+        }
+    }
+    if let Some(operation) = &syntax.operation {
+        walk_zsh_expansion_operation(visitor, operation);
+    }
+}
+
+fn walk_zsh_expansion_operation<V: AstVisitor + ?Sized>(
+    visitor: &mut V,
+    operation: &ZshExpansionOperation,
+) {
+    match operation {
+        ZshExpansionOperation::PatternOperation {
+            operand,
+            operand_word_ast,
+            ..
+        }
+        | ZshExpansionOperation::Defaulting {
+            operand,
+            operand_word_ast,
+            ..
+        }
+        | ZshExpansionOperation::TrimOperation {
+            operand,
+            operand_word_ast,
+            ..
+        } => {
+            visitor.visit_source_text(operand);
+            visitor.visit_word(operand_word_ast);
+        }
+        ZshExpansionOperation::ReplacementOperation {
+            pattern,
+            pattern_word_ast,
+            replacement,
+            replacement_word_ast,
+            ..
+        } => {
+            visitor.visit_source_text(pattern);
+            visitor.visit_word(pattern_word_ast);
+            if let Some(replacement) = replacement {
+                visitor.visit_source_text(replacement);
+            }
+            if let Some(replacement) = replacement_word_ast {
+                visitor.visit_word(replacement);
+            }
+        }
+        ZshExpansionOperation::Slice {
+            offset,
+            offset_word_ast,
+            length,
+            length_word_ast,
+        } => {
+            visitor.visit_source_text(offset);
+            visitor.visit_word(offset_word_ast);
+            if let Some(length) = length {
+                visitor.visit_source_text(length);
+            }
+            if let Some(length) = length_word_ast {
+                visitor.visit_word(length);
+            }
+        }
+        ZshExpansionOperation::Unknown { text, word_ast } => {
+            visitor.visit_source_text(text);
+            visitor.visit_word(word_ast);
+        }
+    }
+}
+
+pub(crate) fn walk_parameter_op<V: AstVisitor + ?Sized>(visitor: &mut V, operator: &ParameterOp) {
+    match operator {
+        ParameterOp::RemovePrefixShort { pattern }
+        | ParameterOp::RemovePrefixLong { pattern }
+        | ParameterOp::RemoveSuffixShort { pattern }
+        | ParameterOp::RemoveSuffixLong { pattern } => visitor.visit_pattern(pattern),
+        ParameterOp::ReplaceFirst {
+            pattern,
+            replacement,
+            replacement_word_ast,
+        }
+        | ParameterOp::ReplaceAll {
+            pattern,
+            replacement,
+            replacement_word_ast,
+        } => {
+            visitor.visit_pattern(pattern);
+            visitor.visit_source_text(replacement);
+            visitor.visit_word(replacement_word_ast);
+        }
+        ParameterOp::UseDefault
+        | ParameterOp::AssignDefault
+        | ParameterOp::UseReplacement
+        | ParameterOp::Error
+        | ParameterOp::UpperFirst
+        | ParameterOp::UpperAll
+        | ParameterOp::LowerFirst
+        | ParameterOp::LowerAll => {}
+    }
+}
+
+fn walk_zsh_qualified_glob<V: AstVisitor + ?Sized>(
+    visitor: &mut V,
+    glob: &shuck_ast::ZshQualifiedGlob,
+) {
+    for segment in &glob.segments {
+        match segment {
+            ZshGlobSegment::Pattern(pattern) => visitor.visit_pattern(pattern),
+            ZshGlobSegment::InlineControl(_) => {}
+        }
+    }
+    if let Some(qualifiers) = &glob.qualifiers {
+        walk_zsh_glob_qualifier_group(visitor, qualifiers);
+    }
+}
+
+fn walk_zsh_glob_qualifier_group<V: AstVisitor + ?Sized>(
+    visitor: &mut V,
+    group: &ZshGlobQualifierGroup,
+) {
+    for fragment in &group.fragments {
+        match fragment {
+            ZshGlobQualifier::LetterSequence { text, .. } => visitor.visit_source_text(text),
+            ZshGlobQualifier::NumericArgument { start, end, .. } => {
+                visitor.visit_source_text(start);
+                if let Some(end) = end {
+                    visitor.visit_source_text(end);
+                }
+            }
+            ZshGlobQualifier::Negation { .. } | ZshGlobQualifier::Flag { .. } => {}
+        }
+    }
+}
+
+pub(crate) fn walk_file_mut<V: AstVisitorMut + ?Sized>(visitor: &mut V, file: &mut File) -> usize {
+    visitor.visit_stmt_seq(&mut file.body)
+}
+
+pub(crate) fn walk_stmt_seq_mut<V: AstVisitorMut + ?Sized>(
+    visitor: &mut V,
+    sequence: &mut StmtSeq,
+) -> usize {
+    sequence
+        .iter_mut()
+        .map(|stmt| visitor.visit_stmt(stmt))
+        .sum()
+}
+
+pub(crate) fn walk_stmt_mut<V: AstVisitorMut + ?Sized>(visitor: &mut V, stmt: &mut Stmt) -> usize {
+    let mut changes = visitor.visit_command(&mut stmt.command);
+    for redirect in &mut stmt.redirects {
+        changes += visitor.visit_redirect(redirect);
+    }
+    changes
+}
+
+pub(crate) fn walk_command_mut<V: AstVisitorMut + ?Sized>(
+    visitor: &mut V,
+    command: &mut Command,
+) -> usize {
+    match command {
+        Command::Simple(command) => {
+            let mut changes = 0;
+            for assignment in &mut command.assignments {
+                changes += visitor.visit_assignment(assignment);
+            }
+            changes += visitor.visit_word(&mut command.name);
+            for word in &mut command.args {
+                changes += visitor.visit_word(word);
+            }
+            changes
+        }
+        Command::Builtin(command) => {
+            let (assignments, primary, extra_args) = builtin_like_parts_mut(command);
+            let mut changes = 0;
+            for assignment in assignments {
+                changes += visitor.visit_assignment(assignment);
+            }
+            if let Some(primary) = primary {
+                changes += visitor.visit_word(primary);
+            }
+            for word in extra_args {
+                changes += visitor.visit_word(word);
+            }
+            changes
+        }
+        Command::Decl(command) => walk_decl_clause_mut(visitor, command),
+        Command::Binary(command) => {
+            visitor.visit_stmt(&mut command.left) + visitor.visit_stmt(&mut command.right)
+        }
+        Command::Compound(command) => visitor.visit_compound_command(command),
+        Command::Function(function) => visitor.visit_function(function),
+        Command::AnonymousFunction(function) => visitor.visit_anonymous_function(function),
+    }
+}
+
+fn walk_decl_clause_mut<V: AstVisitorMut + ?Sized>(
+    visitor: &mut V,
+    command: &mut DeclClause,
+) -> usize {
+    let mut changes = 0;
+    for assignment in &mut command.assignments {
+        changes += visitor.visit_assignment(assignment);
+    }
+    for operand in &mut command.operands {
+        changes += match operand {
+            DeclOperand::Flag(word) | DeclOperand::Dynamic(word) => visitor.visit_word(word),
+            DeclOperand::Name(reference) => visitor.visit_var_ref(reference),
+            DeclOperand::Assignment(assignment) => visitor.visit_assignment(assignment),
+        };
+    }
+    changes
+}
+
+pub(crate) fn walk_compound_command_mut<V: AstVisitorMut + ?Sized>(
+    visitor: &mut V,
+    command: &mut CompoundCommand,
+) -> usize {
+    match command {
+        CompoundCommand::If(command) => {
+            let mut changes = visitor.visit_stmt_seq(&mut command.condition)
+                + visitor.visit_stmt_seq(&mut command.then_branch);
+            for (condition, body) in &mut command.elif_branches {
+                changes += visitor.visit_stmt_seq(condition);
+                changes += visitor.visit_stmt_seq(body);
+            }
+            if let Some(body) = &mut command.else_branch {
+                changes += visitor.visit_stmt_seq(body);
+            }
+            changes
+        }
+        CompoundCommand::For(command) => {
+            let mut changes = 0;
+            for target in &mut command.targets {
+                changes += visitor.visit_word(&mut target.word);
+            }
+            if let Some(words) = &mut command.words {
+                for word in words {
+                    changes += visitor.visit_word(word);
+                }
+            }
+            changes + visitor.visit_stmt_seq(&mut command.body)
+        }
+        CompoundCommand::Repeat(command) => {
+            visitor.visit_word(&mut command.count) + visitor.visit_stmt_seq(&mut command.body)
+        }
+        CompoundCommand::Foreach(command) => {
+            let mut changes = 0;
+            for word in &mut command.words {
+                changes += visitor.visit_word(word);
+            }
+            changes + visitor.visit_stmt_seq(&mut command.body)
+        }
+        CompoundCommand::ArithmeticFor(command) => {
+            let mut changes = 0;
+            if let Some(expression) = &mut command.init_ast {
+                changes += visitor.visit_arithmetic_expr(expression);
+            }
+            if let Some(expression) = &mut command.condition_ast {
+                changes += visitor.visit_arithmetic_expr(expression);
+            }
+            if let Some(expression) = &mut command.step_ast {
+                changes += visitor.visit_arithmetic_expr(expression);
+            }
+            changes + visitor.visit_stmt_seq(&mut command.body)
+        }
+        CompoundCommand::While(command) => {
+            visitor.visit_stmt_seq(&mut command.condition)
+                + visitor.visit_stmt_seq(&mut command.body)
+        }
+        CompoundCommand::Until(command) => {
+            visitor.visit_stmt_seq(&mut command.condition)
+                + visitor.visit_stmt_seq(&mut command.body)
+        }
+        CompoundCommand::Case(command) => {
+            let mut changes = visitor.visit_word(&mut command.word);
+            for item in &mut command.cases {
+                for pattern in &mut item.patterns {
+                    changes += visitor.visit_pattern(pattern);
+                }
+                changes += visitor.visit_stmt_seq(&mut item.body);
+            }
+            changes
+        }
+        CompoundCommand::Select(command) => {
+            let mut changes = 0;
+            for word in &mut command.words {
+                changes += visitor.visit_word(word);
+            }
+            changes + visitor.visit_stmt_seq(&mut command.body)
+        }
+        CompoundCommand::Subshell(commands) | CompoundCommand::BraceGroup(commands) => {
+            visitor.visit_stmt_seq(commands)
+        }
+        CompoundCommand::Arithmetic(command) => command
+            .expr_ast
+            .as_mut()
+            .map_or(0, |expression| visitor.visit_arithmetic_expr(expression)),
+        CompoundCommand::Time(command) => command
+            .command
+            .as_mut()
+            .map_or(0, |command| visitor.visit_stmt(command)),
+        CompoundCommand::Conditional(command) => {
+            visitor.visit_conditional_expr(&mut command.expression)
+        }
+        CompoundCommand::Coproc(command) => visitor.visit_stmt(&mut command.body),
+        CompoundCommand::Always(command) => {
+            visitor.visit_stmt_seq(&mut command.body)
+                + visitor.visit_stmt_seq(&mut command.always_body)
+        }
+    }
+}
+
+pub(crate) fn walk_function_mut<V: AstVisitorMut + ?Sized>(
+    visitor: &mut V,
+    function: &mut FunctionDef,
+) -> usize {
+    let mut changes = 0;
+    for entry in &mut function.header.entries {
+        changes += visitor.visit_word(&mut entry.word);
+    }
+    changes + visitor.visit_stmt(&mut function.body)
+}
+
+pub(crate) fn walk_anonymous_function_mut<V: AstVisitorMut + ?Sized>(
+    visitor: &mut V,
+    function: &mut AnonymousFunctionCommand,
+) -> usize {
+    let mut changes = visitor.visit_stmt(&mut function.body);
+    for argument in &mut function.args {
+        changes += visitor.visit_word(argument);
+    }
+    changes
+}
+
+pub(crate) fn walk_redirect_mut<V: AstVisitorMut + ?Sized>(
+    visitor: &mut V,
+    redirect: &mut Redirect,
+) -> usize {
+    match &mut redirect.target {
+        RedirectTarget::Word(word) => visitor.visit_word(word),
+        RedirectTarget::Heredoc(heredoc) => visitor.visit_heredoc(heredoc),
+    }
+}
+
+pub(crate) fn walk_heredoc_mut<V: AstVisitorMut + ?Sized>(
+    visitor: &mut V,
+    heredoc: &mut Heredoc,
+) -> usize {
+    visitor.visit_word(&mut heredoc.delimiter.raw) + visitor.visit_heredoc_body(&mut heredoc.body)
+}
+
+pub(crate) fn walk_assignment_mut<V: AstVisitorMut + ?Sized>(
+    visitor: &mut V,
+    assignment: &mut Assignment,
+) -> usize {
+    let mut changes = visitor.visit_var_ref(&mut assignment.target);
+    changes += match &mut assignment.value {
+        AssignmentValue::Scalar(word) => visitor.visit_word(word),
+        AssignmentValue::Compound(array) => {
+            let mut inner = 0;
+            for element in &mut array.elements {
+                match element {
+                    shuck_ast::ArrayElem::Sequential(_) => {}
+                    shuck_ast::ArrayElem::Keyed { key, .. }
+                    | shuck_ast::ArrayElem::KeyedAppend { key, .. } => {
+                        inner += visitor.visit_subscript(key);
+                    }
+                }
+                inner += visitor.visit_word(array_elem_value_word_mut(element));
+            }
+            inner
+        }
+    };
+    changes
+}
+
+pub(crate) fn walk_var_ref_mut<V: AstVisitorMut + ?Sized>(
+    visitor: &mut V,
+    reference: &mut VarRef,
+) -> usize {
+    reference
+        .subscript
+        .as_mut()
+        .map_or(0, |subscript| visitor.visit_subscript(subscript))
+}
+
+pub(crate) fn walk_subscript_mut<V: AstVisitorMut + ?Sized>(
+    visitor: &mut V,
+    subscript: &mut Subscript,
+) -> usize {
+    let mut changes = visitor.visit_source_text(&mut subscript.text);
+    if let Some(raw) = &mut subscript.raw {
+        changes += visitor.visit_source_text(raw);
+    }
+    if let Some(word) = &mut subscript.word_ast {
+        changes += visitor.visit_word(word);
+    }
+    if let Some(expression) = &mut subscript.arithmetic_ast {
+        changes += visitor.visit_arithmetic_expr(expression);
+    }
+    changes
+}
+
+pub(crate) fn walk_conditional_expr_mut<V: AstVisitorMut + ?Sized>(
+    visitor: &mut V,
+    expression: &mut ConditionalExpr,
+) -> usize {
+    match expression {
+        ConditionalExpr::Binary(expression) => {
+            visitor.visit_conditional_expr(&mut expression.left)
+                + visitor.visit_conditional_expr(&mut expression.right)
+        }
+        ConditionalExpr::Unary(expression) => visitor.visit_conditional_expr(&mut expression.expr),
+        ConditionalExpr::Parenthesized(expression) => {
+            visitor.visit_conditional_expr(&mut expression.expr)
+        }
+        ConditionalExpr::Word(word) | ConditionalExpr::Regex(word) => visitor.visit_word(word),
+        ConditionalExpr::Pattern(pattern) => visitor.visit_pattern(pattern),
+        ConditionalExpr::VarRef(reference) => visitor.visit_var_ref(reference),
+    }
+}
+
+pub(crate) fn walk_pattern_mut<V: AstVisitorMut + ?Sized>(
+    visitor: &mut V,
+    pattern: &mut Pattern,
+) -> usize {
+    pattern
+        .parts
+        .iter_mut()
+        .map(|part| visitor.visit_pattern_part(part))
+        .sum()
+}
+
+pub(crate) fn walk_pattern_part_mut<V: AstVisitorMut + ?Sized>(
+    visitor: &mut V,
+    part: &mut PatternPartNode,
+) -> usize {
+    match &mut part.kind {
+        PatternPart::CharClass(text) => visitor.visit_source_text(text),
+        PatternPart::Group { patterns, .. } => patterns
+            .iter_mut()
+            .map(|pattern| visitor.visit_pattern(pattern))
+            .sum(),
+        PatternPart::Word(word) => visitor.visit_word(word),
+        PatternPart::Literal(_) | PatternPart::AnyString | PatternPart::AnyChar => 0,
+    }
+}
+
+pub(crate) fn walk_word_mut<V: AstVisitorMut + ?Sized>(visitor: &mut V, word: &mut Word) -> usize {
+    word.parts
+        .iter_mut()
+        .map(|part| visitor.visit_word_part(part))
+        .sum()
+}
+
+pub(crate) fn walk_word_part_mut<V: AstVisitorMut + ?Sized>(
+    visitor: &mut V,
+    part: &mut WordPartNode,
+) -> usize {
+    match &mut part.kind {
+        WordPart::Literal(_) | WordPart::Variable(_) | WordPart::PrefixMatch { .. } => 0,
+        WordPart::ZshQualifiedGlob(glob) => walk_zsh_qualified_glob_mut(visitor, glob),
+        WordPart::SingleQuoted { value, .. } => visitor.visit_source_text(value),
+        WordPart::DoubleQuoted { parts, .. } => parts
+            .iter_mut()
+            .map(|part| visitor.visit_word_part(part))
+            .sum(),
+        WordPart::CommandSubstitution { body, .. } | WordPart::ProcessSubstitution { body, .. } => {
+            visitor.visit_stmt_seq(body)
+        }
+        WordPart::ArithmeticExpansion {
+            expression,
+            expression_ast,
+            expression_word_ast,
+            ..
+        } => {
+            let mut changes = visitor.visit_source_text(expression);
+            if let Some(expression) = expression_ast {
+                changes += visitor.visit_arithmetic_expr(expression);
+            } else {
+                changes += visitor.visit_word(expression_word_ast);
+            }
+            changes
+        }
+        WordPart::Parameter(parameter) => visitor.visit_parameter_expansion(parameter),
+        WordPart::ParameterExpansion {
+            reference,
+            operator,
+            operand,
+            operand_word_ast,
+            ..
+        } => {
+            let mut changes =
+                visitor.visit_var_ref(reference) + visitor.visit_parameter_op(operator);
+            if let Some(operand) = operand {
+                changes += visitor.visit_source_text(operand);
+            }
+            if let Some(operand) = operand_word_ast {
+                changes += visitor.visit_word(operand);
+            }
+            changes
+        }
+        WordPart::Length(reference)
+        | WordPart::ArrayAccess(reference)
+        | WordPart::ArrayLength(reference)
+        | WordPart::ArrayIndices(reference)
+        | WordPart::Transformation { reference, .. } => visitor.visit_var_ref(reference),
+        WordPart::Substring {
+            reference,
+            offset,
+            offset_ast,
+            offset_word_ast,
+            length,
+            length_ast,
+            length_word_ast,
+            ..
+        }
+        | WordPart::ArraySlice {
+            reference,
+            offset,
+            offset_ast,
+            offset_word_ast,
+            length,
+            length_ast,
+            length_word_ast,
+            ..
+        } => {
+            let mut changes = visitor.visit_var_ref(reference) + visitor.visit_source_text(offset);
+            if let Some(expression) = offset_ast {
+                changes += visitor.visit_arithmetic_expr(expression);
+            } else {
+                changes += visitor.visit_word(offset_word_ast);
+            }
+            if let Some(length) = length {
+                changes += visitor.visit_source_text(length);
+            }
+            if let Some(expression) = length_ast {
+                changes += visitor.visit_arithmetic_expr(expression);
+            } else if let Some(word) = length_word_ast {
+                changes += visitor.visit_word(word);
+            }
+            changes
+        }
+        WordPart::IndirectExpansion {
+            reference,
+            operator,
+            operand,
+            operand_word_ast,
+            ..
+        } => {
+            let mut changes = visitor.visit_var_ref(reference);
+            if let Some(operator) = operator {
+                changes += visitor.visit_parameter_op(operator);
+            }
+            if let Some(operand) = operand {
+                changes += visitor.visit_source_text(operand);
+            }
+            if let Some(operand) = operand_word_ast {
+                changes += visitor.visit_word(operand);
+            }
+            changes
+        }
+    }
+}
+
+pub(crate) fn walk_heredoc_body_mut<V: AstVisitorMut + ?Sized>(
+    visitor: &mut V,
+    body: &mut HeredocBody,
+) -> usize {
+    body.parts
+        .iter_mut()
+        .map(|part| visitor.visit_heredoc_body_part(part))
+        .sum()
+}
+
+pub(crate) fn walk_heredoc_body_part_mut<V: AstVisitorMut + ?Sized>(
+    visitor: &mut V,
+    part: &mut HeredocBodyPartNode,
+) -> usize {
+    match &mut part.kind {
+        HeredocBodyPart::Literal(_) | HeredocBodyPart::Variable(_) => 0,
+        HeredocBodyPart::CommandSubstitution { body, .. } => visitor.visit_stmt_seq(body),
+        HeredocBodyPart::ArithmeticExpansion {
+            expression,
+            expression_ast,
+            expression_word_ast,
+            ..
+        } => {
+            let mut changes = visitor.visit_source_text(expression);
+            if let Some(expression) = expression_ast {
+                changes += visitor.visit_arithmetic_expr(expression);
+            } else {
+                changes += visitor.visit_word(expression_word_ast);
+            }
+            changes
+        }
+        HeredocBodyPart::Parameter(parameter) => visitor.visit_parameter_expansion(parameter),
+    }
+}
+
+pub(crate) fn walk_arithmetic_expr_mut<V: AstVisitorMut + ?Sized>(
+    visitor: &mut V,
+    expression: &mut ArithmeticExprNode,
+) -> usize {
+    match &mut expression.kind {
+        ArithmeticExpr::Number(text) => visitor.visit_source_text(text),
+        ArithmeticExpr::Variable(_) => 0,
+        ArithmeticExpr::Indexed { index, .. } => visitor.visit_arithmetic_expr(index),
+        ArithmeticExpr::ShellWord(word) => visitor.visit_word(word),
+        ArithmeticExpr::Parenthesized { expression } => visitor.visit_arithmetic_expr(expression),
+        ArithmeticExpr::Unary { expr, .. } | ArithmeticExpr::Postfix { expr, .. } => {
+            visitor.visit_arithmetic_expr(expr)
+        }
+        ArithmeticExpr::Binary { left, right, .. } => {
+            visitor.visit_arithmetic_expr(left) + visitor.visit_arithmetic_expr(right)
+        }
+        ArithmeticExpr::Conditional {
+            condition,
+            then_expr,
+            else_expr,
+        } => {
+            visitor.visit_arithmetic_expr(condition)
+                + visitor.visit_arithmetic_expr(then_expr)
+                + visitor.visit_arithmetic_expr(else_expr)
+        }
+        ArithmeticExpr::Assignment { target, value, .. } => {
+            visitor.visit_arithmetic_lvalue(target) + visitor.visit_arithmetic_expr(value)
+        }
+    }
+}
+
+pub(crate) fn walk_arithmetic_lvalue_mut<V: AstVisitorMut + ?Sized>(
+    visitor: &mut V,
+    target: &mut ArithmeticLvalue,
+) -> usize {
+    match target {
+        ArithmeticLvalue::Variable(_) => 0,
+        ArithmeticLvalue::Indexed { index, .. } => visitor.visit_arithmetic_expr(index),
+    }
+}
+
+pub(crate) fn walk_parameter_expansion_mut<V: AstVisitorMut + ?Sized>(
+    visitor: &mut V,
+    parameter: &mut ParameterExpansion,
+) -> usize {
+    match &mut parameter.syntax {
+        ParameterExpansionSyntax::Bourne(syntax) => match syntax {
+            BourneParameterExpansion::Access { reference }
+            | BourneParameterExpansion::Length { reference }
+            | BourneParameterExpansion::Indices { reference }
+            | BourneParameterExpansion::Transformation { reference, .. } => {
+                visitor.visit_var_ref(reference)
+            }
+            BourneParameterExpansion::Indirect {
+                reference,
+                operator,
+                operand,
+                operand_word_ast,
+                ..
+            } => {
+                let mut changes = visitor.visit_var_ref(reference);
+                if let Some(operator) = operator {
+                    changes += visitor.visit_parameter_op(operator);
+                }
+                if let Some(operand) = operand {
+                    changes += visitor.visit_source_text(operand);
+                }
+                if let Some(operand) = operand_word_ast {
+                    changes += visitor.visit_word(operand);
+                }
+                changes
+            }
+            BourneParameterExpansion::Operation {
+                reference,
+                operator,
+                operand,
+                operand_word_ast,
+                ..
+            } => {
+                let mut changes =
+                    visitor.visit_var_ref(reference) + visitor.visit_parameter_op(operator);
+                if let Some(operand) = operand {
+                    changes += visitor.visit_source_text(operand);
+                }
+                if let Some(operand) = operand_word_ast {
+                    changes += visitor.visit_word(operand);
+                }
+                changes
+            }
+            BourneParameterExpansion::PrefixMatch { .. } => 0,
+            BourneParameterExpansion::Slice {
+                reference,
+                offset,
+                offset_ast,
+                offset_word_ast,
+                length,
+                length_ast,
+                length_word_ast,
+                ..
+            } => {
+                let mut changes =
+                    visitor.visit_var_ref(reference) + visitor.visit_source_text(offset);
+                if let Some(expression) = offset_ast {
+                    changes += visitor.visit_arithmetic_expr(expression);
+                } else {
+                    changes += visitor.visit_word(offset_word_ast);
+                }
+                if let Some(length) = length {
+                    changes += visitor.visit_source_text(length);
+                }
+                if let Some(expression) = length_ast {
+                    changes += visitor.visit_arithmetic_expr(expression);
+                } else if let Some(word) = length_word_ast {
+                    changes += visitor.visit_word(word);
+                }
+                changes
+            }
+        },
+        ParameterExpansionSyntax::Zsh(syntax) => walk_zsh_parameter_expansion_mut(visitor, syntax),
+    }
+}
+
+fn walk_zsh_parameter_expansion_mut<V: AstVisitorMut + ?Sized>(
+    visitor: &mut V,
+    syntax: &mut ZshParameterExpansion,
+) -> usize {
+    let mut changes = match &mut syntax.target {
+        ZshExpansionTarget::Reference(reference) => visitor.visit_var_ref(reference),
+        ZshExpansionTarget::Nested(parameter) => visitor.visit_parameter_expansion(parameter),
+        ZshExpansionTarget::Word(word) => visitor.visit_word(word),
+        ZshExpansionTarget::Empty => 0,
+    };
+    for modifier in &mut syntax.modifiers {
+        if let Some(argument) = &mut modifier.argument {
+            changes += visitor.visit_source_text(argument);
+        }
+        if let Some(word) = &mut modifier.argument_word_ast {
+            changes += visitor.visit_word(word);
+        }
+    }
+    if let Some(operation) = &mut syntax.operation {
+        changes += walk_zsh_expansion_operation_mut(visitor, operation);
+    }
+    changes
+}
+
+fn walk_zsh_expansion_operation_mut<V: AstVisitorMut + ?Sized>(
+    visitor: &mut V,
+    operation: &mut ZshExpansionOperation,
+) -> usize {
+    match operation {
+        ZshExpansionOperation::PatternOperation {
+            operand,
+            operand_word_ast,
+            ..
+        }
+        | ZshExpansionOperation::Defaulting {
+            operand,
+            operand_word_ast,
+            ..
+        }
+        | ZshExpansionOperation::TrimOperation {
+            operand,
+            operand_word_ast,
+            ..
+        } => visitor.visit_source_text(operand) + visitor.visit_word(operand_word_ast),
+        ZshExpansionOperation::ReplacementOperation {
+            pattern,
+            pattern_word_ast,
+            replacement,
+            replacement_word_ast,
+            ..
+        } => {
+            let mut changes =
+                visitor.visit_source_text(pattern) + visitor.visit_word(pattern_word_ast);
+            if let Some(replacement) = replacement {
+                changes += visitor.visit_source_text(replacement);
+            }
+            if let Some(replacement) = replacement_word_ast {
+                changes += visitor.visit_word(replacement);
+            }
+            changes
+        }
+        ZshExpansionOperation::Slice {
+            offset,
+            offset_word_ast,
+            length,
+            length_word_ast,
+        } => {
+            let mut changes =
+                visitor.visit_source_text(offset) + visitor.visit_word(offset_word_ast);
+            if let Some(length) = length {
+                changes += visitor.visit_source_text(length);
+            }
+            if let Some(length) = length_word_ast {
+                changes += visitor.visit_word(length);
+            }
+            changes
+        }
+        ZshExpansionOperation::Unknown { text, word_ast } => {
+            visitor.visit_source_text(text) + visitor.visit_word(word_ast)
+        }
+    }
+}
+
+pub(crate) fn walk_parameter_op_mut<V: AstVisitorMut + ?Sized>(
+    visitor: &mut V,
+    operator: &mut ParameterOp,
+) -> usize {
+    match operator {
+        ParameterOp::RemovePrefixShort { pattern }
+        | ParameterOp::RemovePrefixLong { pattern }
+        | ParameterOp::RemoveSuffixShort { pattern }
+        | ParameterOp::RemoveSuffixLong { pattern } => visitor.visit_pattern(pattern),
+        ParameterOp::ReplaceFirst {
+            pattern,
+            replacement,
+            replacement_word_ast,
+        }
+        | ParameterOp::ReplaceAll {
+            pattern,
+            replacement,
+            replacement_word_ast,
+        } => {
+            visitor.visit_pattern(pattern)
+                + visitor.visit_source_text(replacement)
+                + visitor.visit_word(replacement_word_ast)
+        }
+        ParameterOp::UseDefault
+        | ParameterOp::AssignDefault
+        | ParameterOp::UseReplacement
+        | ParameterOp::Error
+        | ParameterOp::UpperFirst
+        | ParameterOp::UpperAll
+        | ParameterOp::LowerFirst
+        | ParameterOp::LowerAll => 0,
+    }
+}
+
+fn walk_zsh_qualified_glob_mut<V: AstVisitorMut + ?Sized>(
+    visitor: &mut V,
+    glob: &mut shuck_ast::ZshQualifiedGlob,
+) -> usize {
+    let mut changes = 0;
+    for segment in &mut glob.segments {
+        changes += match segment {
+            ZshGlobSegment::Pattern(pattern) => visitor.visit_pattern(pattern),
+            ZshGlobSegment::InlineControl(_) => 0,
+        };
+    }
+    if let Some(qualifiers) = &mut glob.qualifiers {
+        changes += walk_zsh_glob_qualifier_group_mut(visitor, qualifiers);
+    }
+    changes
+}
+
+fn walk_zsh_glob_qualifier_group_mut<V: AstVisitorMut + ?Sized>(
+    visitor: &mut V,
+    group: &mut ZshGlobQualifierGroup,
+) -> usize {
+    group
+        .fragments
+        .iter_mut()
+        .map(|fragment| match fragment {
+            ZshGlobQualifier::LetterSequence { text, .. } => visitor.visit_source_text(text),
+            ZshGlobQualifier::NumericArgument { start, end, .. } => {
+                let mut changes = visitor.visit_source_text(start);
+                if let Some(end) = end {
+                    changes += visitor.visit_source_text(end);
+                }
+                changes
+            }
+            ZshGlobQualifier::Negation { .. } | ZshGlobQualifier::Flag { .. } => 0,
+        })
+        .sum()
+}
+
+pub(crate) fn walk_word_surface_source_texts_mut<V: AstVisitorMut + ?Sized>(
+    visitor: &mut V,
+    word: &mut Word,
+) -> usize {
+    word.parts
+        .iter_mut()
+        .map(|part| walk_word_part_surface_source_texts_mut(visitor, part))
+        .sum()
+}
+
+pub(crate) fn walk_word_part_surface_source_texts_mut<V: AstVisitorMut + ?Sized>(
+    visitor: &mut V,
+    part: &mut WordPartNode,
+) -> usize {
+    match &mut part.kind {
+        WordPart::ZshQualifiedGlob(glob) => {
+            walk_zsh_qualified_glob_surface_source_texts_mut(visitor, glob)
+        }
+        WordPart::SingleQuoted { value, .. } => visitor.visit_source_text(value),
+        WordPart::DoubleQuoted { parts, .. } => parts
+            .iter_mut()
+            .map(|part| walk_word_part_surface_source_texts_mut(visitor, part))
+            .sum(),
+        WordPart::ArithmeticExpansion { expression, .. } => visitor.visit_source_text(expression),
+        WordPart::Parameter(parameter) => visitor.visit_parameter_expansion(parameter),
+        WordPart::ParameterExpansion {
+            reference,
+            operator,
+            operand,
+            ..
+        } => {
+            let mut changes = walk_var_ref_surface_source_texts_mut(visitor, reference);
+            if let Some(operand) = operand {
+                changes += visitor.visit_source_text(operand);
+            }
+            changes + walk_parameter_op_surface_source_texts_mut(visitor, operator)
+        }
+        WordPart::Length(reference)
+        | WordPart::ArrayAccess(reference)
+        | WordPart::ArrayLength(reference)
+        | WordPart::ArrayIndices(reference)
+        | WordPart::Transformation { reference, .. } => {
+            walk_var_ref_surface_source_texts_mut(visitor, reference)
+        }
+        WordPart::Substring {
+            reference,
+            offset,
+            length,
+            ..
+        }
+        | WordPart::ArraySlice {
+            reference,
+            offset,
+            length,
+            ..
+        } => {
+            let mut changes = walk_var_ref_surface_source_texts_mut(visitor, reference)
+                + visitor.visit_source_text(offset);
+            if let Some(length) = length {
+                changes += visitor.visit_source_text(length);
+            }
+            changes
+        }
+        WordPart::IndirectExpansion {
+            reference,
+            operand,
+            operator,
+            ..
+        } => {
+            let mut changes = walk_var_ref_surface_source_texts_mut(visitor, reference);
+            if let Some(operand) = operand {
+                changes += visitor.visit_source_text(operand);
+            }
+            if let Some(operator) = operator {
+                changes += walk_parameter_op_surface_source_texts_mut(visitor, operator);
+            }
+            changes
+        }
+        WordPart::Literal(_)
+        | WordPart::Variable(_)
+        | WordPart::CommandSubstitution { .. }
+        | WordPart::ProcessSubstitution { .. }
+        | WordPart::PrefixMatch { .. } => 0,
+    }
+}
+
+fn walk_var_ref_surface_source_texts_mut<V: AstVisitorMut + ?Sized>(
+    visitor: &mut V,
+    reference: &mut VarRef,
+) -> usize {
+    reference.subscript.as_mut().map_or(0, |subscript| {
+        walk_subscript_surface_source_texts_mut(visitor, subscript)
+    })
+}
+
+fn walk_subscript_surface_source_texts_mut<V: AstVisitorMut + ?Sized>(
+    visitor: &mut V,
+    subscript: &mut Subscript,
+) -> usize {
+    let mut changes = visitor.visit_source_text(&mut subscript.text);
+    if let Some(raw) = &mut subscript.raw {
+        changes += visitor.visit_source_text(raw);
+    }
+    changes
+}
+
+fn walk_pattern_surface_source_texts_mut<V: AstVisitorMut + ?Sized>(
+    visitor: &mut V,
+    pattern: &mut Pattern,
+) -> usize {
+    pattern
+        .parts
+        .iter_mut()
+        .map(|part| match &mut part.kind {
+            PatternPart::CharClass(text) => visitor.visit_source_text(text),
+            PatternPart::Group { patterns, .. } => patterns
+                .iter_mut()
+                .map(|pattern| walk_pattern_surface_source_texts_mut(visitor, pattern))
+                .sum(),
+            PatternPart::Word(word) => walk_word_surface_source_texts_mut(visitor, word),
+            PatternPart::Literal(_) | PatternPart::AnyString | PatternPart::AnyChar => 0,
+        })
+        .sum()
+}
+
+pub(crate) fn walk_parameter_expansion_surface_source_texts_mut<V: AstVisitorMut + ?Sized>(
+    visitor: &mut V,
+    parameter: &mut ParameterExpansion,
+) -> usize {
+    match &mut parameter.syntax {
+        ParameterExpansionSyntax::Bourne(syntax) => match syntax {
+            BourneParameterExpansion::Access { reference }
+            | BourneParameterExpansion::Length { reference }
+            | BourneParameterExpansion::Indices { reference }
+            | BourneParameterExpansion::Transformation { reference, .. } => {
+                walk_var_ref_surface_source_texts_mut(visitor, reference)
+            }
+            BourneParameterExpansion::Indirect {
+                reference,
+                operator,
+                operand,
+                ..
+            } => {
+                let mut changes = walk_var_ref_surface_source_texts_mut(visitor, reference);
+                if let Some(operand) = operand {
+                    changes += visitor.visit_source_text(operand);
+                }
+                if let Some(operator) = operator {
+                    changes += walk_parameter_op_surface_source_texts_mut(visitor, operator);
+                }
+                changes
+            }
+            BourneParameterExpansion::PrefixMatch { .. } => 0,
+            BourneParameterExpansion::Slice {
+                reference,
+                offset,
+                length,
+                ..
+            } => {
+                let mut changes = walk_var_ref_surface_source_texts_mut(visitor, reference)
+                    + visitor.visit_source_text(offset);
+                if let Some(length) = length {
+                    changes += visitor.visit_source_text(length);
+                }
+                changes
+            }
+            BourneParameterExpansion::Operation {
+                reference,
+                operator,
+                operand,
+                ..
+            } => {
+                let mut changes = walk_var_ref_surface_source_texts_mut(visitor, reference);
+                if let Some(operand) = operand {
+                    changes += visitor.visit_source_text(operand);
+                }
+                changes + walk_parameter_op_surface_source_texts_mut(visitor, operator)
+            }
+        },
+        ParameterExpansionSyntax::Zsh(syntax) => {
+            walk_zsh_parameter_expansion_surface_source_texts_mut(visitor, syntax)
+        }
+    }
+}
+
+fn walk_zsh_parameter_expansion_surface_source_texts_mut<V: AstVisitorMut + ?Sized>(
+    visitor: &mut V,
+    syntax: &mut ZshParameterExpansion,
+) -> usize {
+    match &mut syntax.target {
+        ZshExpansionTarget::Reference(reference) => {
+            walk_var_ref_surface_source_texts_mut(visitor, reference)
+        }
+        ZshExpansionTarget::Word(word) => walk_word_surface_source_texts_mut(visitor, word),
+        ZshExpansionTarget::Nested(parameter) => visitor.visit_parameter_expansion(parameter),
+        ZshExpansionTarget::Empty => 0,
+    }
+}
+
+fn walk_parameter_op_surface_source_texts_mut<V: AstVisitorMut + ?Sized>(
+    visitor: &mut V,
+    operator: &mut ParameterOp,
+) -> usize {
+    match operator {
+        ParameterOp::RemovePrefixShort { pattern }
+        | ParameterOp::RemovePrefixLong { pattern }
+        | ParameterOp::RemoveSuffixShort { pattern }
+        | ParameterOp::RemoveSuffixLong { pattern } => {
+            walk_pattern_surface_source_texts_mut(visitor, pattern)
+        }
+        ParameterOp::ReplaceFirst {
+            pattern,
+            replacement,
+            ..
+        }
+        | ParameterOp::ReplaceAll {
+            pattern,
+            replacement,
+            ..
+        } => {
+            walk_pattern_surface_source_texts_mut(visitor, pattern)
+                + visitor.visit_source_text(replacement)
+        }
+        ParameterOp::UseDefault
+        | ParameterOp::AssignDefault
+        | ParameterOp::UseReplacement
+        | ParameterOp::Error
+        | ParameterOp::UpperFirst
+        | ParameterOp::UpperAll
+        | ParameterOp::LowerFirst
+        | ParameterOp::LowerAll => 0,
+    }
+}
+
+fn walk_zsh_qualified_glob_surface_source_texts_mut<V: AstVisitorMut + ?Sized>(
+    visitor: &mut V,
+    glob: &mut shuck_ast::ZshQualifiedGlob,
+) -> usize {
+    let mut changes = 0;
+    for segment in &mut glob.segments {
+        changes += match segment {
+            ZshGlobSegment::Pattern(pattern) => {
+                walk_pattern_surface_source_texts_mut(visitor, pattern)
+            }
+            ZshGlobSegment::InlineControl(_) => 0,
+        };
+    }
+    if let Some(qualifiers) = &mut glob.qualifiers {
+        changes += walk_zsh_glob_qualifier_group_mut(visitor, qualifiers);
+    }
+    changes
+}

--- a/crates/shuck-formatter/src/word.rs
+++ b/crates/shuck-formatter/src/word.rs
@@ -1,9 +1,6 @@
 use std::fmt::Write as _;
 
-use crate::command::{
-    array_elem_parts, builtin_like_parts, compound_contains_child, stmt_seq_has_heredoc,
-    trim_unescaped_trailing_whitespace,
-};
+use crate::command::{array_elem_parts, stmt_seq_has_heredoc, trim_unescaped_trailing_whitespace};
 use crate::comments::SourceMap;
 use crate::facts::FormatterFacts;
 use crate::options::{IndentStyle, ResolvedShellFormatOptions};
@@ -14,13 +11,13 @@ use crate::scan::{
     shell_comment_can_start,
 };
 use crate::streaming::format_stmt_sequence_streaming_to_buf;
+use crate::visit::{self, AstVisitor};
 use shuck_ast::{
     ArithmeticAssignOp, ArithmeticBinaryOp, ArithmeticExpansionSyntax, ArithmeticExpr,
     ArithmeticExprNode, ArithmeticLvalue, ArithmeticPostfixOp, ArithmeticUnaryOp, Assignment,
-    AssignmentValue, BinaryOp, BourneParameterExpansion, BuiltinCommand, Command,
-    CommandSubstitutionSyntax, CompoundCommand, ConditionalExpr, HeredocBody, HeredocBodyPart,
-    ParameterOp, Pattern, PatternPart, Redirect, Stmt, StmtSeq, SubscriptSelector, VarRef, Word,
-    WordPart, WordPartNode,
+    AssignmentValue, BinaryOp, BourneParameterExpansion, Command, CommandSubstitutionSyntax,
+    CompoundCommand, HeredocBody, HeredocBodyPart, ParameterOp, Pattern, PatternPart, Redirect,
+    Stmt, StmtSeq, SubscriptSelector, VarRef, Word, WordPart, WordPartNode,
 };
 
 pub(crate) fn word_gap_end_before_trailing_continuation(word: &Word, source: &str) -> usize {
@@ -172,134 +169,54 @@ fn word_part_has_multiline_literal_source(
 }
 
 fn stmt_seq_has_multiline_literal_source(sequence: &StmtSeq, source: &str) -> bool {
-    sequence
-        .iter()
-        .any(|stmt| stmt_has_multiline_literal_source(stmt, source))
+    let mut visitor = MultilineLiteralFinder::new(source);
+    visitor.visit_stmt_seq(sequence);
+    visitor.found
 }
 
-fn stmt_has_multiline_literal_source(stmt: &Stmt, source: &str) -> bool {
-    command_has_multiline_literal_source(&stmt.command, source)
-        || stmt
-            .redirects
-            .iter()
-            .any(|redirect| redirect_has_multiline_literal_source(redirect, source))
+struct MultilineLiteralFinder<'source> {
+    source: &'source str,
+    found: bool,
 }
 
-fn words_have_multiline_literal_source(words: &[Word], source: &str) -> bool {
-    words
-        .iter()
-        .any(|word| word_has_multiline_literal_source(word, source))
-}
-
-fn assignments_have_multiline_literal_source(assignments: &[Assignment], source: &str) -> bool {
-    assignments
-        .iter()
-        .any(|assignment| assignment_has_multiline_literal_source(assignment, source))
-}
-
-fn command_has_multiline_literal_source(command: &Command, source: &str) -> bool {
-    match command {
-        Command::Simple(command) => {
-            word_has_multiline_literal_source(&command.name, source)
-                || words_have_multiline_literal_source(&command.args, source)
-                || assignments_have_multiline_literal_source(&command.assignments, source)
-        }
-        Command::Builtin(command) => builtin_has_multiline_literal_source(command, source),
-        Command::Decl(command) => {
-            assignments_have_multiline_literal_source(&command.assignments, source)
-                || command.operands.iter().any(|operand| match operand {
-                    shuck_ast::DeclOperand::Flag(word) | shuck_ast::DeclOperand::Dynamic(word) => {
-                        word_has_multiline_literal_source(word, source)
-                    }
-                    shuck_ast::DeclOperand::Assignment(assignment) => {
-                        assignment_has_multiline_literal_source(assignment, source)
-                    }
-                    shuck_ast::DeclOperand::Name(_) => false,
-                })
-        }
-        Command::Binary(command) => {
-            stmt_has_multiline_literal_source(&command.left, source)
-                || stmt_has_multiline_literal_source(&command.right, source)
-        }
-        Command::Compound(command) => compound_has_multiline_literal_source(command, source),
-        Command::Function(command) => stmt_has_multiline_literal_source(&command.body, source),
-        Command::AnonymousFunction(command) => {
-            words_have_multiline_literal_source(&command.args, source)
-                || stmt_has_multiline_literal_source(&command.body, source)
+impl<'source> MultilineLiteralFinder<'source> {
+    fn new(source: &'source str) -> Self {
+        Self {
+            source,
+            found: false,
         }
     }
 }
 
-fn builtin_has_multiline_literal_source(command: &BuiltinCommand, source: &str) -> bool {
-    let (_, _, assignments, primary, extra_args) = builtin_like_parts(command);
-    builtin_args_have_multiline_literal_source(primary, extra_args, assignments, source)
-}
-
-fn builtin_args_have_multiline_literal_source(
-    primary: Option<&Word>,
-    extra_args: &[Word],
-    assignments: &[Assignment],
-    source: &str,
-) -> bool {
-    primary.is_some_and(|word| word_has_multiline_literal_source(word, source))
-        || words_have_multiline_literal_source(extra_args, source)
-        || assignments_have_multiline_literal_source(assignments, source)
-}
-
-fn compound_has_multiline_literal_source(command: &CompoundCommand, source: &str) -> bool {
-    compound_words_have_multiline_literal_source(command, source)
-        || compound_contains_child(
-            command,
-            |stmt| stmt_has_multiline_literal_source(stmt, source),
-            |sequence| stmt_seq_has_multiline_literal_source(sequence, source),
-        )
-}
-
-fn compound_words_have_multiline_literal_source(command: &CompoundCommand, source: &str) -> bool {
-    match command {
-        CompoundCommand::For(command) => {
-            command
-                .targets
-                .iter()
-                .any(|target| word_has_multiline_literal_source(&target.word, source))
-                || command
-                    .words
-                    .as_deref()
-                    .is_some_and(|words| words_have_multiline_literal_source(words, source))
+impl AstVisitor for MultilineLiteralFinder<'_> {
+    fn visit_stmt_seq(&mut self, sequence: &StmtSeq) {
+        if !self.found {
+            visit::walk_stmt_seq(self, sequence);
         }
-        CompoundCommand::Repeat(command) => {
-            word_has_multiline_literal_source(&command.count, source)
-        }
-        CompoundCommand::Foreach(command) => {
-            words_have_multiline_literal_source(&command.words, source)
-        }
-        CompoundCommand::Case(command) => word_has_multiline_literal_source(&command.word, source),
-        CompoundCommand::Select(command) => {
-            words_have_multiline_literal_source(&command.words, source)
-        }
-        CompoundCommand::Conditional(command) => {
-            conditional_expr_has_multiline_literal_source(&command.expression, source)
-        }
-        _ => false,
     }
-}
 
-fn conditional_expr_has_multiline_literal_source(expr: &ConditionalExpr, source: &str) -> bool {
-    match expr {
-        ConditionalExpr::Binary(expr) => {
-            conditional_expr_has_multiline_literal_source(&expr.left, source)
-                || conditional_expr_has_multiline_literal_source(&expr.right, source)
+    fn visit_stmt(&mut self, stmt: &Stmt) {
+        if !self.found {
+            visit::walk_stmt(self, stmt);
         }
-        ConditionalExpr::Unary(expr) => {
-            conditional_expr_has_multiline_literal_source(&expr.expr, source)
+    }
+
+    fn visit_command(&mut self, command: &Command) {
+        if !self.found {
+            visit::walk_command(self, command);
         }
-        ConditionalExpr::Parenthesized(expr) => {
-            conditional_expr_has_multiline_literal_source(&expr.expr, source)
-        }
-        ConditionalExpr::Word(word) | ConditionalExpr::Regex(word) => {
-            word_has_multiline_literal_source(word, source)
-        }
-        ConditionalExpr::Pattern(_) | ConditionalExpr::VarRef(_) => false,
+    }
+
+    fn visit_redirect(&mut self, redirect: &Redirect) {
+        self.found |= redirect_has_multiline_literal_source(redirect, self.source);
+    }
+
+    fn visit_assignment(&mut self, assignment: &Assignment) {
+        self.found |= assignment_has_multiline_literal_source(assignment, self.source);
+    }
+
+    fn visit_word(&mut self, word: &Word) {
+        self.found |= word_has_multiline_literal_source(word, self.source);
     }
 }
 
@@ -1741,31 +1658,37 @@ fn parameter_prefers_raw_source(
 }
 
 fn stmt_seq_contains_comments(sequence: &StmtSeq) -> bool {
-    !sequence.leading_comments.is_empty()
-        || !sequence.trailing_comments.is_empty()
-        || sequence.iter().any(stmt_contains_comments)
+    let mut visitor = CommentFinder::default();
+    visitor.visit_stmt_seq(sequence);
+    visitor.found
 }
 
-fn stmt_contains_comments(stmt: &Stmt) -> bool {
-    !stmt.leading_comments.is_empty()
-        || stmt.inline_comment.is_some()
-        || command_contains_comments(&stmt.command)
+#[derive(Default)]
+struct CommentFinder {
+    found: bool,
 }
 
-fn command_contains_comments(command: &Command) -> bool {
-    match command {
-        Command::Binary(command) => {
-            stmt_contains_comments(&command.left) || stmt_contains_comments(&command.right)
+impl AstVisitor for CommentFinder {
+    fn visit_stmt_seq(&mut self, sequence: &StmtSeq) {
+        if self.found {
+            return;
         }
-        Command::Compound(command) => compound_contains_comments(command),
-        Command::Function(function) => stmt_contains_comments(&function.body),
-        Command::AnonymousFunction(function) => stmt_contains_comments(&function.body),
-        Command::Simple(_) | Command::Builtin(_) | Command::Decl(_) => false,
+        self.found =
+            !sequence.leading_comments.is_empty() || !sequence.trailing_comments.is_empty();
+        if !self.found {
+            visit::walk_stmt_seq(self, sequence);
+        }
     }
-}
 
-fn compound_contains_comments(command: &CompoundCommand) -> bool {
-    compound_contains_child(command, stmt_contains_comments, stmt_seq_contains_comments)
+    fn visit_stmt(&mut self, stmt: &Stmt) {
+        if self.found {
+            return;
+        }
+        self.found = !stmt.leading_comments.is_empty() || stmt.inline_comment.is_some();
+        if !self.found {
+            visit::walk_stmt(self, stmt);
+        }
+    }
 }
 
 fn push_raw_command_substitution_comment_fallback(
@@ -3389,19 +3312,48 @@ fn render_inline_raw_command_substitution_as_block(
 }
 
 fn stmt_seq_contains_multistatement_pipeline_brace_group(statements: &StmtSeq) -> bool {
-    statements
-        .iter()
-        .any(stmt_contains_multistatement_pipeline_brace_group)
+    let mut visitor = PipelineBraceGroupFinder::default();
+    visitor.visit_stmt_seq(statements);
+    visitor.found
 }
 
-fn stmt_contains_multistatement_pipeline_brace_group(stmt: &Stmt) -> bool {
-    match &stmt.command {
-        Command::Binary(binary) if matches!(binary.op, BinaryOp::Pipe | BinaryOp::PipeAll) => {
-            stmt_contains_multistatement_pipeline_brace_group(&binary.left)
-                || stmt_contains_multistatement_pipeline_brace_group(&binary.right)
+#[derive(Default)]
+struct PipelineBraceGroupFinder {
+    found: bool,
+    in_pipeline: bool,
+}
+
+impl AstVisitor for PipelineBraceGroupFinder {
+    fn visit_stmt_seq(&mut self, sequence: &StmtSeq) {
+        if !self.found {
+            visit::walk_stmt_seq(self, sequence);
         }
-        Command::Compound(CompoundCommand::BraceGroup(body)) => body.len() > 1,
-        _ => false,
+    }
+
+    fn visit_stmt(&mut self, stmt: &Stmt) {
+        if !self.found {
+            visit::walk_stmt(self, stmt);
+        }
+    }
+
+    fn visit_command(&mut self, command: &Command) {
+        if self.found {
+            return;
+        }
+
+        match command {
+            Command::Binary(binary) if matches!(binary.op, BinaryOp::Pipe | BinaryOp::PipeAll) => {
+                let previous = self.in_pipeline;
+                self.in_pipeline = true;
+                self.visit_stmt(&binary.left);
+                self.visit_stmt(&binary.right);
+                self.in_pipeline = previous;
+            }
+            Command::Compound(CompoundCommand::BraceGroup(body)) if self.in_pipeline => {
+                self.found = body.len() > 1;
+            }
+            _ => {}
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

- add a formatter-local AST visitor and mutable visitor for shared traversal logic
- route formatter facts, simplify rewrites, heredoc checks, multiline/comment queries, and pipeline-brace detection through the shared visitor surface
- preserve existing formatter entry points while reducing the number of local recursive walkers that need updates for new AST variants

## Validation

- `cargo test -p shuck-formatter`
- `cargo clippy -p shuck-formatter --all-targets -- -D warnings`
- `git diff --check`
- `/usr/bin/time -p make test-oracle-shfmt-large-corpus` completed the full corpus in `real 30.05s`; the oracle still reports `386` formatter mismatches and `0` shuck errors across `33,733` compared fixtures.