### PR TITLE
refactor(formatter): centralize raw source inspection

### DIFF
--- a/crates/shuck-formatter/src/command/groups.rs
+++ b/crates/shuck-formatter/src/command/groups.rs
@@ -85,7 +85,7 @@ pub(super) fn group_verbatim_span_impl(
         return inner;
     };
     let wrapper_prefix_start = open_offset + open.len_utf8();
-    if !source[wrapper_prefix_start..inner.start.offset].contains('#') {
+    if !source_map.contains_comment_between(wrapper_prefix_start, inner.start.offset) {
         return inner;
     }
     let Some(close_offset) = find_group_close_offset(source, inner.end.offset, close) else {
@@ -106,11 +106,13 @@ pub(crate) fn group_open_suffix<'a>(
     let open_offset = find_group_open_offset_before_stmt(source_map, first_start, open)?;
     let (_, line_end) = source_map.line_bounds_for_offset(open_offset)?;
     let suffix_start = open_offset + open.len_utf8();
+    let comment = source_map.first_source_comment_between(suffix_start, line_end)?;
+    let prefix = source_map.slice_between(suffix_start, comment.span().start.offset)?;
+    if !prefix.chars().all(char::is_whitespace) {
+        return None;
+    }
     let suffix = source.get(suffix_start..line_end)?;
-    suffix
-        .trim_start_matches(char::is_whitespace)
-        .starts_with('#')
-        .then(|| (source_map.span_for_offsets(suffix_start, line_end), suffix))
+    Some((source_map.span_for_offsets(suffix_start, line_end), suffix))
 }
 
 pub(crate) fn group_attachment_span(

--- a/crates/shuck-formatter/src/comments.rs
+++ b/crates/shuck-formatter/src/comments.rs
@@ -3,6 +3,8 @@ use std::sync::{Arc, OnceLock};
 use shuck_ast::{Comment, Position, Span, TextSize};
 use shuck_indexer::{IndexedComment, Indexer, LineIndex};
 
+use crate::source::SourceView;
+
 #[derive(Debug, Clone)]
 pub struct SourceMap<'a> {
     source: &'a str,
@@ -99,6 +101,16 @@ impl<'a> SourceMap<'a> {
     #[must_use]
     pub fn source(&self) -> &'a str {
         self.source
+    }
+
+    #[must_use]
+    pub(crate) fn view(&self) -> SourceView<'a> {
+        SourceView::new(self.source)
+    }
+
+    #[must_use]
+    pub(crate) fn slice_between(&self, start: usize, end: usize) -> Option<&'a str> {
+        self.view().slice_between(start, end)
     }
 
     #[must_use]
@@ -207,6 +219,22 @@ impl<'a> SourceMap<'a> {
             .get(index)
             .copied()
             .filter(|offset| *offset < end)
+    }
+
+    #[must_use]
+    pub(crate) fn first_source_comment_between(
+        &self,
+        start: usize,
+        end: usize,
+    ) -> Option<SourceComment<'a>> {
+        let comment_start = self.first_comment_between(start, end)?;
+        let (_, line_end) = self.line_bounds_for_offset(comment_start)?;
+        let comment_limit = line_end.min(end);
+        let comment = self
+            .source
+            .get(comment_start..comment_limit)?
+            .trim_end_matches([' ', '\t', '\r']);
+        self.source_comment_for_offsets(comment_start, comment_start + comment.len())
     }
 
     #[must_use]

--- a/crates/shuck-formatter/src/facts.rs
+++ b/crates/shuck-formatter/src/facts.rs
@@ -33,6 +33,7 @@ use crate::options::{LineEnding, ResolvedShellFormatOptions};
 use crate::scan::{
     BranchPrefixComment, last_shell_keyword_end, last_shell_keyword_start, source_between_offsets,
 };
+use crate::source::{SourceView, command_substitution_source_starts_with_body_line};
 use crate::visit::{self, AstVisitor};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -1694,24 +1695,12 @@ fn quoted_command_substitution_only_body(word: &Word) -> Option<&StmtSeq> {
     substitution_body
 }
 
-fn command_substitution_source_starts_with_body_line(raw: &str) -> bool {
-    if raw.starts_with(['\n', '\r']) {
-        return true;
-    }
-    raw.strip_prefix("$(")
-        .is_some_and(|after_open| after_open.starts_with(['\n', '\r']))
-}
-
 fn raw_word_source_slice<'a>(word: &Word, source: &'a str) -> Option<&'a str> {
     raw_source_slice(word.span, source)
 }
 
 fn raw_source_slice(span: Span, source: &str) -> Option<&str> {
-    if span.start.offset >= span.end.offset || span.end.offset > source.len() {
-        return None;
-    }
-
-    let slice = span.slice(source);
+    let slice = SourceView::new(source).span_slice(span)?;
     if slice.contains('\n') {
         Some(slice)
     } else {
@@ -2963,11 +2952,7 @@ impl<'source, 'options> FormatterFactsBuilder<'source, 'options> {
                 self.source,
                 self.source_map(),
             ),
-            terminator_suffix_comment: case_item_terminator_suffix_comment(
-                item,
-                self.source,
-                self.source_map(),
-            ),
+            terminator_suffix_comment: case_item_terminator_suffix_comment(item, self.source_map()),
         }
     }
 
