### PR TITLE
refactor(formatter): share compound body site logic

### DIFF
--- a/crates/shuck-formatter/src/command.rs
+++ b/crates/shuck-formatter/src/command.rs
@@ -12,15 +12,17 @@ use crate::scan::{
 };
 use crate::word::{render_arithmetic_expr_to_buf, render_word_syntax_to_buf};
 use shuck_ast::{
-    AnonymousFunctionCommand, ArithmeticExprNode, ArrayElem, Assignment, AssignmentValue,
-    BackgroundOperator, BinaryCommand, BinaryOp, BuiltinCommand, CaseItem, CaseTerminator, Command,
-    CompoundCommand, DeclClause, DeclOperand, ForSyntax, ForeachSyntax, FunctionDef, IfCommand,
-    IfSyntax, RepeatSyntax, SimpleCommand, SourceText, Span, Stmt, StmtSeq, StmtTerminator,
-    Subscript, VarRef, Word, WordPart,
+    AnonymousFunctionCommand, ArithmeticExprNode, ArithmeticForCommand, ArrayElem, Assignment,
+    AssignmentValue, BackgroundOperator, BinaryCommand, BinaryOp, BuiltinCommand, CaseItem,
+    CaseTerminator, Command, CompoundCommand, DeclClause, DeclOperand, ForCommand, ForSyntax,
+    ForeachCommand, ForeachSyntax, FunctionDef, IfCommand, IfSyntax, RepeatCommand, RepeatSyntax,
+    SelectCommand, SimpleCommand, SourceText, Span, Stmt, StmtSeq, StmtTerminator, Subscript,
+    UntilCommand, VarRef, WhileCommand, Word, WordPart,
 };
 
 mod arithmetic;
 mod assignments;
+mod body_site;
 mod compound_assignments;
 mod groups;
 mod render_policy;
@@ -43,6 +45,7 @@ pub(crate) use self::assignments::{
     array_elem_parts, array_elem_value_word_mut, render_assignment_head_to_buf,
     render_assignment_to_buf,
 };
