### PR TITLE
refactor(formatter): move render classifications into facts

### DIFF
--- a/crates/shuck-formatter/src/command.rs
+++ b/crates/shuck-formatter/src/command.rs
@@ -1,5 +1,5 @@
 use crate::comments::SourceMap;
-use crate::facts::FormatterFacts;
+use crate::facts::{FormatterFacts, classify_stmt_contains_heredoc};
 use crate::options::ResolvedShellFormatOptions;
 use crate::scan::{
     branch_keyword_offset, common_nonempty_shell_indent, last_shell_keyword_start,
@@ -7,7 +7,6 @@ use crate::scan::{
     matching_if_close_start, normalized_close_keyword_span, refine_common_indent,
     shell_comment_can_start, skip_escaped_or_quoted,
 };
-use crate::visit::{self, AstVisitor};
 use crate::word::{
     matching_raw_command_substitution_close, normalize_raw_pipeline_continuations,
     render_arithmetic_expr_to_buf, render_word_syntax_to_buf, render_word_syntax_with_facts_to_buf,
@@ -16,8 +15,8 @@ use shuck_ast::{
     AnonymousFunctionCommand, ArithmeticExprNode, ArrayElem, Assignment, AssignmentValue,
     BackgroundOperator, BinaryCommand, BinaryOp, BuiltinCommand, CaseItem, CaseTerminator, Command,
     CompoundCommand, DeclClause, DeclOperand, ForSyntax, ForeachSyntax, FunctionDef, IfCommand,
-    IfSyntax, Redirect, RedirectKind, RepeatSyntax, SimpleCommand, SourceText, Span, Stmt, StmtSeq,
-    StmtTerminator, Subscript, VarRef, Word, WordPart,
+    IfSyntax, RepeatSyntax, SimpleCommand, SourceText, Span, Stmt, StmtSeq, StmtTerminator,
+    Subscript, VarRef, Word, WordPart,
 };
 
 pub(crate) fn array_elem_parts(element: &ArrayElem) -> (Option<&Subscript>, &Word, &'static str) {
@@ -873,50 +872,6 @@ pub(crate) fn render_source_text_to_buf(text: &SourceText, source: &str, rendere
     }
 }
 
-pub(crate) fn has_heredoc(stmt: &Stmt) -> bool {
-    let mut visitor = HeredocFinder::default();
-    visitor.visit_stmt(stmt);
-    visitor.found
-}
-
-pub(crate) fn stmt_seq_has_heredoc(commands: &StmtSeq) -> bool {
-    let mut visitor = HeredocFinder::default();
-    visitor.visit_stmt_seq(commands);
-    visitor.found
-}
-
-#[derive(Default)]
-struct HeredocFinder {
-    found: bool,
-}
-
-impl AstVisitor for HeredocFinder {
-    fn visit_stmt(&mut self, stmt: &Stmt) {
-        if !self.found {
-            visit::walk_stmt(self, stmt);
-        }
-    }
-
-    fn visit_stmt_seq(&mut self, sequence: &StmtSeq) {
-        if !self.found {
-            visit::walk_stmt_seq(self, sequence);
-        }
-    }
-
-    fn visit_redirect(&mut self, redirect: &Redirect) {
-        if matches!(
-            redirect.kind,
-            RedirectKind::HereDoc | RedirectKind::HereDocStrip
-        ) {
-            self.found = true;
-        } else {
-            visit::walk_redirect(self, redirect);
-        }
-    }
-
-    fn visit_word(&mut self, _word: &Word) {}
-}
-
 enum CompoundChild<'a> {
     Stmt(&'a Stmt),
     Sequence(&'a StmtSeq),
@@ -1542,7 +1497,7 @@ fn stmt_group_attachment_end_offset(
 
     match &stmt.command {
         Command::Function(_) | Command::AnonymousFunction(_) => stmt_span(stmt).end.offset,
-        _ if has_heredoc(stmt) => {
+        _ if classify_stmt_contains_heredoc(stmt) => {
             stmt_verbatim_span_with_source_map(stmt, source_map)
                 .end
                 .offset
@@ -1841,7 +1796,7 @@ pub(crate) fn rendered_stmt_end_line(
         Command::Function(_) | Command::AnonymousFunction(_) => {
             span_render_end_line(stmt_span(stmt), source, source_map)
         }
-        _ if has_heredoc(stmt) => span_render_end_line(
+        _ if classify_stmt_contains_heredoc(stmt) => span_render_end_line(
             stmt_verbatim_span_with_source_map(stmt, source_map),
             source,
             source_map,
@@ -1906,7 +1861,7 @@ pub(crate) fn should_render_verbatim(
     (!options.simplify()
         && matches!(&stmt.command, Command::Simple(command) if simple_command_uses_synthetic_words(command, source_map.source())))
         || (options.keep_padding() && stmt_has_alignment_sensitive_padding(stmt, source_map))
-        || (has_heredoc(stmt)
+        || (classify_stmt_contains_heredoc(stmt)
             && !matches!(stmt.command, Command::Binary(_))
             && stmt_has_trailing_comment(stmt, source_map))
 }

--- a/crates/shuck-formatter/src/facts.rs
+++ b/crates/shuck-formatter/src/facts.rs
@@ -4,9 +4,9 @@ use shuck_ast::{
     AnonymousFunctionCommand, ArithmeticExprNode, Assignment, AssignmentValue, BinaryCommand,
     BinaryOp, CaseCommand, CaseItem, Command, CommandSubstitutionSyntax, CompoundCommand,
     ConditionalCommand, ConditionalExpr, File, ForCommand, ForeachCommand, FunctionDef, Heredoc,
-    HeredocBody, HeredocBodyPart, HeredocBodyPartNode, IfCommand, Pattern, Redirect, RepeatCommand,
-    SelectCommand, Span, Stmt, StmtSeq, StmtTerminator, TimeCommand, UntilCommand, WhileCommand,
-    Word, WordPart, WordPartNode,
+    HeredocBody, HeredocBodyPart, HeredocBodyPartNode, IfCommand, Pattern, Redirect, RedirectKind,
+    RepeatCommand, SelectCommand, Span, Stmt, StmtSeq, StmtTerminator, TimeCommand, UntilCommand,
+    WhileCommand, Word, WordPart, WordPartNode,
 };
 use shuck_ast::{TextRange, TextSize};
 use shuck_indexer::{CommentIndex, IndexedComment, Indexer, IndexerOptions, LineIndex};
@@ -20,7 +20,7 @@ use crate::command::{
     matching_group_close, rendered_stmt_end_line, should_render_verbatim, stmt_attachment_span,
     stmt_format_span, stmt_group_attachment_or_verbatim_span, stmt_has_trailing_comment,
     stmt_render_start_line, stmt_span, stmt_start_after_operator,
-    stmt_verbatim_span_with_source_map,
+    stmt_verbatim_span_with_source_map, trim_unescaped_trailing_whitespace,
 };
 use crate::comments::{
     CommentAttachmentModel, SequenceCommentAttachment, SourceComment, SourceMap,
@@ -206,6 +206,7 @@ pub(crate) struct StmtFacts {
     rendered_end_line: usize,
     has_trailing_comment: bool,
     preserve_verbatim: bool,
+    contains_heredoc: bool,
 }
 
 impl StmtFacts {
@@ -228,6 +229,10 @@ impl StmtFacts {
     pub(crate) fn preserve_verbatim(&self) -> bool {
         self.preserve_verbatim
     }
+
+    pub(crate) fn contains_heredoc(&self) -> bool {
+        self.contains_heredoc
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -241,6 +246,10 @@ pub(crate) struct SequenceFacts<'source> {
     has_blank_line_before_close: bool,
     body_content_end: usize,
     close_gap_start: usize,
+    contains_comments: bool,
+    contains_heredoc: bool,
+    contains_multiline_literal_source: bool,
+    contains_multistatement_pipeline_brace_group: bool,
 }
 
 impl<'source> SequenceFacts<'source> {
@@ -255,6 +264,10 @@ impl<'source> SequenceFacts<'source> {
             has_blank_line_before_close: false,
             body_content_end: 0,
             close_gap_start: 0,
+            contains_comments: false,
+            contains_heredoc: false,
+            contains_multiline_literal_source: false,
+            contains_multistatement_pipeline_brace_group: false,
         }
     }
 
@@ -276,6 +289,22 @@ impl<'source> SequenceFacts<'source> {
 
     pub(crate) fn has_comments(&self) -> bool {
         self.comments.has_comments()
+    }
+
+    pub(crate) fn contains_comments(&self) -> bool {
+        self.contains_comments
+    }
+
+    pub(crate) fn contains_heredoc(&self) -> bool {
+        self.contains_heredoc
+    }
+
+    pub(crate) fn contains_multiline_literal_source(&self) -> bool {
+        self.contains_multiline_literal_source
+    }
+
+    pub(crate) fn contains_multistatement_pipeline_brace_group(&self) -> bool {
+        self.contains_multistatement_pipeline_brace_group
     }
 
     pub(crate) fn first_rendered_line_for(&self, index: usize) -> usize {
@@ -315,10 +344,22 @@ impl<'source> SequenceFacts<'source> {
 }
 
 #[derive(Debug, Clone)]
+pub(crate) struct WordFacts {
+    has_multiline_literal_source: bool,
+}
+
+impl WordFacts {
+    pub(crate) fn has_multiline_literal_source(&self) -> bool {
+        self.has_multiline_literal_source
+    }
+}
+
+#[derive(Debug, Clone)]
 pub(crate) struct FormatterFacts<'source> {
     source_map: SourceMap<'source>,
     stmt_facts: HashMap<FactSpan, StmtFacts>,
     sequence_facts: HashMap<SequenceSiteKey, SequenceFacts<'source>>,
+    word_facts: HashMap<FactSpan, WordFacts>,
     pipeline_breaks: HashSet<FactSpan>,
     list_item_breaks: HashSet<FactSpan>,
     background_breaks: HashSet<FactSpan>,
@@ -362,16 +403,73 @@ impl<'source> FormatterFacts<'source> {
         upper_bound: Option<usize>,
     ) -> &SequenceFacts<'source> {
         let key = SequenceSiteKey::new(sequence, upper_bound);
-        self.sequence_facts.get(&key).unwrap_or_else(|| {
-            let Some(facts) = self
-                .sequence_facts
+        self.sequence_facts
+            .get(&key)
+            .unwrap_or_else(|| self.sequence_by_span(key.span))
+    }
+
+    fn sequence_by_span(&self, span: FactSpan) -> &SequenceFacts<'source> {
+        let Some(facts) = self
+            .sequence_facts
+            .iter()
+            .find_map(|(candidate, facts)| (candidate.span == span).then_some(facts))
+        else {
+            unreachable!("missing sequence facts");
+        };
+        facts
+    }
+
+    pub(crate) fn word_has_multiline_literal_source(&self, word: &Word) -> bool {
+        self.word_facts.get(&FactSpan::from(word.span)).map_or_else(
+            || classify_word_has_multiline_literal_source(word, self.source_map.source()),
+            WordFacts::has_multiline_literal_source,
+        )
+    }
+
+    pub(crate) fn assignment_value_has_multiline_literal_source(
+        &self,
+        assignment: &Assignment,
+    ) -> bool {
+        match &assignment.value {
+            AssignmentValue::Scalar(word) => self.word_has_multiline_literal_source(word),
+            AssignmentValue::Compound(array) => array
+                .elements
                 .iter()
-                .find_map(|(candidate, facts)| (candidate.span == key.span).then_some(facts))
-            else {
-                unreachable!("missing sequence facts");
-            };
-            facts
-        })
+                .any(|element| self.word_has_multiline_literal_source(array_elem_parts(element).1)),
+        }
+    }
+
+    pub(crate) fn assignment_has_multiline_literal_source(
+        &self,
+        assignment: &Assignment,
+        source: &str,
+    ) -> bool {
+        self.assignment_value_has_multiline_literal_source(assignment)
+            || matches!(&assignment.value, AssignmentValue::Scalar(_))
+                && assignment_has_raw_backslash_continuation_literal(assignment, source)
+    }
+
+    pub(crate) fn sequence_contains_comments(&self, sequence: &StmtSeq) -> bool {
+        self.sequence_by_span(FactSpan::from(sequence.span))
+            .contains_comments()
+    }
+
+    pub(crate) fn sequence_contains_heredoc(&self, sequence: &StmtSeq) -> bool {
+        self.sequence_by_span(FactSpan::from(sequence.span))
+            .contains_heredoc()
+    }
+
+    pub(crate) fn sequence_contains_multiline_literal_source(&self, sequence: &StmtSeq) -> bool {
+        self.sequence_by_span(FactSpan::from(sequence.span))
+            .contains_multiline_literal_source()
+    }
+
+    pub(crate) fn sequence_contains_multistatement_pipeline_brace_group(
+        &self,
+        sequence: &StmtSeq,
+    ) -> bool {
+        self.sequence_by_span(FactSpan::from(sequence.span))
+            .contains_multistatement_pipeline_brace_group()
     }
 
     pub(crate) fn pipeline_has_explicit_line_break(&self, pipeline: &BinaryCommand) -> bool {
@@ -392,6 +490,10 @@ impl<'source> FormatterFacts<'source> {
                     .then_some(FactSpan::from(stmt_span(stmt)))
             })
             .is_some_and(|key| self.background_breaks.contains(&key))
+    }
+
+    pub(crate) fn stmt_contains_heredoc(&self, stmt: &Stmt) -> bool {
+        self.stmt(stmt).contains_heredoc()
     }
 
     pub(crate) fn group_was_inline_in_source(&self, commands: &StmtSeq) -> bool {
@@ -566,6 +668,7 @@ impl<'source> FormatterFacts<'source> {
     pub(crate) fn len(&self) -> usize {
         self.stmt_facts.len()
             + self.sequence_facts.len()
+            + self.word_facts.len()
             + self.pipeline_breaks.len()
             + self.list_item_breaks.len()
             + self.background_breaks.len()
@@ -576,6 +679,343 @@ impl<'source> FormatterFacts<'source> {
             + self.case_facts.len()
             + self.case_item_facts.len()
             + self.indexer.region_index().heredoc_ranges().len()
+    }
+}
+
+pub(crate) fn classify_word_has_multiline_literal_source(word: &Word, source: &str) -> bool {
+    if raw_word_source_slice(word, source).is_some_and(|raw| {
+        raw.contains("\\\n")
+            && word_has_multiline_double_quoted_source(word, source)
+            && !word_is_quoted_command_substitution_only(word)
+    }) {
+        return true;
+    }
+
+    word_part_nodes_any(&word.parts, &mut |part| {
+        word_part_has_multiline_literal_source(&part.kind, part.span, source)
+    })
+}
+
+pub(crate) fn classify_sequence_contains_multiline_literal_source(
+    sequence: &StmtSeq,
+    source: &str,
+) -> bool {
+    let mut visitor = MultilineLiteralFinder::new(source);
+    visitor.visit_stmt_seq(sequence);
+    visitor.found
+}
+
+pub(crate) fn classify_sequence_contains_comments(sequence: &StmtSeq) -> bool {
+    let mut visitor = CommentFinder::default();
+    visitor.visit_stmt_seq(sequence);
+    visitor.found
+}
+
+pub(crate) fn classify_stmt_contains_heredoc(stmt: &Stmt) -> bool {
+    let mut visitor = HeredocFinder::default();
+    visitor.visit_stmt(stmt);
+    visitor.found
+}
+
+pub(crate) fn classify_sequence_contains_heredoc(sequence: &StmtSeq) -> bool {
+    let mut visitor = HeredocFinder::default();
+    visitor.visit_stmt_seq(sequence);
+    visitor.found
+}
+
+pub(crate) fn classify_sequence_contains_multistatement_pipeline_brace_group(
+    statements: &StmtSeq,
+) -> bool {
+    let mut visitor = PipelineBraceGroupFinder::default();
+    visitor.visit_stmt_seq(statements);
+    visitor.found
+}
+
+fn word_part_nodes_any(
+    parts: &[WordPartNode],
+    predicate: &mut impl FnMut(&WordPartNode) -> bool,
+) -> bool {
+    parts.iter().any(|part| {
+        predicate(part)
+            || matches!(
+                &part.kind,
+                WordPart::DoubleQuoted { parts, .. }
+                    if word_part_nodes_any(parts.as_slice(), predicate)
+            )
+    })
+}
+
+fn word_part_has_multiline_literal_source(part: &WordPart, span: Span, source: &str) -> bool {
+    match part {
+        WordPart::Literal(text) => text.as_str(source, span).contains('\n'),
+        WordPart::SingleQuoted { value, dollar } => {
+            if *dollar {
+                raw_source_slice(span, source).is_some_and(|raw| raw.contains('\n'))
+            } else {
+                value.slice(source).contains('\n')
+            }
+        }
+        WordPart::CommandSubstitution { body, .. } => {
+            classify_sequence_contains_multiline_literal_source(body, source)
+                || (classify_sequence_contains_comments(body)
+                    && raw_source_slice(span, source).is_some_and(|raw| {
+                        raw.contains('\n')
+                            && !command_substitution_source_starts_with_body_line(raw)
+                    }))
+        }
+        WordPart::ProcessSubstitution { body, .. } => {
+            classify_sequence_contains_multiline_literal_source(body, source)
+                || (classify_sequence_contains_comments(body)
+                    && raw_source_slice(span, source).is_some_and(|raw| raw.contains('\n')))
+        }
+        _ => false,
+    }
+}
+
+fn redirect_has_multiline_literal_source(redirect: &Redirect, source: &str) -> bool {
+    redirect
+        .word_target()
+        .is_some_and(|word| classify_word_has_multiline_literal_source(word, source))
+        || redirect.heredoc().is_some_and(|heredoc| {
+            classify_word_has_multiline_literal_source(&heredoc.delimiter.raw, source)
+        })
+}
+
+fn assignment_has_multiline_literal_source(assignment: &Assignment, source: &str) -> bool {
+    assignment_value_has_multiline_literal_source(assignment, source)
+        || matches!(&assignment.value, AssignmentValue::Scalar(_))
+            && assignment_has_raw_backslash_continuation_literal(assignment, source)
+}
+
+fn assignment_value_has_multiline_literal_source(assignment: &Assignment, source: &str) -> bool {
+    match &assignment.value {
+        AssignmentValue::Scalar(word) => classify_word_has_multiline_literal_source(word, source),
+        AssignmentValue::Compound(array) => array.elements.iter().any(|element| {
+            classify_word_has_multiline_literal_source(array_elem_parts(element).1, source)
+        }),
+    }
+}
+
+fn assignment_has_raw_backslash_continuation_literal(
+    assignment: &Assignment,
+    source: &str,
+) -> bool {
+    let raw = assignment.span.slice(source);
+    raw.contains("\\\n")
+        && !raw.contains("$(")
+        && !raw.contains('`')
+        && !raw.contains("<(")
+        && !raw.contains(">(")
+}
+
+struct MultilineLiteralFinder<'source> {
+    source: &'source str,
+    found: bool,
+}
+
+impl<'source> MultilineLiteralFinder<'source> {
+    fn new(source: &'source str) -> Self {
+        Self {
+            source,
+            found: false,
+        }
+    }
+}
+
+impl AstVisitor for MultilineLiteralFinder<'_> {
+    fn visit_stmt_seq(&mut self, sequence: &StmtSeq) {
+        if !self.found {
+            visit::walk_stmt_seq(self, sequence);
+        }
+    }
+
+    fn visit_stmt(&mut self, stmt: &Stmt) {
+        if !self.found {
+            visit::walk_stmt(self, stmt);
+        }
+    }
+
+    fn visit_command(&mut self, command: &Command) {
+        if !self.found {
+            visit::walk_command(self, command);
+        }
+    }
+
+    fn visit_redirect(&mut self, redirect: &Redirect) {
+        self.found |= redirect_has_multiline_literal_source(redirect, self.source);
+    }
+
+    fn visit_assignment(&mut self, assignment: &Assignment) {
+        self.found |= assignment_has_multiline_literal_source(assignment, self.source);
+    }
+
+    fn visit_word(&mut self, word: &Word) {
+        self.found |= classify_word_has_multiline_literal_source(word, self.source);
+    }
+}
+
+#[derive(Default)]
+struct CommentFinder {
+    found: bool,
+}
+
+impl AstVisitor for CommentFinder {
+    fn visit_stmt_seq(&mut self, sequence: &StmtSeq) {
+        if self.found {
+            return;
+        }
+        self.found =
+            !sequence.leading_comments.is_empty() || !sequence.trailing_comments.is_empty();
+        if !self.found {
+            visit::walk_stmt_seq(self, sequence);
+        }
+    }
+
+    fn visit_stmt(&mut self, stmt: &Stmt) {
+        if self.found {
+            return;
+        }
+        self.found = !stmt.leading_comments.is_empty() || stmt.inline_comment.is_some();
+        if !self.found {
+            visit::walk_stmt(self, stmt);
+        }
+    }
+}
+
+#[derive(Default)]
+struct HeredocFinder {
+    found: bool,
+}
+
+impl AstVisitor for HeredocFinder {
+    fn visit_stmt(&mut self, stmt: &Stmt) {
+        if !self.found {
+            visit::walk_stmt(self, stmt);
+        }
+    }
+
+    fn visit_stmt_seq(&mut self, sequence: &StmtSeq) {
+        if !self.found {
+            visit::walk_stmt_seq(self, sequence);
+        }
+    }
+
+    fn visit_redirect(&mut self, redirect: &Redirect) {
+        if matches!(
+            redirect.kind,
+            RedirectKind::HereDoc | RedirectKind::HereDocStrip
+        ) {
+            self.found = true;
+        } else {
+            visit::walk_redirect(self, redirect);
+        }
+    }
+
+    fn visit_word(&mut self, _word: &Word) {}
+}
+
+#[derive(Default)]
+struct PipelineBraceGroupFinder {
+    found: bool,
+    in_pipeline: bool,
+}
+
+impl AstVisitor for PipelineBraceGroupFinder {
+    fn visit_stmt_seq(&mut self, sequence: &StmtSeq) {
+        if !self.found {
+            visit::walk_stmt_seq(self, sequence);
+        }
+    }
+
+    fn visit_stmt(&mut self, stmt: &Stmt) {
+        if !self.found {
+            visit::walk_stmt(self, stmt);
+        }
+    }
+
+    fn visit_command(&mut self, command: &Command) {
+        if self.found {
+            return;
+        }
+
+        match command {
+            Command::Binary(binary) if matches!(binary.op, BinaryOp::Pipe | BinaryOp::PipeAll) => {
+                let previous = self.in_pipeline;
+                self.in_pipeline = true;
+                self.visit_stmt(&binary.left);
+                self.visit_stmt(&binary.right);
+                self.in_pipeline = previous;
+            }
+            Command::Compound(CompoundCommand::BraceGroup(body)) if self.in_pipeline => {
+                self.found = body.len() > 1;
+            }
+            _ => {}
+        }
+    }
+}
+
+fn word_has_multiline_double_quoted_source(word: &Word, source: &str) -> bool {
+    word_part_nodes_any(&word.parts, &mut |part| {
+        matches!(&part.kind, WordPart::DoubleQuoted { .. })
+            && raw_source_slice(part.span, source).is_some_and(|raw| raw.contains('\n'))
+    })
+}
+
+fn word_is_quoted_command_substitution_only(word: &Word) -> bool {
+    quoted_command_substitution_only_body(word).is_some()
+}
+
+fn quoted_command_substitution_only_body(word: &Word) -> Option<&StmtSeq> {
+    let [
+        shuck_ast::WordPartNode {
+            kind:
+                WordPart::DoubleQuoted {
+                    parts,
+                    dollar: false,
+                },
+            ..
+        },
+    ] = word.parts.as_slice()
+    else {
+        return None;
+    };
+
+    let mut substitution_body = None;
+    for part in parts {
+        match &part.kind {
+            WordPart::CommandSubstitution { body, .. } if substitution_body.is_none() => {
+                substitution_body = Some(body);
+            }
+            WordPart::Literal(text) if text.is_empty() => {}
+            _ => return None,
+        }
+    }
+
+    substitution_body
+}
+
+fn command_substitution_source_starts_with_body_line(raw: &str) -> bool {
+    if raw.starts_with(['\n', '\r']) {
+        return true;
+    }
+    raw.strip_prefix("$(")
+        .is_some_and(|after_open| after_open.starts_with(['\n', '\r']))
+}
+
+fn raw_word_source_slice<'a>(word: &Word, source: &'a str) -> Option<&'a str> {
+    raw_source_slice(word.span, source)
+}
+
+fn raw_source_slice(span: Span, source: &str) -> Option<&str> {
+    if span.start.offset >= span.end.offset || span.end.offset > source.len() {
+        return None;
+    }
+
+    let slice = span.slice(source);
+    if slice.contains('\n') {
+        Some(slice)
+    } else {
+        Some(trim_unescaped_trailing_whitespace(slice))
     }
 }
 
@@ -751,6 +1191,7 @@ impl<'source, 'options> FormatterFactsBuilder<'source, 'options> {
                 source_map,
                 stmt_facts: HashMap::new(),
                 sequence_facts: HashMap::new(),
+                word_facts: HashMap::new(),
                 pipeline_breaks: HashSet::new(),
                 list_item_breaks: HashSet::new(),
                 background_breaks: HashSet::new(),
@@ -824,6 +1265,12 @@ impl<'source, 'options> FormatterFactsBuilder<'source, 'options> {
                     .map(|(span, _)| span)
             })
         });
+        facts.contains_comments = classify_sequence_contains_comments(sequence);
+        facts.contains_heredoc = classify_sequence_contains_heredoc(sequence);
+        facts.contains_multiline_literal_source =
+            classify_sequence_contains_multiline_literal_source(sequence, self.source);
+        facts.contains_multistatement_pipeline_brace_group =
+            classify_sequence_contains_multistatement_pipeline_brace_group(sequence);
         let group_attachment_span = group_open_char.and_then(|open| {
             let close = match open {
                 '{' => '}',
@@ -939,6 +1386,7 @@ impl<'source, 'options> FormatterFactsBuilder<'source, 'options> {
     fn visit_stmt(&mut self, stmt: &Stmt) {
         let stmt_key = FactSpan::from(stmt_span(stmt));
         if !self.facts.stmt_facts.contains_key(&stmt_key) {
+            let contains_heredoc = classify_stmt_contains_heredoc(stmt);
             let preserve_verbatim = should_render_verbatim(stmt, self.source_map(), self.options);
             let render_span = if preserve_verbatim {
                 stmt_verbatim_span_with_source_map(stmt, self.source_map())
@@ -958,6 +1406,7 @@ impl<'source, 'options> FormatterFactsBuilder<'source, 'options> {
                     rendered_end_line: rendered_stmt_end_line(stmt, self.source, self.source_map()),
                     has_trailing_comment: stmt_has_trailing_comment(stmt, self.source_map()),
                     preserve_verbatim,
+                    contains_heredoc,
                 },
             );
         }
@@ -1401,6 +1850,7 @@ impl<'source, 'options> FormatterFactsBuilder<'source, 'options> {
             self.visit_word(word);
         }
         if let Some(heredoc) = redirect.heredoc() {
+            self.visit_word(&heredoc.delimiter.raw);
             self.visit_heredoc_body(&heredoc.body);
         }
     }
@@ -1425,7 +1875,21 @@ impl<'source, 'options> FormatterFactsBuilder<'source, 'options> {
     }
 
     fn visit_word(&mut self, word: &Word) {
+        let word_key = FactSpan::from(word.span);
+        if self.facts.word_facts.contains_key(&word_key) {
+            return;
+        }
+
         visit::walk_word(self, word);
+        self.facts.word_facts.insert(
+            word_key,
+            WordFacts {
+                has_multiline_literal_source: classify_word_has_multiline_literal_source(
+                    word,
+                    self.source,
+                ),
+            },
+        );
     }
 
     fn visit_word_part(&mut self, part: &WordPart, span: Span) {
@@ -2531,6 +2995,49 @@ mod tests {
                 .close_suffix_comment_after_span(case_facts.esac_span().unwrap())
                 .is_some()
         );
+    }
+
+    #[test]
+    fn records_non_layout_classification_facts() {
+        let source = "value=\"one\ntwo\"\ncat <<EOF\nhi\nEOF\nfoo | { a; b; }\n";
+        let (file, facts) = build_facts(source);
+
+        let Command::Simple(command) = &file.body[0].command else {
+            panic!("expected simple assignment");
+        };
+        let AssignmentValue::Scalar(word) = &command.assignments[0].value else {
+            panic!("expected scalar assignment");
+        };
+
+        assert!(facts.word_has_multiline_literal_source(word));
+        assert!(facts.stmt(&file.body[1]).contains_heredoc());
+        assert!(facts.sequence_contains_heredoc(&file.body));
+        assert!(facts.sequence_contains_multistatement_pipeline_brace_group(&file.body));
+    }
+
+    #[test]
+    fn records_nested_sequence_comment_classification_facts() {
+        let source = "value=$(echo hi\n  # note\n)\n";
+        let (file, facts) = build_facts(source);
+
+        let Command::Simple(command) = &file.body[0].command else {
+            panic!("expected simple assignment");
+        };
+        let AssignmentValue::Scalar(word) = &command.assignments[0].value else {
+            panic!("expected scalar assignment");
+        };
+        let [
+            WordPartNode {
+                kind: WordPart::CommandSubstitution { body, .. },
+                ..
+            },
+        ] = word.parts.as_slice()
+        else {
+            panic!("expected command substitution word");
+        };
+
+        assert!(facts.sequence_contains_comments(body));
+        assert!(facts.word_has_multiline_literal_source(word));
     }
 
     #[test]

--- a/crates/shuck-formatter/src/streaming/mod.rs
+++ b/crates/shuck-formatter/src/streaming/mod.rs
@@ -33,12 +33,12 @@ use crate::command::{
     multiline_compound_assignment_layout, multiline_compound_assignment_lines,
     render_assignment_head_to_buf, render_assignment_with_facts_to_buf, render_background_operator,
     render_subscript_to_buf, render_var_ref_to_buf, simple_command_uses_synthetic_words,
-    slice_span, stmt_attachment_span, stmt_format_span, stmt_render_start_line,
-    stmt_seq_has_heredoc, stmt_span, stmt_start_after_operator, stmt_verbatim_span_with_source_map,
+    slice_span, stmt_attachment_span, stmt_format_span, stmt_render_start_line, stmt_span,
+    stmt_start_after_operator, stmt_verbatim_span_with_source_map,
     trim_unescaped_trailing_whitespace,
 };
 use crate::comments::{SourceComment, SourceMap};
-use crate::facts::FormatterFacts;
+use crate::facts::{FormatterFacts, classify_sequence_contains_heredoc};
 use crate::options::{IndentStyle, ResolvedShellFormatOptions};
 use crate::scan::{
     BranchPrefixComment, heredoc_start, last_shell_keyword_start,
@@ -46,13 +46,12 @@ use crate::scan::{
     skip_double_quoted, skip_single_quoted, source_between_offsets,
 };
 use crate::word::{
-    assignment_value_has_multiline_literal_source as assignment_has_multiline_literal_source,
     normalize_raw_empty_parameter_replacement_delimiters,
     normalize_raw_unquoted_word_continuations, render_arithmetic_expr_to_buf,
     render_escaped_multiline_word_syntax_with_facts_to_buf, render_heredoc_body_to_buf,
     render_pattern_syntax_to_buf, render_word_syntax_with_facts_to_buf,
-    word_gap_end_before_trailing_continuation, word_has_multiline_literal_source,
-    word_is_quoted_command_substitution_only, word_is_quoted_formattable_command_substitution_only,
+    word_gap_end_before_trailing_continuation, word_is_quoted_command_substitution_only,
+    word_is_quoted_formattable_command_substitution_only_with_facts,
 };
 use writer::{BufferSink, CompareSink, PendingHeredoc, ShellWriter, StreamSink};
 
@@ -448,7 +447,7 @@ fn heredoc_body_contains_command_substitution(body: &HeredocBody) -> bool {
 fn word_part_contains_command_heredoc(part: &WordPart) -> bool {
     match part {
         WordPart::CommandSubstitution { body, .. } | WordPart::ProcessSubstitution { body, .. } => {
-            stmt_seq_has_heredoc(body)
+            classify_sequence_contains_heredoc(body)
         }
         WordPart::DoubleQuoted { parts, .. } => parts
             .iter()
@@ -936,11 +935,11 @@ fn assignment_source_has_leading_pipe_continuation(assignment: &Assignment, sour
 
 fn assignment_value_is_quoted_formattable_command_substitution_only(
     assignment: &Assignment,
-    source: &str,
+    facts: &FormatterFacts<'_>,
 ) -> bool {
     match &assignment.value {
         AssignmentValue::Scalar(word) => {
-            word_is_quoted_formattable_command_substitution_only(word, source)
+            word_is_quoted_formattable_command_substitution_only_with_facts(word, facts)
         }
         AssignmentValue::Compound(_) => false,
     }

--- a/crates/shuck-formatter/src/streaming/statements.rs
+++ b/crates/shuck-formatter/src/streaming/statements.rs
@@ -198,7 +198,9 @@ where
             self.format_redirect_list(&stmt.redirects);
         }
 
-        self.queue_heredocs(&stmt.redirects);
+        if self.facts().stmt_contains_heredoc(stmt) {
+            self.queue_heredocs(&stmt.redirects);
+        }
 
         match stmt.terminator {
             Some(StmtTerminator::Background(operator)) => {
@@ -722,7 +724,9 @@ where
             || !raw.contains(';')
             || raw.contains('#')
             || raw.contains("\n\n")
-            || assignment_has_multiline_literal_source(assignment, self.source())
+            || self
+                .facts()
+                .assignment_has_multiline_literal_source(assignment, self.source())
         {
             return false;
         }

--- a/crates/shuck-formatter/src/streaming/substitutions.rs
+++ b/crates/shuck-formatter/src/streaming/substitutions.rs
@@ -280,11 +280,11 @@ where
         {
             self.write_shell_text_with_heredoc_tails(&scratch, true);
         } else if scratch.contains('\n')
-            && (word_is_quoted_formattable_command_substitution_only(word, self.source())
+            && (word_is_quoted_formattable_command_substitution_only_with_facts(word, self.facts())
                 || word_contains_process_substitution(word))
         {
             self.write_text_preserving_current_line_indent(&scratch);
-        } else if word_has_multiline_literal_source(word, self.source()) {
+        } else if self.facts().word_has_multiline_literal_source(word) {
             if scratch.contains('\n')
                 && (word_contains_command_substitution(word)
                     || rendered_text_has_shell_substitution(&scratch))
@@ -368,7 +368,7 @@ where
         } else if scratch.contains('\n')
             && assignment_value_is_quoted_formattable_command_substitution_only(
                 assignment,
-                self.source(),
+                self.facts(),
             )
         {
             self.write_text_preserving_current_line_indent(&scratch);
@@ -377,7 +377,10 @@ where
         {
             if compound_assignment_is_single_case_command_substitution(assignment) {
                 self.write_text_preserving_current_line_indent(&scratch);
-            } else if assignment_has_multiline_literal_source(assignment, self.source()) {
+            } else if self
+                .facts()
+                .assignment_has_multiline_literal_source(assignment, self.source())
+            {
                 if assignment_value_is_quoted_command_substitution_only(assignment) {
                     self.write_command_substitution_assignment_text(&scratch);
                 } else if assignment_source_has_leading_pipe_continuation(assignment, self.source())
@@ -396,7 +399,10 @@ where
             } else {
                 self.write_text_preserving_current_line_indent(&scratch);
             }
-        } else if assignment_has_multiline_literal_source(assignment, self.source()) {
+        } else if self
+            .facts()
+            .assignment_has_multiline_literal_source(assignment, self.source())
+        {
             self.write_rendered_shell_text(&scratch);
         } else {
             self.write_text(&scratch);
@@ -483,7 +489,10 @@ where
         assignment: &Assignment,
     ) -> bool {
         let source = self.source();
-        if !assignment_has_multiline_literal_source(assignment, source) {
+        if !self
+            .facts()
+            .assignment_has_multiline_literal_source(assignment, source)
+        {
             return false;
         }
 

--- a/crates/shuck-formatter/src/word.rs
+++ b/crates/shuck-formatter/src/word.rs
@@ -1,8 +1,11 @@
 use std::fmt::Write as _;
 
-use crate::command::{array_elem_parts, stmt_seq_has_heredoc, trim_unescaped_trailing_whitespace};
+use crate::command::trim_unescaped_trailing_whitespace;
 use crate::comments::SourceMap;
-use crate::facts::FormatterFacts;
+use crate::facts::{
+    FormatterFacts, classify_sequence_contains_comments, classify_sequence_contains_heredoc,
+    classify_sequence_contains_multiline_literal_source,
+};
 use crate::options::{IndentStyle, ResolvedShellFormatOptions};
 use crate::scan::{
     common_nonempty_shell_indent, heredoc_start, leading_shell_indent as line_leading_shell_indent,
@@ -11,13 +14,12 @@ use crate::scan::{
     shell_comment_can_start,
 };
 use crate::streaming::format_stmt_sequence_streaming_to_buf;
-use crate::visit::{self, AstVisitor};
 use shuck_ast::{
     ArithmeticAssignOp, ArithmeticBinaryOp, ArithmeticExpansionSyntax, ArithmeticExpr,
-    ArithmeticExprNode, ArithmeticLvalue, ArithmeticPostfixOp, ArithmeticUnaryOp, Assignment,
-    AssignmentValue, BinaryOp, BourneParameterExpansion, Command, CommandSubstitutionSyntax,
-    CompoundCommand, HeredocBody, HeredocBodyPart, ParameterOp, Pattern, PatternPart, Redirect,
-    Stmt, StmtSeq, SubscriptSelector, VarRef, Word, WordPart, WordPartNode,
+    ArithmeticExprNode, ArithmeticLvalue, ArithmeticPostfixOp, ArithmeticUnaryOp, BinaryOp,
+    BourneParameterExpansion, Command, CommandSubstitutionSyntax, CompoundCommand, HeredocBody,
+    HeredocBodyPart, ParameterOp, Pattern, PatternPart, Stmt, StmtSeq, SubscriptSelector, VarRef,
+    Word, WordPart, WordPartNode,
 };
 
 pub(crate) fn word_gap_end_before_trailing_continuation(word: &Word, source: &str) -> usize {
@@ -121,143 +123,6 @@ pub(crate) fn render_escaped_multiline_word_syntax_with_facts_to_buf(
     let source_map = Some(source_map);
     let facts = Some(facts);
     render_word_syntax_internal(word, source, options, source_map, facts, false, rendered);
-}
-
-pub(crate) fn word_has_multiline_literal_source(word: &Word, source: &str) -> bool {
-    if raw_word_source_slice(word, source).is_some_and(|raw| {
-        raw.contains("\\\n")
-            && word_has_multiline_double_quoted_source(word, source)
-            && !word_is_quoted_command_substitution_only(word)
-    }) {
-        return true;
-    }
-
-    word_part_nodes_any(&word.parts, &mut |part| {
-        word_part_has_multiline_literal_source(&part.kind, part.span, source)
-    })
-}
-
-fn word_part_has_multiline_literal_source(
-    part: &WordPart,
-    span: shuck_ast::Span,
-    source: &str,
-) -> bool {
-    match part {
-        WordPart::Literal(text) => text.as_str(source, span).contains('\n'),
-        WordPart::SingleQuoted { value, dollar } => {
-            if *dollar {
-                raw_source_slice(span, source).is_some_and(|raw| raw.contains('\n'))
-            } else {
-                value.slice(source).contains('\n')
-            }
-        }
-        WordPart::CommandSubstitution { body, .. } => {
-            stmt_seq_has_multiline_literal_source(body, source)
-                || (stmt_seq_contains_comments(body)
-                    && raw_source_slice(span, source).is_some_and(|raw| {
-                        raw.contains('\n')
-                            && !command_substitution_source_starts_with_body_line(raw)
-                    }))
-        }
-        WordPart::ProcessSubstitution { body, .. } => {
-            stmt_seq_has_multiline_literal_source(body, source)
-                || (stmt_seq_contains_comments(body)
-                    && raw_source_slice(span, source).is_some_and(|raw| raw.contains('\n')))
-        }
-        _ => false,
-    }
-}
-
-fn stmt_seq_has_multiline_literal_source(sequence: &StmtSeq, source: &str) -> bool {
-    let mut visitor = MultilineLiteralFinder::new(source);
-    visitor.visit_stmt_seq(sequence);
-    visitor.found
-}
-
-struct MultilineLiteralFinder<'source> {
-    source: &'source str,
-    found: bool,
-}
-
-impl<'source> MultilineLiteralFinder<'source> {
-    fn new(source: &'source str) -> Self {
-        Self {
-            source,
-            found: false,
-        }
-    }
-}
-
-impl AstVisitor for MultilineLiteralFinder<'_> {
-    fn visit_stmt_seq(&mut self, sequence: &StmtSeq) {
-        if !self.found {
-            visit::walk_stmt_seq(self, sequence);
-        }
-    }
-
-    fn visit_stmt(&mut self, stmt: &Stmt) {
-        if !self.found {
-            visit::walk_stmt(self, stmt);
-        }
-    }
-
-    fn visit_command(&mut self, command: &Command) {
-        if !self.found {
-            visit::walk_command(self, command);
-        }
-    }
-
-    fn visit_redirect(&mut self, redirect: &Redirect) {
-        self.found |= redirect_has_multiline_literal_source(redirect, self.source);
-    }
-
-    fn visit_assignment(&mut self, assignment: &Assignment) {
-        self.found |= assignment_has_multiline_literal_source(assignment, self.source);
-    }
-
-    fn visit_word(&mut self, word: &Word) {
-        self.found |= word_has_multiline_literal_source(word, self.source);
-    }
-}
-
-fn redirect_has_multiline_literal_source(redirect: &Redirect, source: &str) -> bool {
-    redirect
-        .word_target()
-        .is_some_and(|word| word_has_multiline_literal_source(word, source))
-        || redirect.heredoc().is_some_and(|heredoc| {
-            word_has_multiline_literal_source(&heredoc.delimiter.raw, source)
-        })
-}
-
-fn assignment_has_multiline_literal_source(assignment: &Assignment, source: &str) -> bool {
-    assignment_value_has_multiline_literal_source(assignment, source)
-        || matches!(&assignment.value, AssignmentValue::Scalar(_))
-            && assignment_has_raw_backslash_continuation_literal(assignment, source)
-}
-
-pub(crate) fn assignment_value_has_multiline_literal_source(
-    assignment: &Assignment,
-    source: &str,
-) -> bool {
-    match &assignment.value {
-        AssignmentValue::Scalar(word) => word_has_multiline_literal_source(word, source),
-        AssignmentValue::Compound(array) => array
-            .elements
-            .iter()
-            .any(|element| word_has_multiline_literal_source(array_elem_parts(element).1, source)),
-    }
-}
-
-fn assignment_has_raw_backslash_continuation_literal(
-    assignment: &Assignment,
-    source: &str,
-) -> bool {
-    let raw = assignment.span.slice(source);
-    raw.contains("\\\n")
-        && !raw.contains("$(")
-        && !raw.contains('`')
-        && !raw.contains("<(")
-        && !raw.contains(">(")
 }
 
 pub(crate) fn render_heredoc_body_to_buf(
@@ -537,7 +402,15 @@ pub(crate) fn word_is_quoted_formattable_command_substitution_only(
     source: &str,
 ) -> bool {
     quoted_command_substitution_only_body(word)
-        .is_some_and(|body| !stmt_seq_has_multiline_literal_source(body, source))
+        .is_some_and(|body| !classify_sequence_contains_multiline_literal_source(body, source))
+}
+
+pub(crate) fn word_is_quoted_formattable_command_substitution_only_with_facts(
+    word: &Word,
+    facts: &FormatterFacts<'_>,
+) -> bool {
+    quoted_command_substitution_only_body(word)
+        .is_some_and(|body| !facts.sequence_contains_multiline_literal_source(body))
 }
 
 pub(crate) fn word_is_quoted_command_substitution_only(word: &Word) -> bool {
@@ -654,6 +527,7 @@ fn render_heredoc_body_part(
                 span.end.offset,
                 source,
                 options,
+                facts,
                 raw,
             )
             .is_none()
@@ -661,6 +535,7 @@ fn render_heredoc_body_part(
                 let layout = command_substitution_layout(
                     raw,
                     body,
+                    Some(facts),
                     source,
                     options.dialect(),
                     raw.is_none() && *syntax == CommandSubstitutionSyntax::DollarParen,
@@ -1097,6 +972,7 @@ fn render_word_part(
                 let layout = command_substitution_layout(
                     Some(raw),
                     body,
+                    facts,
                     source,
                     options.dialect(),
                     false,
@@ -1108,7 +984,7 @@ fn render_word_part(
                         render_inline_raw_command_substitution_as_block(raw, options)
                 {
                     rendered.push_str(&block);
-                } else if stmt_seq_contains_comments(body) {
+                } else if stmt_seq_contains_comments(facts, body) {
                     if commented_command_substitution_can_use_structural_formatter(body) {
                         let rendered_start = rendered.len();
                         if render_command_substitution(
@@ -1138,6 +1014,7 @@ fn render_word_part(
                                 source,
                                 span.start.offset,
                                 options,
+                                facts,
                                 false,
                             );
                         }
@@ -1149,6 +1026,7 @@ fn render_word_part(
                             source,
                             span.start.offset,
                             options,
+                            facts,
                             true,
                         );
                     }
@@ -1182,6 +1060,7 @@ fn render_word_part(
                 command_substitution_layout(
                     None,
                     body,
+                    facts,
                     source,
                     options.dialect(),
                     *syntax == CommandSubstitutionSyntax::DollarParen,
@@ -1200,9 +1079,9 @@ fn render_word_part(
         }
         WordPart::ProcessSubstitution { body, is_input } => {
             if let Some(raw) = raw_source_slice(span, source) {
-                if stmt_seq_contains_comments(body) {
+                if stmt_seq_contains_comments(facts, body) {
                     if process_substitution_source_opens_to_body_line(raw)
-                        && !stmt_seq_has_heredoc(body)
+                        && !stmt_seq_has_heredoc(facts, body)
                     {
                         push_raw_block_command_substitution_without_outer_indent(
                             rendered,
@@ -1657,38 +1536,18 @@ fn parameter_prefers_raw_source(
     })
 }
 
-fn stmt_seq_contains_comments(sequence: &StmtSeq) -> bool {
-    let mut visitor = CommentFinder::default();
-    visitor.visit_stmt_seq(sequence);
-    visitor.found
+fn stmt_seq_contains_comments(facts: Option<&FormatterFacts<'_>>, sequence: &StmtSeq) -> bool {
+    facts.map_or_else(
+        || classify_sequence_contains_comments(sequence),
+        |facts| facts.sequence_contains_comments(sequence),
+    )
 }
 
-#[derive(Default)]
-struct CommentFinder {
-    found: bool,
-}
-
-impl AstVisitor for CommentFinder {
-    fn visit_stmt_seq(&mut self, sequence: &StmtSeq) {
-        if self.found {
-            return;
-        }
-        self.found =
-            !sequence.leading_comments.is_empty() || !sequence.trailing_comments.is_empty();
-        if !self.found {
-            visit::walk_stmt_seq(self, sequence);
-        }
-    }
-
-    fn visit_stmt(&mut self, stmt: &Stmt) {
-        if self.found {
-            return;
-        }
-        self.found = !stmt.leading_comments.is_empty() || stmt.inline_comment.is_some();
-        if !self.found {
-            visit::walk_stmt(self, stmt);
-        }
-    }
+fn stmt_seq_has_heredoc(facts: Option<&FormatterFacts<'_>>, sequence: &StmtSeq) -> bool {
+    facts.map_or_else(
+        || classify_sequence_contains_heredoc(sequence),
+        |facts| facts.sequence_contains_heredoc(sequence),
+    )
 }
 
 fn push_raw_command_substitution_comment_fallback(
@@ -1698,12 +1557,14 @@ fn push_raw_command_substitution_comment_fallback(
     source: &str,
     span_start: usize,
     options: &ResolvedShellFormatOptions,
+    facts: Option<&FormatterFacts<'_>>,
     try_normalized_body: bool,
 ) {
     if push_inline_raw_command_substitution_as_block(rendered, raw, options) {
         return;
     }
-    if command_substitution_source_starts_with_body_line(raw) && !stmt_seq_has_heredoc(body) {
+    if command_substitution_source_starts_with_body_line(raw) && !stmt_seq_has_heredoc(facts, body)
+    {
         push_raw_block_command_substitution_without_outer_indent(
             rendered, raw, source, span_start, options,
         );
@@ -2030,6 +1891,7 @@ fn render_heredoc_body_command_substitution(
     upper_bound: usize,
     source: &str,
     options: &ResolvedShellFormatOptions,
+    facts: &FormatterFacts<'_>,
     raw: Option<&str>,
 ) -> Option<()> {
     let raw = raw?;
@@ -2042,7 +1904,7 @@ fn render_heredoc_body_command_substitution(
         source,
         body,
         options,
-        None,
+        Some(facts),
         Some(upper_bound),
         &mut nested,
     )?;
@@ -2292,6 +2154,7 @@ enum CommandSubstitutionLayout {
 fn command_substitution_layout(
     raw: Option<&str>,
     body: &shuck_ast::StmtSeq,
+    facts: Option<&FormatterFacts<'_>>,
     source: &str,
     dialect: shuck_parser::ShellDialect,
     force_block: bool,
@@ -2301,7 +2164,7 @@ fn command_substitution_layout(
         return CommandSubstitutionLayout::Block;
     }
 
-    if stmt_seq_has_heredoc(body) {
+    if stmt_seq_has_heredoc(facts, body) {
         return CommandSubstitutionLayout::Block;
     }
 
@@ -3280,7 +3143,9 @@ fn render_inline_raw_command_substitution_as_block(
     if parsed.is_err() {
         return None;
     }
-    let inline_multiline = stmt_seq_contains_multistatement_pipeline_brace_group(&parsed.file.body)
+    let parsed_facts = FormatterFacts::build(body, &parsed.file, options);
+    let inline_multiline = parsed_facts
+        .sequence_contains_multistatement_pipeline_brace_group(&parsed.file.body)
         || raw_body_contains_pipeline_multistatement_brace_group(body);
     if parsed.file.body.len() <= 1 && !inline_multiline {
         return None;
@@ -3309,52 +3174,6 @@ fn render_inline_raw_command_substitution_as_block(
         rendered.push_str("\n)");
     }
     Some(rendered)
-}
-
-fn stmt_seq_contains_multistatement_pipeline_brace_group(statements: &StmtSeq) -> bool {
-    let mut visitor = PipelineBraceGroupFinder::default();
-    visitor.visit_stmt_seq(statements);
-    visitor.found
-}
-
-#[derive(Default)]
-struct PipelineBraceGroupFinder {
-    found: bool,
-    in_pipeline: bool,
-}
-
-impl AstVisitor for PipelineBraceGroupFinder {
-    fn visit_stmt_seq(&mut self, sequence: &StmtSeq) {
-        if !self.found {
-            visit::walk_stmt_seq(self, sequence);
-        }
-    }
-
-    fn visit_stmt(&mut self, stmt: &Stmt) {
-        if !self.found {
-            visit::walk_stmt(self, stmt);
-        }
-    }
-
-    fn visit_command(&mut self, command: &Command) {
-        if self.found {
-            return;
-        }
-
-        match command {
-            Command::Binary(binary) if matches!(binary.op, BinaryOp::Pipe | BinaryOp::PipeAll) => {
-                let previous = self.in_pipeline;
-                self.in_pipeline = true;
-                self.visit_stmt(&binary.left);
-                self.visit_stmt(&binary.right);
-                self.in_pipeline = previous;
-            }
-            Command::Compound(CompoundCommand::BraceGroup(body)) if self.in_pipeline => {
-                self.found = body.len() > 1;
-            }
-            _ => {}
-        }
-    }
 }
 
 fn raw_body_contains_pipeline_multistatement_brace_group(body: &str) -> bool {
@@ -4325,7 +4144,7 @@ fn render_process_substitution(
     raw: Option<&str>,
     facts: Option<&FormatterFacts<'_>>,
 ) -> Option<()> {
-    let has_heredoc = stmt_seq_has_heredoc(body);
+    let has_heredoc = stmt_seq_has_heredoc(facts, body);
     let mut nested = String::new();
     format_nested_stmt_sequence_to_buf(
         source,


### PR DESCRIPTION
## Summary

- Move render-time formatter classifications into typed formatter facts, including word multiline-literal detection, sequence comment/heredoc checks, statement heredoc checks, and pipeline brace-group detection.
- Route formatter rendering decisions through `FormatterFacts`/`WordFacts` instead of local renderer AST walks.
- Add focused fact tests covering the new non-layout classification data.

## Validation

- `cargo test -p shuck-formatter`
- `make test-oracle-shfmt-large-corpus` (runs to completion with `0` shuck errors and `386` shfmt mismatches; the target exits non-zero because the remaining oracle mismatches are still tracked by the harness)