### PR TITLE
refactor(formatter): use explicit render context

### DIFF
--- a/crates/shuck-formatter/src/command.rs
+++ b/crates/shuck-formatter/src/command.rs
@@ -779,16 +779,17 @@ fn for_each_compound_child(command: &CompoundCommand, mut visitor: impl FnMut(Co
 }
 
 pub(crate) fn stmt_verbatim_span_with_source_map(stmt: &Stmt, source_map: &SourceMap<'_>) -> Span {
-    stmt_verbatim_span_impl(stmt, source_map.source(), Some(source_map))
+    stmt_verbatim_span_impl(stmt, source_map)
 }
 
-fn stmt_verbatim_span_impl(stmt: &Stmt, source: &str, source_map: Option<&SourceMap<'_>>) -> Span {
+fn stmt_verbatim_span_impl(stmt: &Stmt, source_map: &SourceMap<'_>) -> Span {
+    let source = source_map.source();
     let command_span = if let Command::Simple(command) = &stmt.command
         && simple_command_uses_synthetic_words(command, source)
     {
-        synthetic_simple_command_verbatim_span(command, source, source_map)
+        synthetic_simple_command_verbatim_span(command, source_map)
     } else {
-        command_verbatim_span(&stmt.command, source, source_map)
+        command_verbatim_span(&stmt.command, source_map)
     };
     let mut span = command_span;
     for redirect in &stmt.redirects {
@@ -803,40 +804,24 @@ fn stmt_verbatim_span_impl(stmt: &Stmt, source: &str, source_map: Option<&Source
     non_empty_or_stmt_span(stmt, merge_stmt_background_span(stmt, span))
 }
 
-fn command_verbatim_span(
-    command: &Command,
-    source: &str,
-    source_map: Option<&SourceMap<'_>>,
-) -> Span {
+fn command_verbatim_span(command: &Command, source_map: &SourceMap<'_>) -> Span {
     match command {
         Command::Simple(command) => command.span,
         Command::Builtin(command) => builtin_like_parts(command).0,
         Command::Decl(command) => command.span,
-        Command::Binary(command) => stmt_verbatim_span_impl(&command.left, source, source_map)
-            .merge(stmt_verbatim_span_impl(&command.right, source, source_map)),
-        Command::Compound(command) => compound_verbatim_span(command, source, source_map),
-        Command::Function(command) => function_header_span(command).merge(
-            function_body_verbatim_span(&command.body, source, source_map),
-        ),
+        Command::Binary(command) => stmt_verbatim_span_impl(&command.left, source_map)
+            .merge(stmt_verbatim_span_impl(&command.right, source_map)),
+        Command::Compound(command) => compound_verbatim_span(command, source_map),
+        Command::Function(command) => function_header_span(command)
+            .merge(function_body_verbatim_span(&command.body, source_map)),
         Command::AnonymousFunction(command) => anonymous_function_header_span(command)
-            .merge(function_body_verbatim_span(
-                &command.body,
-                source,
-                source_map,
-            ))
+            .merge(function_body_verbatim_span(&command.body, source_map))
             .merge(words_span(&command.args)),
     }
 }
 
-fn function_body_verbatim_span(
-    body: &Stmt,
-    source: &str,
-    source_map: Option<&SourceMap<'_>>,
-) -> Span {
-    let mut span = stmt_verbatim_span_impl(body, source, source_map);
-    let Some(source_map) = source_map else {
-        return span;
-    };
+fn function_body_verbatim_span(body: &Stmt, source_map: &SourceMap<'_>) -> Span {
+    let mut span = stmt_verbatim_span_impl(body, source_map);
     if let Some(group_span) = command_group_attachment_span(&body.command, source_map) {
         span = merge_non_empty_span(span, group_span);
     }
@@ -1082,35 +1067,28 @@ fn compound_span(command: &CompoundCommand) -> Span {
     }
 }
 
-fn compound_verbatim_span(
-    command: &CompoundCommand,
-    source: &str,
-    source_map: Option<&SourceMap<'_>>,
-) -> Span {
+fn compound_verbatim_span(command: &CompoundCommand, source_map: &SourceMap<'_>) -> Span {
     match command {
         CompoundCommand::Subshell(commands) => {
-            group_verbatim_span_impl(commands.as_slice(), source, source_map, '(', ')')
+            group_verbatim_span_impl(commands.as_slice(), source_map, '(', ')')
         }
         CompoundCommand::BraceGroup(commands) => {
-            group_verbatim_span_impl(commands.as_slice(), source, source_map, '{', '}')
+            group_verbatim_span_impl(commands.as_slice(), source_map, '{', '}')
         }
-        _ => compound_verbatim_span_from_children(command, source, source_map),
+        _ => compound_verbatim_span_from_children(command, source_map),
     }
 }
 
 fn compound_verbatim_span_from_children(
     command: &CompoundCommand,
-    source: &str,
-    source_map: Option<&SourceMap<'_>>,
+    source_map: &SourceMap<'_>,
 ) -> Span {
     let mut span = compound_span(command);
     for_each_compound_child(command, |child| {
         span = match child {
-            CompoundChild::Stmt(stmt) => {
-                span.merge(stmt_verbatim_span_impl(stmt, source, source_map))
-            }
+            CompoundChild::Stmt(stmt) => span.merge(stmt_verbatim_span_impl(stmt, source_map)),
             CompoundChild::Sequence(sequence) => {
-                merge_stmt_sequence_verbatim_span(span, sequence, source, source_map)
+                merge_stmt_sequence_verbatim_span(span, sequence, source_map)
             }
         };
     });
@@ -1120,25 +1098,24 @@ fn compound_verbatim_span_from_children(
 fn merge_stmt_sequence_verbatim_span(
     mut span: Span,
     commands: &StmtSeq,
-    source: &str,
-    source_map: Option<&SourceMap<'_>>,
+    source_map: &SourceMap<'_>,
 ) -> Span {
     for command in commands.iter() {
-        span = merge_non_empty_span(span, stmt_verbatim_span_impl(command, source, source_map));
+        span = merge_non_empty_span(span, stmt_verbatim_span_impl(command, source_map));
     }
     span
 }
 
 fn group_verbatim_span_impl(
     commands: &[Stmt],
-    source: &str,
-    source_map: Option<&SourceMap<'_>>,
+    source_map: &SourceMap<'_>,
     open: char,
     close: char,
 ) -> Span {
+    let source = source_map.source();
     let inner = commands
         .iter()
-        .map(|command| stmt_verbatim_span_impl(command, source, source_map))
+        .map(|command| stmt_verbatim_span_impl(command, source_map))
         .reduce(Span::merge)
         .unwrap_or_default();
     if inner == Span::new() {
@@ -1156,12 +1133,7 @@ fn group_verbatim_span_impl(
         return inner;
     };
 
-    span_for_offsets(
-        source,
-        source_map,
-        open_offset,
-        close_offset + close.len_utf8(),
-    )
+    span_for_offsets(source_map, open_offset, close_offset + close.len_utf8())
 }
 
 pub(crate) fn group_open_suffix<'a>(
@@ -1675,17 +1647,8 @@ pub(crate) fn merge_non_empty_span(current: Span, next: Span) -> Span {
     }
 }
 
-fn span_for_offsets(
-    source: &str,
-    source_map: Option<&SourceMap<'_>>,
-    start: usize,
-    end: usize,
-) -> Span {
-    if let Some(source_map) = source_map {
-        source_map.span_for_offsets(start, end)
-    } else {
-        crate::comments::SourceMap::new(source).span_for_offsets(start, end)
-    }
+fn span_for_offsets(source_map: &SourceMap<'_>, start: usize, end: usize) -> Span {
+    source_map.span_for_offsets(start, end)
 }
 
 pub(crate) fn line_gap_break_count(current_line: usize, next_line: usize) -> usize {
@@ -1793,9 +1756,9 @@ pub(crate) fn simple_command_uses_synthetic_words(command: &SimpleCommand, sourc
 
 fn synthetic_simple_command_verbatim_span(
     command: &SimpleCommand,
-    source: &str,
-    source_map: Option<&SourceMap<'_>>,
+    source_map: &SourceMap<'_>,
 ) -> Span {
+    let source = source_map.source();
     let start = command.span.start.offset.min(source.len());
     let end = command.span.end.offset.min(source.len());
     let Some(raw) = source.get(start..end) else {
@@ -1817,7 +1780,7 @@ fn synthetic_simple_command_verbatim_span(
     };
     let command_end =
         trim_synthetic_simple_command_trailing_case_terminator(source, command_start, end);
-    span_for_offsets(source, source_map, command_start, command_end)
+    span_for_offsets(source_map, command_start, command_end)
 }
 
 fn trim_synthetic_simple_command_trailing_case_terminator(
@@ -2314,7 +2277,8 @@ mod tests {
             _ => panic!("expected brace group"),
         };
 
-        group_verbatim_span_impl(brace_group.as_slice(), source, None, '{', '}')
+        let source_map = SourceMap::new(source);
+        group_verbatim_span_impl(brace_group.as_slice(), &source_map, '{', '}')
     }
 
     #[test]

--- a/crates/shuck-formatter/src/comments.rs
+++ b/crates/shuck-formatter/src/comments.rs
@@ -1,6 +1,5 @@
 use std::sync::{Arc, OnceLock};
 
-use memchr::memchr_iter;
 use shuck_ast::{Comment, Position, Span, TextSize};
 use shuck_indexer::{IndexedComment, Indexer, LineIndex};
 
@@ -20,6 +19,7 @@ struct SourceMapData {
 
 impl<'a> SourceMap<'a> {
     #[must_use]
+    #[cfg(test)]
     pub fn new(source: &'a str) -> Self {
         Self::new_with_alignment(source, true)
     }
@@ -57,12 +57,13 @@ impl<'a> SourceMap<'a> {
         Self::from_parts(source, line_index, hash_offsets, track_alignment)
     }
 
+    #[cfg(test)]
     fn new_with_alignment(source: &'a str, track_alignment: bool) -> Self {
         let bytes = source.as_bytes();
 
         let mut hash_offsets = Vec::new();
 
-        for offset in memchr_iter(b'#', bytes) {
+        for offset in memchr::memchr_iter(b'#', bytes) {
             hash_offsets.push(offset);
         }
 

--- a/crates/shuck-formatter/src/context.rs
+++ b/crates/shuck-formatter/src/context.rs
@@ -1,6 +1,9 @@
+use crate::Result;
 use crate::comments::SourceMap;
 use crate::facts::FormatterFacts;
 use crate::options::ResolvedShellFormatOptions;
+use shuck_ast::{File, StmtSeq};
+use shuck_parser::parser::Parser;
 
 #[derive(Clone, Copy)]
 pub(crate) struct RenderContext<'source, 'a> {
@@ -24,5 +27,78 @@ impl<'source, 'a> RenderContext<'source, 'a> {
 
     pub(crate) fn source_map(self) -> &'a SourceMap<'source> {
         self.facts.source_map()
+    }
+
+    pub(crate) fn format_stmt_sequence_to_buf(
+        self,
+        statements: &StmtSeq,
+        upper_bound: Option<usize>,
+        output: &mut String,
+    ) -> Result<()> {
+        crate::streaming::format_stmt_sequence_streaming_to_buf(
+            self,
+            statements,
+            upper_bound,
+            output,
+        )
+    }
+}
+
+pub(crate) struct FragmentFormatter<'source, 'a> {
+    source: &'source str,
+    options: &'a ResolvedShellFormatOptions,
+    file: File,
+    facts: FormatterFacts<'source>,
+}
+
+impl<'source, 'a> FragmentFormatter<'source, 'a> {
+    pub(crate) fn parse(
+        source: &'source str,
+        options: &'a ResolvedShellFormatOptions,
+    ) -> Option<Self> {
+        let parsed = Parser::with_dialect(source, options.dialect()).parse();
+        if parsed.is_err() {
+            return None;
+        }
+
+        let file = parsed.file;
+        let facts = FormatterFacts::build(source, &file, options);
+        Some(Self {
+            source,
+            options,
+            file,
+            facts,
+        })
+    }
+
+    pub(crate) fn body(&self) -> &StmtSeq {
+        &self.file.body
+    }
+
+    pub(crate) fn body_len(&self) -> usize {
+        self.file.body.len()
+    }
+
+    pub(crate) fn facts(&self) -> &FormatterFacts<'source> {
+        &self.facts
+    }
+
+    pub(crate) fn render_context(&self) -> RenderContext<'source, '_> {
+        RenderContext::new(self.source, self.options, &self.facts)
+    }
+
+    pub(crate) fn format_body_to_buf(
+        &self,
+        upper_bound: Option<usize>,
+        output: &mut String,
+    ) -> Result<()> {
+        self.render_context()
+            .format_stmt_sequence_to_buf(self.body(), upper_bound, output)
+    }
+
+    pub(crate) fn format_body(&self, upper_bound: Option<usize>) -> Result<String> {
+        let mut output = String::new();
+        self.format_body_to_buf(upper_bound, &mut output)?;
+        Ok(output)
     }
 }

--- a/crates/shuck-formatter/src/lib.rs
+++ b/crates/shuck-formatter/src/lib.rs
@@ -34,6 +34,7 @@ use std::path::Path;
 use shuck_ast::File;
 use shuck_parser::{Error as ParseError, parser::Parser};
 
+use crate::context::RenderContext;
 use crate::facts::FormatterFacts;
 
 /// Formatter option types exposed by the shell formatter.
@@ -160,12 +161,7 @@ fn format_output(
 trait RenderMode {
     type Output;
 
-    fn render(
-        source: &str,
-        file: &File,
-        resolved: &ResolvedShellFormatOptions,
-        facts: &FormatterFacts<'_>,
-    ) -> Result<Self::Output>;
+    fn render(file: &File, context: RenderContext<'_, '_>) -> Result<Self::Output>;
 }
 
 struct BufferedRender;
@@ -173,18 +169,12 @@ struct BufferedRender;
 impl RenderMode for BufferedRender {
     type Output = String;
 
-    fn render(
-        source: &str,
-        file: &File,
-        resolved: &ResolvedShellFormatOptions,
-        facts: &FormatterFacts<'_>,
-    ) -> Result<Self::Output> {
-        let mut output =
-            streaming::format_file_streaming_with_facts(source, file, resolved, facts)?;
-        if resolved.minify() {
-            preserve_initial_shebang(source, &mut output, resolved.line_ending());
+    fn render(file: &File, context: RenderContext<'_, '_>) -> Result<Self::Output> {
+        let mut output = streaming::format_file_streaming(file, context)?;
+        if context.options.minify() {
+            preserve_initial_shebang(context.source, &mut output, context.options.line_ending());
         }
-        ensure_single_trailing_newline(&mut output, resolved.line_ending());
+        ensure_single_trailing_newline(&mut output, context.options.line_ending());
 
         Ok(output)
     }
@@ -195,13 +185,8 @@ struct CompareRender;
 impl RenderMode for CompareRender {
     type Output = bool;
 
-    fn render(
-        source: &str,
-        file: &File,
-        resolved: &ResolvedShellFormatOptions,
-        facts: &FormatterFacts<'_>,
-    ) -> Result<Self::Output> {
-        streaming::format_file_streaming_matches_source_with_facts(source, file, resolved, facts)
+    fn render(file: &File, context: RenderContext<'_, '_>) -> Result<Self::Output> {
+        streaming::format_file_streaming_matches_source(file, context)
     }
 }
 
@@ -216,7 +201,8 @@ fn render_file<M: RenderMode>(
 
     let facts = FormatterFacts::build(source, &file, resolved);
     let resolved = resolved.clone().with_line_ending(facts.line_ending());
-    M::render(source, &file, &resolved, &facts)
+    let context = RenderContext::new(source, &resolved, &facts);
+    M::render(&file, context)
 }
 
 fn formatted_source_from_output(source: &str, output: String) -> FormattedSource {

--- a/crates/shuck-formatter/src/streaming/mod.rs
+++ b/crates/shuck-formatter/src/streaming/mod.rs
@@ -119,42 +119,33 @@ fn move_interspersed_redirects_after_arguments<'a>(parts: &mut Vec<SimpleCommand
     *parts = reordered;
 }
 
-pub(crate) fn format_file_streaming_with_facts(
-    source: &str,
-    file: &File,
-    options: &ResolvedShellFormatOptions,
-    facts: &FormatterFacts<'_>,
-) -> Result<String> {
-    let mut formatter = ShellRenderer::new(source, options, facts);
+pub(crate) fn format_file_streaming(file: &File, context: RenderContext<'_, '_>) -> Result<String> {
+    let mut formatter = ShellRenderer::new(context);
     formatter.format_stmt_sequence(&file.body, None)?;
 
     Ok(formatter.finish_into_string())
 }
 
-pub(crate) fn format_file_streaming_matches_source_with_facts(
-    source: &str,
+pub(crate) fn format_file_streaming_matches_source(
     file: &File,
-    options: &ResolvedShellFormatOptions,
-    facts: &FormatterFacts<'_>,
+    context: RenderContext<'_, '_>,
 ) -> Result<bool> {
-    let mut formatter = ShellRenderer::new_compare(source, options, facts);
+    let mut formatter = ShellRenderer::new_compare(context);
     formatter.format_stmt_sequence(&file.body, None)?;
 
     Ok(formatter.finish_matches_source())
 }
 
 pub(crate) fn format_stmt_sequence_streaming_to_buf(
-    source: &str,
+    context: RenderContext<'_, '_>,
     statements: &StmtSeq,
-    options: &ResolvedShellFormatOptions,
-    facts: &FormatterFacts<'_>,
     upper_bound: Option<usize>,
     output: &mut String,
 ) -> Result<()> {
     let mut nested_output = mem::take(output);
     nested_output.clear();
 
-    let mut formatter = ShellRenderer::with_output_buffer(source, options, facts, nested_output);
+    let mut formatter = ShellRenderer::with_output_buffer(context, nested_output);
     formatter.format_stmt_sequence(statements, upper_bound)?;
     *output = formatter.finish_into_string();
     Ok(())
@@ -190,30 +181,17 @@ struct ShellRenderer<'source, 'facts, S> {
 }
 
 impl<'source, 'facts> ShellRenderer<'source, 'facts, BufferSink> {
-    fn new(
-        source: &'source str,
-        options: &ResolvedShellFormatOptions,
-        facts: &'facts FormatterFacts<'source>,
-    ) -> Self {
+    fn new(context: RenderContext<'source, 'facts>) -> Self {
         Self::with_writer(
-            source,
-            options,
-            facts,
-            ShellWriter::new_buffer(source, options),
+            context,
+            ShellWriter::new_buffer(context.source, context.options),
         )
     }
 
-    fn with_output_buffer(
-        source: &'source str,
-        options: &ResolvedShellFormatOptions,
-        facts: &'facts FormatterFacts<'source>,
-        output: String,
-    ) -> Self {
+    fn with_output_buffer(context: RenderContext<'source, 'facts>, output: String) -> Self {
         Self::with_writer(
-            source,
-            options,
-            facts,
-            ShellWriter::with_output_buffer(options, output),
+            context,
+            ShellWriter::with_output_buffer(context.options, output),
         )
     }
 
@@ -223,16 +201,10 @@ impl<'source, 'facts> ShellRenderer<'source, 'facts, BufferSink> {
 }
 
 impl<'source, 'facts> ShellRenderer<'source, 'facts, CompareSink<'source>> {
-    fn new_compare(
-        source: &'source str,
-        options: &ResolvedShellFormatOptions,
-        facts: &'facts FormatterFacts<'source>,
-    ) -> Self {
+    fn new_compare(context: RenderContext<'source, 'facts>) -> Self {
         Self::with_writer(
-            source,
-            options,
-            facts,
-            ShellWriter::new_compare(source, options),
+            context,
+            ShellWriter::new_compare(context.source, context.options),
         )
     }
 
@@ -245,16 +217,11 @@ impl<'source, 'facts, S> ShellRenderer<'source, 'facts, S>
 where
     S: StreamSink,
 {
-    fn with_writer(
-        source: &'source str,
-        options: &ResolvedShellFormatOptions,
-        facts: &'facts FormatterFacts<'source>,
-        writer: ShellWriter<S>,
-    ) -> Self {
+    fn with_writer(context: RenderContext<'source, 'facts>, writer: ShellWriter<S>) -> Self {
         Self {
-            source,
-            options: options.clone(),
-            facts,
+            source: context.source,
+            options: context.options.clone(),
+            facts: context.facts,
             scratch: String::new(),
             writer,
             pipeline_continuation_indent: 1,

--- a/crates/shuck-formatter/src/word/command_substitution.rs
+++ b/crates/shuck-formatter/src/word/command_substitution.rs
@@ -286,7 +286,9 @@ pub(super) fn render_command_substitution(
     let source = context.source;
     let options = context.options;
     let mut nested = String::new();
-    format_nested_stmt_sequence_to_buf(body, context, Some(upper_bound), &mut nested)?;
+    context
+        .format_stmt_sequence_to_buf(body, Some(upper_bound), &mut nested)
+        .ok()?;
 
     let trimmed = trim_trailing_line_endings(&nested);
     let normalized_backtick_body;
@@ -350,23 +352,6 @@ pub(super) fn render_command_substitution(
     }
 
     Some(())
-}
-
-pub(super) fn format_nested_stmt_sequence_to_buf(
-    body: &StmtSeq,
-    context: RenderContext<'_, '_>,
-    upper_bound: Option<usize>,
-    rendered: &mut String,
-) -> Option<()> {
-    format_stmt_sequence_streaming_to_buf(
-        context.source,
-        body,
-        context.options,
-        context.facts,
-        upper_bound,
-        rendered,
-    )
-    .ok()
 }
 
 pub(super) fn restore_trailing_escaped_horizontal_whitespace(
@@ -601,15 +586,10 @@ pub(super) fn expand_inline_pipeline_brace_group_body(
         return None;
     }
 
-    let parsed = shuck_parser::parser::Parser::with_dialect(body, options.dialect()).parse();
-    if parsed.is_err() {
-        return None;
-    }
-    let parsed_facts = FormatterFacts::build(body, &parsed.file, options);
-    let context = RenderContext::new(body, options, &parsed_facts);
+    let fragment = FragmentFormatter::parse(body, options)?;
 
     let mut nested = String::new();
-    format_nested_stmt_sequence_to_buf(&parsed.file.body, context, None, &mut nested)?;
+    fragment.format_body_to_buf(None, &mut nested).ok()?;
     let trimmed = trim_trailing_line_endings(&nested);
     trimmed.contains('\n').then(|| trimmed.to_string())
 }
@@ -1223,7 +1203,9 @@ pub(super) fn render_process_substitution(
     let options = context.options;
     let has_heredoc = stmt_seq_has_heredoc(context.facts, body);
     let mut nested = String::new();
-    format_nested_stmt_sequence_to_buf(body, context, span.end.offset.checked_sub(1), &mut nested)?;
+    context
+        .format_stmt_sequence_to_buf(body, span.end.offset.checked_sub(1), &mut nested)
+        .ok()?;
 
     let prefix = if is_input { '<' } else { '>' };
     let trimmed = trim_trailing_line_endings(&nested);

--- a/crates/shuck-formatter/src/word/heredoc.rs
+++ b/crates/shuck-formatter/src/word/heredoc.rs
@@ -166,7 +166,9 @@ pub(super) fn render_heredoc_body_command_substitution(
 
     let context = RenderContext::new(source, options, facts);
     let mut nested = String::new();
-    format_nested_stmt_sequence_to_buf(body, context, Some(upper_bound), &mut nested)?;
+    context
+        .format_stmt_sequence_to_buf(body, Some(upper_bound), &mut nested)
+        .ok()?;
     let trimmed = trim_trailing_line_endings(&nested);
     if trimmed.is_empty() {
         rendered.push_str("$()");

--- a/crates/shuck-formatter/src/word/mod.rs
+++ b/crates/shuck-formatter/src/word/mod.rs
@@ -1,7 +1,7 @@
 use std::fmt::Write as _;
 
 use crate::command::trim_unescaped_trailing_whitespace;
-use crate::context::RenderContext;
+use crate::context::{FragmentFormatter, RenderContext};
 use crate::facts::{FormatterFacts, classify_sequence_contains_multiline_literal_source};
 use crate::options::{IndentStyle, ResolvedShellFormatOptions};
 use crate::raw_syntax::{
@@ -11,7 +11,6 @@ use crate::raw_syntax::{
     normalize_raw_pipeline_continuations, redirect_operator_end, refine_common_indent,
 };
 use crate::scan::line_indent_before_offset as line_indent_before_source_offset;
-use crate::streaming::format_stmt_sequence_streaming_to_buf;
 use shuck_ast::{
     ArithmeticAssignOp, ArithmeticBinaryOp, ArithmeticExpansionSyntax, ArithmeticExpr,
     ArithmeticExprNode, ArithmeticLvalue, ArithmeticPostfixOp, ArithmeticUnaryOp, BinaryOp,

--- a/crates/shuck-formatter/src/word/parameter.rs
+++ b/crates/shuck-formatter/src/word/parameter.rs
@@ -182,15 +182,8 @@ pub(super) fn normalize_inline_parameter_command_substitution_body(
         return None;
     }
 
-    let parsed = shuck_parser::parser::Parser::with_dialect(trimmed, options.dialect()).parse();
-    if parsed.is_err() {
-        return None;
-    }
-    let parsed_facts = FormatterFacts::build(trimmed, &parsed.file, options);
-    let context = RenderContext::new(trimmed, options, &parsed_facts);
-
-    let mut nested = String::new();
-    format_nested_stmt_sequence_to_buf(&parsed.file.body, context, None, &mut nested)?;
+    let fragment = FragmentFormatter::parse(trimmed, options)?;
+    let nested = fragment.format_body(None).ok()?;
     let formatted = trim_trailing_line_endings(&nested);
     (!formatted.is_empty() && !formatted.contains('\n')).then(|| formatted.to_string())
 }

--- a/crates/shuck-formatter/src/word/raw_rewrites.rs
+++ b/crates/shuck-formatter/src/word/raw_rewrites.rs
@@ -601,28 +601,24 @@ pub(super) fn render_inline_raw_command_substitution_as_block(
         return None;
     }
 
-    let parsed = shuck_parser::parser::Parser::with_dialect(body, options.dialect()).parse();
-    if parsed.is_err() {
-        return None;
-    }
-    let parsed_facts = FormatterFacts::build(body, &parsed.file, options);
-    let inline_multiline = parsed_facts
-        .sequence_contains_multistatement_pipeline_brace_group(&parsed.file.body)
+    let fragment = FragmentFormatter::parse(body, options)?;
+    let inline_multiline = fragment
+        .facts()
+        .sequence_contains_multistatement_pipeline_brace_group(fragment.body())
         || raw_body_contains_pipeline_multistatement_brace_group(body);
-    if parsed.file.body.len() <= 1 && !inline_multiline {
+    if fragment.body_len() <= 1 && !inline_multiline {
         return None;
     }
 
-    let context = RenderContext::new(body, options, &parsed_facts);
     let mut nested = String::new();
-    format_nested_stmt_sequence_to_buf(&parsed.file.body, context, None, &mut nested)?;
+    fragment.format_body_to_buf(None, &mut nested).ok()?;
     let trimmed = trim_trailing_line_endings(&nested);
     if trimmed.is_empty() {
         return Some("$()".to_string());
     }
 
     let mut rendered = String::new();
-    if inline_multiline && parsed.file.body.len() == 1 {
+    if inline_multiline && fragment.body_len() == 1 {
         rendered.push_str("$(");
         push_command_substitution_inline_body(
             &mut rendered,


### PR DESCRIPTION
## Summary

- Make `RenderContext` the explicit boundary for formatter streaming entrypoints.
- Add `FragmentFormatter` so nested parsed snippets own their parse result and formatter facts together.
- Remove optional source-map fallback plumbing from formatter span helpers.

## Validation

- `cargo test -p shuck-formatter`
- `cargo clippy -p shuck-formatter --all-targets -- -D warnings`