@@ -3492,42 +3477,25 @@ fn case_item_pattern_suffix_comment<'source>(
     if start >= end {
         return None;
     }
-    let between = source.get(start..end)?;
-    let line = between.split_once('\n').map_or(between, |(line, _)| line);
-    let comment_start = line.find('#')?;
-    let before = &line[..comment_start];
+    let (_, source_line_end) = source_map.line_bounds_for_offset(start)?;
+    let line_end = source_line_end.min(end);
+    let comment = source_map.first_source_comment_between(start, line_end)?;
+    let before = source_map.slice_between(start, comment.span().start.offset)?;
     if !before.contains(')') {
         return None;
     }
-    let comment = line[comment_start..].trim_end_matches([' ', '\t', '\r']);
-    let absolute_start = start + comment_start;
-    let absolute_end = absolute_start + comment.len();
-    source_map.source_comment_for_offsets(absolute_start, absolute_end)
+    Some(comment)
 }
 
 fn case_item_terminator_suffix_comment<'source>(
     item: &CaseItem,
-    source: &'source str,
     source_map: &SourceMap<'source>,
 ) -> Option<SourceComment<'source>> {
     let span = item.terminator_span?;
     if span.start.line != span.end.line {
         return None;
     }
-    let start = span.end.offset.min(source.len());
-    let suffix_source = source.get(start..)?;
-    let line_end = suffix_source
-        .find('\n')
-        .map_or(source.len(), |offset| start + offset);
-    let suffix = source.get(start..line_end)?;
-    let leading_padding = suffix.len() - suffix.trim_start_matches([' ', '\t']).len();
-    let comment = suffix[leading_padding..].trim_end_matches([' ', '\t', '\r']);
-    if !comment.starts_with('#') {
-        return None;
-    }
-    let absolute_start = start + leading_padding;
-    let absolute_end = absolute_start + comment.len();
-    source_map.source_comment_for_offsets(absolute_start, absolute_end)
+    source_map.suffix_comment_after_span(span)
 }
 
 fn case_item_source_prefix_comments<'source>(

--- a/crates/shuck-formatter/src/lib.rs
+++ b/crates/shuck-formatter/src/lib.rs
@@ -23,6 +23,8 @@ mod scan;
 #[allow(missing_docs)]
 mod simplify;
 #[allow(missing_docs)]
+mod source;
+#[allow(missing_docs)]
 mod streaming;
 #[allow(missing_docs)]
 mod visit;

--- a/crates/shuck-formatter/src/scan.rs
+++ b/crates/shuck-formatter/src/scan.rs
@@ -1,17 +1,7 @@
 use shuck_ast::Span;
 
 use crate::comments::SourceMap;
