### PR TITLE
refactor(formatter): make render sinks type-safe

### DIFF
--- a/crates/shuck-formatter/src/lib.rs
+++ b/crates/shuck-formatter/src/lib.rs
@@ -137,39 +137,83 @@ pub fn format_file_ast(
     Ok(formatted_source_from_output(source, output))
 }
 
-fn check_file(source: &str, mut file: File, resolved: ResolvedShellFormatOptions) -> Result<bool> {
+fn check_file(source: &str, file: File, resolved: ResolvedShellFormatOptions) -> Result<bool> {
     if resolved.minify() {
-        let output = format_output(source, file, &resolved)?;
+        let output = render_file::<BufferedRender>(source, file, &resolved)?;
         return Ok(output == source);
     }
 
-    if resolved.simplify() {
-        simplify::simplify_file(&mut file, source);
-    }
-
-    let facts = FormatterFacts::build(source, &file, &resolved);
-    let resolved = resolved.with_line_ending(facts.line_ending());
-    streaming::format_file_streaming_matches_source_with_facts(source, &file, &resolved, &facts)
+    render_file::<CompareRender>(source, file, &resolved)
 }
 
 fn format_output(
     source: &str,
-    mut file: File,
+    file: File,
     resolved: &ResolvedShellFormatOptions,
 ) -> Result<String> {
+    render_file::<BufferedRender>(source, file, resolved)
+}
+
+trait RenderMode {
+    type Output;
+
+    fn render(
+        source: &str,
+        file: &File,
+        resolved: &ResolvedShellFormatOptions,
+        facts: &FormatterFacts<'_>,
+    ) -> Result<Self::Output>;
+}
+
+struct BufferedRender;
+
+impl RenderMode for BufferedRender {
+    type Output = String;
+
+    fn render(
+        source: &str,
+        file: &File,
+        resolved: &ResolvedShellFormatOptions,
+        facts: &FormatterFacts<'_>,
+    ) -> Result<Self::Output> {
+        let mut output =
+            streaming::format_file_streaming_with_facts(source, file, resolved, facts)?;
+        if resolved.minify() {
+            preserve_initial_shebang(source, &mut output, resolved.line_ending());
+        }
+        ensure_single_trailing_newline(&mut output, resolved.line_ending());
+
+        Ok(output)
+    }
+}
+
+struct CompareRender;
+
+impl RenderMode for CompareRender {
+    type Output = bool;
+
+    fn render(
+        source: &str,
+        file: &File,
+        resolved: &ResolvedShellFormatOptions,
+        facts: &FormatterFacts<'_>,
+    ) -> Result<Self::Output> {
+        streaming::format_file_streaming_matches_source_with_facts(source, file, resolved, facts)
+    }
+}
+
+fn render_file<M: RenderMode>(
+    source: &str,
+    mut file: File,
+    resolved: &ResolvedShellFormatOptions,
+) -> Result<M::Output> {
     if resolved.simplify() || resolved.minify() {
         simplify::simplify_file(&mut file, source);
     }
 
     let facts = FormatterFacts::build(source, &file, resolved);
     let resolved = resolved.clone().with_line_ending(facts.line_ending());
-    let mut output = streaming::format_file_streaming_with_facts(source, &file, &resolved, &facts)?;
-    if resolved.minify() {
-        preserve_initial_shebang(source, &mut output, resolved.line_ending());
-    }
-    ensure_single_trailing_newline(&mut output, resolved.line_ending());
-
-    Ok(output)
+    M::render(source, &file, &resolved, &facts)
 }
 
 fn formatted_source_from_output(source: &str, output: String) -> FormattedSource {

--- a/crates/shuck-formatter/src/streaming/comments_alignment.rs
+++ b/crates/shuck-formatter/src/streaming/comments_alignment.rs
@@ -1,6 +1,9 @@
 use super::*;
 
-impl<'source, 'facts> ShellRenderer<'source, 'facts> {
+impl<'source, 'facts, S> ShellRenderer<'source, 'facts, S>
+where
+    S: StreamSink,
+{
     pub(super) fn write_comment(&mut self, comment: &SourceComment<'_>) {
         self.write_text(comment.text());
     }

--- a/crates/shuck-formatter/src/streaming/compounds.rs
+++ b/crates/shuck-formatter/src/streaming/compounds.rs
@@ -1,6 +1,9 @@
 use super::*;
 
-impl<'source, 'facts> ShellRenderer<'source, 'facts> {
+impl<'source, 'facts, S> ShellRenderer<'source, 'facts, S>
+where
+    S: StreamSink,
+{
     pub(super) fn format_if(&mut self, command: &IfCommand) -> Result<()> {
         match command.syntax {
             IfSyntax::ThenFi { .. } => self.format_then_fi_if(command),

--- a/crates/shuck-formatter/src/streaming/mod.rs
+++ b/crates/shuck-formatter/src/streaming/mod.rs
@@ -54,7 +54,7 @@ use crate::word::{
     word_gap_end_before_trailing_continuation, word_has_multiline_literal_source,
     word_is_quoted_command_substitution_only, word_is_quoted_formattable_command_substitution_only,
 };
-use writer::{PendingHeredoc, ShellWriter};
+use writer::{BufferSink, CompareSink, PendingHeredoc, ShellWriter, StreamSink};
 
 #[derive(Clone, Copy)]
 enum SimpleCommandPart<'a> {
@@ -171,17 +171,17 @@ enum HeredocTailTextMode {
     Assignment,
 }
 
-struct ShellRenderer<'source, 'facts> {
+struct ShellRenderer<'source, 'facts, S> {
     source: &'source str,
     options: ResolvedShellFormatOptions,
     facts: &'facts FormatterFacts<'source>,
     scratch: String,
-    writer: ShellWriter<'source>,
+    writer: ShellWriter<S>,
     pipeline_continuation_indent: usize,
     filter_next_group_body_leading_before_open: bool,
 }
 
-impl<'source, 'facts> ShellRenderer<'source, 'facts> {
+impl<'source, 'facts> ShellRenderer<'source, 'facts, BufferSink> {
     fn new(
         source: &'source str,
         options: &ResolvedShellFormatOptions,
@@ -192,19 +192,6 @@ impl<'source, 'facts> ShellRenderer<'source, 'facts> {
             options,
             facts,
             ShellWriter::new_buffer(source, options),
-        )
-    }
-
-    fn new_compare(
-        source: &'source str,
-        options: &ResolvedShellFormatOptions,
-        facts: &'facts FormatterFacts<'source>,
-    ) -> Self {
-        Self::with_writer(
-            source,
-            options,
-            facts,
-            ShellWriter::new_compare(source, options),
         )
     }
 
@@ -222,11 +209,39 @@ impl<'source, 'facts> ShellRenderer<'source, 'facts> {
         )
     }
 
+    fn finish_into_string(self) -> String {
+        self.writer.finish_into_string()
+    }
+}
+
+impl<'source, 'facts> ShellRenderer<'source, 'facts, CompareSink<'source>> {
+    fn new_compare(
+        source: &'source str,
+        options: &ResolvedShellFormatOptions,
+        facts: &'facts FormatterFacts<'source>,
+    ) -> Self {
+        Self::with_writer(
+            source,
+            options,
+            facts,
+            ShellWriter::new_compare(source, options),
+        )
+    }
+
+    fn finish_matches_source(self) -> bool {
+        self.writer.finish_matches_source()
+    }
+}
+
+impl<'source, 'facts, S> ShellRenderer<'source, 'facts, S>
+where
+    S: StreamSink,
+{
     fn with_writer(
         source: &'source str,
         options: &ResolvedShellFormatOptions,
         facts: &'facts FormatterFacts<'source>,
-        writer: ShellWriter<'source>,
+        writer: ShellWriter<S>,
     ) -> Self {
         Self {
             source,
@@ -237,14 +252,6 @@ impl<'source, 'facts> ShellRenderer<'source, 'facts> {
             pipeline_continuation_indent: 1,
             filter_next_group_body_leading_before_open: false,
         }
-    }
-
-    fn finish_into_string(self) -> String {
-        self.writer.finish_into_string()
-    }
-
-    fn finish_matches_source(self) -> bool {
-        self.writer.finish_matches_source()
     }
 
     fn push_output_str(&mut self, text: &str) {

--- a/crates/shuck-formatter/src/streaming/redirects.rs
+++ b/crates/shuck-formatter/src/streaming/redirects.rs
@@ -1,6 +1,9 @@
 use super::*;
 
-impl<'source, 'facts> ShellRenderer<'source, 'facts> {
+impl<'source, 'facts, S> ShellRenderer<'source, 'facts, S>
+where
+    S: StreamSink,
+{
     pub(super) fn format_redirect_list(&mut self, redirects: &[Redirect]) {
         let source = self.source();
         let mut index = 0;

--- a/crates/shuck-formatter/src/streaming/shape.rs
+++ b/crates/shuck-formatter/src/streaming/shape.rs
@@ -1,6 +1,9 @@
 use super::*;
 
-impl<'source, 'facts> ShellRenderer<'source, 'facts> {
+impl<'source, 'facts, S> ShellRenderer<'source, 'facts, S>
+where
+    S: StreamSink,
+{
     pub(super) fn can_inline_body(&self, commands: &StmtSeq, enclosing_span: Span) -> bool {
         self.can_inline_body_with_upper_bound(
             commands,

--- a/crates/shuck-formatter/src/streaming/statements.rs
+++ b/crates/shuck-formatter/src/streaming/statements.rs
@@ -1,6 +1,9 @@
 use super::*;
 
-impl<'source, 'facts> ShellRenderer<'source, 'facts> {
+impl<'source, 'facts, S> ShellRenderer<'source, 'facts, S>
+where
+    S: StreamSink,
+{
     pub(super) fn format_stmt_sequence(
         &mut self,
         statements: &StmtSeq,

--- a/crates/shuck-formatter/src/streaming/substitutions.rs
+++ b/crates/shuck-formatter/src/streaming/substitutions.rs
@@ -1,6 +1,9 @@
 use super::*;
 
-impl<'source, 'facts> ShellRenderer<'source, 'facts> {
+impl<'source, 'facts, S> ShellRenderer<'source, 'facts, S>
+where
+    S: StreamSink,
+{
     pub(super) fn write_rendered_shell_text(&mut self, text: &str) {
         if text.contains('\n') {
             if self.line_start() {

--- a/crates/shuck-formatter/src/streaming/writer.rs
+++ b/crates/shuck-formatter/src/streaming/writer.rs
@@ -9,14 +9,18 @@ pub(super) struct PendingHeredoc {
     pub(super) strip_tabs: bool,
 }
 
-enum StreamOutput<'source> {
-    Buffer(String),
-    Compare(CompareSink<'source>),
+pub(super) trait StreamSink {
+    fn push_char(&mut self, ch: char);
+    fn push_str(&mut self, text: &str);
 }
 
-pub(super) struct ShellWriter<'source> {
+pub(super) struct BufferSink {
+    buffer: String,
+}
+
+pub(super) struct ShellWriter<S> {
     options: ResolvedShellFormatOptions,
-    output: StreamOutput<'source>,
+    output: S,
     indent_buffer: String,
     indent_level: usize,
     column: usize,
@@ -25,23 +29,37 @@ pub(super) struct ShellWriter<'source> {
     pending_heredocs: Vec<PendingHeredoc>,
 }
 
-impl<'source> ShellWriter<'source> {
-    pub(super) fn new_buffer(source: &'source str, options: &ResolvedShellFormatOptions) -> Self {
-        Self::with_output(
-            options,
-            StreamOutput::Buffer(String::with_capacity(source.len())),
-        )
-    }
-
-    pub(super) fn new_compare(source: &'source str, options: &ResolvedShellFormatOptions) -> Self {
-        Self::with_output(options, StreamOutput::Compare(CompareSink::new(source)))
+impl ShellWriter<BufferSink> {
+    pub(super) fn new_buffer(source: &str, options: &ResolvedShellFormatOptions) -> Self {
+        Self::with_output(options, BufferSink::with_capacity(source.len()))
     }
 
     pub(super) fn with_output_buffer(options: &ResolvedShellFormatOptions, output: String) -> Self {
-        Self::with_output(options, StreamOutput::Buffer(output))
+        Self::with_output(options, BufferSink::new(output))
     }
 
-    fn with_output(options: &ResolvedShellFormatOptions, output: StreamOutput<'source>) -> Self {
+    pub(super) fn finish_into_string(mut self) -> String {
+        self.flush_pending_heredocs();
+        self.output.finish_into_string()
+    }
+}
+
+impl<'source> ShellWriter<CompareSink<'source>> {
+    pub(super) fn new_compare(source: &'source str, options: &ResolvedShellFormatOptions) -> Self {
+        Self::with_output(options, CompareSink::new(source))
+    }
+
+    pub(super) fn finish_matches_source(mut self) -> bool {
+        self.flush_pending_heredocs();
+        self.output.finish(self.options.line_ending())
+    }
+}
+
+impl<S> ShellWriter<S>
+where
+    S: StreamSink,
+{
+    fn with_output(options: &ResolvedShellFormatOptions, output: S) -> Self {
         Self {
             options: options.clone(),
             output,
@@ -52,17 +70,6 @@ impl<'source> ShellWriter<'source> {
             line_start: true,
             pending_heredocs: Vec::new(),
         }
-    }
-
-    pub(super) fn finish_into_string(mut self) -> String {
-        self.flush_pending_heredocs();
-        self.output.finish_into_string()
-    }
-
-    pub(super) fn finish_matches_source(mut self) -> bool {
-        self.flush_pending_heredocs();
-        self.output
-            .finish_matches_source(self.options.line_ending())
     }
 
     pub(super) fn indent_level(&self) -> usize {
@@ -311,37 +318,33 @@ impl<'source> ShellWriter<'source> {
     }
 }
 
-impl<'source> StreamOutput<'source> {
-    fn push_char(&mut self, ch: char) {
-        match self {
-            Self::Buffer(buffer) => buffer.push(ch),
-            Self::Compare(compare) => compare.push_char(ch),
+impl BufferSink {
+    fn with_capacity(capacity: usize) -> Self {
+        Self {
+            buffer: String::with_capacity(capacity),
         }
     }
 
-    fn push_str(&mut self, text: &str) {
-        match self {
-            Self::Buffer(buffer) => buffer.push_str(text),
-            Self::Compare(compare) => compare.push_str(text),
-        }
+    fn new(buffer: String) -> Self {
+        Self { buffer }
     }
 
     fn finish_into_string(self) -> String {
-        match self {
-            Self::Buffer(buffer) => buffer,
-            Self::Compare(_) => panic!("comparison formatter cannot yield a String"),
-        }
-    }
-
-    fn finish_matches_source(mut self, line_ending: LineEnding) -> bool {
-        match &mut self {
-            Self::Buffer(_) => panic!("buffer formatter cannot compare against the source"),
-            Self::Compare(compare) => compare.finish(line_ending),
-        }
+        self.buffer
     }
 }
 
-struct CompareSink<'source> {
+impl StreamSink for BufferSink {
+    fn push_char(&mut self, ch: char) {
+        self.buffer.push(ch);
+    }
+
+    fn push_str(&mut self, text: &str) {
+        self.buffer.push_str(text);
+    }
+}
+
+pub(super) struct CompareSink<'source> {
     source: &'source str,
     matched_bytes: usize,
     pending_tail: String,
@@ -417,5 +420,15 @@ impl<'source> CompareSink<'source> {
             }
             _ => self.mismatch = true,
         }
+    }
+}
+
+impl StreamSink for CompareSink<'_> {
+    fn push_char(&mut self, ch: char) {
+        CompareSink::push_char(self, ch);
+    }
+
+    fn push_str(&mut self, text: &str) {
+        CompareSink::push_str(self, text);
     }
 }


### PR DESCRIPTION
## Summary

- Replace the formatter streaming writer's runtime buffer/compare enum with typed sinks.
- Add a shared render preparation path so check and format modes both build facts and resolve line endings through the same helper.
- Keep buffered output post-processing in the buffered render mode while compare mode remains source-comparison only.

## Why

The formatter check and format paths were close but duplicated enough setup to drift, and the streaming output abstraction allowed the wrong finish method to be called at runtime. This makes the mode split visible in Rust types instead.

## Validation

- `cargo test -p shuck-formatter`
- `cargo clippy -p shuck-formatter --all-targets -- -D warnings`
- `cargo test -p shuck-cli format`
- `git diff --check`