### PR TITLE
refactor(formatter): centralize raw shell syntax helpers

### DIFF
--- a/crates/shuck-formatter/src/command.rs
+++ b/crates/shuck-formatter/src/command.rs
@@ -419,10 +419,6 @@ fn multiline_compound_assignment_command_substitution_range<T: AsRef<str>>(
     lines: &[T],
     open_index: usize,
 ) -> Option<(usize, usize, bool)> {
-    if !RawShellText::new(lines.get(open_index)?.as_ref()).has_unclosed_command_substitution_open()
-    {
-        return None;
-    }
     let close_index =
         multiline_compound_assignment_command_substitution_close_index(lines, open_index)?;
     let close_line_is_standalone = lines[close_index]
@@ -441,6 +437,8 @@ fn multiline_compound_assignment_command_substitution_close_index<T: AsRef<str>>
     lines: &[T],
     open_index: usize,
 ) -> Option<usize> {
+    let open = RawShellText::new(lines.get(open_index)?.as_ref())
+        .unclosed_command_substitution_body_start()?;
     let mut tail = String::new();
     for (index, line) in lines.get(open_index..)?.iter().enumerate() {
         if index > 0 {
@@ -448,8 +446,7 @@ fn multiline_compound_assignment_command_substitution_close_index<T: AsRef<str>>
         }
         tail.push_str(line.as_ref());
     }
-    let open = tail.find("$(")?;
-    let close = matching_raw_command_substitution_close(&tail, open + 2)?;
+    let close = matching_raw_command_substitution_close(&tail, open)?;
     Some(open_index + tail[..close].bytes().filter(|byte| *byte == b'\n').count())
 }
 
@@ -2275,5 +2272,14 @@ mod tests {
         let span = first_brace_group_verbatim_span(source);
 
         assert_eq!(span.slice(source), "{ # note\n  echo ok; \\\n}");
+    }
+
+    #[test]
+    fn compound_assignment_command_substitution_matches_unclosed_opener() {
+        let raw_lines = [") $(closed) $(open", "echo body", ")"];
+
+        let body_lines = multiline_compound_assignment_command_substitution_body_lines(&raw_lines);
+
+        assert_eq!(body_lines, vec![false, true, false]);
     }
 }

--- a/crates/shuck-formatter/src/command.rs
+++ b/crates/shuck-formatter/src/command.rs
@@ -1,14 +1,16 @@
 use crate::comments::SourceMap;
 use crate::facts::{FormatterFacts, classify_stmt_contains_heredoc};
 use crate::options::ResolvedShellFormatOptions;
+use crate::raw_syntax::{
+    RawShellText, common_nonempty_shell_indent, leading_shell_indent,
+    matching_raw_command_substitution_close, normalize_raw_pipeline_continuations,
+    refine_common_indent, shell_comment_can_start, skip_escaped_or_quoted,
+};
 use crate::scan::{
-    RawShellScanner, branch_keyword_offset, common_nonempty_shell_indent, last_shell_keyword_start,
-    last_uncommented_shell_keyword_before, leading_shell_indent, matching_done_close_start,
-    matching_if_close_start, normalized_close_keyword_span, refine_common_indent,
-    shell_comment_can_start, skip_escaped_or_quoted,
+    branch_keyword_offset, last_shell_keyword_start, last_uncommented_shell_keyword_before,
+    matching_done_close_start, matching_if_close_start, normalized_close_keyword_span,
 };
 use crate::word::{
-    matching_raw_command_substitution_close, normalize_raw_pipeline_continuations,
     render_arithmetic_expr_to_buf, render_word_syntax_to_buf, render_word_syntax_with_facts_to_buf,
 };
 use shuck_ast::{
@@ -353,7 +355,7 @@ pub(crate) fn multiline_compound_assignment_layout(
         })
         .collect::<Vec<_>>();
     for line in &mut lines {
-        *line = trim_inline_command_substitution_open_padding(line);
+        *line = RawShellText::new(line).trim_command_substitution_open_padding();
     }
     let lines = normalize_multiline_compound_assignment_command_substitutions(lines);
 
@@ -362,42 +364,6 @@ pub(crate) fn multiline_compound_assignment_layout(
         open_inline: !open_line.trim().is_empty(),
         close_inline: !close_line.trim().is_empty(),
     })
