### PR TITLE
refactor(formatter): share raw shell scanner

### DIFF
--- a/crates/shuck-formatter/src/command.rs
+++ b/crates/shuck-formatter/src/command.rs
@@ -2,7 +2,7 @@ use crate::comments::SourceMap;
 use crate::facts::FormatterFacts;
 use crate::options::ResolvedShellFormatOptions;
 use crate::scan::{
-    branch_keyword_offset, common_nonempty_shell_indent, last_shell_keyword_start,
+    RawShellScanner, branch_keyword_offset, common_nonempty_shell_indent, last_shell_keyword_start,
     last_uncommented_shell_keyword_before, leading_shell_indent, matching_done_close_start,
     matching_if_close_start, normalized_close_keyword_span, refine_common_indent,
     shell_comment_can_start, skip_escaped_or_quoted,
@@ -643,37 +643,8 @@ fn line_continuation_is_inside_unclosed_substitution(line: &str) -> bool {
         return false;
     };
 
-    let mut depth = 0usize;
-    let mut chars = before_continuation.chars().peekable();
-    let mut in_single_quotes = false;
-    let mut in_double_quotes = false;
-    while let Some(ch) = chars.next() {
-        if ch == '\\' {
-            chars.next();
-            continue;
-        }
-        if ch == '\'' && !in_double_quotes {
-            in_single_quotes = !in_single_quotes;
-            continue;
-        }
-        if ch == '"' && !in_single_quotes {
-            in_double_quotes = !in_double_quotes;
-            continue;
-        }
-        if in_single_quotes {
-            continue;
-        }
-        match ch {
-            '$' | '<' | '>' if chars.peek().is_some_and(|next| *next == '(') => {
-                chars.next();
-                depth += 1;
-            }
-            ')' if depth > 0 => depth -= 1,
-            _ => {}
-        }
-    }
-
-    depth > 0
+    RawShellScanner::new(before_continuation)
+        .has_unclosed_substitution_before(before_continuation.len())
 }
 
 fn multiline_compound_assignment_common_body_indent(lines: &[&str], open_inline: bool) -> String {

--- a/crates/shuck-formatter/src/lib.rs
+++ b/crates/shuck-formatter/src/lib.rs
@@ -246,36 +246,9 @@ fn trailing_backslash_count(text: &str) -> usize {
 
 fn trailing_backslash_is_in_comment(text: &str) -> bool {
     let line = text.rsplit_once('\n').map_or(text, |(_, line)| line);
-    let mut in_single_quotes = false;
-    let mut in_double_quotes = false;
-    let mut escaped = false;
-
-    for (index, ch) in line.char_indices() {
-        if escaped {
-            escaped = false;
-            continue;
-        }
-        match ch {
-            '\\' if !in_single_quotes => {
-                escaped = true;
-            }
-            '\'' if !in_double_quotes => {
-                in_single_quotes = !in_single_quotes;
-            }
-            '"' if !in_single_quotes => {
-                in_double_quotes = !in_double_quotes;
-            }
-            '#' if !in_single_quotes
-                && !in_double_quotes
-                && scan::shell_comment_can_start(line, index) =>
-            {
-                return true;
-            }
-            _ => {}
-        }
-    }
-
-    false
+    scan::RawShellScanner::new(line)
+        .find_comment(0, line.len())
+        .is_some()
 }
 
 fn map_parse_error(error: ParseError) -> FormatError {

--- a/crates/shuck-formatter/src/scan.rs
+++ b/crates/shuck-formatter/src/scan.rs
@@ -81,23 +81,9 @@ pub(crate) fn line_has_shell_comment_before(source: &str, offset: usize) -> bool
     let line_start = source[..upper]
         .rfind('\n')
         .map_or(0, |newline| newline.saturating_add(1));
-    let mut cursor = line_start;
-    while cursor < upper {
-        let Some(ch) = source[cursor..].chars().next() else {
-            break;
-        };
-        match ch {
-            '\'' => {
-                cursor = skip_single_quoted(source, cursor + ch.len_utf8(), upper);
-            }
-            '"' => {
-                cursor = skip_double_quoted(source, cursor + ch.len_utf8(), upper);
-            }
-            '#' if shell_comment_can_start(source, cursor) => return true,
-            _ => cursor += ch.len_utf8(),
-        }
-    }
-    false
+    RawShellScanner::bounded(source, upper)
+        .find_comment(line_start, upper)
+        .is_some()
 }
 
 pub(crate) fn branch_keyword_offset(
@@ -294,34 +280,384 @@ pub(crate) fn shell_comment_can_start(source: &str, offset: usize) -> bool {
         .is_none_or(|ch| ch == '\n' || ch.is_whitespace() || matches!(ch, ';' | '&' | '|'))
 }
 
-pub(crate) fn skip_single_quoted(source: &str, mut offset: usize, upper: usize) -> usize {
-    while offset < upper {
-        let Some(ch) = source[offset..].chars().next() else {
-            break;
-        };
-        offset += ch.len_utf8();
-        if ch == '\'' {
-            break;
-        }
-    }
-    offset
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum RawQuoteKind {
+    Single,
+    Double,
+    Backtick,
 }
 
-pub(crate) fn skip_double_quoted(source: &str, mut offset: usize, upper: usize) -> usize {
-    while offset < upper {
-        let Some(ch) = source[offset..].chars().next() else {
-            break;
-        };
-        offset += ch.len_utf8();
-        if ch == '\\' {
-            if let Some(escaped) = source[offset..].chars().next() {
-                offset += escaped.len_utf8();
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub(crate) struct QuoteState {
+    quote: Option<RawQuoteKind>,
+    escaped: bool,
+}
+
+impl QuoteState {
+    pub(crate) fn in_multiline_literal(&self) -> bool {
+        self.quote.is_some()
+    }
+
+    pub(crate) fn in_single_quotes(&self) -> bool {
+        self.quote == Some(RawQuoteKind::Single)
+    }
+
+    pub(crate) fn in_quotes(&self) -> bool {
+        self.quote.is_some()
+    }
+
+    pub(crate) fn consume_raw_char(&mut self, ch: char, include_backticks: bool) -> bool {
+        if self.escaped {
+            self.escaped = false;
+            return true;
+        }
+
+        match self.quote {
+            Some(RawQuoteKind::Single) => {
+                if ch == '\'' {
+                    self.quote = None;
+                }
+                true
             }
-        } else if ch == '"' {
-            break;
+            Some(RawQuoteKind::Double) => {
+                if ch == '"' {
+                    self.quote = None;
+                } else if ch == '\\' {
+                    self.escaped = true;
+                }
+                true
+            }
+            Some(RawQuoteKind::Backtick) if include_backticks => {
+                if ch == '`' {
+                    self.quote = None;
+                } else if ch == '\\' {
+                    self.escaped = true;
+                }
+                true
+            }
+            _ if ch == '\\' => {
+                self.escaped = true;
+                true
+            }
+            _ if ch == '\'' => {
+                self.quote = Some(RawQuoteKind::Single);
+                true
+            }
+            _ if ch == '"' => {
+                self.quote = Some(RawQuoteKind::Double);
+                true
+            }
+            _ if include_backticks && ch == '`' => {
+                self.quote = Some(RawQuoteKind::Backtick);
+                true
+            }
+            _ => false,
         }
     }
-    offset
+
+    pub(crate) fn consume_shell_word_char(&mut self, ch: char) -> bool {
+        if self.escaped {
+            self.escaped = false;
+            return true;
+        }
+
+        match self.quote {
+            Some(RawQuoteKind::Single) => {
+                if ch == '\'' {
+                    self.quote = None;
+                }
+                true
+            }
+            Some(RawQuoteKind::Double) => {
+                if ch == '"' {
+                    self.quote = None;
+                    return true;
+                }
+                if ch == '\\' {
+                    self.escaped = true;
+                    return true;
+                }
+                false
+            }
+            _ if ch == '\\' => {
+                self.escaped = true;
+                true
+            }
+            _ if ch == '\'' => {
+                self.quote = Some(RawQuoteKind::Single);
+                true
+            }
+            _ if ch == '"' => {
+                self.quote = Some(RawQuoteKind::Double);
+                true
+            }
+            _ => false,
+        }
+    }
+
+    pub(crate) fn scan_line(&mut self, line: &str) {
+        self.escaped = false;
+        for (index, ch) in line.char_indices() {
+            match self.quote {
+                Some(RawQuoteKind::Single) => {
+                    if ch == '\'' {
+                        self.quote = None;
+                    }
+                }
+                Some(RawQuoteKind::Double) => {
+                    if ch == '"' && !self.escaped {
+                        self.quote = None;
+                    }
+                }
+                _ => {
+                    if ch == '#' && shell_comment_can_start(line, index) {
+                        break;
+                    }
+                    if ch == '\'' || (ch == '"' && !self.escaped) {
+                        self.quote = Some(if ch == '\'' {
+                            RawQuoteKind::Single
+                        } else {
+                            RawQuoteKind::Double
+                        });
+                    }
+                }
+            }
+
+            self.escaped = ch == '\\' && !self.escaped;
+            if ch != '\\' {
+                self.escaped = false;
+            }
+        }
+        self.escaped = false;
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct RawShellScanner<'source> {
+    source: &'source str,
+    upper: usize,
+}
+
+impl<'source> RawShellScanner<'source> {
+    pub(crate) fn new(source: &'source str) -> Self {
+        Self::bounded(source, source.len())
+    }
+
+    pub(crate) fn bounded(source: &'source str, upper: usize) -> Self {
+        Self {
+            source,
+            upper: upper.min(source.len()),
+        }
+    }
+
+    pub(crate) fn skip_single_quoted_body(&self, mut offset: usize) -> usize {
+        while offset < self.upper {
+            let Some(ch) = self.source[offset..].chars().next() else {
+                break;
+            };
+            offset += ch.len_utf8();
+            if ch == '\'' {
+                break;
+            }
+        }
+        offset
+    }
+
+    pub(crate) fn skip_double_quoted_body(&self, mut offset: usize) -> usize {
+        while offset < self.upper {
+            let Some(ch) = self.source[offset..].chars().next() else {
+                break;
+            };
+            offset += ch.len_utf8();
+            if ch == '\\' {
+                if let Some(escaped) = self.source[offset..].chars().next() {
+                    offset += escaped.len_utf8();
+                }
+            } else if ch == '"' {
+                break;
+            }
+        }
+        offset
+    }
+
+    pub(crate) fn skip_escaped_or_quoted_at(&self, offset: usize) -> Option<usize> {
+        let ch = self.source[offset..].chars().next()?;
+        let next = offset + ch.len_utf8();
+        match ch {
+            '\\' => Some(
+                self.source[next..self.upper]
+                    .chars()
+                    .next()
+                    .map_or(next, |escaped| next + escaped.len_utf8()),
+            ),
+            '\'' => Some(self.skip_single_quoted_body(next)),
+            '"' => Some(self.skip_double_quoted_body(next)),
+            _ => None,
+        }
+    }
+
+    pub(crate) fn skip_quoted_or_comment_at(&self, offset: usize) -> Option<usize> {
+        self.skip_escaped_or_quoted_at(offset).or_else(|| {
+            self.comment_starts_at(offset)
+                .then(|| self.comment_end_from(offset))
+        })
+    }
+
+    pub(crate) fn find_comment(&self, start: usize, upper: usize) -> Option<usize> {
+        let mut offset = start.min(self.upper);
+        let upper = upper.min(self.upper);
+        while offset < upper {
+            if let Some(next) = self.skip_escaped_or_quoted_at(offset) {
+                offset = next;
+                continue;
+            }
+
+            let ch = self.source[offset..].chars().next()?;
+            if ch == '#' && shell_comment_can_start(self.source, offset) {
+                return Some(offset);
+            }
+            offset += ch.len_utf8();
+        }
+        None
+    }
+
+    pub(crate) fn is_escaped(&self, index: usize) -> bool {
+        let mut backslashes = 0usize;
+        for ch in self.source[..index.min(self.source.len())].chars().rev() {
+            if ch == '\\' {
+                backslashes += 1;
+            } else {
+                break;
+            }
+        }
+        backslashes % 2 == 1
+    }
+
+    pub(crate) fn matching_command_substitution_close(&self, body_start: usize) -> Option<usize> {
+        let mut quote = QuoteState::default();
+        let mut paren_depth = 0usize;
+        let mut index = body_start.min(self.upper);
+
+        while index < self.upper {
+            let ch = self.source[index..].chars().next()?;
+            let next_index = index + ch.len_utf8();
+            if quote.consume_raw_char(ch, false) {
+                index = next_index;
+                continue;
+            }
+
+            match ch {
+                '(' => paren_depth += 1,
+                ')' => {
+                    if paren_depth == 0 {
+                        return Some(index);
+                    }
+                    paren_depth -= 1;
+                }
+                _ => {}
+            }
+
+            index = next_index;
+        }
+
+        None
+    }
+
+    pub(crate) fn next_command_substitution(&self, mut index: usize) -> Option<(usize, usize)> {
+        let bytes = self.source.as_bytes();
+        let mut quote = QuoteState::default();
+
+        while index + 1 < self.upper {
+            let ch = self.source[index..].chars().next()?;
+            let next_index = index + ch.len_utf8();
+            if quote.consume_shell_word_char(ch) {
+                index = next_index;
+                continue;
+            }
+
+            if !quote.in_single_quotes()
+                && bytes[index] == b'$'
+                && bytes[index + 1] == b'('
+                && bytes.get(index + 2).is_none_or(|byte| *byte != b'(')
+                && let Some(close_offset) = self.matching_command_substitution_close(index + 2)
+            {
+                return Some((index, close_offset));
+            }
+            index = next_index;
+        }
+
+        None
+    }
+
+    pub(crate) fn has_unclosed_substitution_before(&self, upper: usize) -> bool {
+        let mut depth = 0usize;
+        let mut index = 0usize;
+        let upper = upper.min(self.upper);
+        let mut in_single_quotes = false;
+        let mut in_double_quotes = false;
+
+        while index < upper {
+            let Some(ch) = self.source[index..].chars().next() else {
+                break;
+            };
+            let next_index = index + ch.len_utf8();
+
+            if ch == '\\' {
+                index = self.source[next_index..upper]
+                    .chars()
+                    .next()
+                    .map_or(next_index, |escaped| next_index + escaped.len_utf8());
+                continue;
+            }
+            if ch == '\'' && !in_double_quotes {
+                in_single_quotes = !in_single_quotes;
+                index = next_index;
+                continue;
+            }
+            if ch == '"' && !in_single_quotes {
+                in_double_quotes = !in_double_quotes;
+                index = next_index;
+                continue;
+            }
+            if in_single_quotes {
+                index = next_index;
+                continue;
+            }
+
+            let bytes = self.source.as_bytes();
+            match ch {
+                '$' | '<' | '>' if bytes.get(index + 1) == Some(&b'(') => {
+                    depth += 1;
+                    index = index.saturating_add(2);
+                    continue;
+                }
+                ')' if depth > 0 => depth -= 1,
+                _ => {}
+            }
+            index = next_index;
+        }
+
+        depth > 0
+    }
+
+    fn comment_starts_at(&self, offset: usize) -> bool {
+        self.source[offset..self.upper].starts_with('#')
+            && shell_comment_can_start(self.source, offset)
+    }
+
+    fn comment_end_from(&self, offset: usize) -> usize {
+        self.source[offset..self.upper]
+            .find('\n')
+            .map_or(self.upper, |newline| offset + newline + 1)
+    }
+}
+
+pub(crate) fn skip_single_quoted(source: &str, offset: usize, upper: usize) -> usize {
+    RawShellScanner::bounded(source, upper).skip_single_quoted_body(offset)
+}
+
+pub(crate) fn skip_double_quoted(source: &str, offset: usize, upper: usize) -> usize {
+    RawShellScanner::bounded(source, upper).skip_double_quoted_body(offset)
 }
 
 pub(crate) fn skip_escaped_or_quoted(
@@ -330,18 +666,8 @@ pub(crate) fn skip_escaped_or_quoted(
     upper: usize,
     ch: char,
 ) -> Option<usize> {
-    let next = offset + ch.len_utf8();
-    match ch {
-        '\\' => Some(
-            source[next..upper]
-                .chars()
-                .next()
-                .map_or(next, |escaped| next + escaped.len_utf8()),
-        ),
-        '\'' => Some(skip_single_quoted(source, next, upper)),
-        '"' => Some(skip_double_quoted(source, next, upper)),
-        _ => None,
-    }
+    debug_assert_eq!(source[offset..].chars().next(), Some(ch));
+    RawShellScanner::bounded(source, upper).skip_escaped_or_quoted_at(offset)
 }
 
 pub(crate) fn normalized_close_keyword_span(
@@ -389,9 +715,10 @@ fn matching_close_keyword_start(
     let upper = span.end.offset.min(source.len());
     let mut offset = span.start.offset.min(upper);
     let mut depth = 0usize;
+    let scanner = RawShellScanner::bounded(source, upper);
     while offset < upper {
         let ch = source[offset..].chars().next()?;
-        if let Some(next) = shell_quoted_or_comment_end(source, offset, upper, ch) {
+        if let Some(next) = scanner.skip_quoted_or_comment_at(offset) {
             offset = next;
             continue;
         }
@@ -416,20 +743,41 @@ fn matching_close_keyword_start(
     None
 }
 
-fn shell_quoted_or_comment_end(
-    source: &str,
-    offset: usize,
-    upper: usize,
-    ch: char,
-) -> Option<usize> {
-    match ch {
-        '\'' => Some(skip_single_quoted(source, offset + ch.len_utf8(), upper)),
-        '"' => Some(skip_double_quoted(source, offset + ch.len_utf8(), upper)),
-        '#' if shell_comment_can_start(source, offset) => Some(
-            source[offset..]
-                .find('\n')
-                .map_or(upper, |newline| offset + newline + 1),
-        ),
-        _ => None,
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn raw_scanner_finds_shell_comments_outside_quotes() {
+        let scanner = RawShellScanner::new("echo '# no' \"# no\" value#no # yes");
+
+        assert_eq!(scanner.find_comment(0, scanner.source.len()), Some(28));
+    }
+
+    #[test]
+    fn raw_scanner_matches_nested_command_substitutions() {
+        let raw = "$(echo \"$(date +%s)\" '(')";
+        let scanner = RawShellScanner::new(raw);
+
+        assert_eq!(
+            scanner.matching_command_substitution_close(2),
+            Some(raw.len() - 1)
+        );
+    }
+
+    #[test]
+    fn raw_scanner_finds_unclosed_process_substitution() {
+        let raw = "cat <(printf '%s\\n' \"$(value)\"";
+        let scanner = RawShellScanner::new(raw);
+
+        assert!(scanner.has_unclosed_substitution_before(raw.len()));
+    }
+
+    #[test]
+    fn raw_scanner_skips_escaped_command_substitutions() {
+        let raw = r#"echo \$(skip) "$(keep)" '$(skip)'"#;
+        let scanner = RawShellScanner::new(raw);
+
+        assert_eq!(scanner.next_command_substitution(0), Some((15, 21)));
     }
 }

--- a/crates/shuck-formatter/src/word.rs
+++ b/crates/shuck-formatter/src/word.rs
@@ -5,10 +5,10 @@ use crate::comments::SourceMap;
 use crate::facts::FormatterFacts;
 use crate::options::{IndentStyle, ResolvedShellFormatOptions};
 use crate::scan::{
-    common_nonempty_shell_indent, heredoc_start, leading_shell_indent as line_leading_shell_indent,
+    QuoteState, RawShellScanner, common_nonempty_shell_indent, heredoc_start,
+    leading_shell_indent as line_leading_shell_indent,
     line_indent_before_offset as line_indent_before_source_offset,
     line_without_continuation_backslash, redirect_operator_end, refine_common_indent,
-    shell_comment_can_start,
 };
 use crate::streaming::format_stmt_sequence_streaming_to_buf;
 use crate::visit::{self, AstVisitor};
@@ -798,7 +798,7 @@ fn push_raw_command_substitution_with_normalized_spacing(
         normalize_continuations_before_substitution_close_lines(raw);
     let raw = normalized_close_continuations.as_deref().unwrap_or(raw);
     let outer_indent = line_indent_before_source_offset(source, start_offset).unwrap_or("");
-    let mut quote = RawShellQuoteState::default();
+    let mut quote = QuoteState::default();
     let raw_lines = raw.split('\n').collect::<Vec<_>>();
     let Some((first, lines)) = raw_lines.split_first() else {
         return;
@@ -965,48 +965,6 @@ fn collect_raw_command_substitution_spans(
                 collect_raw_command_substitution_spans(parts.as_slice(), spans);
             }
             _ => {}
-        }
-    }
-}
-
-#[derive(Debug, Default)]
-struct RawShellQuoteState {
-    quote: Option<char>,
-}
-
-impl RawShellQuoteState {
-    fn in_multiline_literal(&self) -> bool {
-        self.quote.is_some()
-    }
-
-    fn scan_line(&mut self, line: &str) {
-        let mut escaped = false;
-        for (index, ch) in line.char_indices() {
-            match self.quote {
-                Some('\'') => {
-                    if ch == '\'' {
-                        self.quote = None;
-                    }
-                }
-                Some('"') => {
-                    if ch == '"' && !escaped {
-                        self.quote = None;
-                    }
-                }
-                _ => {
-                    if ch == '#' && shell_comment_can_start(line, index) {
-                        break;
-                    }
-                    if ch == '\'' || (ch == '"' && !escaped) {
-                        self.quote = Some(ch);
-                    }
-                }
-            }
-
-            escaped = ch == '\\' && !escaped;
-            if ch != '\\' {
-                escaped = false;
-            }
         }
     }
 }
@@ -2207,7 +2165,7 @@ fn indent_inline_pipeline_continuations(
     let mut previous_ends_pipeline = false;
     let mut pipeline_comment_continuation = false;
     let mut continuation_indent: Option<String> = None;
-    let mut quote = RawShellQuoteState::default();
+    let mut quote = QuoteState::default();
 
     for (index, line) in body.split('\n').enumerate() {
         if index > 0 {
@@ -2641,7 +2599,7 @@ fn push_raw_block_command_substitution_without_outer_indent(
     let mut previous_pipeline_indent: Option<String> = None;
     let mut continuation_indent: Option<String> = None;
     let mut compound_indents = RawCompoundIndentState::default();
-    let mut quote = RawShellQuoteState::default();
+    let mut quote = QuoteState::default();
     for (line_index, line) in lines.iter().enumerate() {
         let line = *line;
         target.push('\n');
@@ -3047,25 +3005,7 @@ fn normalize_padding_before_trailing_comment(line: &str) -> Option<String> {
 }
 
 fn trailing_comment_start(line: &str) -> Option<usize> {
-    let mut in_single_quotes = false;
-    let mut in_double_quotes = false;
-    let mut escaped = false;
-
-    for (index, ch) in line.char_indices() {
-        if escaped {
-            escaped = false;
-            continue;
-        }
-        match ch {
-            '\\' if !in_single_quotes => escaped = true,
-            '\'' if !in_double_quotes => in_single_quotes = !in_single_quotes,
-            '"' if !in_single_quotes => in_double_quotes = !in_double_quotes,
-            '#' if !in_single_quotes && !in_double_quotes => return Some(index),
-            _ => {}
-        }
-    }
-
-    None
+    RawShellScanner::new(line).find_comment(0, line.len())
 }
 
 fn raw_line_closes_substitution_wrapper(content: &str) -> bool {
@@ -3207,37 +3147,26 @@ fn expand_inline_raw_command_substitutions_in_line(
         return false;
     }
 
-    let bytes = line.as_bytes();
     let mut changed = false;
     let mut last = 0usize;
     let mut index = 0usize;
-    let mut in_single_quotes = false;
-    let mut in_double_quotes = false;
-    let mut escaped = false;
+    let mut quote = QuoteState::default();
+    let scanner = RawShellScanner::new(line);
+    let bytes = line.as_bytes();
 
-    while index < bytes.len() {
-        let byte = bytes[index];
-        if escaped {
-            escaped = false;
-            index += 1;
+    while index < line.len() {
+        let Some(ch) = line[index..].chars().next() else {
+            break;
+        };
+        let next_index = index + ch.len_utf8();
+        if quote.consume_raw_char(ch, false) {
+            index = next_index;
             continue;
         }
-        if byte == b'\'' && !in_double_quotes {
-            in_single_quotes = !in_single_quotes;
-            index += 1;
-            continue;
-        }
-        if byte == b'"' && !in_single_quotes {
-            in_double_quotes = !in_double_quotes;
-            index += 1;
-            continue;
-        }
-        if !in_single_quotes && !in_double_quotes && byte == b'#' {
+        if ch == '#' && scanner.find_comment(index, next_index).is_some() {
             break;
         }
-        if !in_single_quotes
-            && !in_double_quotes
-            && byte == b'$'
+        if ch == '$'
             && bytes.get(index + 1) == Some(&b'(')
             && bytes.get(index + 2) != Some(&b'(')
             && let Some(close_offset) = matching_raw_command_substitution_close(line, index + 2)
@@ -3253,8 +3182,7 @@ fn expand_inline_raw_command_substitutions_in_line(
             continue;
         }
 
-        escaped = byte == b'\\';
-        index += 1;
+        index = next_index;
     }
 
     if changed {
@@ -3502,61 +3430,12 @@ fn raw_command_substitution_needs_structural_spacing(raw: &str) -> bool {
     false
 }
 
-#[derive(Default)]
-struct RawQuoteState {
-    quote: Option<char>,
-    escaped: bool,
-}
-
-impl RawQuoteState {
-    fn consume(&mut self, ch: char, include_backticks: bool) -> bool {
-        if self.escaped {
-            self.escaped = false;
-            return true;
-        }
-
-        match self.quote {
-            Some('\'') => {
-                if ch == '\'' {
-                    self.quote = None;
-                }
-                true
-            }
-            Some('"') => {
-                if ch == '"' {
-                    self.quote = None;
-                } else if ch == '\\' {
-                    self.escaped = true;
-                }
-                true
-            }
-            Some('`') if include_backticks => {
-                if ch == '`' {
-                    self.quote = None;
-                } else if ch == '\\' {
-                    self.escaped = true;
-                }
-                true
-            }
-            _ if ch == '\\' => {
-                self.escaped = true;
-                true
-            }
-            _ if ch == '\'' || ch == '"' || (include_backticks && ch == '`') => {
-                self.quote = Some(ch);
-                true
-            }
-            _ => false,
-        }
-    }
-}
-
 fn raw_shell_body_needs_structural_spacing(body: &str) -> bool {
     let body = body.trim_matches([' ', '\t']);
     if raw_body_contains_pipeline_multistatement_brace_group(body) {
         return true;
     }
-    let mut quote = RawQuoteState::default();
+    let mut quote = QuoteState::default();
     let mut horizontal_run = 0usize;
     let mut index = 0usize;
 
@@ -3567,7 +3446,7 @@ fn raw_shell_body_needs_structural_spacing(body: &str) -> bool {
         };
         let next_index = index + ch.len_utf8();
 
-        if quote.consume(ch, true) {
+        if quote.consume_raw_char(ch, true) {
             horizontal_run = 0;
             index = next_index;
             continue;
@@ -3822,19 +3701,7 @@ fn raw_has_final_replacement_delimiter(after_operator: &str) -> bool {
         return false;
     };
     after_operator[last_index..].starts_with('/')
-        && !raw_char_is_escaped(after_operator, last_index)
-}
-
-fn raw_char_is_escaped(raw: &str, index: usize) -> bool {
-    let mut backslashes = 0usize;
-    for ch in raw[..index].chars().rev() {
-        if ch == '\\' {
-            backslashes += 1;
-        } else {
-            break;
-        }
-    }
-    backslashes % 2 == 1
+        && !RawShellScanner::new(after_operator).is_escaped(last_index)
 }
 
 fn replacement_ends_with_ambiguous_quote(replacement: &str) -> bool {
@@ -3918,7 +3785,7 @@ fn normalize_raw_arithmetic_expansion_padding(raw: &str) -> Option<String> {
 }
 
 fn matching_raw_arithmetic_expansion_close(raw: &str, body_start: usize) -> Option<usize> {
-    let mut quote = RawQuoteState::default();
+    let mut quote = QuoteState::default();
     let mut paren_depth = 0usize;
     let mut index = body_start;
 
@@ -3926,7 +3793,7 @@ fn matching_raw_arithmetic_expansion_close(raw: &str, body_start: usize) -> Opti
         let rest = &raw[index..];
         let ch = rest.chars().next()?;
         let next_index = index + ch.len_utf8();
-        if quote.consume(ch, true) {
+        if quote.consume_raw_char(ch, true) {
             index = next_index;
             continue;
         }
@@ -3956,62 +3823,31 @@ pub(crate) fn matching_raw_command_substitution_close(
     raw: &str,
     body_start: usize,
 ) -> Option<usize> {
-    let mut quote = RawQuoteState::default();
-    let mut paren_depth = 0usize;
-    let mut index = body_start;
-
-    while index < raw.len() {
-        let ch = raw[index..].chars().next()?;
-        let next_index = index + ch.len_utf8();
-        if quote.consume(ch, false) {
-            index = next_index;
-            continue;
-        }
-
-        match ch {
-            '(' => paren_depth += 1,
-            ')' => {
-                if paren_depth == 0 {
-                    return Some(index);
-                }
-                paren_depth -= 1;
-            }
-            _ => {}
-        }
-
-        index = next_index;
-    }
-
-    None
+    RawShellScanner::new(raw).matching_command_substitution_close(body_start)
 }
 
 fn push_raw_shell_line_with_normalized_redirect_spacing(target: &mut String, line: &str) {
     let mut last = 0;
     let mut index = 0;
-    let mut in_single_quotes = false;
-    let mut in_double_quotes = false;
-    let mut escaped = false;
+    let mut quote = QuoteState::default();
+    let scanner = RawShellScanner::new(line);
     let bytes = line.as_bytes();
 
-    while index < bytes.len() {
-        let byte = bytes[index];
-        if byte == b'\'' && !in_double_quotes && !escaped {
-            in_single_quotes = !in_single_quotes;
-            index += 1;
+    while index < line.len() {
+        let Some(ch) = line[index..].chars().next() else {
+            break;
+        };
+        let next_index = index + ch.len_utf8();
+        if quote.consume_shell_word_char(ch) {
+            index = next_index;
             continue;
         }
-        if byte == b'"' && !in_single_quotes && !escaped {
-            in_double_quotes = !in_double_quotes;
-            index += 1;
-            continue;
-        }
-        if !in_single_quotes && !in_double_quotes && byte == b'#' {
+        if !quote.in_quotes() && ch == '#' && scanner.find_comment(index, next_index).is_some() {
             break;
         }
 
-        if !in_single_quotes
-            && !escaped
-            && byte == b'$'
+        if !quote.in_single_quotes()
+            && ch == '$'
             && bytes.get(index + 1) == Some(&b'(')
             && bytes.get(index + 2) != Some(&b'(')
             && let Some(close_offset) = matching_raw_command_substitution_close(line, index + 2)
@@ -4025,11 +3861,10 @@ fn push_raw_shell_line_with_normalized_redirect_spacing(target: &mut String, lin
             target.push(')');
             last = close_offset + 1;
             index = close_offset + 1;
-            escaped = false;
             continue;
         }
 
-        if !in_single_quotes && !in_double_quotes && matches!(byte, b' ' | b'\t' | b'\r') {
+        if !quote.in_quotes() && matches!(bytes[index], b' ' | b'\t' | b'\r') {
             let whitespace_start = index;
             let mut semicolon_start = index + 1;
             while semicolon_start < bytes.len()
@@ -4044,12 +3879,11 @@ fn push_raw_shell_line_with_normalized_redirect_spacing(target: &mut String, lin
                 target.push_str(&line[last..whitespace_start]);
                 last = semicolon_start;
                 index = semicolon_start;
-                escaped = false;
                 continue;
             }
         }
 
-        if !in_single_quotes && !in_double_quotes && byte.is_ascii_digit() {
+        if !quote.in_quotes() && bytes[index].is_ascii_digit() {
             let fd_start = index;
             let mut operator_start = index + 1;
             while operator_start < bytes.len() && bytes[operator_start].is_ascii_digit() {
@@ -4066,16 +3900,14 @@ fn push_raw_shell_line_with_normalized_redirect_spacing(target: &mut String, lin
                     target.push_str(&line[last..operator_end]);
                     last = target_start;
                     index = target_start;
-                    escaped = false;
                     continue;
                 }
             }
             index = fd_start;
         }
 
-        if !in_single_quotes
-            && !in_double_quotes
-            && matches!(byte, b'<' | b'>')
+        if !quote.in_quotes()
+            && matches!(bytes[index], b'<' | b'>')
             && let Some(operator_end) = redirect_operator_end(bytes, index)
         {
             let mut target_start = operator_end;
@@ -4090,12 +3922,11 @@ fn push_raw_shell_line_with_normalized_redirect_spacing(target: &mut String, lin
                 target.push_str(&line[last..operator_end]);
                 last = target_start;
                 index = target_start;
-                escaped = false;
                 continue;
             }
         }
 
-        if !in_single_quotes && !in_double_quotes && bytes.get(index..index + 3) == Some(b"<<<") {
+        if !quote.in_quotes() && bytes.get(index..index + 3) == Some(b"<<<") {
             let operator_end = index + 3;
             let mut target_start = operator_end;
             while target_start < bytes.len() && matches!(bytes[target_start], b' ' | b'\t' | b'\r')
@@ -4106,16 +3937,11 @@ fn push_raw_shell_line_with_normalized_redirect_spacing(target: &mut String, lin
                 target.push_str(&line[last..operator_end]);
                 last = target_start;
                 index = target_start;
-                escaped = false;
                 continue;
             }
         }
 
-        escaped = !in_single_quotes && byte == b'\\' && !escaped;
-        if byte != b'\\' {
-            escaped = false;
-        }
-        index += 1;
+        index = next_index;
     }
 
     target.push_str(&line[last..]);
@@ -4529,7 +4355,7 @@ fn normalize_literal_continuation_indent_for_block(rendered: &str) -> Option<Str
         return None;
     }
 
-    let mut quote = RawShellQuoteState::default();
+    let mut quote = QuoteState::default();
     let mut continuation_indent: Option<String> = None;
     let mut normalized = String::with_capacity(rendered.len());
     let mut changed = false;
@@ -5566,48 +5392,8 @@ fn normalize_inline_command_substitutions_in_parameter_operand(
     finish_raw_rewrite(rendered, raw, cursor, changed)
 }
 
-fn next_raw_command_substitution(raw: &str, mut index: usize) -> Option<(usize, usize)> {
-    let bytes = raw.as_bytes();
-    let mut in_single_quotes = false;
-    let mut escaped = false;
-
-    while index + 1 < bytes.len() {
-        let ch = raw[index..].chars().next()?;
-        let next_index = index + ch.len_utf8();
-        if in_single_quotes {
-            if ch == '\'' {
-                in_single_quotes = false;
-            }
-            index = next_index;
-            continue;
-        }
-        if escaped {
-            escaped = false;
-            index = next_index;
-            continue;
-        }
-        if ch == '\\' {
-            escaped = true;
-            index = next_index;
-            continue;
-        }
-        if ch == '\'' {
-            in_single_quotes = true;
-            index = next_index;
-            continue;
-        }
-
-        if bytes[index] == b'$'
-            && bytes[index + 1] == b'('
-            && bytes.get(index + 2).is_none_or(|byte| *byte != b'(')
-            && let Some(close_offset) = matching_raw_command_substitution_close(raw, index + 2)
-        {
-            return Some((index, close_offset));
-        }
-        index = next_index;
-    }
-
-    None
+fn next_raw_command_substitution(raw: &str, index: usize) -> Option<(usize, usize)> {
+    RawShellScanner::new(raw).next_command_substitution(index)
 }
 
 fn finish_raw_rewrite(


### PR DESCRIPTION
## Summary

- Add a formatter-owned `RawShellScanner` and shared `QuoteState` for raw shell quote, escape, comment, and command-substitution scanning.
- Replace the duplicated scanner state machines in formatter scan, word, command, and trailing-newline paths.
- Add focused scanner unit coverage for comments, nested substitutions, escaped substitutions, and unclosed process substitutions.

## Validation

- `cargo fmt --check`
- `cargo test -p shuck-formatter`
- `make test-oracle-shfmt-large-corpus` ran to completion with `0` Shuck errors and the existing nonzero shfmt mismatch gate: `383` mismatches over `33733` compared fixtures.