-use crate::raw_syntax::RawShellScanner;
-
-pub(crate) fn line_has_shell_comment_before(source: &str, offset: usize) -> bool {
-    let upper = offset.min(source.len());
-    let line_start = source[..upper]
-        .rfind('\n')
-        .map_or(0, |newline| newline.saturating_add(1));
-    RawShellScanner::bounded(source, upper)
-        .find_comment(line_start, upper)
-        .is_some()
-}
+use crate::source::SourceView;
 
 pub(crate) fn branch_keyword_offset(
     source: &str,
@@ -19,41 +9,7 @@ pub(crate) fn branch_keyword_offset(
     end: usize,
     keyword: &str,
 ) -> Option<usize> {
-    let start = start.min(end).min(source.len());
-    let end = end.min(source.len());
-    let mut line_start = start;
-    while line_start < end {
-        let line_end = source[line_start..end]
-            .find('\n')
-            .map_or(end, |offset| line_start + offset);
-        let line = source.get(line_start..line_end)?;
-        let mut search_start = 0;
-        while let Some(relative) = line[search_start..].find(keyword) {
-            let keyword_start = search_start + relative;
-            let keyword_end = keyword_start + keyword.len();
-            if branch_keyword_candidate_matches(line, keyword_start, keyword_end) {
-                return Some(line_start + keyword_start);
-            }
-            search_start = keyword_end;
-        }
-        line_start = line_end.saturating_add(1);
-    }
-    None
-}
-
-fn branch_keyword_candidate_matches(line: &str, start: usize, end: usize) -> bool {
-    if !shell_keyword_boundaries_match(line, start, end) {
-        return false;
-    }
-
-    let prefix = &line[..start];
-    let trimmed = prefix.trim_start_matches([' ', '\t']);
-    if trimmed.starts_with('#') {
-        return false;
-    }
-
-    let before = prefix.trim_end_matches([' ', '\t']);
-    before.is_empty() || before.ends_with(';') || before.ends_with('&')
+    SourceView::new(source).branch_keyword_offset(start, end, keyword)
 }
 
 #[derive(Debug, Clone)]
@@ -68,23 +24,11 @@ pub(crate) fn last_uncommented_shell_keyword_before(
     search_end: usize,
     keyword: &str,
 ) -> Option<usize> {
-    let mut search_end = search_end.min(source.len());
-    loop {
-        let offset = source[..search_end].rfind(keyword)?;
-        let end = offset + keyword.len();
-        if shell_keyword_boundaries_match(source, offset, end)
-            && !line_has_shell_comment_before(source, offset)
-        {
-            return Some(offset);
-        }
-        search_end = offset;
-    }
+    SourceView::new(source).last_uncommented_shell_keyword_before(search_end, keyword)
 }
 
 pub(crate) fn last_shell_keyword_start(source: &str, span: Span, keyword: &str) -> Option<usize> {
-    let upper = span.end.offset.min(source.len());
-    let lower = span.start.offset.min(upper);
-    last_shell_keyword_start_between(source, lower, upper, keyword)
+    SourceView::new(source).last_shell_keyword_start(span, keyword)
 }
 
 pub(crate) fn last_shell_keyword_start_between(
@@ -93,16 +37,7 @@ pub(crate) fn last_shell_keyword_start_between(
     upper: usize,
     keyword: &str,
 ) -> Option<usize> {
-    let upper = upper.min(source.len());
-    let lower = lower.min(upper);
-    let slice = source.get(lower..upper)?;
-    slice
-        .match_indices(keyword)
-        .filter_map(|(start, _)| {
-            let end = start + keyword.len();
-            shell_keyword_boundaries_match(slice, start, end).then_some(lower + start)
-        })
-        .last()
+    SourceView::new(source).last_shell_keyword_start_between(lower, upper, keyword)
 }
 
 pub(crate) fn last_shell_keyword_end(text: &str, keyword: &str) -> Option<usize> {
@@ -111,73 +46,15 @@ pub(crate) fn last_shell_keyword_end(text: &str, keyword: &str) -> Option<usize>
 }
 
 pub(crate) fn line_indent_before_offset(source: &str, offset: usize) -> Option<&str> {
-    let offset = offset.min(source.len());
-    let bytes = source.as_bytes();
-    let mut line_start = offset;
-    while line_start > 0 && bytes.get(line_start - 1) != Some(&b'\n') {
-        line_start -= 1;
-    }
-    let line = source.get(line_start..offset)?;
-    let indent_end = line
-        .char_indices()
-        .find(|(_, ch)| !matches!(ch, ' ' | '\t'))
-        .map_or(line.len(), |(index, _)| index);
-    line.get(..indent_end)
+    SourceView::new(source).line_indent_before_offset(offset)
 }
 
 pub(crate) fn source_between_offsets(source: &str, start: usize, end: usize) -> Option<&str> {
-    let lower = start.min(end).min(source.len());
-    let upper = start.max(end).min(source.len());
-    source.get(lower..upper)
+    SourceView::new(source).slice_between(start, end)
 }
 
 pub(crate) fn shell_keyword_at(source: &str, offset: usize, upper: usize, keyword: &str) -> bool {
-    let end = offset.saturating_add(keyword.len());
-    end <= upper
-        && source.get(offset..end) == Some(keyword)
-        && shell_keyword_boundaries_match(source, offset, end)
-}
-
-fn shell_control_keyword_at(source: &str, offset: usize, upper: usize, keyword: &str) -> bool {
-    shell_keyword_at(source, offset, upper, keyword)
-        && shell_keyword_has_command_prefix(source, offset)
-}
-
-fn shell_keyword_has_command_prefix(source: &str, offset: usize) -> bool {
-    let prefix = &source[..offset];
-    let Some((previous_offset, previous)) = prefix
-        .char_indices()
-        .rev()
-        .find(|(_, ch)| !matches!(ch, ' ' | '\t' | '\r'))
-    else {
-        return true;
-    };
-
-    if previous == '\n' || matches!(previous, ';' | '&' | '|' | '(' | ')' | '{' | '!') {
-        return true;
-    }
-
-    let word_end = previous_offset + previous.len_utf8();
-    let word_start = prefix[..word_end]
-        .char_indices()
-        .rev()
-        .find(|(_, ch)| !is_shell_keyword_char(*ch))
-        .map_or(0, |(index, ch)| index + ch.len_utf8());
-    matches!(
-        &prefix[word_start..word_end],
-        "do" | "then" | "else" | "elif" | "time" | "coproc"
-    )
-}
-
-pub(crate) fn shell_keyword_boundaries_match(text: &str, start: usize, end: usize) -> bool {
-    let before = text[..start].chars().next_back();
-    let after = text[end..].chars().next();
-    before.is_none_or(|ch| !is_shell_keyword_char(ch))
-        && after.is_none_or(|ch| !is_shell_keyword_char(ch))
-}
-
-fn is_shell_keyword_char(ch: char) -> bool {
-    ch.is_ascii_alphanumeric() || ch == '_'
+    SourceView::new(source).shell_keyword_at(offset, upper, keyword)
 }
 
 pub(crate) fn normalized_close_keyword_span(
@@ -188,7 +65,7 @@ pub(crate) fn normalized_close_keyword_span(
 ) -> Span {
     let start = span.start.offset.min(source.len());
     let end = start.saturating_add(keyword.len()).min(source.len());
-    if source.get(start..end) == Some(keyword) {
+    if SourceView::new(source).slice_between(start, end) == Some(keyword) {
         source_map.span_for_offsets(start, end)
     } else {
         span
@@ -196,59 +73,9 @@ pub(crate) fn normalized_close_keyword_span(
 }
 
 pub(crate) fn matching_if_close_start(source: &str, span: Span) -> Option<usize> {
-    matching_close_keyword_start(source, span, "fi", |source, offset, upper| {
-        shell_control_keyword_at(source, offset, upper, "if").then_some("if".len())
-    })
+    SourceView::new(source).matching_if_close_start(span)
 }
 
 pub(crate) fn matching_done_close_start(source: &str, span: Span) -> Option<usize> {
-    matching_close_keyword_start(source, span, "done", |source, offset, upper| {
-        ["for", "select", "while", "until", "foreach", "repeat"]
-            .iter()
-            .find(|keyword| shell_control_keyword_at(source, offset, upper, keyword))
-            .map(|_| {
-                source[offset..]
-                    .chars()
-                    .take_while(char::is_ascii_alphabetic)
-                    .map(char::len_utf8)
-                    .sum()
-            })
-    })
-}
-
-fn matching_close_keyword_start(
-    source: &str,
-    span: Span,
-    close_keyword: &str,
-    mut open_len_at: impl FnMut(&str, usize, usize) -> Option<usize>,
-) -> Option<usize> {
-    let upper = span.end.offset.min(source.len());
-    let mut offset = span.start.offset.min(upper);
-    let mut depth = 0usize;
-    let scanner = RawShellScanner::bounded(source, upper);
-    while offset < upper {
-        let ch = source[offset..].chars().next()?;
-        if let Some(next) = scanner.skip_quoted_or_comment_at(offset) {
-            offset = next;
-            continue;
-        }
-
-        if let Some(open_len) = open_len_at(source, offset, upper) {
-            depth = depth.saturating_add(1);
-            offset += open_len;
-            continue;
-        }
-        if shell_control_keyword_at(source, offset, upper, close_keyword) {
-            if depth > 0 {
-                depth -= 1;
-                if depth == 0 {
-                    return Some(offset);
-                }
-            }
-            offset += close_keyword.len();
-            continue;
-        }
-        offset += ch.len_utf8();
-    }
-    None
+    SourceView::new(source).matching_done_close_start(span)
 }

--- a/crates/shuck-formatter/src/source.rs
+++ b/crates/shuck-formatter/src/source.rs
@@ -1,0 +1,386 @@
+use shuck_ast::Span;
+
+use crate::raw_syntax::{RawShellScanner, matching_raw_command_substitution_close};
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct SourceView<'source> {
+    source: &'source str,
+}
+
+impl<'source> SourceView<'source> {
+    pub(crate) fn new(source: &'source str) -> Self {
+        Self { source }
+    }
+
+    pub(crate) fn slice_between(self, start: usize, end: usize) -> Option<&'source str> {
+        let lower = start.min(end).min(self.source.len());
+        let upper = start.max(end).min(self.source.len());
+        self.source.get(lower..upper)
+    }
+
+    pub(crate) fn span_slice(self, span: Span) -> Option<&'source str> {
+        if span.start.offset >= span.end.offset || span.end.offset > self.source.len() {
+            return None;
+        }
+        Some(span.slice(self.source))
+    }
+
+    pub(crate) fn line_indent_before_offset(self, offset: usize) -> Option<&'source str> {
+        let offset = offset.min(self.source.len());
+        let line_start = self.line_start_before(offset)?;
+        let prefix = self.source.get(line_start..offset)?;
+        let indent_end = prefix
+            .char_indices()
+            .find(|(_, ch)| !matches!(ch, ' ' | '\t'))
+            .map_or(prefix.len(), |(index, _)| index);
+        prefix.get(..indent_end)
+    }
+
+    pub(crate) fn line_has_shell_comment_before(self, offset: usize) -> bool {
+        let upper = offset.min(self.source.len());
+        let Some(line_start) = self.line_start_before(upper) else {
+            return false;
+        };
+        self.shell_comment_start_between(line_start, upper)
+            .is_some()
+    }
+
+    pub(crate) fn shell_comment_start_between(self, start: usize, end: usize) -> Option<usize> {
+        let lower = start.min(end).min(self.source.len());
+        let upper = start.max(end).min(self.source.len());
+        RawShellScanner::bounded(self.source, upper).find_comment(lower, upper)
+    }
+
+    pub(crate) fn branch_keyword_offset(
+        self,
+        start: usize,
+        end: usize,
+        keyword: &str,
+    ) -> Option<usize> {
+        let start = start.min(end).min(self.source.len());
+        let end = end.min(self.source.len());
+        let mut line_start = start;
+        while line_start < end {
+            let line_end = self.source[line_start..end]
+                .find('\n')
+                .map_or(end, |offset| line_start + offset);
+            let line = self.source.get(line_start..line_end)?;
+            let mut search_start = 0;
+            while let Some(relative) = line[search_start..].find(keyword) {
+                let keyword_start = search_start + relative;
+                let keyword_end = keyword_start + keyword.len();
+                if branch_keyword_candidate_matches(line, keyword_start, keyword_end) {
+                    return Some(line_start + keyword_start);
+                }
+                search_start = keyword_end;
+            }
+            line_start = line_end.saturating_add(1);
+        }
+        None
+    }
+
+    pub(crate) fn last_uncommented_shell_keyword_before(
+        self,
+        search_end: usize,
+        keyword: &str,
+    ) -> Option<usize> {
+        let mut search_end = search_end.min(self.source.len());
+        loop {
+            let offset = self.source.get(..search_end)?.rfind(keyword)?;
+            let end = offset + keyword.len();
+            if shell_keyword_boundaries_match(self.source, offset, end)
+                && !self.line_has_shell_comment_before(offset)
+            {
+                return Some(offset);
+            }
+            search_end = offset;
+        }
+    }
+
+    pub(crate) fn last_shell_keyword_start(self, span: Span, keyword: &str) -> Option<usize> {
+        let upper = span.end.offset.min(self.source.len());
+        let lower = span.start.offset.min(upper);
+        self.last_shell_keyword_start_between(lower, upper, keyword)
+    }
+
+    pub(crate) fn last_shell_keyword_start_between(
+        self,
+        lower: usize,
+        upper: usize,
+        keyword: &str,
+    ) -> Option<usize> {
+        let upper = upper.min(self.source.len());
+        let lower = lower.min(upper);
+        let slice = self.source.get(lower..upper)?;
+        slice
+            .match_indices(keyword)
+            .filter_map(|(start, _)| {
+                let end = start + keyword.len();
+                shell_keyword_boundaries_match(slice, start, end).then_some(lower + start)
+            })
+            .last()
+    }
+
+    pub(crate) fn shell_keyword_at(self, offset: usize, upper: usize, keyword: &str) -> bool {
+        let end = offset.saturating_add(keyword.len());
+        end <= upper
+            && self.source.get(offset..end) == Some(keyword)
+            && shell_keyword_boundaries_match(self.source, offset, end)
+    }
+
+    pub(crate) fn matching_if_close_start(self, span: Span) -> Option<usize> {
+        self.matching_close_keyword_start(span, "fi", |source, offset, upper| {
+            shell_control_keyword_at(source, offset, upper, "if").then_some("if".len())
+        })
+    }
+
+    pub(crate) fn matching_done_close_start(self, span: Span) -> Option<usize> {
+        self.matching_close_keyword_start(span, "done", |source, offset, upper| {
+            ["for", "select", "while", "until", "foreach", "repeat"]
+                .iter()
+                .find(|keyword| shell_control_keyword_at(source, offset, upper, keyword))
+                .map(|_| {
+                    source[offset..]
+                        .chars()
+                        .take_while(char::is_ascii_alphabetic)
+                        .map(char::len_utf8)
+                        .sum()
+                })
+        })
+    }
+
+    pub(crate) fn dollar_command_substitution(
+        self,
+    ) -> Option<DollarCommandSubstitutionSource<'source>> {
+        self.source.strip_prefix("$(")?;
+        let close_offset = matching_raw_command_substitution_close(self.source, 2)?;
+        Some(DollarCommandSubstitutionSource {
+            view: self,
+            close_offset,
+        })
+    }
+
+    pub(crate) fn substitution_closes_on_own_line(self) -> bool {
+        let Some(close_offset) = self.source.rfind(')') else {
+            return false;
+        };
+        let line_start = self.source[..close_offset]
+            .rfind('\n')
+            .map_or(0, |newline| newline.saturating_add(1));
+        line_start > 0 && self.source[line_start..close_offset].trim().is_empty()
+    }
+
+    fn line_start_before(self, offset: usize) -> Option<usize> {
+        let prefix = self.source.get(..offset)?;
+        Some(
+            prefix
+                .rfind('\n')
+                .map_or(0, |newline| newline.saturating_add(1)),
+        )
+    }
+
+    fn matching_close_keyword_start(
+        self,
+        span: Span,
+        close_keyword: &str,
+        mut open_len_at: impl FnMut(&str, usize, usize) -> Option<usize>,
+    ) -> Option<usize> {
+        let upper = span.end.offset.min(self.source.len());
+        let mut offset = span.start.offset.min(upper);
+        let mut depth = 0usize;
+        let scanner = RawShellScanner::bounded(self.source, upper);
+        while offset < upper {
+            let ch = self.source[offset..].chars().next()?;
+            if let Some(next) = scanner.skip_quoted_or_comment_at(offset) {
+                offset = next;
+                continue;
+            }
+
+            if let Some(open_len) = open_len_at(self.source, offset, upper) {
+                depth = depth.saturating_add(1);
+                offset += open_len;
+                continue;
+            }
+            if shell_control_keyword_at(self.source, offset, upper, close_keyword) {
+                if depth > 0 {
+                    depth -= 1;
+                    if depth == 0 {
+                        return Some(offset);
+                    }
+                }
+                offset += close_keyword.len();
+                continue;
+            }
+            offset += ch.len_utf8();
+        }
+        None
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct DollarCommandSubstitutionSource<'source> {
+    view: SourceView<'source>,
+    close_offset: usize,
+}
+
+impl<'source> DollarCommandSubstitutionSource<'source> {
+    pub(crate) fn body(self) -> Option<&'source str> {
+        self.view.source.get(2..self.close_offset)
+    }
+
+    pub(crate) fn closed_slice(self) -> Option<&'source str> {
+        self.view.source.get(..self.close_offset.saturating_add(1))
+    }
+
+    pub(crate) fn closes_on_own_line(self) -> bool {
+        self.view.substitution_closes_on_own_line()
+    }
+}
+
+pub(crate) fn dollar_command_substitution_body(raw: &str) -> Option<&str> {
+    SourceView::new(raw).dollar_command_substitution()?.body()
+}
+
+pub(crate) fn dollar_command_substitution_slice(raw: &str) -> Option<&str> {
+    SourceView::new(raw)
+        .dollar_command_substitution()?
+        .closed_slice()
+}
+
+pub(crate) fn command_substitution_source_starts_with_body_line(raw: &str) -> bool {
+    raw.starts_with(['\n', '\r'])
+        || raw
+            .strip_prefix("$(")
+            .is_some_and(|after_open| after_open.starts_with(['\n', '\r']))
+}
+
+pub(crate) fn command_substitution_source_closes_on_own_line(raw: &str) -> bool {
+    SourceView::new(raw)
+        .dollar_command_substitution()
+        .is_some_and(DollarCommandSubstitutionSource::closes_on_own_line)
+}
+
+pub(crate) fn command_substitution_source_prefers_continued_inline_body(raw: &str) -> bool {
+    let Some(after_open) = raw.strip_prefix("$(") else {
+        return false;
+    };
+    if after_open.starts_with(['\n', '\r']) {
+        return false;
+    }
+
+    raw.lines()
+        .any(|line| line.trim_end_matches([' ', '\t', '\r']).ends_with('\\'))
+}
+
+pub(crate) fn substitution_source_closes_on_own_line(raw: &str) -> bool {
+    SourceView::new(raw).substitution_closes_on_own_line()
+}
+
+fn branch_keyword_candidate_matches(line: &str, start: usize, end: usize) -> bool {
+    if !shell_keyword_boundaries_match(line, start, end) {
+        return false;
+    }
+
+    let prefix = &line[..start];
+    let trimmed = prefix.trim_start_matches([' ', '\t']);
+    if trimmed.starts_with('#') {
+        return false;
+    }
+
+    let before = prefix.trim_end_matches([' ', '\t']);
+    before.is_empty() || before.ends_with(';') || before.ends_with('&')
+}
+
+fn shell_control_keyword_at(source: &str, offset: usize, upper: usize, keyword: &str) -> bool {
+    SourceView::new(source).shell_keyword_at(offset, upper, keyword)
+        && shell_keyword_has_command_prefix(source, offset)
+}
+
+fn shell_keyword_has_command_prefix(source: &str, offset: usize) -> bool {
+    let prefix = &source[..offset];
+    let Some((previous_offset, previous)) = prefix
+        .char_indices()
+        .rev()
+        .find(|(_, ch)| !matches!(ch, ' ' | '\t' | '\r'))
+    else {
+        return true;
+    };
+
+    if previous == '\n' || matches!(previous, ';' | '&' | '|' | '(' | ')' | '{' | '!') {
+        return true;
+    }
+
+    let word_end = previous_offset + previous.len_utf8();
+    let word_start = prefix[..word_end]
+        .char_indices()
+        .rev()
+        .find(|(_, ch)| !is_shell_keyword_char(*ch))
+        .map_or(0, |(index, ch)| index + ch.len_utf8());
+    matches!(
+        &prefix[word_start..word_end],
+        "do" | "then" | "else" | "elif" | "time" | "coproc"
+    )
+}
+
+fn shell_keyword_boundaries_match(text: &str, start: usize, end: usize) -> bool {
+    let before = text[..start].chars().next_back();
+    let after = text[end..].chars().next();
+    before.is_none_or(|ch| !is_shell_keyword_char(ch))
+        && after.is_none_or(|ch| !is_shell_keyword_char(ch))
+}
+
+fn is_shell_keyword_char(ch: char) -> bool {
+    ch.is_ascii_alphanumeric() || ch == '_'
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn command_substitution_view_slices_body_with_nested_close() {
+        let raw = "$(echo $(date); echo done) trailing";
+        let view = SourceView::new(raw).dollar_command_substitution().unwrap();
+
+        assert_eq!(view.body(), Some("echo $(date); echo done"));
+        assert_eq!(view.closed_slice(), Some("$(echo $(date); echo done)"));
+    }
+
+    #[test]
+    fn command_substitution_view_reports_source_shape() {
+        assert!(command_substitution_source_starts_with_body_line(
+            "$(\necho ok\n)"
+        ));
+        assert!(command_substitution_source_closes_on_own_line(
+            "$(echo ok\n)"
+        ));
+        assert!(!command_substitution_source_prefers_continued_inline_body(
+            "$(\necho ok \\"
+        ));
+        assert!(command_substitution_source_prefers_continued_inline_body(
+            "$(echo ok \\\n  && echo again)"
+        ));
+    }
+
+    #[test]
+    fn source_view_skips_comments_when_matching_close_keywords() {
+        let source = "if true; then\n  echo fi # fi\nfi\n";
+        let span = Span {
+            start: shuck_ast::Position {
+                line: 1,
+                column: 1,
+                offset: 0,
+            },
+            end: shuck_ast::Position {
+                line: 3,
+                column: 3,
+                offset: source.len(),
+            },
+        };
+
+        assert_eq!(
+            SourceView::new(source).matching_if_close_start(span),
+            source.rfind("fi")
+        );
+    }
+}