-}
-
-fn trim_inline_command_substitution_open_padding(line: &str) -> String {
-    let mut rendered = String::with_capacity(line.len());
-    let mut cursor = 0usize;
-    let mut index = 0usize;
-    let mut in_single_quotes = false;
-    let mut in_double_quotes = false;
-    let mut escaped = false;
-
-    while index < line.len() {
-        let Some(ch) = line[index..].chars().next() else {
-            break;
-        };
-        let next_index = index + ch.len_utf8();
-        if escaped {
-            escaped = false;
-        } else if ch == '\\' && !in_single_quotes {
-            escaped = true;
-        } else if ch == '\'' && !in_double_quotes {
-            in_single_quotes = !in_single_quotes;
-        } else if ch == '"' && !in_single_quotes {
-            in_double_quotes = !in_double_quotes;
-        } else if !in_single_quotes && line[index..].starts_with("$(") {
-            rendered.push_str(&line[cursor..index + 2]);
-            index += 2;
-            while line[index..].starts_with([' ', '\t']) {
-                index += 1;
-            }
-            cursor = index;
-            continue;
-        }
-        index = next_index;
-    }
-    rendered.push_str(&line[cursor..]);
-    rendered
 }
 
 fn normalize_multiline_compound_assignment_command_substitutions(
@@ -453,7 +419,8 @@ fn multiline_compound_assignment_command_substitution_range<T: AsRef<str>>(
     lines: &[T],
     open_index: usize,
 ) -> Option<(usize, usize, bool)> {
-    if !line_has_unclosed_command_substitution_open(lines.get(open_index)?.as_ref()) {
+    if !RawShellText::new(lines.get(open_index)?.as_ref()).has_unclosed_command_substitution_open()
+    {
         return None;
     }
     let close_index =
@@ -551,13 +518,6 @@ pub(crate) fn multiline_compound_assignment_command_substitution_body_prefix(
     }
 }
 
-pub(crate) fn line_has_unclosed_command_substitution_open(line: &str) -> bool {
-    let Some(open) = line.find("$(") else {
-        return false;
-    };
-    !line[open + 2..].contains(')')
-}
-
 fn normalize_multiline_compound_assignment_line(
     line: &str,
     common_indent: &str,
@@ -593,32 +553,19 @@ fn normalize_multiline_compound_assignment_line(
             }
         })
         .unwrap_or(trimmed);
-    let normalized =
-        if preserve_line_continuation && line_starts_with_redirect_continuation(stripped) {
-            format!("\t{}", stripped.trim_start_matches([' ', '\t']))
-        } else if preserve_line_continuation {
-            canonicalize_multiline_compound_assignment_residual_indent(
-                stripped,
-                residual_space_indent_width,
-            )
-        } else {
-            stripped.trim_start_matches([' ', '\t']).to_string()
-        };
+    let normalized = if preserve_line_continuation
+        && RawShellText::new(stripped).starts_with_redirect_continuation()
+    {
+        format!("\t{}", stripped.trim_start_matches([' ', '\t']))
+    } else if preserve_line_continuation {
+        canonicalize_multiline_compound_assignment_residual_indent(
+            stripped,
+            residual_space_indent_width,
+        )
+    } else {
+        stripped.trim_start_matches([' ', '\t']).to_string()
+    };
     normalize_multiline_compound_assignment_spacing(&normalized)
-}
-
-fn line_starts_with_redirect_continuation(line: &str) -> bool {
-    let trimmed = line.trim_start_matches([' ', '\t']);
-    let bytes = trimmed.as_bytes();
-    let mut index = 0;
-    while bytes.get(index).is_some_and(u8::is_ascii_digit) {
-        index += 1;
-    }
-    match bytes.get(index) {
-        Some(b'<' | b'>') => true,
-        Some(b'&') => bytes.get(index + 1) == Some(&b'>'),
-        _ => false,
-    }
 }
 
 fn trim_multiline_compound_assignment_line_continuation(line: &str) -> &str {
@@ -629,21 +576,13 @@ fn trim_multiline_compound_assignment_line_continuation(line: &str) -> &str {
         .rev()
         .take_while(|byte| **byte == b'\\')
         .count();
-    if trailing_backslashes % 2 == 1 && !line_continuation_is_inside_unclosed_substitution(trimmed)
+    if trailing_backslashes % 2 == 1
+        && !RawShellText::new(trimmed).continuation_inside_unclosed_substitution()
     {
         trimmed[..trimmed.len().saturating_sub(1)].trim_end_matches([' ', '\t'])
     } else {
         trimmed
     }
-}
-
-fn line_continuation_is_inside_unclosed_substitution(line: &str) -> bool {
-    let Some(before_continuation) = line.strip_suffix('\\') else {
-        return false;
-    };
-
-    RawShellScanner::new(before_continuation)
-        .has_unclosed_substitution_before(before_continuation.len())
 }
 
 fn multiline_compound_assignment_common_body_indent(lines: &[&str], open_inline: bool) -> String {

--- a/crates/shuck-formatter/src/lib.rs
+++ b/crates/shuck-formatter/src/lib.rs
@@ -16,6 +16,8 @@ mod facts;
 #[allow(missing_docs)]
 mod options;
 #[allow(missing_docs)]
+mod raw_syntax;
+#[allow(missing_docs)]
 mod scan;
 #[allow(missing_docs)]
 mod simplify;
@@ -290,7 +292,7 @@ fn trailing_backslash_count(text: &str) -> usize {
 
 fn trailing_backslash_is_in_comment(text: &str) -> bool {
     let line = text.rsplit_once('\n').map_or(text, |(_, line)| line);
-    scan::RawShellScanner::new(line)
+    raw_syntax::RawShellScanner::new(line)
         .find_comment(0, line.len())
         .is_some()
 }

--- a/crates/shuck-formatter/src/raw_syntax.rs
+++ b/crates/shuck-formatter/src/raw_syntax.rs
@@ -130,7 +130,7 @@ impl<'source> RawShellText<'source> {
         RawShellScanner::new(self.text).next_command_substitution(index)
     }
 
-    pub(crate) fn has_unclosed_command_substitution_open(&self) -> bool {
+    pub(crate) fn unclosed_command_substitution_body_start(&self) -> Option<usize> {
         let bytes = self.text.as_bytes();
         let mut quote = QuoteState::default();
         let mut index = 0usize;
@@ -150,7 +150,7 @@ impl<'source> RawShellText<'source> {
                 && bytes.get(index + 2).is_none_or(|byte| *byte != b'(')
             {
                 let Some(close_offset) = self.matching_command_substitution_close(index + 2) else {
-                    return true;
+                    return Some(index + 2);
                 };
                 index = close_offset + 1;
                 continue;
@@ -158,7 +158,11 @@ impl<'source> RawShellText<'source> {
             index = next_index;
         }
 
-        false
+        None
+    }
+
+    pub(crate) fn has_unclosed_command_substitution_open(&self) -> bool {
+        self.unclosed_command_substitution_body_start().is_some()
     }
 
     pub(crate) fn normalize_pipeline_continuations(&self) -> Option<String> {
@@ -652,6 +656,10 @@ mod tests {
     fn unclosed_command_substitution_ignores_quoted_open() {
         assert!(!RawShellText::new("'$(").has_unclosed_command_substitution_open());
         assert!(RawShellText::new("value=$(echo").has_unclosed_command_substitution_open());
+        assert_eq!(
+            RawShellText::new("$(closed) $(open").unclosed_command_substitution_body_start(),
+            Some(12)
+        );
     }
 
     #[test]

--- a/crates/shuck-formatter/src/raw_syntax.rs
+++ b/crates/shuck-formatter/src/raw_syntax.rs
@@ -1,0 +1,666 @@
+pub(crate) use shuck_ast::raw_shell::{QuoteState, RawShellScanner, shell_comment_can_start};
+
+pub(crate) fn leading_shell_indent(line: &str) -> &str {
+    let indent_end = line
+        .char_indices()
+        .find(|(_, ch)| !matches!(ch, ' ' | '\t'))
+        .map_or(line.len(), |(index, _)| index);
+    &line[..indent_end]
+}
+
+pub(crate) struct HeredocStart<'line> {
+    pub(crate) delimiter: &'line str,
+    pub(crate) strip_tabs: bool,
+    pub(crate) operator_end: usize,
+}
+
+pub(crate) fn heredoc_start(line: &str) -> Option<HeredocStart<'_>> {
+    let marker = line.find("<<")?;
+    let after_marker = &line[marker + 2..];
+    if after_marker.starts_with('<') {
+        return None;
+    }
+    let (strip_tabs, after_marker) = if let Some(rest) = after_marker.strip_prefix('-') {
+        (true, rest)
+    } else {
+        (false, after_marker)
+    };
+    let delimiter = after_marker
+        .split_whitespace()
+        .next()?
+        .trim_matches(['\'', '"']);
+    (!delimiter.is_empty()).then_some(HeredocStart {
+        delimiter,
+        strip_tabs,
+        operator_end: marker + if strip_tabs { 3 } else { 2 },
+    })
+}
+
+pub(crate) fn common_indent_prefix<'a>(left: &'a str, right: &str) -> &'a str {
+    let len = left
+        .as_bytes()
+        .iter()
+        .zip(right.as_bytes())
+        .take_while(|(left, right)| left == right)
+        .count();
+    &left[..len]
+}
+
+pub(crate) fn refine_common_indent(common: &mut Option<String>, indent: &str) -> bool {
+    *common = Some(match common.take() {
+        Some(previous) => common_indent_prefix(&previous, indent).to_string(),
+        None => indent.to_string(),
+    });
+    common.as_deref() == Some("")
+}
+
+pub(crate) fn common_nonempty_shell_indent<'a>(lines: impl IntoIterator<Item = &'a str>) -> String {
+    let mut common: Option<String> = None;
+    for line in lines {
+        if line.trim().is_empty() {
+            continue;
+        }
+        let indent = leading_shell_indent(line);
+        if indent.is_empty() || refine_common_indent(&mut common, indent) {
+            return String::new();
+        }
+    }
+    common.unwrap_or_default()
+}
+
+pub(crate) fn line_without_continuation_backslash(line: &str) -> Option<&str> {
+    let trimmed = line.trim_end_matches([' ', '\t', '\r']);
+    let prefix = trimmed.strip_suffix('\\')?;
+    Some(prefix.trim_end_matches([' ', '\t', '\r']))
+}
+
+pub(crate) fn redirect_operator_end(bytes: &[u8], start: usize) -> Option<usize> {
+    match bytes.get(start).copied()? {
+        b'>' => Some(match bytes.get(start + 1).copied() {
+            Some(b'>' | b'|' | b'&') => start + 2,
+            _ => start + 1,
+        }),
+        b'<' => Some(match bytes.get(start + 1).copied() {
+            Some(b'<' | b'>' | b'&') => {
+                if bytes.get(start + 2) == Some(&b'<') {
+                    start + 3
+                } else {
+                    start + 2
+                }
+            }
+            _ => start + 1,
+        }),
+        _ => None,
+    }
+}
+
+pub(crate) fn skip_single_quoted(source: &str, offset: usize, upper: usize) -> usize {
+    RawShellScanner::bounded(source, upper).skip_single_quoted_body(offset)
+}
+
+pub(crate) fn skip_double_quoted(source: &str, offset: usize, upper: usize) -> usize {
+    RawShellScanner::bounded(source, upper).skip_double_quoted_body(offset)
+}
+
+pub(crate) fn skip_escaped_or_quoted(
+    source: &str,
+    offset: usize,
+    upper: usize,
+    ch: char,
+) -> Option<usize> {
+    debug_assert_eq!(source[offset..].chars().next(), Some(ch));
+    RawShellScanner::bounded(source, upper).skip_escaped_or_quoted_at(offset)
+}
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct RawShellText<'source> {
+    text: &'source str,
+}
+
+impl<'source> RawShellText<'source> {
+    pub(crate) fn new(text: &'source str) -> Self {
+        Self { text }
+    }
+
+    pub(crate) fn matching_command_substitution_close(&self, body_start: usize) -> Option<usize> {
+        RawShellScanner::new(self.text).matching_command_substitution_close(body_start)
+    }
+
+    pub(crate) fn next_command_substitution(&self, index: usize) -> Option<(usize, usize)> {
+        RawShellScanner::new(self.text).next_command_substitution(index)
+    }
+
+    pub(crate) fn has_unclosed_command_substitution_open(&self) -> bool {
+        let bytes = self.text.as_bytes();
+        let mut quote = QuoteState::default();
+        let mut index = 0usize;
+
+        while index + 1 < self.text.len() {
+            let Some(ch) = self.text[index..].chars().next() else {
+                break;
+            };
+            let next_index = index + ch.len_utf8();
+            if quote.consume_shell_word_char(ch) {
+                index = next_index;
+                continue;
+            }
+            if !quote.in_single_quotes()
+                && bytes[index] == b'$'
+                && bytes[index + 1] == b'('
+                && bytes.get(index + 2).is_none_or(|byte| *byte != b'(')
+            {
+                let Some(close_offset) = self.matching_command_substitution_close(index + 2) else {
+                    return true;
+                };
+                index = close_offset + 1;
+                continue;
+            }
+            index = next_index;
+        }
+
+        false
+    }
+
+    pub(crate) fn normalize_pipeline_continuations(&self) -> Option<String> {
+        let trailing = normalize_raw_trailing_pipe_continuations(self.text);
+        let leading =
+            normalize_raw_leading_pipe_continuations(trailing.as_deref().unwrap_or(self.text));
+        leading.or(trailing)
+    }
+
+    pub(crate) fn line_ends_with_continuation_operator(&self) -> bool {
+        line_ends_with_raw_continuation_operator(self.text)
+    }
+
+    pub(crate) fn line_without_trailing_pipe_continuation(&self) -> Option<&'source str> {
+        let prefix = line_without_continuation_backslash(self.text)?;
+        RawShellText::new(prefix)
+            .line_ends_with_continuation_operator()
+            .then_some(prefix)
+    }
+
+    pub(crate) fn leading_pipe_continuation(
+        &self,
+    ) -> Option<(&'source str, &'static str, &'source str)> {
+        leading_pipe_continuation(self.text)
+    }
+
+    pub(crate) fn trim_command_substitution_open_padding(&self) -> String {
+        let mut rendered = String::with_capacity(self.text.len());
+        let mut cursor = 0usize;
+        let mut index = 0usize;
+        let mut in_single_quotes = false;
+        let mut in_double_quotes = false;
+        let mut escaped = false;
+
+        while index < self.text.len() {
+            let Some(ch) = self.text[index..].chars().next() else {
+                break;
+            };
+            let next_index = index + ch.len_utf8();
+            if escaped {
+                escaped = false;
+            } else if ch == '\\' && !in_single_quotes {
+                escaped = true;
+            } else if ch == '\'' && !in_double_quotes {
+                in_single_quotes = !in_single_quotes;
+            } else if ch == '"' && !in_single_quotes {
+                in_double_quotes = !in_double_quotes;
+            } else if !in_single_quotes && self.text[index..].starts_with("$(") {
+                rendered.push_str(&self.text[cursor..index + 2]);
+                index += 2;
+                while self.text[index..].starts_with([' ', '\t']) {
+                    index += 1;
+                }
+                cursor = index;
+                continue;
+            }
+            index = next_index;
+        }
+        rendered.push_str(&self.text[cursor..]);
+        rendered
+    }
+
+    pub(crate) fn starts_with_redirect_continuation(&self) -> bool {
+        let trimmed = self.text.trim_start_matches([' ', '\t']);
+        let bytes = trimmed.as_bytes();
+        let mut index = 0;
+        while bytes.get(index).is_some_and(u8::is_ascii_digit) {
+            index += 1;
+        }
+        match bytes.get(index) {
+            Some(b'<' | b'>') => true,
+            Some(b'&') => bytes.get(index + 1) == Some(&b'>'),
+            _ => false,
+        }
+    }
+
+    pub(crate) fn continuation_inside_unclosed_substitution(&self) -> bool {
+        let Some(before_continuation) = self.text.strip_suffix('\\') else {
+            return false;
+        };
+
+        RawShellScanner::new(before_continuation)
+            .has_unclosed_substitution_before(before_continuation.len())
+    }
+
+    pub(crate) fn quoted_backslash_continuation(&self) -> bool {
+        let mut chars = self.text.chars().peekable();
+        let mut in_single_quotes = false;
+        let mut in_double_quotes = false;
+        while let Some(ch) = chars.next() {
+            if ch == '\'' && !in_double_quotes {
+                in_single_quotes = !in_single_quotes;
+                continue;
+            }
+            if ch == '"' && !in_single_quotes {
+                in_double_quotes = !in_double_quotes;
+                continue;
+            }
+            if ch == '\\' {
+                let mut probe = chars.clone();
+                let escaped_newline = match probe.next() {
+                    Some('\n') => true,
+                    Some('\r') => probe.next().is_some_and(|next| next == '\n'),
+                    _ => false,
+                };
+                if escaped_newline {
+                    return in_single_quotes || in_double_quotes;
+                }
+                if !in_single_quotes {
+                    chars.next();
+                }
+            }
+        }
+        false
+    }
+}
+
+pub(crate) fn normalize_raw_pipeline_continuations(text: &str) -> Option<String> {
+    RawShellText::new(text).normalize_pipeline_continuations()
+}
+
+pub(crate) fn line_ends_with_raw_continuation_operator(line: &str) -> bool {
+    let code = trailing_comment_start(line)
+        .map(|comment_start| &line[..comment_start])
+        .unwrap_or(line);
+    let trimmed = code.trim_end_matches([' ', '\t', '\r']);
+    line_ends_with_pipeline_operator(trimmed) || trimmed.ends_with("&&") || trimmed.ends_with("||")
+}
+
+pub(crate) fn matching_raw_command_substitution_close(
+    raw: &str,
+    body_start: usize,
+) -> Option<usize> {
+    RawShellText::new(raw).matching_command_substitution_close(body_start)
+}
+
+fn line_ends_with_pipeline_operator(line: &str) -> bool {
+    let trimmed = line.trim_end_matches([' ', '\t', '\r']);
+    trimmed.ends_with("|&") || (trimmed.ends_with('|') && !trimmed.ends_with("||"))
+}
+
+fn normalize_raw_trailing_pipe_continuations(text: &str) -> Option<String> {
+    let mut lines = text
+        .split('\n')
+        .map(ToString::to_string)
+        .collect::<Vec<_>>();
+    let mut changed = false;
+
+    for line in &mut lines {
+        let Some(prefix) = RawShellText::new(line)
+            .line_without_trailing_pipe_continuation()
+            .map(str::to_string)
+        else {
+            continue;
+        };
+        *line = prefix;
+        changed = true;
+    }
+
+    changed.then(|| lines.join("\n"))
+}
+
+fn normalize_raw_leading_pipe_continuations(text: &str) -> Option<String> {
+    let mut lines = text
+        .split('\n')
+        .map(ToString::to_string)
+        .collect::<Vec<_>>();
+    let mut changed = false;
+
+    for index in 0..lines.len().saturating_sub(1) {
+        let Some(prefix) = line_without_continuation_backslash(&lines[index]).map(str::to_string)
+        else {
+            continue;
+        };
+        let Some((indent, operator, rest)) = RawShellText::new(&lines[index + 1])
+            .leading_pipe_continuation()
+            .map(|(indent, operator, rest)| {
+                (
+                    indent.to_string(),
+                    operator,
+                    rest.trim_start_matches([' ', '\t', '\r']).to_string(),
+                )
+            })
+        else {
+            continue;
+        };
+
+        lines[index] = format!("{prefix} {operator}");
+        lines[index + 1] = format!("{indent}{rest}");
+        changed = true;
+    }
+
+    changed.then(|| lines.join("\n"))
+}
+
+fn leading_pipe_continuation(line: &str) -> Option<(&str, &'static str, &str)> {
+    let content_start = line
+        .char_indices()
+        .find_map(|(index, ch)| (!matches!(ch, ' ' | '\t')).then_some(index))
+        .unwrap_or(line.len());
+    let indent = &line[..content_start];
+    let rest = &line[content_start..];
+    if let Some(remainder) = rest.strip_prefix("|&") {
+        Some((indent, "|&", remainder))
+    } else if let Some(remainder) = rest.strip_prefix("||") {
+        Some((indent, "||", remainder))
+    } else if let Some(remainder) = rest.strip_prefix("&&") {
+        Some((indent, "&&", remainder))
+    } else {
+        rest.strip_prefix('|')
+            .map(|remainder| (indent, "|", remainder))
+    }
+}
+
+fn trailing_comment_start(line: &str) -> Option<usize> {
+    RawShellScanner::new(line).find_comment(0, line.len())
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct RenderedHeredocTail {
+    pub(crate) delimiter: String,
+    pub(crate) strip_tabs: bool,
+    pub(crate) command_indent: String,
+}
+
+impl RenderedHeredocTail {
+    pub(crate) fn body_line<'a>(&self, line: &'a str) -> &'a str {
+        if self.strip_tabs {
+            line
+        } else if let Some(stripped) = line.strip_prefix(&self.command_indent)
+            && stripped == self.delimiter
+        {
+            stripped
+        } else {
+            line
+        }
+    }
+
+    pub(crate) fn closes(&self, line: &str) -> bool {
+        let line = self.body_line(line);
+        if self.strip_tabs {
+            line.trim_start_matches('\t') == self.delimiter
+        } else {
+            line == self.delimiter
+        }
+    }
+}
+
+pub(crate) fn rendered_shell_text_has_heredoc_tail(text: &str) -> bool {
+    text.lines()
+        .any(|line| rendered_heredoc_tail_start(line).is_some())
+}
+
+pub(crate) fn rendered_heredoc_tail_start(line: &str) -> Option<RenderedHeredocTail> {
+    let start = heredoc_start(line)?;
+    Some(RenderedHeredocTail {
+        delimiter: start.delimiter.to_string(),
+        strip_tabs: start.strip_tabs,
+        command_indent: leading_shell_indent(line).to_string(),
+    })
+}
+
+pub(crate) fn normalize_rendered_heredoc_start_spacing(line: &str) -> Option<String> {
+    let operator_end = heredoc_start(line)?.operator_end;
+    let target_start = line[operator_end..]
+        .char_indices()
+        .find_map(|(index, ch)| (!matches!(ch, ' ' | '\t' | '\r')).then_some(operator_end + index))
+        .unwrap_or(line.len());
+    if target_start == operator_end || target_start == line.len() {
+        return None;
+    }
+
+    let mut normalized = String::with_capacity(line.len());
+    normalized.push_str(&line[..operator_end]);
+    normalized.push_str(&line[target_start..]);
+    Some(normalized)
+}
+
+#[derive(Clone, Copy)]
+pub(crate) enum CommandSubstitutionPipelineContinuation {
+    None,
+    Comment,
+    StructuralPipe { line_started_in_quote: bool },
+}
+
+#[derive(Default)]
+pub(crate) struct RawLineQuoteState {
+    single_quoted: bool,
+    double_quoted: bool,
+    escaped: bool,
+}
+
+impl RawLineQuoteState {
+    fn reset(&mut self) {
+        *self = Self::default();
+    }
+
+    pub(crate) fn in_quote(&self) -> bool {
+        self.single_quoted || self.double_quoted
+    }
+
+    fn operator_is_unquoted_at(&mut self, line: &str, operator_offset: usize) -> bool {
+        for (offset, ch) in line.char_indices() {
+            if offset == operator_offset {
+                return !self.in_quote() && !self.escaped;
+            }
+
+            self.consume(ch);
+        }
+
+        false
+    }
+
+    fn consume(&mut self, ch: char) {
+        if self.escaped {
+            self.escaped = false;
+            return;
+        }
+
+        match ch {
+            '\\' if !self.single_quoted => self.escaped = true,
+            '\'' if !self.double_quoted => {
+                self.single_quoted = !self.single_quoted;
+            }
+            '"' if !self.single_quoted => {
+                self.double_quoted = !self.double_quoted;
+            }
+            _ => {}
+        }
+    }
+}
+
+pub(crate) fn command_substitution_pipeline_stage_continuation(
+    line: &str,
+    was_pipeline_stage: bool,
+    quote_state: &mut RawLineQuoteState,
+) -> CommandSubstitutionPipelineContinuation {
+    let content = line.trim_end_matches(['\r', '\n']);
+    let scan_start = command_substitution_context_start(content).unwrap_or(0);
+    if scan_start > 0 {
+        quote_state.reset();
+    }
+    let content = &content[scan_start..];
+
+    if was_pipeline_stage
+        && !quote_state.in_quote()
+        && content.trim_start_matches([' ', '\t']).starts_with('#')
+    {
+        return CommandSubstitutionPipelineContinuation::Comment;
+    }
+    let line_started_in_quote = quote_state.in_quote();
+    if rendered_line_ends_with_command_substitution_continuation_in_quote_state(
+        content,
+        quote_state,
+    ) {
+        CommandSubstitutionPipelineContinuation::StructuralPipe {
+            line_started_in_quote,
+        }
+    } else {
+        CommandSubstitutionPipelineContinuation::None
+    }
+}
+
+pub(crate) fn rendered_line_opens_command_substitution_pipeline(line: &str) -> bool {
+    if !rendered_line_ends_with_structural_pipe_continuation(line) {
+        return false;
+    }
+
+    command_substitution_context_start(line).is_some()
+        && line
+            .bytes()
+            .take_while(|byte| matches!(*byte, b' ' | b'\t'))
+            .any(|byte| byte == b' ')
+}
+
+pub(crate) fn rendered_line_ends_with_structural_pipe_continuation(line: &str) -> bool {
+    let trimmed = line.trim_end_matches([' ', '\t', '\r']);
+    let Some((pipe_offset, scan_end)) = final_pipe_operator_bounds(trimmed) else {
+        return false;
+    };
+    let scan_start = command_substitution_context_start(&trimmed[..pipe_offset]).unwrap_or(0);
+
+    final_pipe_operator_is_unquoted(&trimmed[scan_start..scan_end])
+}
+
+pub(crate) fn command_substitution_context_start(line: &str) -> Option<usize> {
+    line.rfind("$(")
+        .or_else(|| line.rfind("<("))
+        .or_else(|| line.rfind(">("))
+        .map(|offset| offset.saturating_add(2))
+}
+
+fn rendered_line_ends_with_command_substitution_continuation_in_quote_state(
+    line: &str,
+    quote_state: &mut RawLineQuoteState,
+) -> bool {
+    let trimmed = line.trim_end_matches([' ', '\t', '\r']);
+    let operator_offset =
+        final_command_substitution_continuation_operator_bounds(trimmed).map(|(offset, _)| offset);
+    let Some(operator_offset) = operator_offset else {
+        for ch in trimmed.chars() {
+            quote_state.consume(ch);
+        }
+        quote_state.escaped = false;
+        return false;
+    };
+
+    let operator_is_unquoted = quote_state.operator_is_unquoted_at(trimmed, operator_offset);
+    quote_state.escaped = false;
+    operator_is_unquoted
+}
+
+fn final_pipe_operator_bounds(line: &str) -> Option<(usize, usize)> {
+    if line.ends_with("|&") {
+        Some((line.len().saturating_sub(2), line.len()))
+    } else if line.ends_with('|') && !line.ends_with("||") {
+        Some((line.len().saturating_sub(1), line.len()))
+    } else {
+        None
+    }
+}
+
+fn final_command_substitution_continuation_operator_bounds(line: &str) -> Option<(usize, usize)> {
+    if line.ends_with("||") || line.ends_with("&&") || line.ends_with("|&") {
+        Some((line.len().saturating_sub(2), line.len()))
+    } else if line.ends_with('|') {
+        Some((line.len().saturating_sub(1), line.len()))
+    } else {
+        None
+    }
+}
+
+fn final_pipe_operator_is_unquoted(text: &str) -> bool {
+    let Some((pipe_offset, _)) =
+        final_pipe_operator_bounds(text.trim_end_matches([' ', '\t', '\r']))
+    else {
+        return false;
+    };
+    let mut quote_state = RawLineQuoteState::default();
+    quote_state.operator_is_unquoted_at(text, pipe_offset)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn pipeline_continuation_normalization_moves_leading_operator() {
+        assert_eq!(
+            normalize_raw_pipeline_continuations("echo a \\\n  | grep a"),
+            Some("echo a |\n  grep a".to_string())
+        );
+    }
+
+    #[test]
+    fn raw_scanner_finds_shell_comments_outside_quotes() {
+        let source = "echo '# no' \"# no\" value#no # yes";
+        let scanner = RawShellScanner::new(source);
+
+        assert_eq!(scanner.find_comment(0, source.len()), Some(28));
+    }
+
+    #[test]
+    fn raw_scanner_matches_nested_command_substitutions() {
+        let raw = "$(echo \"$(date +%s)\" '(')";
+        let scanner = RawShellScanner::new(raw);
+
+        assert_eq!(
+            scanner.matching_command_substitution_close(2),
+            Some(raw.len() - 1)
+        );
+    }
+
+    #[test]
+    fn raw_scanner_finds_unclosed_process_substitution() {
+        let raw = "cat <(printf '%s\\n' \"$(value)\"";
+        let scanner = RawShellScanner::new(raw);
+
+        assert!(scanner.has_unclosed_substitution_before(raw.len()));
+    }
+
+    #[test]
+    fn raw_scanner_skips_escaped_command_substitutions() {
+        let raw = r#"echo \$(skip) "$(keep)" '$(skip)'"#;
+        let scanner = RawShellScanner::new(raw);
+
+        assert_eq!(scanner.next_command_substitution(0), Some((15, 21)));
+    }
+
+    #[test]
+    fn unclosed_command_substitution_ignores_quoted_open() {
+        assert!(!RawShellText::new("'$(").has_unclosed_command_substitution_open());
+        assert!(RawShellText::new("value=$(echo").has_unclosed_command_substitution_open());
+    }
+
+    #[test]
+    fn rendered_pipeline_continuation_ignores_quoted_pipe() {
+        assert!(!rendered_line_ends_with_structural_pipe_continuation(
+            "printf '%s|'"
+        ));
+        assert!(rendered_line_ends_with_structural_pipe_continuation(
+            "printf '%s' |"
+        ));
+    }
+}