+pub(crate) use self::body_site::{CompoundBodyOpen, CompoundBodySite};
 pub(crate) use self::compound_assignments::{
     MultilineCompoundAssignmentLayout,
     multiline_compound_assignment_command_substitution_body_prefix,
@@ -54,7 +57,7 @@ pub(crate) use self::groups::{
     stmt_group_attachment_or_verbatim_span_with_heredoc, stmt_start_after_operator,
 };
 pub(crate) use self::render_policy::{
-    case_item_body_upper_bound, case_item_was_inline_in_source, done_close_span, if_close_span,
+    case_item_body_upper_bound, case_item_was_inline_in_source, if_close_span,
     line_gap_break_count, rendered_stmt_end_line_with_heredoc, should_render_verbatim_with_heredoc,
     stmt_attachment_span, stmt_attachment_span_with_heredoc, stmt_has_trailing_comment,
     stmt_render_start_line,

--- a/crates/shuck-formatter/src/command/body_site.rs
+++ b/crates/shuck-formatter/src/command/body_site.rs
@@ -1,0 +1,267 @@
+use super::*;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum CompoundBodyOpen {
+    Keyword(&'static str),
+    Group(char),
+    Direct,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct CompoundBodySite<'a> {
+    body: &'a StmtSeq,
+    enclosing_span: Span,
+    facts_upper_bound: usize,
+    renderer_upper_bound: usize,
+    open: CompoundBodyOpen,
+    close_span: Option<Span>,
+}
+
+impl<'a> CompoundBodySite<'a> {
+    pub(crate) fn for_command(
+        command: &'a ForCommand,
+        source_map: &crate::comments::SourceMap<'_>,
+    ) -> Self {
+        match command.syntax {
+            ForSyntax::InDoDone { done_span, .. } | ForSyntax::ParenDoDone { done_span, .. } => {
+                Self::do_done(&command.body, command.span, Some(done_span), source_map)
+            }
+            ForSyntax::InDirect { .. } | ForSyntax::ParenDirect { .. } => {
+                Self::direct(&command.body, command.span)
+            }
+            ForSyntax::InBrace {
+                right_brace_span, ..
+            }
+            | ForSyntax::ParenBrace {
+                right_brace_span, ..
+            } => Self::brace(&command.body, command.span, right_brace_span),
+        }
+    }
+
+    pub(crate) fn foreach_command(
+        command: &'a ForeachCommand,
+        source_map: &crate::comments::SourceMap<'_>,
+    ) -> Self {
+        match command.syntax {
+            ForeachSyntax::InDoDone { done_span, .. } => {
+                Self::do_done(&command.body, command.span, Some(done_span), source_map)
+            }
+            ForeachSyntax::ParenBrace {
+                right_brace_span, ..
+            } => Self::brace(&command.body, command.span, right_brace_span),
+        }
+    }
+
+    pub(crate) fn repeat_command(
+        command: &'a RepeatCommand,
+        source_map: &crate::comments::SourceMap<'_>,
+    ) -> Self {
+        match command.syntax {
+            RepeatSyntax::DoDone { done_span, .. } => {
+                Self::do_done(&command.body, command.span, Some(done_span), source_map)
+            }
+            RepeatSyntax::Direct => Self::direct(&command.body, command.span),
+            RepeatSyntax::Brace {
+                right_brace_span, ..
+            } => Self::brace(&command.body, command.span, right_brace_span),
+        }
+    }
+
+    pub(crate) fn while_command(
+        command: &'a WhileCommand,
+        source_map: &crate::comments::SourceMap<'_>,
+    ) -> Self {
+        Self::do_done(&command.body, command.span, None, source_map)
+    }
+
+    pub(crate) fn until_command(
+        command: &'a UntilCommand,
+        source_map: &crate::comments::SourceMap<'_>,
+    ) -> Self {
+        Self::do_done(&command.body, command.span, None, source_map)
+    }
+
+    pub(crate) fn select_command(
+        command: &'a SelectCommand,
+        source_map: &crate::comments::SourceMap<'_>,
+    ) -> Self {
+        Self::do_done(&command.body, command.span, None, source_map)
+    }
+
+    pub(crate) fn arithmetic_for_command(
+        command: &'a ArithmeticForCommand,
+        source_map: &crate::comments::SourceMap<'_>,
+    ) -> Self {
+        Self::do_done(&command.body, command.span, None, source_map)
+    }
+
+    pub(crate) fn if_then_branch(
+        command: &IfCommand,
+        body: &'a StmtSeq,
+        upper_bound: usize,
+    ) -> Self {
+        let open = match command.syntax {
+            IfSyntax::ThenFi { .. } => CompoundBodyOpen::Keyword("then"),
+            IfSyntax::Brace { .. } => CompoundBodyOpen::Group('{'),
+        };
+        Self::branch(body, command.span, upper_bound, open)
+    }
+
+    pub(crate) fn if_else_branch(
+        command: &IfCommand,
+        body: &'a StmtSeq,
+        upper_bound: usize,
+    ) -> Self {
+        let open = match command.syntax {
+            IfSyntax::ThenFi { .. } => CompoundBodyOpen::Keyword("else"),
+            IfSyntax::Brace { .. } => CompoundBodyOpen::Group('{'),
+        };
+        Self::branch(body, command.span, upper_bound, open)
+    }
+
+    pub(crate) fn function_group_body(body: &'a Stmt, function_end_offset: usize) -> Option<Self> {
+        if body.negated || !body.redirects.is_empty() || body.terminator.is_some() {
+            return None;
+        }
+        let (commands, open) = command_group_commands(&body.command)?;
+        Some(Self {
+            body: commands,
+            enclosing_span: stmt_span(body),
+            facts_upper_bound: function_end_offset,
+            renderer_upper_bound: function_end_offset,
+            open: CompoundBodyOpen::Group(open),
+            close_span: None,
+        })
+    }
+
+    pub(crate) fn body(self) -> &'a StmtSeq {
+        self.body
+    }
+
+    pub(crate) fn enclosing_span(self) -> Span {
+        self.enclosing_span
+    }
+
+    pub(crate) fn facts_upper_bound(self) -> usize {
+        self.facts_upper_bound
+    }
+
+    pub(crate) fn renderer_upper_bound(self) -> usize {
+        self.renderer_upper_bound
+    }
+
+    pub(crate) fn open(self) -> CompoundBodyOpen {
+        self.open
+    }
+
+    pub(crate) fn group_open_char(self) -> Option<char> {
+        match self.open {
+            CompoundBodyOpen::Group(open) => Some(open),
+            CompoundBodyOpen::Keyword(_) | CompoundBodyOpen::Direct => None,
+        }
+    }
+
+    pub(crate) fn open_keyword(self) -> Option<&'static str> {
+        match self.open {
+            CompoundBodyOpen::Keyword(keyword) => Some(keyword),
+            CompoundBodyOpen::Group(_) | CompoundBodyOpen::Direct => None,
+        }
+    }
+
+    pub(crate) fn open_keyword_start(self, source: &str) -> Option<usize> {
+        let keyword = self.open_keyword()?;
+        super::structure::branch_open_keyword_start(self.body, source, keyword)
+    }
+
+    pub(crate) fn open_suffix_span(
+        self,
+        source_map: &crate::comments::SourceMap<'_>,
+    ) -> Option<Span> {
+        let keyword = self.open_keyword()?;
+        let source = source_map.source();
+        let keyword_offset =
+            super::structure::branch_open_keyword_start(self.body, source, keyword)?;
+        let (_, line_end) = source_map.line_bounds_for_offset(keyword_offset)?;
+        let suffix_start = keyword_offset + keyword.len();
+        let suffix = source.get(suffix_start..line_end)?;
+        suffix
+            .trim_start_matches(char::is_whitespace)
+            .starts_with('#')
+            .then(|| source_map.span_for_offsets(suffix_start, line_end))
+    }
+
+    pub(crate) fn open_end_offset(self, source: &str) -> Option<usize> {
+        let keyword = self.open_keyword()?;
+        self.open_keyword_start(source)
+            .map(|start| start + keyword.len())
+    }
+
+    pub(crate) fn close_span(self) -> Option<Span> {
+        self.close_span
+    }
+
+    fn do_done(
+        body: &'a StmtSeq,
+        enclosing_span: Span,
+        done_span: Option<Span>,
+        source_map: &crate::comments::SourceMap<'_>,
+    ) -> Self {
+        let close_span = super::render_policy::done_close_span(
+            source_map.source(),
+            source_map,
+            enclosing_span,
+            done_span,
+        );
+        let upper_bound = close_span.map(|span| span.start.offset).unwrap_or_else(|| {
+            done_span.map_or(enclosing_span.end.offset, |span| span.start.offset)
+        });
+        Self {
+            body,
+            enclosing_span,
+            facts_upper_bound: upper_bound,
+            renderer_upper_bound: upper_bound,
+            open: CompoundBodyOpen::Keyword("do"),
+            close_span,
+        }
+    }
+
+    fn direct(body: &'a StmtSeq, enclosing_span: Span) -> Self {
+        Self {
+            body,
+            enclosing_span,
+            facts_upper_bound: enclosing_span.end.offset,
+            renderer_upper_bound: enclosing_span.end.offset,
+            open: CompoundBodyOpen::Direct,
+            close_span: None,
+        }
+    }
+
+    fn brace(body: &'a StmtSeq, enclosing_span: Span, right_brace_span: Span) -> Self {
+        // Preserve the legacy split: facts are keyed at the closing brace, while
+        // renderer call sites ask for the enclosing command's full span.
+        Self {
+            body,
+            enclosing_span,
+            facts_upper_bound: right_brace_span.start.offset,
+            renderer_upper_bound: enclosing_span.end.offset,
+            open: CompoundBodyOpen::Group('{'),
+            close_span: None,
+        }
+    }
+
+    fn branch(
+        body: &'a StmtSeq,
+        enclosing_span: Span,
+        upper_bound: usize,
+        open: CompoundBodyOpen,
+    ) -> Self {
+        Self {
+            body,
+            enclosing_span,
+            facts_upper_bound: upper_bound,
+            renderer_upper_bound: upper_bound,
+            open,
+            close_span: None,
+        }
+    }
+}

--- a/crates/shuck-formatter/src/facts.rs
+++ b/crates/shuck-formatter/src/facts.rs
@@ -4,21 +4,21 @@ use shuck_ast::{
     AnonymousFunctionCommand, ArithmeticExpr, ArithmeticExprNode, ArithmeticLvalue, Assignment,
     AssignmentValue, BinaryCommand, BinaryOp, BourneParameterExpansion, CaseCommand, CaseItem,
     Command, CommandSubstitutionSyntax, CompoundCommand, ConditionalCommand, ConditionalExpr,
-    DeclOperand, File, ForCommand, ForeachCommand, FunctionDef, Heredoc, HeredocBody,
-    HeredocBodyPart, HeredocBodyPartNode, IfCommand, ParameterExpansion, ParameterExpansionSyntax,
-    ParameterOp, Pattern, PatternPart, Redirect, RedirectKind, RedirectTarget, RepeatCommand,
-    SelectCommand, Span, Stmt, StmtSeq, StmtTerminator, Subscript, TimeCommand, UntilCommand,
-    VarRef, WhileCommand, Word, WordPart, WordPartNode, ZshExpansionOperation, ZshExpansionTarget,
+    DeclOperand, File, ForCommand, FunctionDef, Heredoc, HeredocBody, HeredocBodyPart,
+    HeredocBodyPartNode, IfCommand, ParameterExpansion, ParameterExpansionSyntax, ParameterOp,
+    Pattern, PatternPart, Redirect, RedirectKind, RedirectTarget, RepeatCommand, SelectCommand,
+    Span, Stmt, StmtSeq, StmtTerminator, Subscript, TimeCommand, UntilCommand, VarRef,
+    WhileCommand, Word, WordPart, WordPartNode, ZshExpansionOperation, ZshExpansionTarget,
     ZshGlobSegment,
 };
 use shuck_ast::{TextRange, TextSize};
 use shuck_indexer::{CommentIndex, IndexedComment, Indexer, IndexerOptions, LineIndex};
 
 use crate::command::{
-    array_elem_parts, branch_open_keyword_start, builtin_like_parts, case_item_body_upper_bound,
+    CompoundBodySite, array_elem_parts, builtin_like_parts, case_item_body_upper_bound,
     case_item_was_inline_in_source, case_terminator,
     collect_binary_list_first as collect_binary_list_first_with, collect_pipeline_parts,
-    command_group_commands, done_close_span, group_attachment_span_with_heredoc, group_open_suffix,
+    command_group_commands, group_attachment_span_with_heredoc, group_open_suffix,
     group_was_inline_in_source, if_close_span, if_next_branch_region_with_body_end,
     matching_group_close, rendered_stmt_end_line_with_heredoc, should_render_verbatim_with_heredoc,
     stmt_attachment_span_with_heredoc, stmt_format_span,
@@ -1970,16 +1970,18 @@ impl<'source, 'options> FormatterFactsBuilder<'source, 'options> {
         self.visit_sequence_with_suffix(sequence, upper_bound, group_open_char, None, None);
     }
 
-    fn visit_do_done_body(&mut self, body: &StmtSeq, span: Span) {
-        let close_span = done_close_span(self.source_map().source(), self.source_map(), span, None);
-        self.record_close_suffix(close_span);
+    fn visit_compound_body_site(&mut self, site: CompoundBodySite<'_>) {
+        if let Some(open) = site.group_open_char() {
+            self.record_inline_group_sequence(site.body(), open, matching_group_close(open));
+        }
         self.visit_sequence_with_suffix(
-            body,
-            Some(done_body_upper_bound(self.source_map(), span)),
-            None,
-            branch_open_suffix_span(body, self.source_map(), "do"),
-            branch_open_end_offset(body, self.source_map().source(), "do"),
+            site.body(),
+            Some(site.facts_upper_bound()),
+            site.group_open_char(),
+            site.open_suffix_span(self.source_map()),
+            site.open_end_offset(self.source),
         );
+        self.record_close_suffix(site.close_span());
     }
 
     fn record_inline_group_sequence(&mut self, body: &StmtSeq, open: char, close: char) {
@@ -2282,39 +2284,8 @@ impl<'source, 'options> FormatterFactsBuilder<'source, 'options> {
                 for word in &command.words {
                     self.visit_word(word);
                 }
-                let group_open_char =
-                    matches!(command.syntax, shuck_ast::ForeachSyntax::ParenBrace { .. })
-                        .then_some('{');
-                if group_open_char.is_some() {
-                    self.record_inline_group_sequence(&command.body, '{', '}');
-                }
-                self.visit_sequence_with_suffix(
-                    &command.body,
-                    Some(foreach_body_upper_bound(command, self.source_map())),
-                    group_open_char,
-                    group_open_char
-                        .is_none()
-                        .then(|| {
-                            matches!(command.syntax, shuck_ast::ForeachSyntax::InDoDone { .. })
-                                .then(|| {
-                                    branch_open_suffix_span(&command.body, self.source_map(), "do")
-                                })
-                                .flatten()
-                        })
-                        .flatten(),
-                    group_open_char
-                        .is_none()
-                        .then(|| branch_open_end_offset(&command.body, self.source, "do"))
-                        .flatten(),
-                );
-                if matches!(command.syntax, shuck_ast::ForeachSyntax::InDoDone { .. }) {
-                    self.record_close_suffix(done_close_span(
-                        self.source_map().source(),
-                        self.source_map(),
-                        command.span,
-                        None,
-                    ));
-                }
+                let site = CompoundBodySite::foreach_command(command, self.source_map());
+                self.visit_compound_body_site(site);
             }
             CompoundCommand::ArithmeticFor(command) => {
                 if let Some(expr) = &command.init_ast {
@@ -2326,7 +2297,8 @@ impl<'source, 'options> FormatterFactsBuilder<'source, 'options> {
                 if let Some(expr) = &command.step_ast {
                     self.visit_arithmetic_expr(expr);
                 }
-                self.visit_do_done_body(&command.body, command.span);
+                let site = CompoundBodySite::arithmetic_for_command(command, self.source_map());
+                self.visit_compound_body_site(site);
             }
             CompoundCommand::While(command) => self.visit_while(command),
             CompoundCommand::Until(command) => self.visit_until(command),
@@ -2370,44 +2342,22 @@ impl<'source, 'options> FormatterFactsBuilder<'source, 'options> {
         };
         self.visit_sequence(&command.condition, condition_upper_bound, None);
         let brace_syntax = matches!(command.syntax, shuck_ast::IfSyntax::Brace { .. });
-        let group_open_char = brace_syntax.then_some('{');
-        if brace_syntax {
-            self.record_inline_group_sequence(&command.then_branch, '{', '}');
-        }
-        self.visit_sequence_with_suffix(
-            &command.then_branch,
-            Some(if_branch_upper_bound(
-                command,
-                0,
-                self.source,
-                self.source_map(),
-                &self.facts,
-            )),
-            group_open_char,
-            (!brace_syntax)
-                .then(|| branch_open_suffix_span(&command.then_branch, self.source_map(), "then"))
-                .flatten(),
-            (!brace_syntax)
-                .then(|| branch_open_end_offset(&command.then_branch, self.source, "then"))
-                .flatten(),
-        );
+        let then_upper_bound =
+            if_branch_upper_bound(command, 0, self.source, self.source_map(), &self.facts);
+        let then_site =
+            CompoundBodySite::if_then_branch(command, &command.then_branch, then_upper_bound);
+        self.visit_compound_body_site(then_site);
         for (index, (condition, body)) in command.elif_branches.iter().enumerate() {
-            let body_upper_bound = Some(if_branch_upper_bound(
+            let body_upper_bound = if_branch_upper_bound(
                 command,
                 index + 1,
                 self.source,
                 self.source_map(),
                 &self.facts,
-            ));
+            );
+            let body_site = CompoundBodySite::if_then_branch(command, body, body_upper_bound);
             if brace_syntax {
-                self.record_inline_group_sequence(body, '{', '}');
-                self.visit_sequence_with_suffix(
-                    body,
-                    body_upper_bound,
-                    group_open_char,
-                    None,
-                    None,
-                );
+                self.visit_compound_body_site(body_site);
             }
             let condition_upper_bound = if brace_syntax {
                 group_attachment_span_with_heredoc(
@@ -2419,35 +2369,17 @@ impl<'source, 'options> FormatterFactsBuilder<'source, 'options> {
                 )
                 .map(|span| span.start.offset)
             } else {
-                branch_open_keyword_start(body, self.source_map().source(), "then")
+                body_site.open_keyword_start(self.source)
             };
             self.visit_sequence(condition, condition_upper_bound, None);
             if !brace_syntax {
-                self.visit_sequence_with_suffix(
-                    body,
-                    body_upper_bound,
-                    group_open_char,
-                    branch_open_suffix_span(body, self.source_map(), "then"),
-                    branch_open_end_offset(body, self.source, "then"),
-                );
+                self.visit_compound_body_site(body_site);
             }
         }
         if let Some(else_branch) = &command.else_branch {
-            if brace_syntax {
-                self.record_inline_group_sequence(else_branch, '{', '}');
-            }
-            let upper_bound = Some(if_close_start(command, self.source_map()));
-            self.visit_sequence_with_suffix(
-                else_branch,
-                upper_bound,
-                group_open_char,
-                (!brace_syntax)
-                    .then(|| branch_open_suffix_span(else_branch, self.source_map(), "else"))
-                    .flatten(),
-                (!brace_syntax)
-                    .then(|| branch_open_end_offset(else_branch, self.source, "else"))
-                    .flatten(),
-            );
+            let upper_bound = if_close_start(command, self.source_map());
+            let site = CompoundBodySite::if_else_branch(command, else_branch, upper_bound);
+            self.visit_compound_body_site(site);
         }
         self.record_if_branch_prefix_facts(command);
         self.record_close_suffix(Some(if_close_span(command, self.source, self.source_map())));
@@ -2462,94 +2394,28 @@ impl<'source, 'options> FormatterFactsBuilder<'source, 'options> {
                 self.visit_word(word);
             }
         }
-        let group_open_char = matches!(
-            command.syntax,
-            shuck_ast::ForSyntax::InBrace { .. } | shuck_ast::ForSyntax::ParenBrace { .. }
-        )
-        .then_some('{');
-        if group_open_char.is_some() {
-            self.record_inline_group_sequence(&command.body, '{', '}');
-        }
-        self.visit_sequence_with_suffix(
-            &command.body,
-            Some(for_body_upper_bound(command, self.source_map())),
-            group_open_char,
-            group_open_char
-                .is_none()
-                .then(|| {
-                    matches!(
-                        command.syntax,
-                        shuck_ast::ForSyntax::InDoDone { .. }
-                            | shuck_ast::ForSyntax::ParenDoDone { .. }
-                    )
-                    .then(|| branch_open_suffix_span(&command.body, self.source_map(), "do"))
-                    .flatten()
-                })
-                .flatten(),
-            group_open_char
-                .is_none()
-                .then(|| branch_open_end_offset(&command.body, self.source, "do"))
-                .flatten(),
-        );
-        if matches!(
-            command.syntax,
-            shuck_ast::ForSyntax::InDoDone { .. } | shuck_ast::ForSyntax::ParenDoDone { .. }
-        ) {
-            self.record_close_suffix(done_close_span(
-                self.source_map().source(),
-                self.source_map(),
-                command.span,
-                None,
-            ));
-        }
+        let site = CompoundBodySite::for_command(command, self.source_map());
+        self.visit_compound_body_site(site);
     }
 
     fn visit_repeat(&mut self, command: &RepeatCommand) {
         self.visit_word(&command.count);
-        let group_open_char =
-            matches!(command.syntax, shuck_ast::RepeatSyntax::Brace { .. }).then_some('{');
-        if group_open_char.is_some() {
-            self.record_inline_group_sequence(&command.body, '{', '}');
-        }
-        self.visit_sequence_with_suffix(
-            &command.body,
-            Some(repeat_body_upper_bound(command, self.source_map())),
-            group_open_char,
-            group_open_char
-                .is_none()
-                .then(|| {
-                    matches!(command.syntax, shuck_ast::RepeatSyntax::DoDone { .. })
-                        .then(|| branch_open_suffix_span(&command.body, self.source_map(), "do"))
-                        .flatten()
-                })
-                .flatten(),
-            group_open_char
-                .is_none()
-                .then(|| branch_open_end_offset(&command.body, self.source, "do"))
-                .flatten(),
-        );
-        if matches!(command.syntax, shuck_ast::RepeatSyntax::DoDone { .. }) {
-            self.record_close_suffix(done_close_span(
-                self.source_map().source(),
-                self.source_map(),
-                command.span,
-                None,
-            ));
-        }
+        let site = CompoundBodySite::repeat_command(command, self.source_map());
+        self.visit_compound_body_site(site);
     }
 
     fn visit_while(&mut self, command: &WhileCommand) {
-        let condition_upper_bound =
-            branch_open_keyword_start(&command.body, self.source_map().source(), "do");
+        let site = CompoundBodySite::while_command(command, self.source_map());
+        let condition_upper_bound = site.open_keyword_start(self.source);
         self.visit_sequence(&command.condition, condition_upper_bound, None);
-        self.visit_do_done_body(&command.body, command.span);
+        self.visit_compound_body_site(site);
     }
 
     fn visit_until(&mut self, command: &UntilCommand) {
-        let condition_upper_bound =
-            branch_open_keyword_start(&command.body, self.source_map().source(), "do");
+        let site = CompoundBodySite::until_command(command, self.source_map());
+        let condition_upper_bound = site.open_keyword_start(self.source);
         self.visit_sequence(&command.condition, condition_upper_bound, None);
-        self.visit_do_done_body(&command.body, command.span);
+        self.visit_compound_body_site(site);
     }
 
     fn visit_case(&mut self, command: &CaseCommand) {
@@ -2584,7 +2450,8 @@ impl<'source, 'options> FormatterFactsBuilder<'source, 'options> {
         for word in &command.words {
             self.visit_word(word);
         }
-        self.visit_do_done_body(&command.body, command.span);
+        let site = CompoundBodySite::select_command(command, self.source_map());
+        self.visit_compound_body_site(site);
     }
 
     fn visit_time(&mut self, command: &TimeCommand) {
@@ -2615,36 +2482,12 @@ impl<'source, 'options> FormatterFactsBuilder<'source, 'options> {
     }
 
     fn visit_function_body(&mut self, body: &Stmt, function_end_offset: usize) {
-        if !body.negated
-            && body.redirects.is_empty()
-            && body.terminator.is_none()
-            && let Some((commands, open)) = command_group_commands(&body.command)
-        {
-            self.visit_function_group_body(
-                commands,
-                function_end_offset,
-                open,
-                matching_group_close(open),
-            );
+        if let Some(site) = CompoundBodySite::function_group_body(body, function_end_offset) {
+            self.visit_compound_body_site(site);
             self.record_stmt_layout(body);
         } else {
             self.visit_stmt(body);
         }
-    }
-
-    fn visit_function_group_body(
-        &mut self,
-        commands: &StmtSeq,
-        function_end_offset: usize,
-        open: char,
-        close: char,
-    ) {
-        if group_was_inline_in_source(commands.as_slice(), self.source_map(), open, close) {
-            self.facts
-                .inline_group_sequences
-                .insert(FactSpan::from(commands.span));
-        }
-        self.visit_sequence(commands, Some(function_end_offset), Some(open));
     }
 
     fn visit_redirect(&mut self, redirect: &Redirect) {
@@ -3078,26 +2921,6 @@ fn pipeline_has_explicit_line_break(
     false
 }
 
-fn branch_open_suffix_span(
-    sequence: &StmtSeq,
-    source_map: &SourceMap<'_>,
-    keyword: &str,
-) -> Option<Span> {
-    let source = source_map.source();
-    let keyword_offset = branch_open_keyword_start(sequence, source, keyword)?;
-    let (_, line_end) = source_map.line_bounds_for_offset(keyword_offset)?;
-    let suffix_start = keyword_offset + keyword.len();
-    let suffix = source.get(suffix_start..line_end)?;
-    suffix
-        .trim_start_matches(char::is_whitespace)
-        .starts_with('#')
-        .then(|| source_map.span_for_offsets(suffix_start, line_end))
-}
-
-fn branch_open_end_offset(sequence: &StmtSeq, source: &str, keyword: &str) -> Option<usize> {
-    branch_open_keyword_start(sequence, source, keyword).map(|start| start + keyword.len())
-}
-
 fn sequence_comment_lower_bound(sequence: &StmtSeq, source_map: &SourceMap<'_>) -> usize {
     let mut lower_bound = sequence.span.start.offset;
     for comment in &sequence.leading_comments {
@@ -3124,64 +2947,6 @@ fn sequence_comment_lower_bound(sequence: &StmtSeq, source_map: &SourceMap<'_>) 
 fn case_close_span(command: &CaseCommand, source_map: &SourceMap<'_>) -> Option<Span> {
     let start = last_shell_keyword_start(source_map.source(), command.span, "esac")?;
     Some(source_map.span_for_offsets(start, start + "esac".len()))
-}
-
-fn done_body_upper_bound(source_map: &SourceMap<'_>, span: Span) -> usize {
-    done_close_span(source_map.source(), source_map, span, None)
-        .map_or(span.end.offset, |close| close.start.offset)
-}
-
-fn for_body_upper_bound(command: &ForCommand, source_map: &SourceMap<'_>) -> usize {
-    match command.syntax {
-        shuck_ast::ForSyntax::InDoDone { done_span, .. }
-        | shuck_ast::ForSyntax::ParenDoDone { done_span, .. } => done_close_span(
-            source_map.source(),
-            source_map,
-            command.span,
-            Some(done_span),
-        )
-        .map_or(done_span.start.offset, |span| span.start.offset),
-        shuck_ast::ForSyntax::InBrace {
-            right_brace_span, ..
-        }
-        | shuck_ast::ForSyntax::ParenBrace {
-            right_brace_span, ..
-        } => right_brace_span.start.offset,
-        shuck_ast::ForSyntax::InDirect { .. } | shuck_ast::ForSyntax::ParenDirect { .. } => {
-            command.span.end.offset
-        }
-    }
-}
-
-fn foreach_body_upper_bound(command: &ForeachCommand, source_map: &SourceMap<'_>) -> usize {
-    match command.syntax {
-        shuck_ast::ForeachSyntax::InDoDone { done_span, .. } => done_close_span(
-            source_map.source(),
-            source_map,
-            command.span,
-            Some(done_span),
-        )
-        .map_or(done_span.start.offset, |span| span.start.offset),
-        shuck_ast::ForeachSyntax::ParenBrace {
-            right_brace_span, ..
-        } => right_brace_span.start.offset,
-    }
-}
-
-fn repeat_body_upper_bound(command: &RepeatCommand, source_map: &SourceMap<'_>) -> usize {
-    match command.syntax {
-        shuck_ast::RepeatSyntax::DoDone { done_span, .. } => done_close_span(
-            source_map.source(),
-            source_map,
-            command.span,
-            Some(done_span),
-        )
-        .map_or(done_span.start.offset, |span| span.start.offset),
-        shuck_ast::RepeatSyntax::Brace {
-            right_brace_span, ..
-        } => right_brace_span.start.offset,
-        shuck_ast::RepeatSyntax::Direct => command.span.end.offset,
-    }
 }
 
 fn group_close_offset(

--- a/crates/shuck-formatter/src/streaming/compounds.rs
+++ b/crates/shuck-formatter/src/streaming/compounds.rs
@@ -69,7 +69,7 @@ where
 
         match layout {
             ThenFiIfLayout::RawGroupedCondition { raw_condition } => {
-                self.format_raw_grouped_then_fi_if(command, then_span, fi_span, &raw_condition)
+                self.format_raw_grouped_then_fi_if(command, fi_span, &raw_condition)
             }
             ThenFiIfLayout::SplitCondition => {
                 self.format_split_condition_then_fi_if(command, then_span, fi_span)
@@ -81,7 +81,6 @@ where
     pub(super) fn format_raw_grouped_then_fi_if(
         &mut self,
         command: &IfCommand,
-        then_span: Span,
         fi_span: Span,
         raw_condition: &str,
     ) -> Result<()> {
@@ -92,18 +91,17 @@ where
         self.write_text("then");
         let then_upper_bound =
             if_branch_upper_bound(command, 0, source, self.source_map(), self.facts());
-        self.format_if_branch_body_after_open(
-            &command.then_branch,
-            then_upper_bound,
-            then_span.end.offset,
-        )?;
+        let then_site =
+            CompoundBodySite::if_then_branch(command, &command.then_branch, then_upper_bound);
+        self.format_if_branch_body_site(then_site)?;
         if let Some(body) = &command.else_branch {
             if self.if_next_branch_has_blank_line_before_keyword(command, 0, source) {
                 self.newline();
             }
             self.newline();
             self.write_text("else");
-            self.format_else_branch_body(command, body, fi_upper_bound)?;
+            let site = CompoundBodySite::if_else_branch(command, body, fi_upper_bound);
+            self.format_if_branch_body_site(site)?;
         }
         self.finish_multiline_if_close(command, then_upper_bound, fi_span);
         Ok(())
@@ -126,27 +124,22 @@ where
         self.write_text("then");
         let then_upper_bound =
             if_branch_upper_bound(command, 0, source, self.source_map(), self.facts());
-        self.format_if_branch_body_after_open(
-            &command.then_branch,
-            then_upper_bound,
-            then_span.end.offset,
-        )?;
+        let then_site =
+            CompoundBodySite::if_then_branch(command, &command.then_branch, then_upper_bound);
+        self.format_if_branch_body_site(then_site)?;
         for (index, (condition, body)) in command.elif_branches.iter().enumerate() {
             self.write_if_branch_prefix(command, index, source);
             self.write_elif_header(command, index, condition, body, source)?;
             let body_upper_bound =
                 if_branch_upper_bound(command, index + 1, source, self.source_map(), self.facts());
-            self.format_if_branch_body_after_keyword(
-                body,
-                body_upper_bound,
-                condition.span.start.offset,
-                "then",
-            )?;
+            let site = CompoundBodySite::if_then_branch(command, body, body_upper_bound);
+            self.format_if_branch_body_site(site)?;
         }
         if let Some(body) = &command.else_branch {
             self.write_if_branch_prefix(command, command.elif_branches.len(), source);
             self.write_text("else");
-            self.format_else_branch_body(command, body, fi_upper_bound)?;
+            let site = CompoundBodySite::if_else_branch(command, body, fi_upper_bound);
+            self.format_if_branch_body_site(site)?;
         }
         self.finish_multiline_if_close(command, then_upper_bound, fi_span);
         Ok(())
@@ -191,7 +184,9 @@ where
                 self.write_space();
                 self.format_inline_stmts(&command.then_branch)?;
                 self.write_text("; else");
-                self.format_else_branch_body(command, else_branch, fi_span.start.offset)?;
+                let site =
+                    CompoundBodySite::if_else_branch(command, else_branch, fi_span.start.offset);
+                self.format_if_branch_body_site(site)?;
                 let then_upper_bound = if_branch_upper_bound(
                     command,
                     0,
@@ -249,19 +244,12 @@ where
         self.write_text(then_separator);
         let then_upper_bound =
             if_branch_upper_bound(command, 0, source, self.source_map(), self.facts());
+        let then_site =
+            CompoundBodySite::if_then_branch(command, &command.then_branch, then_upper_bound);
         if !self.write_condition_separator_suffix_comment(&command.condition, then_span) {
-            self.write_sequence_open_suffix(&command.then_branch, Some(then_upper_bound));
+            self.write_compound_body_open_suffix(then_site);
         }
-        let preserve_then_open_blank = self
-            .facts()
-            .sequence(&command.then_branch, Some(then_upper_bound))
-            .has_blank_line_after_open();
-        self.format_body_with_upper_bound_and_open_blank(
-            &command.then_branch,
-            Some(then_upper_bound),
-            preserve_then_open_blank,
-        )?;
-        self.write_unmodeled_branch_background_terminator(&command.then_branch, then_upper_bound);
+        self.format_if_branch_body_site_with_open_suffix(then_site, false)?;
         for (index, (condition, body)) in command.elif_branches.iter().enumerate() {
             if matches!(layout, ExpandedThenFiIfLayout::Compact) {
                 self.write_text("; elif ");
@@ -273,12 +261,8 @@ where
             }
             let body_upper_bound =
                 if_branch_upper_bound(command, index + 1, source, self.source_map(), self.facts());
-            self.format_if_branch_body_after_keyword(
-                body,
-                body_upper_bound,
-                condition.span.start.offset,
-                "then",
-            )?;
+            let site = CompoundBodySite::if_then_branch(command, body, body_upper_bound);
+            self.format_if_branch_body_site(site)?;
         }
         if let Some(body) = &command.else_branch {
             match layout {
@@ -294,7 +278,8 @@ where
                     self.write_text("else");
                 }
             }
-            self.format_else_branch_body(command, body, fi_upper_bound)?;
+            let site = CompoundBodySite::if_else_branch(command, body, fi_upper_bound);
+            self.format_if_branch_body_site(site)?;
         }
         match layout {
             ExpandedThenFiIfLayout::Compact => self.write_if_close("; fi", fi_span),
@@ -484,14 +469,10 @@ where
             })
     }
 
-    pub(super) fn write_sequence_open_suffix(
-        &mut self,
-        commands: &StmtSeq,
-        upper_bound: Option<usize>,
-    ) {
+    pub(super) fn write_compound_body_open_suffix(&mut self, site: CompoundBodySite<'_>) {
         let Some(span) = self
             .facts()
-            .sequence(commands, upper_bound)
+            .sequence(site.body(), Some(site.renderer_upper_bound()))
             .group_open_suffix_span()
         else {
             return;
@@ -556,55 +537,24 @@ where
         self.write_text(operator);
     }
 
-    pub(super) fn format_if_branch_body_after_open(
+    pub(super) fn format_if_branch_body_site(&mut self, site: CompoundBodySite<'_>) -> Result<()> {
+        self.format_if_branch_body_site_with_open_suffix(site, true)
+    }
+
+    pub(super) fn format_if_branch_body_site_with_open_suffix(
         &mut self,
-        body: &StmtSeq,
-        upper_bound: usize,
-        _open_end_offset: usize,
+        site: CompoundBodySite<'_>,
+        write_open_suffix: bool,
     ) -> Result<()> {
+        let body = site.body();
+        let upper_bound = site.renderer_upper_bound();
         let preserve_open_blank = self
             .facts()
             .sequence(body, Some(upper_bound))
             .has_blank_line_after_open();
-        self.format_if_branch_body(body, upper_bound, preserve_open_blank)
-    }
-
-    pub(super) fn format_if_branch_body_after_keyword(
-        &mut self,
-        body: &StmtSeq,
-        upper_bound: usize,
-        keyword_start_offset: usize,
-        keyword: &'static str,
-    ) -> Result<()> {
-        let _ = (keyword_start_offset, keyword);
-        let preserve_open_blank = self
-            .facts()
-            .sequence(body, Some(upper_bound))
-            .has_blank_line_after_open();
-        self.format_if_branch_body(body, upper_bound, preserve_open_blank)
-    }
-
-    pub(super) fn format_else_branch_body(
-        &mut self,
-        command: &IfCommand,
-        body: &StmtSeq,
-        fi_upper_bound: usize,
-    ) -> Result<()> {
-        self.format_if_branch_body_after_keyword(
-            body,
-            fi_upper_bound,
-            command.span.start.offset,
-            "else",
-        )
-    }
-
-    pub(super) fn format_if_branch_body(
-        &mut self,
-        body: &StmtSeq,
-        upper_bound: usize,
-        preserve_open_blank: bool,
-    ) -> Result<()> {
-        self.write_sequence_open_suffix(body, Some(upper_bound));
+        if write_open_suffix {
+            self.write_compound_body_open_suffix(site);
+        }
         self.format_body_with_upper_bound_and_open_blank(
             body,
             Some(upper_bound),
@@ -619,34 +569,24 @@ where
         self.write_text("if ");
         self.format_inline_stmts(&command.condition)?;
         self.write_space();
-        self.format_brace_group(
-            &command.then_branch,
-            Some(if_branch_upper_bound(
-                command,
-                0,
-                source,
-                self.source_map(),
-                self.facts(),
-            )),
-        )?;
+        let then_upper_bound =
+            if_branch_upper_bound(command, 0, source, self.source_map(), self.facts());
+        let then_site =
+            CompoundBodySite::if_then_branch(command, &command.then_branch, then_upper_bound);
+        self.format_brace_group(then_site.body(), Some(then_site.renderer_upper_bound()))?;
         for (index, (condition, body)) in command.elif_branches.iter().enumerate() {
             self.write_text(" elif ");
             self.format_inline_stmts(condition)?;
             self.write_space();
-            self.format_brace_group(
-                body,
-                Some(if_branch_upper_bound(
-                    command,
-                    index + 1,
-                    source,
-                    self.source_map(),
-                    self.facts(),
-                )),
-            )?;
+            let upper_bound =
+                if_branch_upper_bound(command, index + 1, source, self.source_map(), self.facts());
+            let site = CompoundBodySite::if_then_branch(command, body, upper_bound);
+            self.format_brace_group(site.body(), Some(site.renderer_upper_bound()))?;
         }
         if let Some(body) = &command.else_branch {
             self.write_text(" else ");
-            self.format_brace_group(body, Some(command.span.end.offset))?;
+            let site = CompoundBodySite::if_else_branch(command, body, command.span.end.offset);
+            self.format_brace_group(site.body(), Some(site.renderer_upper_bound()))?;
         }
         Ok(())
     }
@@ -673,18 +613,20 @@ where
             }
         }
 
-        match command.syntax {
-            ForSyntax::InDoDone { done_span, .. } | ForSyntax::ParenDoDone { done_span, .. } => {
-                self.format_done_body(&command.body, command.span, Some(done_span))?;
+        let site = CompoundBodySite::for_command(command, self.source_map());
+        match site.open() {
+            CompoundBodyOpen::Keyword("do") => {
+                self.format_do_done_body(site, "done")?;
             }
-            ForSyntax::InDirect { .. } | ForSyntax::ParenDirect { .. } => {
+            CompoundBodyOpen::Direct => {
                 self.write_space();
-                self.format_inline_stmts(&command.body)?;
+                self.format_inline_stmts(site.body())?;
             }
-            ForSyntax::InBrace { .. } | ForSyntax::ParenBrace { .. } => {
+            CompoundBodyOpen::Group('{') => {
                 self.write_text("; ");
-                self.format_brace_group(&command.body, Some(command.span.end.offset))?;
+                self.format_brace_group(site.body(), Some(site.renderer_upper_bound()))?;
             }
+            _ => unreachable!("for body uses do, direct, or brace syntax"),
         }
         Ok(())
     }
@@ -719,18 +661,20 @@ where
     pub(super) fn format_repeat(&mut self, command: &RepeatCommand) -> Result<()> {
         self.write_text("repeat ");
         self.write_word(&command.count);
-        match command.syntax {
-            RepeatSyntax::DoDone { done_span, .. } => {
-                self.format_done_body(&command.body, command.span, Some(done_span))?;
+        let site = CompoundBodySite::repeat_command(command, self.source_map());
+        match site.open() {
+            CompoundBodyOpen::Keyword("do") => {
+                self.format_do_done_body(site, "done")?;
             }
-            RepeatSyntax::Direct => {
+            CompoundBodyOpen::Direct => {
                 self.write_space();
-                self.format_inline_stmts(&command.body)?;
+                self.format_inline_stmts(site.body())?;
             }
-            RepeatSyntax::Brace { .. } => {
+            CompoundBodyOpen::Group('{') => {
                 self.write_space();
-                self.format_brace_group(&command.body, Some(command.span.end.offset))?;
+                self.format_brace_group(site.body(), Some(site.renderer_upper_bound()))?;
             }
+            _ => unreachable!("repeat body uses do, direct, or brace syntax"),
         }
         Ok(())
     }
@@ -738,15 +682,16 @@ where
     pub(super) fn format_foreach(&mut self, command: &ForeachCommand) -> Result<()> {
         self.write_text("foreach ");
         self.write_text(command.variable.as_ref());
+        let site = CompoundBodySite::foreach_command(command, self.source_map());
         match command.syntax {
             ForeachSyntax::ParenBrace { .. } => {
                 self.write_parenthesized_word_list(Some(&command.words));
                 self.write_space();
-                self.format_brace_group(&command.body, Some(command.span.end.offset))?;
+                self.format_brace_group(site.body(), Some(site.renderer_upper_bound()))?;
             }
-            ForeachSyntax::InDoDone { done_span, .. } => {
+            ForeachSyntax::InDoDone { .. } => {
                 self.write_for_in_words(Some(&command.words), None);
-                self.format_done_body(&command.body, command.span, Some(done_span))?;
+                self.format_do_done_body(site, "done")?;
             }
         }
         Ok(())
@@ -756,43 +701,44 @@ where
         self.write_text("select ");
         self.write_text(command.variable.as_ref());
         self.write_for_in_words(Some(&command.words), None);
-        self.format_done_body(&command.body, command.span, None)?;
+        let site = CompoundBodySite::select_command(command, self.source_map());
+        self.format_do_done_body(site, "done")?;
         Ok(())
     }
 
     pub(super) fn format_while(&mut self, command: &WhileCommand) -> Result<()> {
-        self.format_loop("while", &command.condition, &command.body, command.span)
+        let site = CompoundBodySite::while_command(command, self.source_map());
+        self.format_loop("while", &command.condition, site)
     }
 
     pub(super) fn format_until(&mut self, command: &UntilCommand) -> Result<()> {
-        self.format_loop("until", &command.condition, &command.body, command.span)
+        let site = CompoundBodySite::until_command(command, self.source_map());
+        self.format_loop("until", &command.condition, site)
     }
 
     pub(super) fn format_loop(
         &mut self,
         keyword: &'static str,
         condition: &StmtSeq,
-        body: &StmtSeq,
-        span: Span,
+        site: CompoundBodySite<'_>,
     ) -> Result<()> {
-        let close_span = command_done_close_span(self.source(), self.source_map(), span, None);
-        if loop_condition_starts_after_keyword(condition, span)
+        if loop_condition_starts_after_keyword(condition, site.enclosing_span())
             || loop_condition_has_multiple_commands(condition)
         {
             self.write_text(keyword);
             self.newline();
-            let condition_upper_bound = branch_open_keyword_start(body, self.source(), "do");
+            let condition_upper_bound = site.open_keyword_start(self.source());
             self.with_indent(|formatter| {
                 formatter.format_stmt_sequence(condition, condition_upper_bound)
             })?;
             self.newline();
-            return self.format_split_do_done_body(body, span, close_span, "done");
+            return self.format_split_do_done_body(site, "done");
         }
 
         self.write_text(keyword);
         self.write_space();
         self.format_inline_stmts(condition)?;
-        self.format_do_done_body(body, span, close_span, "done")
+        self.format_do_done_body(site, "done")
     }
 
     pub(super) fn format_case(&mut self, command: &CaseCommand) -> Result<()> {
@@ -1333,7 +1279,8 @@ where
         self.write_text("; ");
         self.write_text(&step);
         self.write_text("))");
-        self.format_done_body(&command.body, command.span, None)
+        let site = CompoundBodySite::arithmetic_for_command(command, self.source_map());
+        self.format_do_done_body(site, "done")
     }
 
     pub(super) fn format_time(&mut self, command: &TimeCommand) -> Result<()> {
@@ -1474,54 +1421,43 @@ where
         upper_bound: usize,
         header_comment: Option<(Span, String)>,
     ) -> Result<()> {
-        match body {
-            Stmt {
-                command: Command::Compound(CompoundCommand::BraceGroup(commands)),
-                negated: false,
-                redirects,
-                terminator: None,
-                ..
-            } if redirects.is_empty() => {
+        match CompoundBodySite::function_group_body(body, upper_bound) {
+            Some(site) if site.group_open_char() == Some('{') => {
                 if let Some((_, comment)) = header_comment {
                     return self.format_function_brace_group_with_header_comment(
-                        commands,
-                        upper_bound,
+                        site.body(),
+                        site.renderer_upper_bound(),
                         &comment,
                     );
                 }
 
                 let should_inline = !self.options().function_next_line()
-                    && self.group_has_inline_source_shape(commands, '{')
-                    && self.can_inline_group(commands, '{');
+                    && self.group_has_inline_source_shape(site.body(), '{')
+                    && self.can_inline_group(site.body(), '{');
                 if should_inline {
                     self.write_text("{ ");
-                    self.format_inline_stmts(commands)?;
+                    self.format_inline_stmts(site.body())?;
                     self.write_text("; }");
                     Ok(())
                 } else {
-                    self.format_brace_group(commands, Some(upper_bound))
+                    self.format_brace_group(site.body(), Some(site.renderer_upper_bound()))
                 }
             }
-            Stmt {
-                command: Command::Compound(CompoundCommand::Subshell(commands)),
-                negated: false,
-                redirects,
-                terminator: None,
-                ..
-            } if redirects.is_empty() => {
+            Some(site) if site.group_open_char() == Some('(') => {
                 let should_inline = !self.options().function_next_line()
-                    && self.group_has_inline_source_shape(commands, '(')
-                    && self.can_inline_group(commands, '(');
+                    && self.group_has_inline_source_shape(site.body(), '(')
+                    && self.can_inline_group(site.body(), '(');
                 if should_inline {
                     self.write_text("(");
-                    self.format_inline_stmts(commands)?;
+                    self.format_inline_stmts(site.body())?;
                     self.write_text(")");
                     Ok(())
                 } else {
-                    self.format_subshell(commands, Some(upper_bound))
+                    self.format_subshell(site.body(), Some(site.renderer_upper_bound()))
                 }
             }
-            _ => self.format_stmt(body),
+            Some(_) => unreachable!("function body group uses brace or subshell syntax"),
+            None => self.format_stmt(body),
         }
     }
 

--- a/crates/shuck-formatter/src/streaming/mod.rs
+++ b/crates/shuck-formatter/src/streaming/mod.rs
@@ -8,8 +8,8 @@ use shuck_ast::{
     ConditionalExpr, ConditionalParenExpr, ConditionalUnaryExpr, ConditionalUnaryOp, CoprocCommand,
     DeclClause, DeclOperand, File, ForCommand, ForSyntax, ForeachCommand, ForeachSyntax,
     FunctionDef, HeredocBody, HeredocBodyPart, IfCommand, IfSyntax, Pattern, PatternPart, Redirect,
-    RedirectKind, RepeatCommand, RepeatSyntax, SelectCommand, SimpleCommand, Span, Stmt, StmtSeq,
-    StmtTerminator, TimeCommand, UntilCommand, VarRef, WhileCommand, Word, WordPart,
+    RedirectKind, RepeatCommand, SelectCommand, SimpleCommand, Span, Stmt, StmtSeq, StmtTerminator,
+    TimeCommand, UntilCommand, VarRef, WhileCommand, Word, WordPart,
 };
 
 mod branches;
@@ -26,11 +26,11 @@ mod writer;
 
 use crate::Result;
 use crate::command::{
-    array_elem_parts, binary_operator, branch_open_keyword_start, builtin_like_parts,
-    case_item_body_upper_bound, case_terminator,
+    CompoundBodyOpen, CompoundBodySite, array_elem_parts, binary_operator,
+    branch_open_keyword_start, builtin_like_parts, case_item_body_upper_bound, case_terminator,
     collect_binary_list_first as collect_binary_list_first_with, collect_pipeline_parts,
-    command_format_span, command_group_commands, done_close_span as command_done_close_span,
-    format_arithmetic_command_source, format_arithmetic_for_clause_source, group_attachment_span,
+    command_format_span, command_group_commands, format_arithmetic_command_source,
+    format_arithmetic_for_clause_source, group_attachment_span,
     if_close_span as command_if_close_span, if_next_branch_region_with_body_end,
     line_gap_break_count, matching_group_close,
     multiline_compound_assignment_command_substitution_body_prefix,

--- a/crates/shuck-formatter/src/streaming/statements.rs
+++ b/crates/shuck-formatter/src/streaming/statements.rs
@@ -555,27 +555,15 @@ where
         }
     }
 
-    pub(super) fn format_done_body(
-        &mut self,
-        body: &StmtSeq,
-        enclosing_span: Span,
-        done_span: Option<Span>,
-    ) -> Result<()> {
-        let close_span =
-            command_done_close_span(self.source(), self.source_map(), enclosing_span, done_span);
-        self.format_do_done_body(body, enclosing_span, close_span, "done")
-    }
-
     pub(super) fn format_do_done_body(
         &mut self,
-        body: &StmtSeq,
-        enclosing_span: Span,
-        close_span: Option<Span>,
+        site: CompoundBodySite<'_>,
         close: &'static str,
     ) -> Result<()> {
-        let body_upper_bound = close_span
-            .map(|span| span.start.offset)
-            .unwrap_or(enclosing_span.end.offset);
+        let body = site.body();
+        let body_upper_bound = site.renderer_upper_bound();
+        let close_span = site.close_span();
+        let enclosing_span = site.enclosing_span();
         let has_open_suffix = self
             .facts()
             .sequence(body, Some(body_upper_bound))
@@ -608,33 +596,29 @@ where
             }
         }
 
-        self.format_multiline_do_done_body(body, enclosing_span, close_span, close, "; do")
+        self.format_multiline_do_done_body(site, close, "; do")
     }
 
     pub(super) fn format_split_do_done_body(
         &mut self,
-        body: &StmtSeq,
-        enclosing_span: Span,
-        close_span: Option<Span>,
+        site: CompoundBodySite<'_>,
         close: &'static str,
     ) -> Result<()> {
-        self.format_multiline_do_done_body(body, enclosing_span, close_span, close, "do")
+        self.format_multiline_do_done_body(site, close, "do")
     }
 
     pub(super) fn format_multiline_do_done_body(
         &mut self,
-        body: &StmtSeq,
-        enclosing_span: Span,
-        close_span: Option<Span>,
+        site: CompoundBodySite<'_>,
         close: &'static str,
         open: &'static str,
     ) -> Result<()> {
-        let body_upper_bound = close_span
-            .map(|span| span.start.offset)
-            .unwrap_or(enclosing_span.end.offset);
+        let body = site.body();
+        let body_upper_bound = site.renderer_upper_bound();
+        let close_span = site.close_span();
 
         self.write_text(open);
-        self.write_sequence_open_suffix(body, Some(body_upper_bound));
+        self.write_compound_body_open_suffix(site);
         let preserve_open_blank = self
             .facts()
             .sequence(body, Some(body_upper_bound))


### PR DESCRIPTION
## Summary

- Add a shared `CompoundBodySite` descriptor for compound command bodies.
- Route formatter facts and streaming rendering through the shared site model for do/done, brace, direct, if-branch, loop, and function bodies.
- Remove duplicated upper-bound, open-suffix, and close-span branching from the facts pass and renderer while preserving formatter behavior.

## Validation

- `cargo fmt --check`
- `cargo check -p shuck-formatter`
- `cargo test -p shuck-formatter`
- `make test-oracle-shfmt-large-corpus` (`blocking_mismatches=0`, `shuck_errors=0`)