--- a/crates/shuck-formatter/src/streaming/compounds.rs
+++ b/crates/shuck-formatter/src/streaming/compounds.rs
@@ -516,31 +516,21 @@ where
         condition: &StmtSeq,
         then_span: Span,
     ) -> Option<SourceComment<'source>> {
-        let source = self.source();
+        let source_map = self.source_map();
         let start = condition.last().map(condition_stmt_command_end)?;
-        let end = then_span.start.offset.min(source.len());
+        let end = then_span.start.offset.min(source_map.source().len());
         if start >= end {
             return None;
         }
-        let region = source.get(start..end)?;
-        let comment_rel = region.find('#')?;
-        let before_comment = region.get(..comment_rel)?;
+        let comment = source_map.first_source_comment_between(start, end)?;
+        let before_comment = source_map.slice_between(start, comment.span().start.offset)?;
         if !before_comment
             .chars()
             .all(|ch| matches!(ch, ' ' | '\t' | '\r' | '\n' | ';'))
         {
             return None;
         }
-        let comment_start = start + comment_rel;
-        let line_end = source
-            .get(comment_start..end)?
-            .find('\n')
-            .map_or(end, |offset| comment_start + offset);
-        let comment = source
-            .get(comment_start..line_end)?
-            .trim_end_matches([' ', '\t', '\r']);
-        self.source_map()
-            .source_comment_for_offsets(comment_start, comment_start + comment.len())
+        Some(comment)
     }
 
     pub(super) fn write_unmodeled_branch_background_terminator(
@@ -1633,27 +1623,23 @@ where
             return None;
         }
 