--- a/crates/shuck-formatter/src/scan.rs
+++ b/crates/shuck-formatter/src/scan.rs
@@ -1,81 +1,7 @@
 use shuck_ast::Span;
-pub(crate) use shuck_ast::raw_shell::{QuoteState, RawShellScanner, shell_comment_can_start};
 
 use crate::comments::SourceMap;
-
-pub(crate) fn leading_shell_indent(line: &str) -> &str {
-    let indent_end = line
-        .char_indices()
-        .find(|(_, ch)| !matches!(ch, ' ' | '\t'))
-        .map_or(line.len(), |(index, _)| index);
-    &line[..indent_end]
-}
-
-pub(crate) struct HeredocStart<'line> {
-    pub(crate) delimiter: &'line str,
-    pub(crate) strip_tabs: bool,
-    pub(crate) operator_end: usize,
-}
-
-pub(crate) fn heredoc_start(line: &str) -> Option<HeredocStart<'_>> {
-    let marker = line.find("<<")?;
-    let after_marker = &line[marker + 2..];
-    if after_marker.starts_with('<') {
-        return None;
-    }
-    let (strip_tabs, after_marker) = if let Some(rest) = after_marker.strip_prefix('-') {
-        (true, rest)
-    } else {
-        (false, after_marker)
-    };
-    let delimiter = after_marker
-        .split_whitespace()
-        .next()?
-        .trim_matches(['\'', '"']);
-    (!delimiter.is_empty()).then_some(HeredocStart {
-        delimiter,
-        strip_tabs,
-        operator_end: marker + if strip_tabs { 3 } else { 2 },
-    })
-}
-
-pub(crate) fn common_indent_prefix<'a>(left: &'a str, right: &str) -> &'a str {
-    let len = left
-        .as_bytes()
-        .iter()
-        .zip(right.as_bytes())
-        .take_while(|(left, right)| left == right)
-        .count();
-    &left[..len]
-}
-
-pub(crate) fn refine_common_indent(common: &mut Option<String>, indent: &str) -> bool {
-    *common = Some(match common.take() {
-        Some(previous) => common_indent_prefix(&previous, indent).to_string(),
-        None => indent.to_string(),
-    });
-    common.as_deref() == Some("")
-}
-
-pub(crate) fn common_nonempty_shell_indent<'a>(lines: impl IntoIterator<Item = &'a str>) -> String {
-    let mut common: Option<String> = None;
-    for line in lines {
-        if line.trim().is_empty() {
-            continue;
-        }
-        let indent = leading_shell_indent(line);
-        if indent.is_empty() || refine_common_indent(&mut common, indent) {
-            return String::new();
-        }
-    }
-    common.unwrap_or_default()
-}
-
-pub(crate) fn line_without_continuation_backslash(line: &str) -> Option<&str> {
-    let trimmed = line.trim_end_matches([' ', '\t', '\r']);
-    let prefix = trimmed.strip_suffix('\\')?;
-    Some(prefix.trim_end_matches([' ', '\t', '\r']))
-}
+use crate::raw_syntax::RawShellScanner;
 
 pub(crate) fn line_has_shell_comment_before(source: &str, offset: usize) -> bool {
     let upper = offset.min(source.len());
@@ -205,26 +131,6 @@ pub(crate) fn source_between_offsets(source: &str, start: usize, end: usize) -> 
     source.get(lower..upper)
 }
 
