### PR TITLE
fix(ast): stop backtick recovery scan at first close

### DIFF
--- a/crates/shuck-ast/src/raw_shell.rs
+++ b/crates/shuck-ast/src/raw_shell.rs
@@ -553,6 +553,25 @@ impl<'source> RawShellScanner<'source> {
         None
     }
 
+    /// Skips a legacy backtick command substitution body during recovery scanning.
+    ///
+    /// Unlike shell word scanning, this stops at the first unescaped backtick even when
+    /// an earlier quote in the partially parsed body is not balanced.
+    #[must_use]
+    pub fn skip_legacy_backtick_substitution_body(&self, mut index: usize) -> Option<usize> {
+        let bytes = self.source.as_bytes();
+
+        while index < self.upper {
+            match bytes[index] {
+                b'\\' => index = advance_escaped_shell_char(self.source, index).min(self.upper),
+                b'`' => return Some(index + 1),
+                _ => index = advance_shell_char(self.source, index).min(self.upper),
+            }
+        }
+
+        None
+    }
+
     fn comment_starts_at(&self, offset: usize) -> bool {
         self.source[offset..self.upper].starts_with('#')
             && shell_comment_can_start(self.source, offset)
@@ -647,5 +666,22 @@ mod tests {
         let raw = "echo '$(nope)' $(date) $((1 + 2))";
         let scanner = RawShellScanner::new(raw);
         assert_eq!(scanner.next_command_substitution(0), Some((15, 21)));
+    }
+
+    #[test]
+    fn legacy_backtick_substitution_body_stops_at_first_unescaped_backtick() {
+        let raw = "`echo \"`\" tail`";
+        let scanner = RawShellScanner::new(raw);
+        assert_eq!(
+            scanner.skip_legacy_backtick_substitution_body(1),
+            Some("`echo \"`".len()),
+        );
+    }
+
+    #[test]
+    fn legacy_backtick_construct_keeps_quote_aware_word_scan_behavior() {
+        let raw = "`echo \"`\" tail`";
+        let scanner = RawShellScanner::new(raw);
+        assert_eq!(scanner.skip_legacy_backtick_construct(1), Some(raw.len()));
     }
 }

--- a/crates/shuck-linter/src/facts/word_spans/command_substitution.rs
+++ b/crates/shuck-linter/src/facts/word_spans/command_substitution.rs
@@ -154,7 +154,7 @@ pub(crate) fn widen_backtick_command_substitution_span(
     }
 
     let end_offset = shuck_ast::raw_shell::RawShellScanner::new(source)
-        .skip_legacy_backtick_construct(span.start.offset + 1)?;
+        .skip_legacy_backtick_substitution_body(span.start.offset + 1)?;
     let start = locator.position_at_offset(span.start.offset)?;
     let end = locator.position_at_offset(end_offset)?;
     Some(Span::from_positions(start, end))
@@ -169,6 +169,7 @@ mod tests {
     use super::{
         CommandSubstitutionSpanVisitor, WordTraversalContext, normalize_command_substitution_spans,
         unquoted_command_substitution_part_spans, walk_word_subtree,
+        widen_backtick_command_substitution_span,
     };
     use crate::Locator;
 
@@ -242,5 +243,20 @@ printf '%s\\n' \"left \"$(printf '%s' dollar)\" right\" \"left \"`printf '%s' ti
             .collect::<Vec<_>>();
 
         assert_eq!(spans, vec!["$(printf '%s' dollar)"]);
+    }
+
+    #[test]
+    fn backtick_span_widening_stops_at_unescaped_backtick_inside_double_quote() {
+        let source = "`echo \"`\" tail`";
+        let line_index = LineIndex::new(source);
+        let locator = Locator::new(source, &line_index);
+        let partial = Span::from_positions(
+            locator.position_at_offset(0).unwrap(),
+            locator.position_at_offset(1).unwrap(),
+        );
+
+        let widened = widen_backtick_command_substitution_span(partial, locator).unwrap();
+
+        assert_eq!(widened.slice(source), "`echo \"`");
     }
 }


### PR DESCRIPTION
## Summary
- add a recovery-specific legacy backtick scanner that stops at the first unescaped backtick
- use it for linter command-substitution span widening while preserving quote-aware shell word scanning
- cover both scanner behaviors and the linter widening regression

## Tests
- `cargo fmt --check`
- `cargo test -p shuck-ast raw_shell`
- `cargo test -p shuck-linter backtick_span_widening_stops`
- `cargo clippy -p shuck-ast -p shuck-formatter -p shuck-linter --all-targets -- -D warnings`