-        let line_end = source[header_end..body_start]
+        let source_map = self.source_map();
+        let line_end = source_map
+            .slice_between(header_end, body_start)?
             .find('\n')
             .map(|offset| header_end + offset)
             .unwrap_or(body_start);
-        let between = source.get(header_end..line_end)?;
-        let comment_offset = between.find('#')?;
-        if between[..comment_offset].contains('{') {
+        let comment = source_map.first_source_comment_between(header_end, line_end)?;
+        let before_comment = source_map.slice_between(header_end, comment.span().start.offset)?;
+        if before_comment.contains('{') {
             return None;
         }
         let suffix_start = header_end;
-        let comment = source
-            .get(suffix_start..line_end)?
+        let comment_text = source_map
+            .slice_between(suffix_start, comment.span().end.offset)?
             .trim_end_matches([' ', '\t', '\r'])
             .to_string();
-        (!comment.is_empty()).then(|| {
-            (
-                self.source_map()
-                    .span_for_offsets(header_end + comment_offset, line_end),
-                comment,
-            )
-        })
+        (!comment_text.is_empty()).then(|| (comment.span(), comment_text))
     }
 
     pub(super) fn then_separator_for_condition(&self, commands: &StmtSeq) -> &'static str {

--- a/crates/shuck-formatter/src/word/command_substitution.rs
+++ b/crates/shuck-formatter/src/word/command_substitution.rs
@@ -13,6 +13,7 @@ pub(super) fn push_raw_word_with_normalized_command_redirect_spacing(
     spans.sort_by_key(|span| span.start.offset);
     let mut cursor = word.span.start.offset;
     let word_end = word.span.end.offset.min(source.len());
+    let source_view = SourceView::new(source);
     let mut wrote_span = false;
     for span in spans {
         let start = span.start.offset;
@@ -20,10 +21,10 @@ pub(super) fn push_raw_word_with_normalized_command_redirect_spacing(
         if start < cursor || end > word_end || start >= end {
             continue;
         }
-        if let Some(prefix) = source.get(cursor..start) {
+        if let Some(prefix) = source_view.slice_between(cursor, start) {
             rendered.push_str(prefix);
         }
-        if let Some(command) = source.get(start..end) {
+        if let Some(command) = source_view.slice_between(start, end) {
             push_raw_command_substitution_with_normalized_spacing(
                 rendered, command, source, start, options,
             );
@@ -32,7 +33,7 @@ pub(super) fn push_raw_word_with_normalized_command_redirect_spacing(
         cursor = end;
     }
     if wrote_span {
-        if let Some(suffix) = source.get(cursor..word_end) {
+        if let Some(suffix) = source_view.slice_between(cursor, word_end) {
             rendered.push_str(suffix);
         }
     } else {
@@ -381,7 +382,7 @@ pub(super) fn source_trailing_escaped_horizontal_whitespace_before_offset(
     if source.as_bytes().get(close_offset) != Some(&b')') {
         return None;
     }
-    trailing_escaped_horizontal_whitespace(source.get(..close_offset)?)
+    trailing_escaped_horizontal_whitespace(SourceView::new(source).slice_between(0, close_offset)?)
 }
 
 pub(super) fn trailing_escaped_horizontal_whitespace(body: &str) -> Option<char> {
@@ -774,30 +775,6 @@ pub(super) fn command_substitution_source_parses_as_multiple_statements(
     !parsed.is_err() && parsed.file.body.len() > 1
 }
 
-pub(super) fn raw_dollar_command_substitution_body(raw: &str) -> Option<&str> {
-    raw.strip_prefix("$(")?;
-    let close_offset = matching_raw_command_substitution_close(raw, 2)?;
-    raw.get(2..close_offset)
-}
-
-pub(super) fn raw_dollar_command_substitution_slice(raw: &str) -> Option<&str> {
-    raw.strip_prefix("$(")?;
-    let close_offset = matching_raw_command_substitution_close(raw, 2)?;
-    raw.get(..close_offset + 1)
-}
-
-pub(super) fn command_substitution_source_starts_with_body_line(raw: &str) -> bool {
-    if raw.starts_with(['\n', '\r']) {
-        return true;
-    }
-    raw.strip_prefix("$(")
-        .is_some_and(|after_open| after_open.starts_with(['\n', '\r']))
-}
-
-pub(super) fn command_substitution_source_closes_on_own_line(raw: &str) -> bool {
-    substitution_source_closes_on_own_line(raw)
-}
-
 pub(super) fn push_inline_raw_command_substitution_as_block(
     target: &mut String,
     raw: &str,
@@ -1020,18 +997,6 @@ pub(super) fn inline_raw_body_relative_source_indent<'a>(
         return indent;
     };
     indent.strip_prefix(source_base_indent).unwrap_or("")
-}
-
-pub(super) fn command_substitution_source_prefers_continued_inline_body(raw: &str) -> bool {
-    let Some(after_open) = raw.strip_prefix("$(") else {
-        return false;
-    };
-    if after_open.starts_with(['\n', '\r']) {
-        return false;
-    }
-
-    raw.lines()
-        .any(|line| line.trim_end_matches([' ', '\t', '\r']).ends_with('\\'))
 }
 
 pub(super) fn push_raw_block_command_substitution_without_outer_indent(
@@ -1272,16 +1237,6 @@ pub(super) fn process_substitution_source_opens_to_body_line(raw: &str) -> bool 
     raw.get(2..).is_some_and(|body| {
         (raw.starts_with("<(") || raw.starts_with(">(")) && body.starts_with(['\n', '\r'])
     })
-}
-
-pub(super) fn substitution_source_closes_on_own_line(raw: &str) -> bool {
-    let Some(close_offset) = raw.rfind(')') else {
-        return false;
-    };
-    let line_start = raw[..close_offset]
-        .rfind('\n')
-        .map_or(0, |newline| newline.saturating_add(1));
-    line_start > 0 && raw[line_start..close_offset].trim().is_empty()
 }
 
 pub(super) fn trim_trailing_line_endings(rendered: &str) -> &str {

--- a/crates/shuck-formatter/src/word/mod.rs
+++ b/crates/shuck-formatter/src/word/mod.rs
@@ -11,6 +11,14 @@ use crate::raw_syntax::{
     normalize_raw_pipeline_continuations, redirect_operator_end, refine_common_indent,
 };
 use crate::scan::line_indent_before_offset as line_indent_before_source_offset;
+use crate::source::{
+    SourceView, command_substitution_source_closes_on_own_line,
+    command_substitution_source_prefers_continued_inline_body,
+    command_substitution_source_starts_with_body_line,
+    dollar_command_substitution_body as raw_dollar_command_substitution_body,
+    dollar_command_substitution_slice as raw_dollar_command_substitution_slice,
+    substitution_source_closes_on_own_line,
+};
 use shuck_ast::{
     ArithmeticAssignOp, ArithmeticBinaryOp, ArithmeticExpansionSyntax, ArithmeticExpr,
     ArithmeticExprNode, ArithmeticLvalue, ArithmeticPostfixOp, ArithmeticUnaryOp, BinaryOp,


### PR DESCRIPTION
## Summary

- add a formatter-owned `SourceView` for raw source slicing, shell keyword scanning, and command-substitution source-shape helpers
- make `scan.rs` delegate to `SourceView` while preserving the existing formatter call surface
- route comment-sensitive formatter paths through `SourceMap` helpers instead of local raw `#` scans

## Validation

- `cargo fmt --check`
- `cargo test -p shuck-formatter`
- `make test-oracle-shfmt-large-corpus`

Oracle summary: 34,593 fixtures, 33,733 compared, 33,352 matched, 381 reviewed mismatches, 0 blocking mismatches, 0 shuck errors.