-pub(crate) fn redirect_operator_end(bytes: &[u8], start: usize) -> Option<usize> {
-    match bytes.get(start).copied()? {
-        b'>' => Some(match bytes.get(start + 1).copied() {
-            Some(b'>' | b'|' | b'&') => start + 2,
-            _ => start + 1,
-        }),
-        b'<' => Some(match bytes.get(start + 1).copied() {
-            Some(b'<' | b'>' | b'&') => {
-                if bytes.get(start + 2) == Some(&b'<') {
-                    start + 3
-                } else {
-                    start + 2
-                }
-            }
-            _ => start + 1,
-        }),
-        _ => None,
-    }
-}
-
 pub(crate) fn shell_keyword_at(source: &str, offset: usize, upper: usize, keyword: &str) -> bool {
     let end = offset.saturating_add(keyword.len());
     end <= upper
@@ -272,24 +178,6 @@ pub(crate) fn shell_keyword_boundaries_match(text: &str, start: usize, end: usiz
 
 fn is_shell_keyword_char(ch: char) -> bool {
     ch.is_ascii_alphanumeric() || ch == '_'
-}
-
-pub(crate) fn skip_single_quoted(source: &str, offset: usize, upper: usize) -> usize {
-    RawShellScanner::bounded(source, upper).skip_single_quoted_body(offset)
-}
-
-pub(crate) fn skip_double_quoted(source: &str, offset: usize, upper: usize) -> usize {
-    RawShellScanner::bounded(source, upper).skip_double_quoted_body(offset)
-}
-
-pub(crate) fn skip_escaped_or_quoted(
-    source: &str,
-    offset: usize,
-    upper: usize,
-    ch: char,
-) -> Option<usize> {
-    debug_assert_eq!(source[offset..].chars().next(), Some(ch));
-    RawShellScanner::bounded(source, upper).skip_escaped_or_quoted_at(offset)
 }
 
 pub(crate) fn normalized_close_keyword_span(
@@ -363,44 +251,4 @@ fn matching_close_keyword_start(
         offset += ch.len_utf8();
     }
     None
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn raw_scanner_finds_shell_comments_outside_quotes() {
-        let source = "echo '# no' \"# no\" value#no # yes";
-        let scanner = RawShellScanner::new(source);
-
-        assert_eq!(scanner.find_comment(0, source.len()), Some(28));
-    }
-
-    #[test]
-    fn raw_scanner_matches_nested_command_substitutions() {
-        let raw = "$(echo \"$(date +%s)\" '(')";
-        let scanner = RawShellScanner::new(raw);
-
-        assert_eq!(
-            scanner.matching_command_substitution_close(2),
-            Some(raw.len() - 1)
-        );
-    }
-
-    #[test]
-    fn raw_scanner_finds_unclosed_process_substitution() {
-        let raw = "cat <(printf '%s\\n' \"$(value)\"";
-        let scanner = RawShellScanner::new(raw);
-
-        assert!(scanner.has_unclosed_substitution_before(raw.len()));
-    }
-
-    #[test]
-    fn raw_scanner_skips_escaped_command_substitutions() {
-        let raw = r#"echo \$(skip) "$(keep)" '$(skip)'"#;
-        let scanner = RawShellScanner::new(raw);
-
-        assert_eq!(scanner.next_command_substitution(0), Some((15, 21)));
-    }
 }

--- a/crates/shuck-formatter/src/streaming/mod.rs
+++ b/crates/shuck-formatter/src/streaming/mod.rs
@@ -28,7 +28,7 @@ use crate::command::{
     command_format_span, command_group_commands, done_close_span as command_done_close_span,
     format_arithmetic_command_source, format_arithmetic_for_clause_source, group_attachment_span,
     if_close_span as command_if_close_span, if_next_branch_region_with_body_end,
-    line_gap_break_count, line_has_unclosed_command_substitution_open, matching_group_close,
+    line_gap_break_count, matching_group_close,
     multiline_compound_assignment_command_substitution_body_prefix,
     multiline_compound_assignment_layout, multiline_compound_assignment_lines,
     render_assignment_head_to_buf, render_assignment_with_facts_to_buf, render_background_operator,
@@ -40,10 +40,17 @@ use crate::command::{
 use crate::comments::{SourceComment, SourceMap};
 use crate::facts::{FormatterFacts, classify_sequence_contains_heredoc};
 use crate::options::{IndentStyle, ResolvedShellFormatOptions};
+use crate::raw_syntax::{
+    CommandSubstitutionPipelineContinuation, RawLineQuoteState, RawShellText, RenderedHeredocTail,
+    command_substitution_context_start, command_substitution_pipeline_stage_continuation,
+    line_without_continuation_backslash, normalize_rendered_heredoc_start_spacing,
+    redirect_operator_end, rendered_heredoc_tail_start,
+    rendered_line_ends_with_structural_pipe_continuation,
+    rendered_line_opens_command_substitution_pipeline, rendered_shell_text_has_heredoc_tail,
+    skip_double_quoted, skip_single_quoted,
+};
 use crate::scan::{
-    BranchPrefixComment, heredoc_start, last_shell_keyword_start,
-    line_without_continuation_backslash, redirect_operator_end, shell_keyword_at,
-    skip_double_quoted, skip_single_quoted, source_between_offsets,
+    BranchPrefixComment, last_shell_keyword_start, shell_keyword_at, source_between_offsets,
 };
 use crate::word::{
     normalize_raw_empty_parameter_replacement_delimiters,
@@ -456,66 +463,6 @@ fn word_part_contains_command_heredoc(part: &WordPart) -> bool {
     }
 }
 
-#[derive(Debug, Clone)]
-struct RenderedHeredocTail {
-    delimiter: String,
-    strip_tabs: bool,
-    command_indent: String,
-}
-
-impl RenderedHeredocTail {
-    fn body_line<'a>(&self, line: &'a str) -> &'a str {
-        if self.strip_tabs {
-            line
-        } else if let Some(stripped) = line.strip_prefix(&self.command_indent)
-            && stripped == self.delimiter
-        {
-            stripped
-        } else {
-            line
-        }
-    }
-
-    fn closes(&self, line: &str) -> bool {
-        let line = self.body_line(line);
-        if self.strip_tabs {
-            line.trim_start_matches('\t') == self.delimiter
-        } else {
-            line == self.delimiter
-        }
-    }
-}
-
-fn rendered_shell_text_has_heredoc_tail(text: &str) -> bool {
-    text.lines()
-        .any(|line| rendered_heredoc_tail_start(line).is_some())
-}
-
-fn rendered_heredoc_tail_start(line: &str) -> Option<RenderedHeredocTail> {
-    let start = heredoc_start(line)?;
-    Some(RenderedHeredocTail {
-        delimiter: start.delimiter.to_string(),
-        strip_tabs: start.strip_tabs,
-        command_indent: line_leading_indent(line).to_string(),
-    })
-}
-
-fn normalize_rendered_heredoc_start_spacing(line: &str) -> Option<String> {
-    let operator_end = heredoc_start(line)?.operator_end;
-    let target_start = line[operator_end..]
-        .char_indices()
-        .find_map(|(index, ch)| (!matches!(ch, ' ' | '\t' | '\r')).then_some(operator_end + index))
-        .unwrap_or(line.len());
-    if target_start == operator_end || target_start == line.len() {
-        return None;
-    }
-
-    let mut normalized = String::with_capacity(line.len());
-    normalized.push_str(&line[..operator_end]);
-    normalized.push_str(&line[target_start..]);
-    Some(normalized)
-}
-
 fn raw_redirect_source_slice<'a>(redirect: &Redirect, source: &'a str) -> Option<&'a str> {
     let span = redirect.span;
     (span.start.offset < span.end.offset && span.end.offset <= source.len())
@@ -876,42 +823,11 @@ fn assignment_has_quoted_backslash_continuation_literal(
     };
     let raw = assignment.span.slice(source);
     raw.contains("\\\n")
-        && raw_backslash_continuation_is_quoted(raw)
+        && RawShellText::new(raw).quoted_backslash_continuation()
         && !raw.contains("$(")
         && !raw.contains('`')
         && !raw.contains("<(")
         && !raw.contains(">(")
-}
-
-fn raw_backslash_continuation_is_quoted(raw: &str) -> bool {
-    let mut chars = raw.chars().peekable();
-    let mut in_single_quotes = false;
-    let mut in_double_quotes = false;
-    while let Some(ch) = chars.next() {
-        if ch == '\'' && !in_double_quotes {
-            in_single_quotes = !in_single_quotes;
-            continue;
-        }
-        if ch == '"' && !in_single_quotes {
-            in_double_quotes = !in_double_quotes;
-            continue;
-        }
-        if ch == '\\' {
-            let mut probe = chars.clone();
-            let escaped_newline = match probe.next() {
-                Some('\n') => true,
-                Some('\r') => probe.next().is_some_and(|next| next == '\n'),
-                _ => false,
-            };
-            if escaped_newline {
-                return in_single_quotes || in_double_quotes;
-            }
-            if !in_single_quotes {
-                chars.next();
-            }
-        }
-    }
-    false
 }
 
 fn assignment_source_has_command_substitution(assignment: &Assignment, source: &str) -> bool {
@@ -2708,13 +2624,6 @@ fn inline_assignment_command_substitution_context(content: &str, scan_start: usi
     prefix.ends_with('"') && prefix.contains('=')
 }
 
-#[derive(Clone, Copy)]
-enum CommandSubstitutionPipelineContinuation {
-    None,
-    Comment,
-    StructuralPipe { line_started_in_quote: bool },
-}
-
 fn next_command_substitution_pipeline_indent_column(
     continuation: CommandSubstitutionPipelineContinuation,
     starts_with_block_command_substitution: bool,
@@ -2741,86 +2650,6 @@ fn next_command_substitution_pipeline_indent_column(
             }
         }
     }
