### PR TITLE
refactor(formatter): require render context facts

### DIFF
--- a/crates/shuck-formatter/src/command.rs
+++ b/crates/shuck-formatter/src/command.rs
@@ -1,6 +1,6 @@
 use crate::comments::SourceMap;
-use crate::facts::{FormatterFacts, classify_stmt_contains_heredoc};
-use crate::options::ResolvedShellFormatOptions;
+use crate::context::RenderContext;
+use crate::facts::classify_stmt_contains_heredoc;
 use crate::raw_syntax::{
     RawShellText, common_nonempty_shell_indent, leading_shell_indent,
     matching_raw_command_substitution_close, normalize_raw_pipeline_continuations,
@@ -10,9 +10,7 @@ use crate::scan::{
     branch_keyword_offset, last_shell_keyword_start, last_uncommented_shell_keyword_before,
     matching_done_close_start, matching_if_close_start, normalized_close_keyword_span,
 };
-use crate::word::{
-    render_arithmetic_expr_to_buf, render_word_syntax_to_buf, render_word_syntax_with_facts_to_buf,
-};
+use crate::word::{render_arithmetic_expr_to_buf, render_word_syntax_to_buf};
 use shuck_ast::{
     AnonymousFunctionCommand, ArithmeticExprNode, ArrayElem, Assignment, AssignmentValue,
     BackgroundOperator, BinaryCommand, BinaryOp, BuiltinCommand, CaseItem, CaseTerminator, Command,
@@ -67,15 +65,14 @@ pub(crate) fn format_arithmetic_for_init_source(raw: &str) -> String {
 pub(crate) fn format_arithmetic_for_clause_source(
     raw: &str,
     ast: Option<&ArithmeticExprNode>,
-    source: &str,
-    options: &ResolvedShellFormatOptions,
+    context: RenderContext<'_, '_>,
 ) -> String {
     if raw.trim().is_empty() {
         return String::new();
     }
     if let Some(ast) = ast {
         let mut rendered = String::new();
-        render_arithmetic_expr_to_buf(&mut rendered, ast, source, options);
+        render_arithmetic_expr_to_buf(&mut rendered, ast, context);
         rendered
     } else {
         format_arithmetic_for_init_source(raw)
@@ -167,39 +164,17 @@ fn format_multiline_arithmetic_command_body(body: &str) -> String {
     rendered
 }
 
-pub(crate) fn render_assignment_with_facts_to_buf(
+pub(crate) fn render_assignment_to_buf(
     assignment: &Assignment,
-    source: &str,
-    options: &ResolvedShellFormatOptions,
-    source_map: &SourceMap<'_>,
-    facts: &FormatterFacts<'_>,
-    rendered: &mut String,
-) {
-    render_assignment_inner(
-        assignment,
-        source,
-        options,
-        Some(source_map),
-        Some(facts),
-        rendered,
-    );
-}
-
-fn render_assignment_inner(
-    assignment: &Assignment,
-    source: &str,
-    options: &ResolvedShellFormatOptions,
-    source_map: Option<&SourceMap<'_>>,
-    facts: Option<&FormatterFacts<'_>>,
+    context: RenderContext<'_, '_>,
     rendered: &mut String,
 ) {
     let start = rendered.len();
+    let source = context.source;
     render_assignment_head_to_buf(assignment, source, rendered);
     match &assignment.value {
         AssignmentValue::Scalar(value) => {
-            render_word_syntax_with_optional_facts_to_buf(
-                value, source, options, source_map, facts, rendered,
-            );
+            render_word_syntax_to_buf(value, context, rendered);
         }
         AssignmentValue::Compound(array) => {
             rendered.push('(');
@@ -207,7 +182,7 @@ fn render_assignment_inner(
                 if index > 0 {
                     rendered.push(' ');
                 }
-                render_array_elem_to_buf(value, source, options, source_map, facts, rendered);
+                render_array_elem_to_buf(value, context, rendered);
             }
             rendered.push(')');
         }
@@ -218,42 +193,29 @@ fn render_assignment_inner(
 
 fn render_array_elem_to_buf(
     element: &ArrayElem,
-    source: &str,
-    options: &crate::options::ResolvedShellFormatOptions,
-    source_map: Option<&SourceMap<'_>>,
-    facts: Option<&FormatterFacts<'_>>,
+    context: RenderContext<'_, '_>,
     rendered: &mut String,
 ) {
     let (key, value, op) = array_elem_parts(element);
     if let Some(key) = key {
-        render_keyed_array_elem_to_buf(
-            key, value, source, options, source_map, facts, op, rendered,
-        );
+        render_keyed_array_elem_to_buf(key, value, context, op, rendered);
     } else {
-        render_word_syntax_with_optional_facts_to_buf(
-            value, source, options, source_map, facts, rendered,
-        );
+        render_word_syntax_to_buf(value, context, rendered);
     }
 }
 
-#[allow(clippy::too_many_arguments)]
 fn render_keyed_array_elem_to_buf(
     key: &Subscript,
     value: &Word,
-    source: &str,
-    options: &crate::options::ResolvedShellFormatOptions,
-    source_map: Option<&SourceMap<'_>>,
-    facts: Option<&FormatterFacts<'_>>,
+    context: RenderContext<'_, '_>,
     operator: &str,
     rendered: &mut String,
 ) {
     rendered.push('[');
-    render_subscript_to_buf(key, source, rendered);
+    render_subscript_to_buf(key, context.source, rendered);
     rendered.push(']');
     rendered.push_str(operator);
-    render_word_syntax_with_optional_facts_to_buf(
-        value, source, options, source_map, facts, rendered,
-    );
+    render_word_syntax_to_buf(value, context, rendered);
 }
 
 pub(crate) fn render_assignment_head_to_buf(
@@ -271,22 +233,6 @@ pub(crate) fn render_assignment_head_to_buf(
         rendered.push_str("+=");
     } else {
         rendered.push('=');
-    }
-}
-
-fn render_word_syntax_with_optional_facts_to_buf(
-    word: &Word,
-    source: &str,
-    options: &ResolvedShellFormatOptions,
-    source_map: Option<&SourceMap<'_>>,
-    facts: Option<&FormatterFacts<'_>>,
-    rendered: &mut String,
-) {
-    match (source_map, facts) {
-        (Some(source_map), Some(facts)) => {
-            render_word_syntax_with_facts_to_buf(word, source, options, source_map, facts, rendered)
-        }
-        _ => render_word_syntax_to_buf(word, source, options, rendered),
     }
 }
 

--- a/crates/shuck-formatter/src/context.rs
+++ b/crates/shuck-formatter/src/context.rs
@@ -1,0 +1,28 @@
+use crate::comments::SourceMap;
+use crate::facts::FormatterFacts;
+use crate::options::ResolvedShellFormatOptions;
+
+#[derive(Clone, Copy)]
+pub(crate) struct RenderContext<'source, 'a> {
+    pub(crate) source: &'source str,
+    pub(crate) options: &'a ResolvedShellFormatOptions,
+    pub(crate) facts: &'a FormatterFacts<'source>,
+}
+
+impl<'source, 'a> RenderContext<'source, 'a> {
+    pub(crate) fn new(
+        source: &'source str,
+        options: &'a ResolvedShellFormatOptions,
+        facts: &'a FormatterFacts<'source>,
+    ) -> Self {
+        Self {
+            source,
+            options,
+            facts,
+        }
+    }
+
+    pub(crate) fn source_map(self) -> &'a SourceMap<'source> {
+        self.facts.source_map()
+    }
+}

--- a/crates/shuck-formatter/src/facts.rs
+++ b/crates/shuck-formatter/src/facts.rs
@@ -1567,12 +1567,6 @@ pub(crate) fn classify_sequence_contains_multiline_literal_source(
         .contains_multiline_literal_source
 }
 
-pub(crate) fn classify_sequence_contains_comments(sequence: &StmtSeq) -> bool {
-    LayoutAnnotations::build_for_sequence("", sequence)
-        .sequence(sequence)
-        .contains_comments
-}
-
 pub(crate) fn classify_stmt_contains_heredoc(stmt: &Stmt) -> bool {
     LayoutAnnotations::build_for_stmt("", stmt)
         .stmt(stmt)
@@ -2595,22 +2589,72 @@ impl<'source, 'options> FormatterFactsBuilder<'source, 'options> {
                 expression_ast: Some(expr),
                 ..
             } => self.visit_arithmetic_expr(expr),
+            WordPart::Parameter(parameter) => self.visit_parameter_expansion(parameter),
+            WordPart::ParameterExpansion {
+                reference,
+                operator,
+                operand_word_ast,
+                ..
+            } => {
+                self.visit_var_ref(reference);
+                self.visit_parameter_op(operator);
+                if let Some(operand) = operand_word_ast {
+                    self.visit_word(operand);
+                }
+            }
+            WordPart::Length(reference)
+            | WordPart::ArrayAccess(reference)
+            | WordPart::ArrayLength(reference)
+            | WordPart::ArrayIndices(reference)
+            | WordPart::Transformation { reference, .. } => self.visit_var_ref(reference),
+            WordPart::Substring {
+                reference,
+                offset_ast,
+                offset_word_ast,
+                length_ast,
+                length_word_ast,
+                ..
+            }
+            | WordPart::ArraySlice {
+                reference,
+                offset_ast,
+                offset_word_ast,
+                length_ast,
+                length_word_ast,
+                ..
+            } => {
+                self.visit_var_ref(reference);
+                if let Some(expr) = offset_ast {
+                    self.visit_arithmetic_expr(expr);
+                } else {
+                    self.visit_word(offset_word_ast);
+                }
+                if let Some(expr) = length_ast {
+                    self.visit_arithmetic_expr(expr);
+                } else if let Some(word) = length_word_ast {
+                    self.visit_word(word);
+                }
+            }
+            WordPart::IndirectExpansion {
+                reference,
+                operator,
+                operand_word_ast,
+                ..
+            } => {
+                self.visit_var_ref(reference);
+                if let Some(operator) = operator {
+                    self.visit_parameter_op(operator);
+                }
+                if let Some(operand) = operand_word_ast {
+                    self.visit_word(operand);
+                }
+            }
             WordPart::CommandSubstitution { .. }
             | WordPart::Literal(_)
             | WordPart::SingleQuoted { .. }
             | WordPart::Variable(_)
             | WordPart::ArithmeticExpansion { .. }
-            | WordPart::Parameter(_)
-            | WordPart::ParameterExpansion { .. }
-            | WordPart::Length(_)
-            | WordPart::ArrayAccess(_)
-            | WordPart::ArrayLength(_)
-            | WordPart::ArrayIndices(_)
-            | WordPart::Substring { .. }
-            | WordPart::ArraySlice { .. }
-            | WordPart::IndirectExpansion { .. }
             | WordPart::PrefixMatch { .. }
-            | WordPart::Transformation { .. }
             | WordPart::ZshQualifiedGlob(_) => {}
             WordPart::DoubleQuoted { parts, .. } => {
                 for part in parts {
@@ -2645,10 +2689,10 @@ impl<'source, 'options> FormatterFactsBuilder<'source, 'options> {
                 expression_word_ast,
                 ..
             } => self.visit_word(expression_word_ast),
+            HeredocBodyPart::Parameter(parameter) => self.visit_parameter_expansion(parameter),
             HeredocBodyPart::Literal(_)
             | HeredocBodyPart::Variable(_)
-            | HeredocBodyPart::CommandSubstitution { .. }
-            | HeredocBodyPart::Parameter(_) => {}
+            | HeredocBodyPart::CommandSubstitution { .. } => {}
         }
     }
 

--- a/crates/shuck-formatter/src/lib.rs
+++ b/crates/shuck-formatter/src/lib.rs
@@ -12,6 +12,7 @@
 mod command;
 #[allow(missing_docs)]
 mod comments;
+mod context;
 mod facts;
 #[allow(missing_docs)]
 mod options;

--- a/crates/shuck-formatter/src/streaming/compounds.rs
+++ b/crates/shuck-formatter/src/streaming/compounds.rs
@@ -1234,7 +1234,7 @@ where
             && !expression_source.is_some_and(|source| source.contains('\n'))
         {
             let mut body = self.take_scratch_buffer();
-            render_arithmetic_expr_to_buf(&mut body, expr, self.source(), self.options());
+            render_arithmetic_expr_to_buf(&mut body, expr, self.render_context());
             self.write_text("((");
             self.write_text(&body);
             self.write_text("))");
@@ -1267,20 +1267,17 @@ where
         let init = format_arithmetic_for_clause_source(
             init,
             command.init_ast.as_ref(),
-            source,
-            self.options(),
+            self.render_context(),
         );
         let condition = format_arithmetic_for_clause_source(
             condition,
             command.condition_ast.as_ref(),
-            source,
-            self.options(),
+            self.render_context(),
         );
         let step = format_arithmetic_for_clause_source(
             step,
             command.step_ast.as_ref(),
-            source,
-            self.options(),
+            self.render_context(),
         );
         self.write_text("for ((");
         self.write_text(&init);
@@ -1387,10 +1384,7 @@ where
             && let Some(name) = function.header.entries[0].static_name.as_ref()
         {
             let mut rendered_entry = self.take_scratch_buffer();
-            self.render_word_with_facts_to_buffer(
-                &function.header.entries[0].word,
-                &mut rendered_entry,
-            );
+            self.render_word_to_buffer(&function.header.entries[0].word, &mut rendered_entry);
             let classic_single_name = name.as_str() == rendered_entry;
             self.restore_scratch_buffer(rendered_entry);
 
@@ -1834,7 +1828,7 @@ where
 
     pub(super) fn conditional_word_needs_tight_close(&mut self, word: &Word) -> bool {
         let mut rendered = self.take_scratch_buffer();
-        self.render_word_with_facts_to_buffer(word, &mut rendered);
+        self.render_word_to_buffer(word, &mut rendered);
         let needs_tight_close = matches!(
             rendered.as_str(),
             "!" | "-a"

--- a/crates/shuck-formatter/src/streaming/mod.rs
+++ b/crates/shuck-formatter/src/streaming/mod.rs
@@ -31,13 +31,14 @@ use crate::command::{
     line_gap_break_count, matching_group_close,
     multiline_compound_assignment_command_substitution_body_prefix,
     multiline_compound_assignment_layout, multiline_compound_assignment_lines,
-    render_assignment_head_to_buf, render_assignment_with_facts_to_buf, render_background_operator,
+    render_assignment_head_to_buf, render_assignment_to_buf, render_background_operator,
     render_subscript_to_buf, render_var_ref_to_buf, simple_command_uses_synthetic_words,
     slice_span, stmt_attachment_span, stmt_format_span, stmt_render_start_line, stmt_span,
     stmt_start_after_operator, stmt_verbatim_span_with_source_map,
     trim_unescaped_trailing_whitespace,
 };
 use crate::comments::{SourceComment, SourceMap};
+use crate::context::RenderContext;
 use crate::facts::{FormatterFacts, classify_sequence_contains_heredoc};
 use crate::options::{IndentStyle, ResolvedShellFormatOptions};
 use crate::raw_syntax::{
@@ -55,8 +56,8 @@ use crate::scan::{
 use crate::word::{
     normalize_raw_empty_parameter_replacement_delimiters,
     normalize_raw_unquoted_word_continuations, render_arithmetic_expr_to_buf,
-    render_escaped_multiline_word_syntax_with_facts_to_buf, render_heredoc_body_to_buf,
-    render_pattern_syntax_to_buf, render_word_syntax_with_facts_to_buf,
+    render_escaped_multiline_word_syntax_to_buf, render_heredoc_body_to_buf,
+    render_pattern_syntax_to_buf, render_word_syntax_to_buf,
     word_gap_end_before_trailing_continuation, word_is_quoted_command_substitution_only,
     word_is_quoted_formattable_command_substitution_only_with_facts,
 };
@@ -278,7 +279,11 @@ where
     }
 
     fn source_map(&self) -> &SourceMap<'source> {
-        self.facts.source_map()
+        self.render_context().source_map()
+    }
+
+    fn render_context(&self) -> RenderContext<'source, '_> {
+        RenderContext::new(self.source(), self.options(), self.facts())
     }
 
     fn line_ending(&self) -> &'static str {
@@ -322,17 +327,8 @@ where
         self.scratch = scratch;
     }
 
-    fn render_word_with_facts_to_buffer(&self, word: &Word, rendered: &mut String) {
-        let source_map = self.source_map().clone();
-        let facts = self.facts();
-        render_word_syntax_with_facts_to_buf(
-            word,
-            self.source(),
-            self.options(),
-            &source_map,
-            facts,
-            rendered,
-        );
+    fn render_word_to_buffer(&self, word: &Word, rendered: &mut String) {
+        render_word_syntax_to_buf(word, self.render_context(), rendered);
     }
 
     fn write_rendered(

--- a/crates/shuck-formatter/src/streaming/redirects.rs
+++ b/crates/shuck-formatter/src/streaming/redirects.rs
@@ -82,9 +82,9 @@ where
     ) {
         let mut target = self.take_scratch_buffer();
         match (redirect.word_target(), redirect.heredoc()) {
-            (Some(word), None) => self.render_word_with_facts_to_buffer(word, &mut target),
+            (Some(word), None) => self.render_word_to_buffer(word, &mut target),
             (None, Some(heredoc)) => {
-                self.render_word_with_facts_to_buffer(&heredoc.delimiter.raw, &mut target);
+                self.render_word_to_buffer(&heredoc.delimiter.raw, &mut target);
             }
             (None, None) => {}
             (Some(_), Some(_)) => {

--- a/crates/shuck-formatter/src/streaming/statements.rs
+++ b/crates/shuck-formatter/src/streaming/statements.rs
@@ -268,7 +268,7 @@ where
 
     pub(super) fn format_simple_command(&mut self, command: &SimpleCommand) -> Result<()> {
         let mut rendered_name = self.take_scratch_buffer();
-        self.render_word_with_facts_to_buffer(&command.name, &mut rendered_name);
+        self.render_word_to_buffer(&command.name, &mut rendered_name);
         if command.args.is_empty()
             && command.assignments.len() == 1
             && rendered_name.is_empty()
@@ -288,7 +288,7 @@ where
         redirects: &[Redirect],
     ) {
         let mut rendered_name = self.take_scratch_buffer();
-        self.render_word_with_facts_to_buffer(&command.name, &mut rendered_name);
+        self.render_word_to_buffer(&command.name, &mut rendered_name);
         self.format_simple_command_parts(command, redirects, rendered_name);
     }
 

--- a/crates/shuck-formatter/src/streaming/substitutions.rs
+++ b/crates/shuck-formatter/src/streaming/substitutions.rs
@@ -272,7 +272,7 @@ where
 
     pub(super) fn write_word(&mut self, word: &Word) {
         let mut scratch = self.take_scratch_buffer();
-        self.render_word_with_facts_to_buffer(word, &mut scratch);
+        self.render_word_to_buffer(word, &mut scratch);
         if rendered_shell_text_has_heredoc_tail(&scratch)
             && (word_contains_command_heredoc(word)
                 || word_source_has_shell_substitution(word, self.source())
@@ -311,14 +311,15 @@ where
     }
 
     pub(super) fn write_pattern(&mut self, pattern: &Pattern) {
-        self.write_rendered(|scratch, source, options| {
-            render_pattern_syntax_to_buf(pattern, source, options, scratch);
-        });
+        let mut scratch = self.take_scratch_buffer();
+        render_pattern_syntax_to_buf(pattern, self.render_context(), &mut scratch);
+        self.write_text(&scratch);
+        self.restore_scratch_buffer(scratch);
     }
 
     pub(super) fn write_case_pattern(&mut self, item: &CaseItem, pattern: &Pattern) {
         let mut scratch = self.take_scratch_buffer();
-        render_pattern_syntax_to_buf(pattern, self.source(), self.options(), &mut scratch);
+        render_pattern_syntax_to_buf(pattern, self.render_context(), &mut scratch);
         if case_item_pattern_close_paren_on_own_line(item, self.source(), self.source_map()) {
             trim_trailing_pattern_line_continuation(&mut scratch);
         }
@@ -346,19 +347,8 @@ where
             return;
         }
 
-        let source_map = self.source_map().clone();
         let mut scratch = self.take_scratch_buffer();
-        {
-            let facts = self.facts();
-            render_assignment_with_facts_to_buf(
-                assignment,
-                self.source(),
-                self.options(),
-                &source_map,
-                facts,
-                &mut scratch,
-            );
-        }
+        render_assignment_to_buf(assignment, self.render_context(), &mut scratch);
         if rendered_shell_text_has_heredoc_tail(&scratch)
             && (assignment_contains_command_heredoc(assignment)
                 || assignment_source_has_command_substitution(assignment, self.source())
@@ -528,19 +518,8 @@ where
     }
 
     pub(super) fn write_word_with_escaped_multiline_substitution_indent(&mut self, word: &Word) {
-        let source_map = self.source_map().clone();
         let mut scratch = self.take_scratch_buffer();
-        {
-            let facts = self.facts();
-            render_escaped_multiline_word_syntax_with_facts_to_buf(
-                word,
-                self.source(),
-                self.options(),
-                &source_map,
-                facts,
-                &mut scratch,
-            );
-        }
+        render_escaped_multiline_word_syntax_to_buf(word, self.render_context(), &mut scratch);
 
         let normalized =
             normalize_escaped_multiline_word_command_substitution_indent(&scratch, self.options());

--- a/crates/shuck-formatter/src/word/arithmetic.rs
+++ b/crates/shuck-formatter/src/word/arithmetic.rs
@@ -4,23 +4,15 @@ use super::*;
 pub(crate) fn render_arithmetic_expr_to_buf(
     rendered: &mut String,
     expr: &ArithmeticExprNode,
-    source: &str,
-    options: &ResolvedShellFormatOptions,
+    context: RenderContext<'_, '_>,
 ) {
-    push_arithmetic_expr(
-        rendered,
-        expr,
-        ArithmeticContext::TopLevel,
-        false,
-        WordRenderEnv::new(source, options, None, None),
-    );
+    push_arithmetic_expr(rendered, expr, ArithmeticContext::TopLevel, false, context);
 }
 
 pub(super) fn render_arithmetic_subscript_expr_to_buf(
     rendered: &mut String,
     expr: &ArithmeticExprNode,
-    source: &str,
-    options: &ResolvedShellFormatOptions,
+    context: RenderContext<'_, '_>,
     compact: bool,
 ) {
     push_arithmetic_expr(
@@ -28,7 +20,7 @@ pub(super) fn render_arithmetic_subscript_expr_to_buf(
         expr,
         ArithmeticContext::Subscript,
         compact,
-        WordRenderEnv::new(source, options, None, None),
+        context,
     );
 }
 
@@ -49,7 +41,7 @@ pub(super) fn push_arithmetic_expr(
     expr: &ArithmeticExprNode,
     context: ArithmeticContext,
     compact: bool,
-    env: WordRenderEnv<'_, '_>,
+    env: RenderContext<'_, '_>,
 ) {
     let needs_parentheses = arithmetic_needs_parentheses(expr, context);
     if needs_parentheses {
@@ -66,13 +58,7 @@ pub(super) fn push_arithmetic_expr(
             rendered.push(']');
         }
         ArithmeticExpr::ShellWord(word) => {
-            let word = render_arithmetic_shell_word(
-                word,
-                env.source,
-                env.options,
-                env.source_map,
-                env.facts,
-            );
+            let word = render_arithmetic_shell_word(word, env);
             if compact {
                 rendered.push_str(&compact_dynamic_arithmetic_subscript(
                     word.trim_matches([' ', '\t', '\r']),
@@ -167,7 +153,7 @@ pub(super) fn push_arithmetic_expr(
 pub(super) fn push_arithmetic_expansion_body(
     rendered: &mut String,
     expr: &ArithmeticExprNode,
-    env: WordRenderEnv<'_, '_>,
+    env: RenderContext<'_, '_>,
 ) {
     let mut body = String::new();
     push_arithmetic_expr(&mut body, expr, ArithmeticContext::TopLevel, false, env);
@@ -228,28 +214,14 @@ pub(super) fn arithmetic_lvalue_contains_command_substitution(target: &Arithmeti
     }
 }
 
-pub(super) fn render_arithmetic_shell_word(
-    word: &Word,
-    source: &str,
-    options: &ResolvedShellFormatOptions,
-    source_map: Option<&SourceMap<'_>>,
-    facts: Option<&FormatterFacts<'_>>,
-) -> String {
+pub(super) fn render_arithmetic_shell_word(word: &Word, context: RenderContext<'_, '_>) -> String {
     let render_with_context = || {
         let mut rendered = String::new();
-        render_word_syntax_internal(
-            word,
-            source,
-            options,
-            source_map,
-            facts,
-            true,
-            &mut rendered,
-        );
+        render_word_syntax_internal(word, context, true, &mut rendered);
         rendered
     };
 
-    if options.simplify() || options.minify() {
+    if context.options.simplify() || context.options.minify() {
         let [part] = word.parts.as_slice() else {
             return render_with_context();
         };
@@ -260,9 +232,9 @@ pub(super) fn render_arithmetic_shell_word(
                 reference.name.to_string()
             }
             WordPart::Parameter(parameter)
-                if is_plain_arithmetic_identifier(parameter.raw_body.slice(source)) =>
+                if is_plain_arithmetic_identifier(parameter.raw_body.slice(context.source)) =>
             {
-                parameter.raw_body.slice(source).to_string()
+                parameter.raw_body.slice(context.source).to_string()
             }
             _ => render_with_context(),
         };
@@ -404,7 +376,7 @@ pub(super) fn arithmetic_assign_operator(op: ArithmeticAssignOp) -> &'static str
 pub(super) fn push_arithmetic_lvalue(
     rendered: &mut String,
     target: &ArithmeticLvalue,
-    env: WordRenderEnv<'_, '_>,
+    env: RenderContext<'_, '_>,
 ) {
     match target {
         ArithmeticLvalue::Variable(name) => rendered.push_str(name),
@@ -421,18 +393,19 @@ pub(super) fn push_arithmetic_source_text(
     rendered: &mut String,
     text: &shuck_ast::SourceText,
     ast: Option<&ArithmeticExprNode>,
-    source: &str,
-    options: &ResolvedShellFormatOptions,
+    context: RenderContext<'_, '_>,
 ) {
     if let Some(ast) = ast {
         match &ast.kind {
-            ArithmeticExpr::ShellWord(word) if !options.simplify() && !options.minify() => {
-                rendered.push_str(&render_arithmetic_slice_shell_word(word, source, options));
+            ArithmeticExpr::ShellWord(word)
+                if !context.options.simplify() && !context.options.minify() =>
+            {
+                rendered.push_str(&render_arithmetic_slice_shell_word(word, context));
             }
-            _ => render_arithmetic_subscript_expr_to_buf(rendered, ast, source, options, true),
+            _ => render_arithmetic_subscript_expr_to_buf(rendered, ast, context, true),
         }
     } else {
-        rendered.push_str(text.slice(source));
+        rendered.push_str(text.slice(context.source));
     }
 }
 
@@ -440,11 +413,10 @@ pub(super) fn push_parameter_slice_offset(
     rendered: &mut String,
     text: &shuck_ast::SourceText,
     ast: Option<&ArithmeticExprNode>,
-    source: &str,
-    options: &ResolvedShellFormatOptions,
+    context: RenderContext<'_, '_>,
 ) {
     let mut offset = String::new();
-    push_arithmetic_source_text(&mut offset, text, ast, source, options);
+    push_arithmetic_source_text(&mut offset, text, ast, context);
     if offset.starts_with('-') {
         rendered.push(' ');
     }
@@ -453,11 +425,12 @@ pub(super) fn push_parameter_slice_offset(
 
 pub(super) fn render_arithmetic_slice_shell_word(
     word: &Word,
-    source: &str,
-    options: &ResolvedShellFormatOptions,
+    context: RenderContext<'_, '_>,
 ) -> String {
     let [part] = word.parts.as_slice() else {
-        return render_word_syntax(word, source, options);
+        let mut rendered = String::new();
+        render_word_syntax_to_buf(word, context, &mut rendered);
+        return rendered;
     };
 
     match &part.kind {
@@ -469,9 +442,9 @@ pub(super) fn render_arithmetic_slice_shell_word(
         } => {
             let mut body = String::new();
             if let Some(ast) = expression_ast.as_deref() {
-                render_arithmetic_expr_to_buf(&mut body, ast, source, options);
+                render_arithmetic_expr_to_buf(&mut body, ast, context);
             } else {
-                body.push_str(expression.slice(source).trim());
+                body.push_str(expression.slice(context.source).trim());
             }
             let (open, close) = match syntax {
                 ArithmeticExpansionSyntax::DollarParenParen => ("$((", "))"),
@@ -479,7 +452,11 @@ pub(super) fn render_arithmetic_slice_shell_word(
             };
             format!("{open}{body}{close}")
         }
-        _ => render_word_syntax(word, source, options),
+        _ => {
+            let mut rendered = String::new();
+            render_word_syntax_to_buf(word, context, &mut rendered);
+            rendered
+        }
     }
 }
 
@@ -488,18 +465,14 @@ pub(super) fn push_arithmetic_expansion(
     expression: &shuck_ast::SourceText,
     expression_ast: Option<&ArithmeticExprNode>,
     syntax: ArithmeticExpansionSyntax,
-    env: WordRenderEnv<'_, '_>,
+    env: RenderContext<'_, '_>,
 ) {
     let expression_source = expression.slice(env.source);
     if matches!(syntax, ArithmeticExpansionSyntax::LegacyBracket) {
         push_trimmed_arithmetic_expansion_source(rendered, expression_source, syntax);
-    } else if let Some(formatted) = format_multiline_arithmetic_expansion_source(
-        expression_source,
-        syntax,
-        expression_ast,
-        env.source,
-        env.options,
-    ) {
+    } else if let Some(formatted) =
+        format_multiline_arithmetic_expansion_source(expression_source, syntax, expression_ast, env)
+    {
         rendered.push_str(&formatted);
     } else if arithmetic_expression_prefers_raw_source(expression_source)
         || !expression.is_source_backed()
@@ -542,8 +515,7 @@ pub(super) fn format_multiline_arithmetic_expansion_source(
     expression_source: &str,
     syntax: ArithmeticExpansionSyntax,
     expression_ast: Option<&ArithmeticExprNode>,
-    source: &str,
-    options: &ResolvedShellFormatOptions,
+    context: RenderContext<'_, '_>,
 ) -> Option<String> {
     if !matches!(syntax, ArithmeticExpansionSyntax::DollarParenParen)
         || !expression_source.contains('\n')
@@ -555,13 +527,15 @@ pub(super) fn format_multiline_arithmetic_expansion_source(
     let operators = multiline_arithmetic_source_trailing_operators(expression_source)?;
     let mut rendered_body = String::new();
     if let Some(expression_ast) = expression_ast {
-        render_arithmetic_expr_to_buf(&mut rendered_body, expression_ast, source, options);
+        render_arithmetic_expr_to_buf(&mut rendered_body, expression_ast, context);
     } else {
         rendered_body.push_str(expression_source.trim());
     }
     let lines = split_rendered_arithmetic_body_at_source_operators(&rendered_body, &operators)?;
     let mut continuation_indent = String::new();
-    options.push_indent_units(&mut continuation_indent, 1);
+    context
+        .options
+        .push_indent_units(&mut continuation_indent, 1);
     let lines = lines
         .into_iter()
         .map(|line| format!("{continuation_indent}{line}"))
@@ -625,8 +599,7 @@ pub(super) fn arithmetic_expression_prefers_raw_source(expression_source: &str) 
 pub(super) fn push_var_ref(
     rendered: &mut String,
     reference: &VarRef,
-    source: &str,
-    options: &ResolvedShellFormatOptions,
+    context: RenderContext<'_, '_>,
 ) {
     rendered.push_str(reference.name.as_ref());
     if let Some(subscript) = &reference.subscript {
@@ -637,12 +610,13 @@ pub(super) fn push_var_ref(
                 SubscriptSelector::Star => '*',
             });
         } else if let Some(ast) = subscript.arithmetic_ast.as_ref() {
-            let compact =
-                !arithmetic_subscript_prefers_spaced_expression(subscript.syntax_text(source));
-            render_arithmetic_subscript_expr_to_buf(rendered, ast, source, options, compact);
+            let compact = !arithmetic_subscript_prefers_spaced_expression(
+                subscript.syntax_text(context.source),
+            );
+            render_arithmetic_subscript_expr_to_buf(rendered, ast, context, compact);
         } else {
             rendered.push_str(&compact_dynamic_arithmetic_subscript(
-                subscript.syntax_text(source),
+                subscript.syntax_text(context.source),
             ));
         }
         rendered.push(']');

--- a/crates/shuck-formatter/src/word/command_substitution.rs
+++ b/crates/shuck-formatter/src/word/command_substitution.rs
@@ -236,10 +236,8 @@ pub(super) fn collect_raw_command_substitution_spans(
 pub(super) struct RawCommandSubstitutionCommentFallback<'source, 'facts> {
     pub(super) raw: &'source str,
     pub(super) body: &'source shuck_ast::StmtSeq,
-    pub(super) source: &'source str,
     pub(super) span_start: usize,
-    pub(super) options: &'source ResolvedShellFormatOptions,
-    pub(super) facts: Option<&'source FormatterFacts<'facts>>,
+    pub(super) context: RenderContext<'source, 'facts>,
 }
 
 pub(super) fn push_raw_command_substitution_comment_fallback(
@@ -250,16 +248,17 @@ pub(super) fn push_raw_command_substitution_comment_fallback(
     let RawCommandSubstitutionCommentFallback {
         raw,
         body,
-        source,
         span_start,
-        options,
-        facts,
+        context,
     } = fallback;
+    let source = context.source;
+    let options = context.options;
 
     if push_inline_raw_command_substitution_as_block(rendered, raw, options) {
         return;
     }
-    if command_substitution_source_starts_with_body_line(raw) && !stmt_seq_has_heredoc(facts, body)
+    if command_substitution_source_starts_with_body_line(raw)
+        && !stmt_seq_has_heredoc(context.facts, body)
     {
         push_raw_block_command_substitution_without_outer_indent(
             rendered, raw, source, span_start, options,
@@ -279,23 +278,15 @@ pub(super) fn render_command_substitution(
     rendered: &mut String,
     body: &shuck_ast::StmtSeq,
     upper_bound: usize,
-    source: &str,
-    options: &ResolvedShellFormatOptions,
+    context: RenderContext<'_, '_>,
     layout: CommandSubstitutionLayout,
     inline_continuation_indent_levels: usize,
     raw: Option<&str>,
-    _source_map: Option<&SourceMap<'_>>,
-    facts: Option<&FormatterFacts<'_>>,
 ) -> Option<()> {
+    let source = context.source;
+    let options = context.options;
     let mut nested = String::new();
-    format_nested_stmt_sequence_to_buf(
-        source,
-        body,
-        options,
-        facts,
-        Some(upper_bound),
-        &mut nested,
-    )?;
+    format_nested_stmt_sequence_to_buf(body, context, Some(upper_bound), &mut nested)?;
 
     let trimmed = trim_trailing_line_endings(&nested);
     let normalized_backtick_body;
@@ -362,26 +353,20 @@ pub(super) fn render_command_substitution(
 }
 
 pub(super) fn format_nested_stmt_sequence_to_buf(
-    source: &str,
     body: &StmtSeq,
-    options: &ResolvedShellFormatOptions,
-    facts: Option<&FormatterFacts<'_>>,
+    context: RenderContext<'_, '_>,
     upper_bound: Option<usize>,
     rendered: &mut String,
 ) -> Option<()> {
-    let owned_facts;
-    let facts = match facts {
-        Some(facts) => facts,
-        None => {
-            let file = shuck_ast::File {
-                body: body.clone(),
-                span: body.span,
-            };
-            owned_facts = FormatterFacts::build(source, &file, options);
-            &owned_facts
-        }
-    };
-    format_stmt_sequence_streaming_to_buf(source, body, options, facts, upper_bound, rendered).ok()
+    format_stmt_sequence_streaming_to_buf(
+        context.source,
+        body,
+        context.options,
+        context.facts,
+        upper_bound,
+        rendered,
+    )
+    .ok()
 }
 
 pub(super) fn restore_trailing_escaped_horizontal_whitespace(
@@ -620,9 +605,11 @@ pub(super) fn expand_inline_pipeline_brace_group_body(
     if parsed.is_err() {
         return None;
     }
+    let parsed_facts = FormatterFacts::build(body, &parsed.file, options);
+    let context = RenderContext::new(body, options, &parsed_facts);
 
     let mut nested = String::new();
-    format_nested_stmt_sequence_to_buf(body, &parsed.file.body, options, None, None, &mut nested)?;
+    format_nested_stmt_sequence_to_buf(&parsed.file.body, context, None, &mut nested)?;
     let trimmed = trim_trailing_line_endings(&nested);
     trimmed.contains('\n').then(|| trimmed.to_string())
 }
@@ -743,9 +730,7 @@ pub(super) enum CommandSubstitutionLayout {
 pub(super) fn command_substitution_layout(
     raw: Option<&str>,
     body: &shuck_ast::StmtSeq,
-    facts: Option<&FormatterFacts<'_>>,
-    source: &str,
-    dialect: shuck_parser::ShellDialect,
+    context: RenderContext<'_, '_>,
     force_block: bool,
     allow_source_indented_inline: bool,
 ) -> CommandSubstitutionLayout {
@@ -753,7 +738,7 @@ pub(super) fn command_substitution_layout(
         return CommandSubstitutionLayout::Block;
     }
 
-    if stmt_seq_has_heredoc(facts, body) {
+    if stmt_seq_has_heredoc(context.facts, body) {
         return CommandSubstitutionLayout::Block;
     }
 
@@ -764,7 +749,8 @@ pub(super) fn command_substitution_layout(
         if command_substitution_source_closes_on_own_line(raw) {
             return CommandSubstitutionLayout::Block;
         }
-        if command_substitution_source_parses_as_multiple_statements(raw, dialect) {
+        if command_substitution_source_parses_as_multiple_statements(raw, context.options.dialect())
+        {
             return CommandSubstitutionLayout::Block;
         }
         if command_substitution_source_prefers_continued_inline_body(raw) {
@@ -778,7 +764,7 @@ pub(super) fn command_substitution_layout(
     if body.len() > 1
         || body
             .span
-            .slice(source)
+            .slice(context.source)
             .trim_start_matches([' ', '\t', '\r'])
             .starts_with('\n')
     {
@@ -1229,22 +1215,15 @@ pub(super) fn render_process_substitution(
     body: &shuck_ast::StmtSeq,
     is_input: bool,
     span: shuck_ast::Span,
-    source: &str,
-    options: &ResolvedShellFormatOptions,
+    context: RenderContext<'_, '_>,
     multiline: bool,
     raw: Option<&str>,
-    facts: Option<&FormatterFacts<'_>>,
 ) -> Option<()> {
-    let has_heredoc = stmt_seq_has_heredoc(facts, body);
+    let source = context.source;
+    let options = context.options;
+    let has_heredoc = stmt_seq_has_heredoc(context.facts, body);
     let mut nested = String::new();
-    format_nested_stmt_sequence_to_buf(
-        source,
-        body,
-        options,
-        facts,
-        span.end.offset.checked_sub(1),
-        &mut nested,
-    )?;
+    format_nested_stmt_sequence_to_buf(body, context, span.end.offset.checked_sub(1), &mut nested)?;
 
     let prefix = if is_input { '<' } else { '>' };
     let trimmed = trim_trailing_line_endings(&nested);

--- a/crates/shuck-formatter/src/word/core.rs
+++ b/crates/shuck-formatter/src/word/core.rs
@@ -62,60 +62,30 @@ pub(super) fn word_part_nodes_any(
     })
 }
 
-pub(crate) fn render_word_syntax(
-    word: &Word,
-    source: &str,
-    options: &ResolvedShellFormatOptions,
-) -> String {
-    let mut rendered = String::new();
-    render_word_syntax_to_buf(word, source, options, &mut rendered);
-    rendered
-}
-
 pub(crate) fn render_word_syntax_to_buf(
     word: &Word,
-    source: &str,
-    options: &ResolvedShellFormatOptions,
+    context: RenderContext<'_, '_>,
     rendered: &mut String,
 ) {
-    render_word_syntax_internal(word, source, options, None, None, true, rendered);
+    render_word_syntax_internal(word, context, true, rendered);
 }
 
-pub(crate) fn render_word_syntax_with_facts_to_buf(
+pub(crate) fn render_escaped_multiline_word_syntax_to_buf(
     word: &Word,
-    source: &str,
-    options: &ResolvedShellFormatOptions,
-    source_map: &SourceMap<'_>,
-    facts: &FormatterFacts<'_>,
+    context: RenderContext<'_, '_>,
     rendered: &mut String,
 ) {
-    let source_map = Some(source_map);
-    let facts = Some(facts);
-    render_word_syntax_internal(word, source, options, source_map, facts, true, rendered);
-}
-
-pub(crate) fn render_escaped_multiline_word_syntax_with_facts_to_buf(
-    word: &Word,
-    source: &str,
-    options: &ResolvedShellFormatOptions,
-    source_map: &SourceMap<'_>,
-    facts: &FormatterFacts<'_>,
-    rendered: &mut String,
-) {
-    let source_map = Some(source_map);
-    let facts = Some(facts);
-    render_word_syntax_internal(word, source, options, source_map, facts, false, rendered);
+    render_word_syntax_internal(word, context, false, rendered);
 }
 
 pub(super) fn render_word_syntax_internal(
     word: &Word,
-    source: &str,
-    options: &ResolvedShellFormatOptions,
-    source_map: Option<&SourceMap<'_>>,
-    facts: Option<&FormatterFacts<'_>>,
+    context: RenderContext<'_, '_>,
     preserve_escaped_multiline_words: bool,
     rendered: &mut String,
 ) {
+    let source = context.source;
+    let options = context.options;
     let preserve_raw = !options.simplify() && !options.minify();
 
     if preserve_raw
@@ -187,12 +157,11 @@ pub(super) fn render_word_syntax_internal(
         return;
     }
 
-    if word_needs_formatter_rendering(word, source, options) {
+    if word_needs_formatter_rendering(word, context) {
         let start = rendered.len();
-        let env = WordRenderEnv::new(source, options, source_map, facts);
         if render_word_parts(
             word.parts.as_slice(),
-            env,
+            context,
             preserve_escaped_multiline_words,
             rendered,
         )
@@ -290,37 +259,33 @@ pub(super) fn word_needs_special_rendering(word: &Word) -> bool {
     })
 }
 
-pub(super) fn word_needs_formatter_rendering(
-    word: &Word,
-    source: &str,
-    options: &ResolvedShellFormatOptions,
-) -> bool {
+pub(super) fn word_needs_formatter_rendering(word: &Word, context: RenderContext<'_, '_>) -> bool {
     word_part_nodes_any(&word.parts, &mut |part| {
-        word_part_needs_formatter_rendering(part, source, options)
+        word_part_needs_formatter_rendering(part, context)
     })
 }
 
 pub(super) fn word_part_needs_formatter_rendering(
     part: &WordPartNode,
-    source: &str,
-    options: &ResolvedShellFormatOptions,
+    context: RenderContext<'_, '_>,
 ) -> bool {
     part_needs_special_rendering(&part.kind)
-        || word_part_has_parameter_raw_subscript_needs_compaction(&part.kind, source, options)
+        || word_part_has_parameter_raw_subscript_needs_compaction(&part.kind, context)
         || word_part_has_parameter_command_redirect_spacing_needs_normalization(
-            &part.kind, part.span, source,
+            &part.kind,
+            part.span,
+            context.source,
         )
-        || word_part_has_arithmetic_expansion_source_needs_trim(&part.kind, source)
+        || word_part_has_arithmetic_expansion_source_needs_trim(&part.kind, context.source)
 }
 
 pub(super) fn word_part_has_parameter_raw_subscript_needs_compaction(
     part: &WordPart,
-    source: &str,
-    options: &ResolvedShellFormatOptions,
+    context: RenderContext<'_, '_>,
 ) -> bool {
     match part {
         WordPart::Parameter(parameter) => {
-            parameter_raw_subscript_needs_compaction(parameter, source, options)
+            parameter_raw_subscript_needs_compaction(parameter, context)
         }
         _ => false,
     }
@@ -427,7 +392,7 @@ pub(super) fn part_needs_special_rendering(part: &WordPart) -> bool {
 
 pub(super) fn render_word_parts(
     parts: &[shuck_ast::WordPartNode],
-    env: WordRenderEnv<'_, '_>,
+    env: RenderContext<'_, '_>,
     allow_source_indented_inline_command_substitution: bool,
     rendered: &mut String,
 ) -> Result<(), std::fmt::Error> {
@@ -456,15 +421,14 @@ pub(super) fn render_word_part(
     rendered: &mut String,
     part: &WordPart,
     span: shuck_ast::Span,
-    env: WordRenderEnv<'_, '_>,
-    context: WordPartRenderContext,
+    env: RenderContext<'_, '_>,
+    part_context: WordPartRenderContext,
 ) -> Result<(), std::fmt::Error> {
     let source = env.source;
     let options = env.options;
-    let source_map = env.source_map;
     let facts = env.facts;
 
-    if let Some(raw) = preferred_raw_word_part_source(part, span, source, options) {
+    if let Some(raw) = preferred_raw_word_part_source(part, span, env) {
         rendered.push_str(raw);
         return Ok(());
     }
@@ -511,9 +475,9 @@ pub(super) fn render_word_part(
                             part.span,
                             env,
                             WordPartRenderContext {
-                                allow_source_indented_inline_command_substitution: context
+                                allow_source_indented_inline_command_substitution: part_context
                                     .allow_source_indented_inline_command_substitution,
-                                source_indented_inline_command_substitution: context
+                                source_indented_inline_command_substitution: part_context
                                     .allow_source_indented_inline_command_substitution
                                     && follows_line_indent_literal,
                             },
@@ -538,11 +502,9 @@ pub(super) fn render_word_part(
                 let layout = command_substitution_layout(
                     Some(raw),
                     body,
-                    facts,
-                    source,
-                    options.dialect(),
+                    env,
                     false,
-                    context.source_indented_inline_command_substitution,
+                    part_context.source_indented_inline_command_substitution,
                 );
                 if raw_dollar_command_substitution_body(raw)
                     .is_some_and(raw_body_contains_pipeline_multistatement_brace_group)
@@ -554,10 +516,8 @@ pub(super) fn render_word_part(
                     let fallback = RawCommandSubstitutionCommentFallback {
                         raw,
                         body,
-                        source,
                         span_start: span.start.offset,
-                        options,
-                        facts,
+                        context: env,
                     };
                     if commented_command_substitution_can_use_structural_formatter(body) {
                         let rendered_start = rendered.len();
@@ -565,13 +525,10 @@ pub(super) fn render_word_part(
                             rendered,
                             body,
                             span.end.offset,
-                            source,
-                            options,
+                            env,
                             layout,
                             1,
                             Some(raw),
-                            source_map,
-                            None,
                         )
                         .is_some()
                         {
@@ -596,13 +553,10 @@ pub(super) fn render_word_part(
                     rendered,
                     body,
                     span.end.offset,
-                    source,
-                    options,
+                    env,
                     layout,
                     1,
                     Some(raw),
-                    source_map,
-                    facts,
                 )
                 .is_some()
                 {
@@ -613,21 +567,16 @@ pub(super) fn render_word_part(
                 rendered,
                 body,
                 span.end.offset,
-                source,
-                options,
+                env,
                 command_substitution_layout(
                     None,
                     body,
-                    facts,
-                    source,
-                    options.dialect(),
+                    env,
                     *syntax == CommandSubstitutionSyntax::DollarParen,
                     false,
                 ),
                 1,
                 None,
-                source_map,
-                facts,
             )
             .is_some()
             {
@@ -656,21 +605,17 @@ pub(super) fn render_word_part(
                     body,
                     *is_input,
                     span,
-                    source,
-                    options,
+                    env,
                     raw.contains('\n'),
                     Some(raw),
-                    facts,
                 )
                 .is_some()
                 {
                 } else {
                     rendered.push_str(raw);
                 }
-            } else if render_process_substitution(
-                rendered, body, *is_input, span, source, options, false, None, facts,
-            )
-            .is_some()
+            } else if render_process_substitution(rendered, body, *is_input, span, env, false, None)
+                .is_some()
             {
             } else {
                 let prefix = if *is_input { "<" } else { ">" };
@@ -690,7 +635,7 @@ pub(super) fn render_word_part(
             env,
         ),
         WordPart::Parameter(parameter) => {
-            push_parameter_word(rendered, parameter, source, options)?;
+            push_parameter_word(rendered, parameter, env)?;
         }
         WordPart::ParameterExpansion {
             reference,
@@ -708,13 +653,13 @@ pub(super) fn render_word_part(
             env,
         )?,
         WordPart::Length(reference) | WordPart::ArrayLength(reference) => {
-            push_braced_var_ref(rendered, "#", reference, source, options);
+            push_braced_var_ref(rendered, "#", reference, env);
         }
         WordPart::ArrayAccess(reference) => {
-            push_braced_var_ref(rendered, "", reference, source, options);
+            push_braced_var_ref(rendered, "", reference, env);
         }
         WordPart::ArrayIndices(reference) => {
-            push_braced_var_ref(rendered, "!", reference, source, options);
+            push_braced_var_ref(rendered, "!", reference, env);
         }
         WordPart::Substring {
             reference,
@@ -733,18 +678,12 @@ pub(super) fn render_word_part(
             ..
         } => {
             rendered.push_str("${");
-            push_var_ref(rendered, reference, source, options);
+            push_var_ref(rendered, reference, env);
             rendered.push(':');
-            push_parameter_slice_offset(rendered, offset, offset_ast.as_deref(), source, options);
+            push_parameter_slice_offset(rendered, offset, offset_ast.as_deref(), env);
             if let Some(length) = length {
                 rendered.push(':');
-                push_arithmetic_source_text(
-                    rendered,
-                    length,
-                    length_ast.as_deref(),
-                    source,
-                    options,
-                );
+                push_arithmetic_source_text(rendered, length, length_ast.as_deref(), env);
             }
             rendered.push('}');
         }
@@ -756,14 +695,14 @@ pub(super) fn render_word_part(
             ..
         } => {
             rendered.push_str("${!");
-            push_var_ref(rendered, reference, source, options);
+            push_var_ref(rendered, reference, env);
             if let Some(operator) = operator {
                 if *colon_variant {
                     rendered.push(':');
                 }
                 rendered.push_str(parameter_defaulting_operator(operator.as_ref()));
                 if let Some(operand) = operand {
-                    push_parameter_operand(rendered, operand, source, options);
+                    push_parameter_operand(rendered, operand, env);
                 }
             }
             rendered.push('}');
@@ -783,12 +722,11 @@ pub(super) fn push_braced_var_ref(
     rendered: &mut String,
     prefix: &str,
     reference: &VarRef,
-    source: &str,
-    options: &ResolvedShellFormatOptions,
+    context: RenderContext<'_, '_>,
 ) {
     rendered.push_str("${");
     rendered.push_str(prefix);
-    push_var_ref(rendered, reference, source, options);
+    push_var_ref(rendered, reference, context);
     rendered.push('}');
 }
 
@@ -802,9 +740,10 @@ pub(super) fn literal_ends_with_line_indent_for_word_part(literal: &str) -> bool
 pub(super) fn preferred_raw_word_part_source<'a>(
     part: &WordPart,
     span: shuck_ast::Span,
-    source: &'a str,
-    options: &ResolvedShellFormatOptions,
+    context: RenderContext<'a, '_>,
 ) -> Option<&'a str> {
+    let source = context.source;
+    let options = context.options;
     if options.simplify() || options.minify() {
         return None;
     }
@@ -814,14 +753,14 @@ pub(super) fn preferred_raw_word_part_source<'a>(
         WordPart::DoubleQuoted { parts, .. } => {
             let raw = raw_source_slice(span, source)?;
             let has_formattable_parts = word_part_nodes_any(parts, &mut |part| {
-                word_part_needs_formatter_rendering(part, source, options)
+                word_part_needs_formatter_rendering(part, context)
             });
             (!has_formattable_parts).then_some(raw)
         }
         WordPart::Parameter(parameter) => {
             let raw = raw_source_slice(span, source)?;
             (parameter_prefers_raw_source(parameter, span, source)
-                && !parameter_raw_subscript_needs_compaction(parameter, source, options)
+                && !parameter_raw_subscript_needs_compaction(parameter, context)
                 && !raw_parameter_command_spacing_would_change(raw))
             .then_some(raw)
         }
@@ -847,9 +786,9 @@ pub(super) fn preferred_raw_word_part_source<'a>(
 
 pub(super) fn parameter_raw_subscript_needs_compaction(
     parameter: &shuck_ast::ParameterExpansion,
-    source: &str,
-    options: &ResolvedShellFormatOptions,
+    context: RenderContext<'_, '_>,
 ) -> bool {
+    let source = context.source;
     if parameter_bourne_operand_needs_subscript_compaction(parameter, source) {
         return true;
     }
@@ -859,7 +798,7 @@ pub(super) fn parameter_raw_subscript_needs_compaction(
             && arithmetic_subscript_prefers_spaced_expression(syntax)
         {
             let mut rendered = String::new();
-            render_arithmetic_subscript_expr_to_buf(&mut rendered, ast, source, options, false);
+            render_arithmetic_subscript_expr_to_buf(&mut rendered, ast, context, false);
             return rendered != syntax;
         }
         return compact_dynamic_arithmetic_subscript(syntax) != syntax;
@@ -915,29 +854,6 @@ pub(super) fn render_double_quoted_literal(rendered: &mut String, text: &str) {
                 rendered.push(ch);
             }
             _ => rendered.push(ch),
-        }
-    }
-}
-#[derive(Clone, Copy)]
-pub(super) struct WordRenderEnv<'source, 'a> {
-    pub(super) source: &'source str,
-    pub(super) options: &'a ResolvedShellFormatOptions,
-    pub(super) source_map: Option<&'a SourceMap<'source>>,
-    pub(super) facts: Option<&'a FormatterFacts<'source>>,
-}
-
-impl<'source, 'a> WordRenderEnv<'source, 'a> {
-    pub(super) fn new(
-        source: &'source str,
-        options: &'a ResolvedShellFormatOptions,
-        source_map: Option<&'a SourceMap<'source>>,
-        facts: Option<&'a FormatterFacts<'source>>,
-    ) -> Self {
-        Self {
-            source,
-            options,
-            source_map,
-            facts,
         }
     }
 }

--- a/crates/shuck-formatter/src/word/heredoc.rs
+++ b/crates/shuck-formatter/src/word/heredoc.rs
@@ -1,6 +1,5 @@
 use super::arithmetic::*;
 use super::command_substitution::*;
-use super::core::WordRenderEnv;
 use super::parameter::*;
 use super::raw_rewrites::*;
 use super::*;
@@ -38,6 +37,7 @@ pub(super) fn render_heredoc_body_part(
     facts: &FormatterFacts<'_>,
     embedded_command_indent_levels: usize,
 ) -> Result<(), std::fmt::Error> {
+    let context = RenderContext::new(source, options, facts);
     match part {
         HeredocBodyPart::Literal(text) => {
             let raw = span.slice(source);
@@ -74,9 +74,7 @@ pub(super) fn render_heredoc_body_part(
                 let layout = command_substitution_layout(
                     raw,
                     body,
-                    Some(facts),
-                    source,
-                    options.dialect(),
+                    context,
                     raw.is_none() && *syntax == CommandSubstitutionSyntax::DollarParen,
                     false,
                 );
@@ -85,13 +83,10 @@ pub(super) fn render_heredoc_body_part(
                     rendered,
                     body,
                     span.end.offset,
-                    source,
-                    options,
+                    context,
                     layout,
                     embedded_command_indent_levels,
                     raw,
-                    Some(facts.source_map()),
-                    Some(facts),
                 )
                 .is_none()
                 {
@@ -117,7 +112,7 @@ pub(super) fn render_heredoc_body_part(
                     expression,
                     expression_ast.as_ref(),
                     *syntax,
-                    WordRenderEnv::new(source, options, Some(facts.source_map()), Some(facts)),
+                    context,
                 );
             }
         }
@@ -125,7 +120,7 @@ pub(super) fn render_heredoc_body_part(
             if let Some(raw) = escaped_heredoc_expansion_source(span, source) {
                 rendered.push_str(raw);
             } else {
-                push_parameter_word(rendered, parameter, source, options)?;
+                push_parameter_word(rendered, parameter, context)?;
             }
         }
     }
@@ -169,15 +164,9 @@ pub(super) fn render_heredoc_body_command_substitution(
         return None;
     }
 
+    let context = RenderContext::new(source, options, facts);
     let mut nested = String::new();
-    format_nested_stmt_sequence_to_buf(
-        source,
-        body,
-        options,
-        Some(facts),
-        Some(upper_bound),
-        &mut nested,
-    )?;
+    format_nested_stmt_sequence_to_buf(body, context, Some(upper_bound), &mut nested)?;
     let trimmed = trim_trailing_line_endings(&nested);
     if trimmed.is_empty() {
         rendered.push_str("$()");

--- a/crates/shuck-formatter/src/word/mod.rs
+++ b/crates/shuck-formatter/src/word/mod.rs
@@ -1,11 +1,8 @@
 use std::fmt::Write as _;
 
 use crate::command::trim_unescaped_trailing_whitespace;
-use crate::comments::SourceMap;
-use crate::facts::{
-    FormatterFacts, classify_sequence_contains_comments, classify_sequence_contains_heredoc,
-    classify_sequence_contains_multiline_literal_source,
-};
+use crate::context::RenderContext;
+use crate::facts::{FormatterFacts, classify_sequence_contains_multiline_literal_source};
 use crate::options::{IndentStyle, ResolvedShellFormatOptions};
 use crate::raw_syntax::{
     QuoteState, RawShellScanner, RawShellText, common_nonempty_shell_indent, heredoc_start,
@@ -32,9 +29,8 @@ mod raw_rewrites;
 
 pub(crate) use self::arithmetic::render_arithmetic_expr_to_buf;
 pub(crate) use self::core::{
-    render_escaped_multiline_word_syntax_with_facts_to_buf, render_word_syntax_to_buf,
-    render_word_syntax_with_facts_to_buf, word_gap_end_before_trailing_continuation,
-    word_is_quoted_command_substitution_only,
+    render_escaped_multiline_word_syntax_to_buf, render_word_syntax_to_buf,
+    word_gap_end_before_trailing_continuation, word_is_quoted_command_substitution_only,
     word_is_quoted_formattable_command_substitution_only_with_facts,
 };
 pub(crate) use self::heredoc::render_heredoc_body_to_buf;

--- a/crates/shuck-formatter/src/word/parameter.rs
+++ b/crates/shuck-formatter/src/word/parameter.rs
@@ -7,9 +7,9 @@ use super::*;
 pub(super) fn push_parameter_word(
     rendered: &mut String,
     parameter: &shuck_ast::ParameterExpansion,
-    source: &str,
-    options: &ResolvedShellFormatOptions,
+    context: RenderContext<'_, '_>,
 ) -> Result<(), std::fmt::Error> {
+    let source = context.source;
     let Some(syntax) = parameter.bourne() else {
         let raw = parameter.raw_body.slice(source);
         rendered.push_str("${");
@@ -20,13 +20,13 @@ pub(super) fn push_parameter_word(
 
     match syntax {
         BourneParameterExpansion::Access { reference } => {
-            push_braced_var_ref(rendered, "", reference, source, options);
+            push_braced_var_ref(rendered, "", reference, context);
         }
         BourneParameterExpansion::Length { reference } => {
-            push_braced_var_ref(rendered, "#", reference, source, options);
+            push_braced_var_ref(rendered, "#", reference, context);
         }
         BourneParameterExpansion::Indices { reference } => {
-            push_braced_var_ref(rendered, "!", reference, source, options);
+            push_braced_var_ref(rendered, "!", reference, context);
         }
         BourneParameterExpansion::Indirect {
             reference,
@@ -36,7 +36,7 @@ pub(super) fn push_parameter_word(
             ..
         } => {
             rendered.push_str("${!");
-            push_var_ref(rendered, reference, source, options);
+            push_var_ref(rendered, reference, context);
             if let Some(operator) = operator {
                 if *colon_variant {
                     rendered.push(':');
@@ -63,18 +63,12 @@ pub(super) fn push_parameter_word(
             ..
         } => {
             rendered.push_str("${");
-            push_var_ref(rendered, reference, source, options);
+            push_var_ref(rendered, reference, context);
             rendered.push(':');
-            push_parameter_slice_offset(rendered, offset, offset_ast.as_deref(), source, options);
+            push_parameter_slice_offset(rendered, offset, offset_ast.as_deref(), context);
             if let Some(length) = length {
                 rendered.push(':');
-                push_arithmetic_source_text(
-                    rendered,
-                    length,
-                    length_ast.as_deref(),
-                    source,
-                    options,
-                );
+                push_arithmetic_source_text(rendered, length, length_ast.as_deref(), context);
             }
             rendered.push('}');
         }
@@ -92,7 +86,7 @@ pub(super) fn push_parameter_word(
                 operand.as_ref(),
                 *colon_variant,
                 Some(parameter.span),
-                WordRenderEnv::new(source, options, None, None),
+                context,
             )?;
         }
         BourneParameterExpansion::Transformation {
@@ -100,7 +94,7 @@ pub(super) fn push_parameter_word(
             operator,
         } => {
             rendered.push_str("${");
-            push_var_ref(rendered, reference, source, options);
+            push_var_ref(rendered, reference, context);
             rendered.push('@');
             std::write!(rendered, "{operator}")?;
             rendered.push('}');
@@ -113,15 +107,17 @@ pub(super) fn push_parameter_word(
 pub(super) fn push_parameter_operand(
     rendered: &mut String,
     operand: &shuck_ast::SourceText,
-    source: &str,
-    options: &ResolvedShellFormatOptions,
+    context: RenderContext<'_, '_>,
 ) {
-    let operand = compact_parameter_operand_subscripts(operand.slice(source));
+    let operand = compact_parameter_operand_subscripts(operand.slice(context.source));
     if operand.contains("$(") || operand.contains('`') {
         let mut normalized = String::new();
         push_raw_shell_text_with_normalized_redirect_spacing(&mut normalized, &operand);
         if let Some(command_normalized) =
-            normalize_inline_command_substitutions_in_parameter_operand(&normalized, options)
+            normalize_inline_command_substitutions_in_parameter_operand(
+                &normalized,
+                context.options,
+            )
         {
             rendered.push_str(&command_normalized);
         } else {
@@ -190,16 +186,11 @@ pub(super) fn normalize_inline_parameter_command_substitution_body(
     if parsed.is_err() {
         return None;
     }
+    let parsed_facts = FormatterFacts::build(trimmed, &parsed.file, options);
+    let context = RenderContext::new(trimmed, options, &parsed_facts);
 
     let mut nested = String::new();
-    format_nested_stmt_sequence_to_buf(
-        trimmed,
-        &parsed.file.body,
-        options,
-        None,
-        None,
-        &mut nested,
-    )?;
+    format_nested_stmt_sequence_to_buf(&parsed.file.body, context, None, &mut nested)?;
     let formatted = trim_trailing_line_endings(&nested);
     (!formatted.is_empty() && !formatted.contains('\n')).then(|| formatted.to_string())
 }
@@ -246,12 +237,12 @@ pub(super) fn render_parameter_expansion(
     operand: Option<&shuck_ast::SourceText>,
     colon_variant: bool,
     raw_parameter_span: Option<shuck_ast::Span>,
-    env: WordRenderEnv<'_, '_>,
+    env: RenderContext<'_, '_>,
 ) -> Result<(), std::fmt::Error> {
     let (source, options) = (env.source, env.options);
 
     rendered.push_str("${");
-    push_var_ref(rendered, reference, source, options);
+    push_var_ref(rendered, reference, env);
     match operator {
         ParameterOp::UseDefault
         | ParameterOp::AssignDefault
@@ -262,7 +253,7 @@ pub(super) fn render_parameter_expansion(
             }
             rendered.push_str(parameter_defaulting_operator(operator));
             if let Some(operand) = operand {
-                push_parameter_operand(rendered, operand, source, options);
+                push_parameter_operand(rendered, operand, env);
             }
         }
         ParameterOp::RemovePrefixShort { pattern }
@@ -277,7 +268,7 @@ pub(super) fn render_parameter_expansion(
                 _ => unreachable!(),
             };
             rendered.push_str(removal_operator);
-            render_pattern_syntax_to_buf(pattern, source, options, rendered);
+            render_pattern_syntax_to_buf(pattern, env, rendered);
         }
         ParameterOp::ReplaceFirst {
             pattern,
@@ -305,7 +296,7 @@ pub(super) fn render_parameter_expansion(
                 rendered.push('/');
                 rendered.push_str(raw_replacement);
             } else {
-                render_parameter_replacement_pattern(rendered, pattern, source, options);
+                render_parameter_replacement_pattern(rendered, pattern, env);
                 rendered.push('/');
                 push_parameter_replacement_text(rendered, replacement, source);
             }
@@ -371,9 +362,10 @@ pub(super) fn split_raw_parameter_replacement(raw: &str) -> (&str, &str) {
 pub(super) fn render_parameter_replacement_pattern(
     rendered: &mut String,
     pattern: &Pattern,
-    source: &str,
-    options: &ResolvedShellFormatOptions,
+    context: RenderContext<'_, '_>,
 ) {
+    let source = context.source;
+    let options = context.options;
     if !options.simplify()
         && !options.minify()
         && let Some(raw) = raw_pattern_source_slice(pattern, source)
@@ -382,7 +374,7 @@ pub(super) fn render_parameter_replacement_pattern(
         return;
     }
 
-    render_pattern_syntax_to_buf(pattern, source, options, rendered);
+    render_pattern_syntax_to_buf(pattern, context, rendered);
 }
 
 pub(super) fn push_parameter_replacement_text(
@@ -409,12 +401,13 @@ pub(crate) fn parameter_defaulting_operator(operator: &ParameterOp) -> &'static 
 
 pub(crate) fn render_pattern_syntax_to_buf(
     pattern: &Pattern,
-    source: &str,
-    options: &ResolvedShellFormatOptions,
+    context: RenderContext<'_, '_>,
     rendered: &mut String,
 ) {
+    let source = context.source;
+    let options = context.options;
     if pattern_needs_formatter_rendering(pattern) {
-        render_pattern_parts_syntax_to_buf(pattern, source, options, rendered);
+        render_pattern_parts_syntax_to_buf(pattern, context, rendered);
         return;
     }
 
@@ -447,14 +440,13 @@ pub(super) fn pattern_needs_formatter_rendering(pattern: &Pattern) -> bool {
 
 pub(super) fn render_pattern_parts_syntax_to_buf(
     pattern: &Pattern,
-    source: &str,
-    options: &ResolvedShellFormatOptions,
+    context: RenderContext<'_, '_>,
     rendered: &mut String,
 ) {
     for part in &pattern.parts {
         match &part.kind {
             PatternPart::Word(word) => {
-                render_word_syntax_to_buf(word, source, options, rendered);
+                render_word_syntax_to_buf(word, context, rendered);
             }
             PatternPart::Group { kind, patterns } => {
                 let _ = std::write!(rendered, "{}(", kind.prefix());
@@ -462,7 +454,7 @@ pub(super) fn render_pattern_parts_syntax_to_buf(
                     if index > 0 {
                         rendered.push('|');
                     }
-                    render_pattern_syntax_to_buf(pattern, source, options, rendered);
+                    render_pattern_syntax_to_buf(pattern, context, rendered);
                 }
                 rendered.push(')');
             }
@@ -471,7 +463,7 @@ pub(super) fn render_pattern_parts_syntax_to_buf(
                     parts: vec![part.clone()],
                     span: part.span,
                 };
-                single.render_syntax_to_buf(source, rendered);
+                single.render_syntax_to_buf(context.source, rendered);
             }
         }
     }

--- a/crates/shuck-formatter/src/word/raw_rewrites.rs
+++ b/crates/shuck-formatter/src/word/raw_rewrites.rs
@@ -189,21 +189,12 @@ pub(super) fn parameter_prefers_raw_source(
     })
 }
 
-pub(super) fn stmt_seq_contains_comments(
-    facts: Option<&FormatterFacts<'_>>,
-    sequence: &StmtSeq,
-) -> bool {
-    facts.map_or_else(
-        || classify_sequence_contains_comments(sequence),
-        |facts| facts.sequence_contains_comments(sequence),
-    )
+pub(super) fn stmt_seq_contains_comments(facts: &FormatterFacts<'_>, sequence: &StmtSeq) -> bool {
+    facts.sequence_contains_comments(sequence)
 }
 
-pub(super) fn stmt_seq_has_heredoc(facts: Option<&FormatterFacts<'_>>, sequence: &StmtSeq) -> bool {
-    facts.map_or_else(
-        || classify_sequence_contains_heredoc(sequence),
-        |facts| facts.sequence_contains_heredoc(sequence),
-    )
+pub(super) fn stmt_seq_has_heredoc(facts: &FormatterFacts<'_>, sequence: &StmtSeq) -> bool {
+    facts.sequence_contains_heredoc(sequence)
 }
 
 pub(super) fn normalize_raw_backtick_command_substitution(raw: &str) -> Option<String> {
@@ -622,8 +613,9 @@ pub(super) fn render_inline_raw_command_substitution_as_block(
         return None;
     }
 
+    let context = RenderContext::new(body, options, &parsed_facts);
     let mut nested = String::new();
-    format_nested_stmt_sequence_to_buf(body, &parsed.file.body, options, None, None, &mut nested)?;
+    format_nested_stmt_sequence_to_buf(&parsed.file.body, context, None, &mut nested)?;
     let trimmed = trim_trailing_line_endings(&nested);
     if trimmed.is_empty() {
         return Some("$()".to_string());


### PR DESCRIPTION
## Summary
- add a shared formatter `RenderContext` carrying source text, options, and `FormatterFacts`
- require context/facts in lower word, assignment, arithmetic, pattern, heredoc, and substitution render helpers
- expand formatter facts traversal so parameter expansions in word and heredoc parts are indexed before rendering

## Validation
- `cargo fmt --check`
- `cargo check -p shuck-formatter`
- `cargo test -p shuck-formatter`
- `make test-oracle-shfmt-large-corpus` (current nonzero oracle set: 383 mismatches, 0 shuck errors)