-}
-
-#[derive(Default)]
-struct RenderedLineQuoteState {
-    single_quoted: bool,
-    double_quoted: bool,
-    escaped: bool,
-}
-
-impl RenderedLineQuoteState {
-    fn in_quote(&self) -> bool {
-        self.single_quoted || self.double_quoted
-    }
-}
-
-fn command_substitution_pipeline_stage_continuation(
-    line: &str,
-    was_pipeline_stage: bool,
-    quote_state: &mut RenderedLineQuoteState,
-) -> CommandSubstitutionPipelineContinuation {
-    let content = line.trim_end_matches(['\r', '\n']);
-    let scan_start = command_substitution_context_start(content).unwrap_or(0);
-    if scan_start > 0 {
-        *quote_state = RenderedLineQuoteState::default();
-    }
-    let content = &content[scan_start..];
-
-    if was_pipeline_stage
-        && !quote_state.in_quote()
-        && content.trim_start_matches([' ', '\t']).starts_with('#')
-    {
-        return CommandSubstitutionPipelineContinuation::Comment;
-    }
-    let line_started_in_quote = quote_state.in_quote();
-    if rendered_line_ends_with_command_substitution_continuation_in_quote_state(
-        content,
-        quote_state,
-    ) {
-        CommandSubstitutionPipelineContinuation::StructuralPipe {
-            line_started_in_quote,
-        }
-    } else {
-        CommandSubstitutionPipelineContinuation::None
-    }
-}
-
-fn rendered_line_ends_with_command_substitution_continuation_in_quote_state(
-    line: &str,
-    quote_state: &mut RenderedLineQuoteState,
-) -> bool {
-    let trimmed = line.trim_end_matches([' ', '\t', '\r']);
-    let operator_offset =
-        final_command_substitution_continuation_operator_bounds(trimmed).map(|(offset, _)| offset);
-    let mut operator_is_unquoted = false;
-
-    for (offset, ch) in trimmed.char_indices() {
-        if operator_offset == Some(offset) {
-            operator_is_unquoted = !quote_state.in_quote() && !quote_state.escaped;
-            break;
-        }
-
-        if quote_state.escaped {
-            quote_state.escaped = false;
-            continue;
-        }
-
-        match ch {
-            '\\' if !quote_state.single_quoted => quote_state.escaped = true,
-            '\'' if !quote_state.double_quoted => {
-                quote_state.single_quoted = !quote_state.single_quoted;
-            }
-            '"' if !quote_state.single_quoted => {
-                quote_state.double_quoted = !quote_state.double_quoted;
-            }
-            _ => {}
-        }
-    }
-
-    quote_state.escaped = false;
-    operator_is_unquoted
 }
 
 fn strip_assignment_context_indent<'a>(
@@ -2894,86 +2723,6 @@ fn normalize_literal_assignment_command_substitution_pipelines(
     }
 
     if changed { output } else { text.to_string() }
-}
-
-fn rendered_line_opens_command_substitution_pipeline(line: &str) -> bool {
-    if !rendered_line_ends_with_structural_pipe_continuation(line) {
-        return false;
-    }
-
-    command_substitution_context_start(line).is_some()
-        && line
-            .bytes()
-            .take_while(|byte| matches!(*byte, b' ' | b'\t'))
-            .any(|byte| byte == b' ')
-}
-
-fn rendered_line_ends_with_structural_pipe_continuation(line: &str) -> bool {
-    let trimmed = line.trim_end_matches([' ', '\t', '\r']);
-    let Some((pipe_offset, scan_end)) = final_pipe_operator_bounds(trimmed) else {
-        return false;
-    };
-    let scan_start = command_substitution_context_start(&trimmed[..pipe_offset]).unwrap_or(0);
-
-    final_pipe_operator_is_unquoted(&trimmed[scan_start..scan_end])
-}
-
-fn final_pipe_operator_bounds(line: &str) -> Option<(usize, usize)> {
-    if line.ends_with("|&") {
-        Some((line.len().saturating_sub(2), line.len()))
-    } else if line.ends_with('|') && !line.ends_with("||") {
-        Some((line.len().saturating_sub(1), line.len()))
-    } else {
-        None
-    }
-}
-
-fn final_command_substitution_continuation_operator_bounds(line: &str) -> Option<(usize, usize)> {
-    if line.ends_with("||") || line.ends_with("&&") || line.ends_with("|&") {
-        Some((line.len().saturating_sub(2), line.len()))
-    } else if line.ends_with('|') {
-        Some((line.len().saturating_sub(1), line.len()))
-    } else {
-        None
-    }
-}
-
-fn command_substitution_context_start(line: &str) -> Option<usize> {
-    line.rfind("$(")
-        .or_else(|| line.rfind("<("))
-        .or_else(|| line.rfind(">("))
-        .map(|offset| offset.saturating_add(2))
-}
-
-fn final_pipe_operator_is_unquoted(text: &str) -> bool {
-    let Some((pipe_offset, _)) =
-        final_pipe_operator_bounds(text.trim_end_matches([' ', '\t', '\r']))
-    else {
-        return false;
-    };
-    let mut single_quoted = false;
-    let mut double_quoted = false;
-    let mut escaped = false;
-
-    for (offset, ch) in text.char_indices() {
-        if offset == pipe_offset {
-            return !single_quoted && !double_quoted && !escaped;
-        }
-
-        if escaped {
-            escaped = false;
-            continue;
-        }
-
-        match ch {
-            '\\' if !single_quoted => escaped = true,
-            '\'' if !double_quoted => single_quoted = !single_quoted,
-            '"' if !single_quoted => double_quoted = !double_quoted,
-            _ => {}
-        }
-    }
-
-    false
 }
 
 fn conditional_binary_has_explicit_rhs_break(

--- a/crates/shuck-formatter/src/streaming/statements.rs
+++ b/crates/shuck-formatter/src/streaming/statements.rs
@@ -829,7 +829,7 @@ where
 
         let mut inline_command_substitution_open = layout.open_inline
             && layout.lines.first().is_some_and(|line| {
-                line_has_unclosed_command_substitution_open(line)
+                RawShellText::new(line).has_unclosed_command_substitution_open()
                     && !multiline_compound_assignment_command_substitution_body_prefix(line)
                         .is_empty()
             });

--- a/crates/shuck-formatter/src/streaming/substitutions.rs
+++ b/crates/shuck-formatter/src/streaming/substitutions.rs
@@ -83,7 +83,7 @@ where
         let mut next_block_line_is_pipeline_stage = false;
         let mut next_block_line_aligns_with_command_continuation = false;
         let mut command_continuation_active = false;
-        let mut pipeline_quote_state = RenderedLineQuoteState::default();
+        let mut pipeline_quote_state = RawLineQuoteState::default();
         let mut remaining = text;
         while !remaining.is_empty() {
             let line_started_as_command_continuation = command_continuation_active;

--- a/crates/shuck-formatter/src/word/command_substitution.rs
+++ b/crates/shuck-formatter/src/word/command_substitution.rs
@@ -732,19 +732,6 @@ pub(super) fn indent_inline_pipeline_continuations(
     changed.then_some(rendered)
 }
 
-pub(super) fn line_ends_with_pipeline_operator(line: &str) -> bool {
-    let trimmed = line.trim_end_matches([' ', '\t', '\r']);
-    trimmed.ends_with("|&") || (trimmed.ends_with('|') && !trimmed.ends_with("||"))
-}
-
-pub(super) fn line_ends_with_raw_continuation_operator(line: &str) -> bool {
-    let code = trailing_comment_start(line)
-        .map(|comment_start| &line[..comment_start])
-        .unwrap_or(line);
-    let trimmed = code.trim_end_matches([' ', '\t', '\r']);
-    line_ends_with_pipeline_operator(trimmed) || trimmed.ends_with("&&") || trimmed.ends_with("||")
-}
-
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(super) enum CommandSubstitutionLayout {
     Inline,

--- a/crates/shuck-formatter/src/word/mod.rs
+++ b/crates/shuck-formatter/src/word/mod.rs
@@ -7,12 +7,13 @@ use crate::facts::{
     classify_sequence_contains_multiline_literal_source,
 };
 use crate::options::{IndentStyle, ResolvedShellFormatOptions};
-use crate::scan::{
-    QuoteState, RawShellScanner, common_nonempty_shell_indent, heredoc_start,
-    leading_shell_indent as line_leading_shell_indent,
-    line_indent_before_offset as line_indent_before_source_offset,
-    line_without_continuation_backslash, redirect_operator_end, refine_common_indent,
+use crate::raw_syntax::{
+    QuoteState, RawShellScanner, RawShellText, common_nonempty_shell_indent, heredoc_start,
+    leading_shell_indent as line_leading_shell_indent, line_ends_with_raw_continuation_operator,
+    line_without_continuation_backslash, matching_raw_command_substitution_close,
+    normalize_raw_pipeline_continuations, redirect_operator_end, refine_common_indent,
 };
+use crate::scan::line_indent_before_offset as line_indent_before_source_offset;
 use crate::streaming::format_stmt_sequence_streaming_to_buf;
 use shuck_ast::{
     ArithmeticAssignOp, ArithmeticBinaryOp, ArithmeticExpansionSyntax, ArithmeticExpr,
@@ -39,6 +40,5 @@ pub(crate) use self::core::{
 pub(crate) use self::heredoc::render_heredoc_body_to_buf;
 pub(crate) use self::parameter::{parameter_defaulting_operator, render_pattern_syntax_to_buf};
 pub(crate) use self::raw_rewrites::{
-    matching_raw_command_substitution_close, normalize_raw_empty_parameter_replacement_delimiters,
-    normalize_raw_pipeline_continuations, normalize_raw_unquoted_word_continuations,
+    normalize_raw_empty_parameter_replacement_delimiters, normalize_raw_unquoted_word_continuations,
 };

--- a/crates/shuck-formatter/src/word/parameter.rs
+++ b/crates/shuck-formatter/src/word/parameter.rs
@@ -162,7 +162,7 @@ pub(super) fn normalize_inline_command_substitutions_in_parameter_operand(
 }
 
 pub(super) fn next_raw_command_substitution(raw: &str, index: usize) -> Option<(usize, usize)> {
-    RawShellScanner::new(raw).next_command_substitution(index)
+    RawShellText::new(raw).next_command_substitution(index)
 }
 
 pub(super) fn finish_raw_rewrite(

--- a/crates/shuck-formatter/src/word/raw_rewrites.rs
+++ b/crates/shuck-formatter/src/word/raw_rewrites.rs
@@ -544,86 +544,6 @@ pub(super) fn push_raw_shell_line_content_with_normalized_spacing(
     }
 }
 
-pub(crate) fn normalize_raw_pipeline_continuations(text: &str) -> Option<String> {
-    let trailing = normalize_raw_trailing_pipe_continuations(text);
-    let leading = normalize_raw_leading_pipe_continuations(trailing.as_deref().unwrap_or(text));
-    leading.or(trailing)
-}
-
-pub(super) fn normalize_raw_trailing_pipe_continuations(text: &str) -> Option<String> {
-    let mut lines = text
-        .split('\n')
-        .map(ToString::to_string)
-        .collect::<Vec<_>>();
-    let mut changed = false;
-
-    for line in &mut lines {
-        let Some(prefix) = line_without_trailing_pipe_continuation(line) else {
-            continue;
-        };
-        *line = prefix.to_string();
-        changed = true;
-    }
-
-    changed.then(|| lines.join("\n"))
-}
-
-pub(super) fn normalize_raw_leading_pipe_continuations(text: &str) -> Option<String> {
-    let mut lines = text
-        .split('\n')
-        .map(ToString::to_string)
-        .collect::<Vec<_>>();
-    let mut changed = false;
-
-    for index in 0..lines.len().saturating_sub(1) {
-        let Some(prefix) = line_without_continuation_backslash(&lines[index]).map(str::to_string)
-        else {
-            continue;
-        };
-        let Some((indent, operator, rest)) =
-            leading_pipe_continuation(&lines[index + 1]).map(|(indent, operator, rest)| {
-                (
-                    indent.to_string(),
-                    operator,
-                    rest.trim_start_matches([' ', '\t', '\r']).to_string(),
-                )
-            })
-        else {
-            continue;
-        };
-
-        lines[index] = format!("{prefix} {operator}");
-        lines[index + 1] = format!("{indent}{rest}");
-        changed = true;
-    }
-
-    changed.then(|| lines.join("\n"))
-}
-
-pub(super) fn line_without_trailing_pipe_continuation(line: &str) -> Option<&str> {
-    let prefix = line_without_continuation_backslash(line)?;
-    line_ends_with_raw_continuation_operator(prefix).then_some(prefix)
-}
-
-pub(super) fn leading_pipe_continuation(line: &str) -> Option<(&str, &'static str, &str)> {
-    let content_start = line
-        .char_indices()
-        .find_map(|(index, ch)| (!matches!(ch, ' ' | '\t')).then_some(index))
-        .unwrap_or(line.len());
-    let indent = &line[..content_start];
-    let rest = &line[content_start..];
-    if let Some(remainder) = rest.strip_prefix("|&") {
-        Some((indent, "|&", remainder))
-    } else if let Some(remainder) = rest.strip_prefix("||") {
-        Some((indent, "||", remainder))
-    } else if let Some(remainder) = rest.strip_prefix("&&") {
-        Some((indent, "&&", remainder))
-    } else {
-        rest.strip_prefix('|')
-            .map(|remainder| (indent, "|", remainder))
-    }
-}
-
 pub(super) fn expand_inline_raw_command_substitutions_in_line(
     target: &mut String,
     line: &str,
@@ -1265,13 +1185,6 @@ pub(super) fn matching_raw_arithmetic_expansion_close(
     }
 
     None
-}
-
-pub(crate) fn matching_raw_command_substitution_close(
-    raw: &str,
-    body_start: usize,
-) -> Option<usize> {
-    RawShellScanner::new(raw).matching_command_substitution_close(body_start)
 }
 
 pub(super) fn push_raw_shell_line_with_normalized_redirect_spacing(


### PR DESCRIPTION
## Summary
- Add a formatter-local `raw_syntax` module for raw shell text helpers.
- Move quote-aware command substitution matching, pipeline continuation normalization, heredoc tail handling, and redirect/operator scanning behind that shared API.
- Rewire the formatter renderers to use the shared helper instead of local hand scanners.

## Validation
- `cargo fmt --check`
- `cargo check -p shuck-formatter`
- `cargo test -p shuck-formatter`