### PR TITLE
perf(formatter): reduce corpus allocations

### DIFF
--- a/crates/shuck-formatter/src/comments.rs
+++ b/crates/shuck-formatter/src/comments.rs
@@ -516,39 +516,62 @@ impl<'a> CommentAttachmentModel<'a> {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SequenceCommentAttachment<'a> {
-    leading: Vec<Vec<SourceComment<'a>>>,
-    trailing: Vec<Vec<SourceComment<'a>>>,
+    leading: Option<Vec<Vec<SourceComment<'a>>>>,
+    trailing: Option<Vec<Vec<SourceComment<'a>>>>,
     dangling: Vec<SourceComment<'a>>,
+    child_count: usize,
     ambiguous: bool,
 }
 
 impl<'a> SequenceCommentAttachment<'a> {
     pub(crate) fn new(child_count: usize) -> Self {
         Self {
-            leading: vec![Vec::new(); child_count],
-            trailing: vec![Vec::new(); child_count],
+            leading: None,
+            trailing: None,
             dangling: Vec::new(),
+            child_count,
             ambiguous: false,
         }
     }
 
     pub(crate) fn with_dangling(dangling: Vec<SourceComment<'a>>, ambiguous: bool) -> Self {
         Self {
-            leading: Vec::new(),
-            trailing: Vec::new(),
+            leading: None,
+            trailing: None,
             dangling,
+            child_count: 0,
             ambiguous,
         }
     }
 
+    fn leading_mut(&mut self, index: usize) -> &mut Vec<SourceComment<'a>> {
+        self.leading
+            .get_or_insert_with(|| vec![Vec::new(); self.child_count])
+            .get_mut(index)
+            .expect("comment attachment index should match child count")
+    }
+
+    fn trailing_mut(&mut self, index: usize) -> &mut Vec<SourceComment<'a>> {
+        self.trailing
+            .get_or_insert_with(|| vec![Vec::new(); self.child_count])
+            .get_mut(index)
+            .expect("comment attachment index should match child count")
+    }
+
     #[must_use]
     pub fn leading_for(&self, index: usize) -> &[SourceComment<'a>] {
-        self.leading.get(index).map_or(&[], Vec::as_slice)
+        self.leading
+            .as_ref()
+            .and_then(|leading| leading.get(index))
+            .map_or(&[], Vec::as_slice)
     }
 
     #[must_use]
     pub fn trailing_for(&self, index: usize) -> &[SourceComment<'a>] {
-        self.trailing.get(index).map_or(&[], Vec::as_slice)
+        self.trailing
+            .as_ref()
+            .and_then(|trailing| trailing.get(index))
+            .map_or(&[], Vec::as_slice)
     }
 
     #[must_use]
@@ -565,8 +588,14 @@ impl<'a> SequenceCommentAttachment<'a> {
     pub fn has_comments(&self) -> bool {
         self.ambiguous
             || !self.dangling.is_empty()
-            || self.leading.iter().any(|comments| !comments.is_empty())
-            || self.trailing.iter().any(|comments| !comments.is_empty())
+            || self
+                .leading
+                .as_ref()
+                .is_some_and(|leading| leading.iter().any(|comments| !comments.is_empty()))
+            || self
+                .trailing
+                .as_ref()
+                .is_some_and(|trailing| trailing.iter().any(|comments| !comments.is_empty()))
     }
 }
 
@@ -628,7 +657,7 @@ fn compute_sequence_attachment<'a>(
                 && child_spans[prev_idx].end.line == comment.line
                 && child_spans[prev_idx].start.offset <= start
             {
-                attachment.trailing[prev_idx].push(comment);
+                attachment.trailing_mut(prev_idx).push(comment);
                 index += 1;
                 continue;
             }
@@ -638,7 +667,7 @@ fn compute_sequence_attachment<'a>(
                     if next_idx.is_none_or(|next_idx| prev_idx + 1 == next_idx)
                         && child_spans[prev_idx].end.line == comment.line =>
                 {
-                    attachment.trailing[prev_idx].push(comment);
+                    attachment.trailing_mut(prev_idx).push(comment);
                 }
                 _ => attachment.ambiguous = true,
             }
@@ -651,7 +680,7 @@ fn compute_sequence_attachment<'a>(
                 candidate.span.end.offset <= first_child_start
             });
             for item in &items[index..run_end] {
-                attachment.leading[0].push(*item);
+                attachment.leading_mut(0).push(*item);
             }
             index = run_end;
         } else if let Some(next_idx) = next {
@@ -663,7 +692,7 @@ fn compute_sequence_attachment<'a>(
                 candidate.span.start.offset >= gap_start && candidate.span.end.offset <= gap_end
             });
             for item in &items[index..run_end] {
-                attachment.leading[next_idx].push(*item);
+                attachment.leading_mut(next_idx).push(*item);
             }
             index = run_end;
         } else if start >= last_child_end {

--- a/crates/shuck-formatter/src/comments.rs
+++ b/crates/shuck-formatter/src/comments.rs
@@ -497,6 +497,10 @@ impl<'a> CommentAttachmentModel<'a> {
         compute_sequence_attachment(comments, child_spans, upper_bound, skip_span)
     }
 
+    pub(crate) fn comments(&self) -> &[SourceComment<'a>] {
+        &self.comments
+    }
+
     fn comment_window(
         &self,
         lower_bound: usize,

--- a/crates/shuck-formatter/src/facts.rs
+++ b/crates/shuck-formatter/src/facts.rs
@@ -18,10 +18,10 @@ use crate::command::{
     CompoundBodySite, array_elem_parts, builtin_like_parts, case_item_body_upper_bound,
     case_item_was_inline_in_source, case_terminator,
     collect_binary_list_first as collect_binary_list_first_with, collect_pipeline_parts,
-    command_group_commands, group_attachment_span_with_heredoc, group_open_suffix,
-    group_was_inline_in_source, if_close_span, if_next_branch_region_with_body_end,
-    matching_group_close, rendered_stmt_end_line_with_heredoc, should_render_verbatim_with_heredoc,
-    stmt_attachment_span_with_heredoc, stmt_format_span,
+    command_format_span, command_group_commands, group_attachment_span_with_heredoc,
+    group_open_suffix, group_was_inline_in_source, if_close_span,
+    if_next_branch_region_with_body_end, matching_group_close, rendered_stmt_end_line_with_heredoc,
+    should_render_verbatim_with_heredoc, stmt_attachment_span_with_heredoc, stmt_format_span,
     stmt_group_attachment_or_verbatim_span_with_heredoc, stmt_has_trailing_comment,
     stmt_render_start_line, stmt_span, stmt_start_after_operator,
     stmt_verbatim_span_with_source_map, trim_unescaped_trailing_whitespace,
@@ -34,6 +34,7 @@ use crate::scan::{
     BranchPrefixComment, last_shell_keyword_end, last_shell_keyword_start, source_between_offsets,
 };
 use crate::source::{SourceView, command_substitution_source_starts_with_body_line};
+use crate::streaming::comments_alignment::CommentAlignmentFacts;
 use crate::visit::{self, AstVisitor};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -1286,6 +1287,8 @@ pub(crate) struct FormatterFacts<'source> {
     inline_group_sequences: HashSet<FactSpan>,
     inline_case_item_bodies: HashSet<FactSpan>,
     branch_prefix_facts: HashMap<OffsetRegionKey, BranchPrefixFacts>,
+    comment_alignment: HashMap<FactSpan, CommentAlignmentFacts>,
+    suffix_comments: HashMap<FactSpan, SourceComment<'source>>,
     close_suffix_comments: HashMap<FactSpan, SourceComment<'source>>,
     case_facts: HashMap<FactSpan, CaseCommandFacts>,
     case_item_facts: HashMap<FactSpan, CaseItemFacts<'source>>,
@@ -1434,6 +1437,65 @@ impl<'source> FormatterFacts<'source> {
             .get(&FactSpan::from(span))
             .copied()
             .or_else(|| self.source_map.suffix_comment_after_span(span))
+    }
+
+    pub(crate) fn suffix_comment_for_span(&self, span: Span) -> Option<SourceComment<'source>> {
+        self.suffix_comments.get(&FactSpan::from(span)).copied()
+    }
+
+    pub(crate) fn trailing_comment_padding(
+        &self,
+        comment: &SourceComment<'_>,
+        current_code_column: usize,
+        current_indent_column: usize,
+    ) -> usize {
+        self.comment_alignment
+            .get(&FactSpan::from(comment.span()))
+            .map_or(1, |alignment| {
+                alignment.trailing_padding(
+                    self.source_map.source(),
+                    &self.source_map,
+                    comment,
+                    current_code_column,
+                    current_indent_column,
+                )
+            })
+    }
+
+    pub(crate) fn trailing_comment_has_alignment(
+        &self,
+        comment: &SourceComment<'_>,
+        current_indent_column: usize,
+    ) -> bool {
+        self.comment_alignment
+            .get(&FactSpan::from(comment.span()))
+            .is_some_and(|alignment| {
+                alignment.has_trailing_alignment(
+                    self.source_map.source(),
+                    &self.source_map,
+                    comment,
+                    current_indent_column,
+                )
+            })
+    }
+
+    pub(crate) fn close_suffix_comment_padding(
+        &self,
+        comment: &SourceComment<'_>,
+        current_code_column: usize,
+        current_indent_column: usize,
+    ) -> usize {
+        self.comment_alignment
+            .get(&FactSpan::from(comment.span()))
+            .map_or(1, |alignment| {
+                alignment.close_suffix_padding(
+                    self.source_map.source(),
+                    &self.source_map,
+                    comment,
+                    current_code_column,
+                    current_indent_column,
+                )
+            })
     }
 
     pub(crate) fn branch_prefix_facts(&self, start: usize, end: usize) -> BranchPrefixFacts {
@@ -1595,6 +1657,8 @@ impl<'source> FormatterFacts<'source> {
             + self.inline_group_sequences.len()
             + self.inline_case_item_bodies.len()
             + self.branch_prefix_facts.len()
+            + self.comment_alignment.len()
+            + self.suffix_comments.len()
             + self.close_suffix_comments.len()
             + self.case_facts.len()
             + self.case_item_facts.len()
@@ -1873,6 +1937,16 @@ impl<'source, 'options> FormatterFactsBuilder<'source, 'options> {
     ) -> Self {
         let source_map = SourceMap::from_indexer(source, &indexer, options.keep_padding());
         let comment_attachments = CommentAttachmentModel::from_indexer(&source_map, &indexer);
+        let comment_alignment = comment_attachments
+            .comments()
+            .iter()
+            .map(|comment| {
+                (
+                    FactSpan::from(comment.span()),
+                    CommentAlignmentFacts::new(source, &source_map, comment),
+                )
+            })
+            .collect();
 
         Self {
             source,
@@ -1888,6 +1962,8 @@ impl<'source, 'options> FormatterFactsBuilder<'source, 'options> {
                 inline_group_sequences: HashSet::default(),
                 inline_case_item_bodies: HashSet::default(),
                 branch_prefix_facts: HashMap::default(),
+                comment_alignment,
+                suffix_comments: HashMap::default(),
                 close_suffix_comments: HashMap::default(),
                 case_facts: HashMap::default(),
                 case_item_facts: HashMap::default(),
@@ -2012,6 +2088,9 @@ impl<'source, 'options> FormatterFactsBuilder<'source, 'options> {
                     .map(|(span, _)| span)
             })
         });
+        if let Some(span) = facts.group_open_suffix_span {
+            self.record_suffix_attachment(span);
+        }
         let layout = self.record_sequence_layout(sequence);
         facts.contains_comments = layout.contains_comments;
         facts.contains_heredoc = layout.contains_heredoc;
@@ -2331,6 +2410,18 @@ impl<'source, 'options> FormatterFactsBuilder<'source, 'options> {
         };
         self.visit_sequence(&command.condition, condition_upper_bound, None);
         let brace_syntax = matches!(command.syntax, shuck_ast::IfSyntax::Brace { .. });
+        if let shuck_ast::IfSyntax::ThenFi { then_span, .. } = command.syntax
+            && let Some(comment) = condition_separator_suffix_comment(
+                &command.condition,
+                then_span,
+                self.source,
+                self.source_map(),
+            )
+        {
+            self.facts
+                .suffix_comments
+                .insert(FactSpan::from(then_span), comment);
+        }
         let then_upper_bound =
             if_branch_upper_bound(command, 0, self.source, self.source_map(), &self.facts);
         let then_site =
@@ -2662,6 +2753,14 @@ impl<'source, 'options> FormatterFactsBuilder<'source, 'options> {
         if let Some(comment) = self.source_map().suffix_comment_after_span(span) {
             self.facts
                 .close_suffix_comments
+                .insert(FactSpan::from(span), comment);
+        }
+    }
+
+    fn record_suffix_attachment(&mut self, span: Span) {
+        if let Some(comment) = suffix_comment_from_span(self.source, self.source_map(), span) {
+            self.facts
+                .suffix_comments
                 .insert(FactSpan::from(span), comment);
         }
     }
@@ -3326,6 +3425,64 @@ fn if_close_start(command: &IfCommand, source_map: &SourceMap<'_>) -> usize {
         .offset
 }
 
+fn suffix_comment_from_span<'source>(
+    source: &'source str,
+    source_map: &SourceMap<'source>,
+    span: Span,
+) -> Option<SourceComment<'source>> {
+    let raw = span.slice(source);
+    let leading_padding = raw.len() - raw.trim_start_matches([' ', '\t']).len();
+    let comment = raw[leading_padding..].trim_end_matches([' ', '\t', '\r']);
+    if !comment.starts_with('#') {
+        return None;
+    }
+    let absolute_start = span.start.offset + leading_padding;
+    let absolute_end = absolute_start + comment.len();
+    source_map.source_comment_for_offsets(absolute_start, absolute_end)
+}
+
+fn condition_separator_suffix_comment<'source>(
+    condition: &StmtSeq,
+    then_span: Span,
+    source: &'source str,
+    source_map: &SourceMap<'source>,
+) -> Option<SourceComment<'source>> {
+    let start = condition.last().map(condition_stmt_command_end)?;
+    let end = then_span.start.offset.min(source.len());
+    if start >= end {
+        return None;
+    }
+    let region = source.get(start..end)?;
+    let comment_rel = region.find('#')?;
+    let before_comment = region.get(..comment_rel)?;
+    if !before_comment
+        .chars()
+        .all(|ch| matches!(ch, ' ' | '\t' | '\r' | '\n' | ';'))
+    {
+        return None;
+    }
+    let comment_start = start + comment_rel;
+    let line_end = source
+        .get(comment_start..end)?
+        .find('\n')
+        .map_or(end, |offset| comment_start + offset);
+    let comment = source
+        .get(comment_start..line_end)?
+        .trim_end_matches([' ', '\t', '\r']);
+    source_map.source_comment_for_offsets(comment_start, comment_start + comment.len())
+}
+
+fn condition_stmt_command_end(stmt: &Stmt) -> usize {
+    let mut end = command_format_span(&stmt.command).end.offset;
+    if end == 0 {
+        end = stmt_span(stmt).end.offset;
+    }
+    for redirect in &stmt.redirects {
+        end = end.max(redirect.span.end.offset);
+    }
+    end
+}
+
 fn if_branch_upper_bound(
     command: &IfCommand,
     branch_index: usize,
@@ -3456,8 +3613,28 @@ mod tests {
         };
 
         let sequence = facts.sequence(inner, Some(body[0].span.end.offset));
-        assert!(sequence.group_open_suffix_span().is_some());
+        let span = sequence
+            .group_open_suffix_span()
+            .expect("expected group open suffix span");
+        let comment = facts
+            .suffix_comment_for_span(span)
+            .expect("expected suffix comment attachment");
+        assert_eq!(comment.text(), "# note");
         assert!(sequence.leading_for(0).is_empty());
+    }
+
+    #[test]
+    fn precomputes_trailing_comment_alignment_targets() {
+        let source = "one  # a\ntwo_long  # b\n";
+        let (file, facts) = build_facts(source);
+        let sequence = facts.sequence(&file.body, None);
+        let comment = sequence
+            .trailing_for(0)
+            .first()
+            .expect("expected first trailing comment");
+
+        assert!(facts.trailing_comment_has_alignment(comment, 0));
+        assert_eq!(facts.trailing_comment_padding(comment, "one".len(), 0), 6);
     }
 
     #[test]

--- a/crates/shuck-formatter/src/facts.rs
+++ b/crates/shuck-formatter/src/facts.rs
@@ -1449,17 +1449,13 @@ impl<'source> FormatterFacts<'source> {
         current_code_column: usize,
         current_indent_column: usize,
     ) -> usize {
-        self.comment_alignment
-            .get(&FactSpan::from(comment.span()))
-            .map_or(1, |alignment| {
-                alignment.trailing_padding(
-                    self.source_map.source(),
-                    &self.source_map,
-                    comment,
-                    current_code_column,
-                    current_indent_column,
-                )
-            })
+        self.comment_alignment_for(comment).trailing_padding(
+            self.source_map.source(),
+            &self.source_map,
+            comment,
+            current_code_column,
+            current_indent_column,
+        )
     }
 
     pub(crate) fn trailing_comment_has_alignment(
@@ -1467,16 +1463,12 @@ impl<'source> FormatterFacts<'source> {
         comment: &SourceComment<'_>,
         current_indent_column: usize,
     ) -> bool {
-        self.comment_alignment
-            .get(&FactSpan::from(comment.span()))
-            .is_some_and(|alignment| {
-                alignment.has_trailing_alignment(
-                    self.source_map.source(),
-                    &self.source_map,
-                    comment,
-                    current_indent_column,
-                )
-            })
+        self.comment_alignment_for(comment).has_trailing_alignment(
+            self.source_map.source(),
+            &self.source_map,
+            comment,
+            current_indent_column,
+        )
     }
 
     pub(crate) fn close_suffix_comment_padding(
@@ -1485,16 +1477,21 @@ impl<'source> FormatterFacts<'source> {
         current_code_column: usize,
         current_indent_column: usize,
     ) -> usize {
+        self.comment_alignment_for(comment).close_suffix_padding(
+            self.source_map.source(),
+            &self.source_map,
+            comment,
+            current_code_column,
+            current_indent_column,
+        )
+    }
+
+    fn comment_alignment_for(&self, comment: &SourceComment<'_>) -> CommentAlignmentFacts {
         self.comment_alignment
             .get(&FactSpan::from(comment.span()))
-            .map_or(1, |alignment| {
-                alignment.close_suffix_padding(
-                    self.source_map.source(),
-                    &self.source_map,
-                    comment,
-                    current_code_column,
-                    current_indent_column,
-                )
+            .copied()
+            .unwrap_or_else(|| {
+                CommentAlignmentFacts::new(self.source_map.source(), &self.source_map, comment)
             })
     }
 

--- a/crates/shuck-formatter/src/streaming/comments_alignment.rs
+++ b/crates/shuck-formatter/src/streaming/comments_alignment.rs
@@ -54,9 +54,7 @@ where
     pub(super) fn emit_trailing_comments_for_stmt(&mut self, comments: &[SourceComment<'_>]) {
         for comment in comments {
             let current_code_column = self.column().saturating_sub(self.line_indent_column());
-            let padding = trailing_comment_padding(
-                self.source(),
-                self.source_map(),
+            let padding = self.facts().trailing_comment_padding(
                 comment,
                 current_code_column,
                 self.line_indent_column(),
@@ -140,118 +138,172 @@ where
         else {
             return;
         };
-        self.write_comment_with_padding(&comment, close_suffix_comment_padding);
+        let current_code_column = self.column().saturating_sub(self.line_indent_column());
+        let padding = self.facts().close_suffix_comment_padding(
+            &comment,
+            current_code_column,
+            self.line_indent_column(),
+        );
+        self.write_spaces(padding);
+        self.write_comment(&comment);
     }
 
-    pub(super) fn write_comment_with_padding(
+    pub(super) fn write_trailing_comment(
         &mut self,
         comment: &SourceComment<'_>,
-        padding_for: impl FnOnce(&str, &SourceMap<'_>, &SourceComment<'_>, usize, usize) -> usize,
+        nudge_aligned: bool,
     ) {
         let current_code_column = self.column().saturating_sub(self.line_indent_column());
-        let padding = padding_for(
-            self.source(),
-            self.source_map(),
+        let mut padding = self.facts().trailing_comment_padding(
             comment,
             current_code_column,
             self.line_indent_column(),
         );
+        if nudge_aligned
+            && self
+                .facts()
+                .trailing_comment_has_alignment(comment, self.line_indent_column())
+        {
+            padding += 1;
+        }
         self.write_spaces(padding);
         self.write_comment(comment);
     }
 
     pub(super) fn write_suffix_comment_after_span(&mut self, span: Span, nudge_aligned: bool) {
-        let Some(comment) = self.suffix_comment_from_span(span) else {
+        let Some(comment) = self.facts().suffix_comment_for_span(span) else {
             self.write_space();
             self.write_text(span.slice(self.source()).trim_start());
             return;
         };
-        let current_code_column = self.column().saturating_sub(self.line_indent_column());
-        let mut padding = trailing_comment_padding(
-            self.source(),
-            self.source_map(),
-            &comment,
-            current_code_column,
-            self.line_indent_column(),
-        );
-        if nudge_aligned
-            && trailing_comment_alignment_column(
-                self.source(),
-                self.source_map(),
-                &comment,
-                self.line_indent_column(),
-            )
+        self.write_trailing_comment(&comment, nudge_aligned);
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct CommentAlignmentFacts {
+    source_indent_column: usize,
+    trailing_target_column: Option<usize>,
+    trailing_indent_adjust: usize,
+    close_suffix_target_column: Option<usize>,
+}
+
+impl CommentAlignmentFacts {
+    pub(crate) fn new(
+        source: &str,
+        source_map: &SourceMap<'_>,
+        comment: &SourceComment<'_>,
+    ) -> Self {
+        let source_indent_column = source_map
+            .line_indent_before_offset(comment.span().start.offset)
+            .map_or(0, |indent| indent.chars().count());
+        Self {
+            source_indent_column,
+            trailing_target_column: trailing_comment_alignment_column(
+                source,
+                source_map,
+                comment,
+                source_indent_column,
+            ),
+            trailing_indent_adjust: trailing_comment_tab_indent_adjust(source, source_map, comment),
+            close_suffix_target_column: aligned_close_suffix_comment_target_column(
+                source,
+                source_map,
+                comment,
+                source_indent_column,
+            ),
+        }
+    }
+
+    pub(crate) fn trailing_padding(
+        &self,
+        source: &str,
+        source_map: &SourceMap<'_>,
+        comment: &SourceComment<'_>,
+        current_code_column: usize,
+        current_indent_column: usize,
+    ) -> usize {
+        let Some(target_column) =
+            self.trailing_target_column(source, source_map, comment, current_indent_column)
+        else {
+            return 1;
+        };
+        target_column
+            .saturating_sub(current_code_column.saturating_add(self.trailing_indent_adjust))
+            .max(1)
+    }
+
+    pub(crate) fn has_trailing_alignment(
+        &self,
+        source: &str,
+        source_map: &SourceMap<'_>,
+        comment: &SourceComment<'_>,
+        current_indent_column: usize,
+    ) -> bool {
+        self.trailing_target_column(source, source_map, comment, current_indent_column)
             .is_some()
+    }
+
+    pub(crate) fn close_suffix_padding(
+        &self,
+        source: &str,
+        source_map: &SourceMap<'_>,
+        comment: &SourceComment<'_>,
+        current_code_column: usize,
+        current_indent_column: usize,
+    ) -> usize {
+        if let Some(target_column) =
+            self.close_suffix_target_column(source, source_map, comment, current_indent_column)
         {
-            padding += 1;
+            return target_column
+                .saturating_sub(current_indent_column + current_code_column)
+                .max(1);
         }
-        self.write_spaces(padding);
-        self.write_comment(&comment);
+        self.trailing_padding(
+            source,
+            source_map,
+            comment,
+            current_code_column,
+            current_indent_column,
+        )
     }
 
-    pub(super) fn suffix_comment_from_span(&self, span: Span) -> Option<SourceComment<'source>> {
-        let source = self.source();
-        let raw = span.slice(source);
-        let leading_padding = raw.len() - raw.trim_start_matches([' ', '\t']).len();
-        let comment = raw[leading_padding..].trim_end_matches([' ', '\t', '\r']);
-        if !comment.starts_with('#') {
-            return None;
+    fn trailing_target_column(
+        &self,
+        source: &str,
+        source_map: &SourceMap<'_>,
+        comment: &SourceComment<'_>,
+        current_indent_column: usize,
+    ) -> Option<usize> {
+        if current_indent_column == self.source_indent_column {
+            return self.trailing_target_column;
         }
-        let absolute_start = span.start.offset + leading_padding;
-        let absolute_end = absolute_start + comment.len();
-        self.source_map()
-            .source_comment_for_offsets(absolute_start, absolute_end)
-    }
-}
-
-pub(super) fn trailing_comment_padding(
-    source: &str,
-    source_map: &SourceMap<'_>,
-    comment: &SourceComment<'_>,
-    current_code_column: usize,
-    current_indent_column: usize,
-) -> usize {
-    let Some(target_column) =
         trailing_comment_alignment_column(source, source_map, comment, current_indent_column)
-    else {
-        return 1;
-    };
-    let indent_adjust = trailing_comment_tab_indent_adjust(source, source_map, comment);
-    target_column
-        .saturating_sub(current_code_column.saturating_add(indent_adjust))
-        .max(1)
-}
-
-pub(super) fn close_suffix_comment_padding(
-    source: &str,
-    source_map: &SourceMap<'_>,
-    comment: &SourceComment<'_>,
-    current_code_column: usize,
-    current_indent_column: usize,
-) -> usize {
-    if let Some(padding) = aligned_close_suffix_comment_padding(
-        source,
-        source_map,
-        comment,
-        current_code_column,
-        current_indent_column,
-    ) {
-        return padding;
     }
-    trailing_comment_padding(
-        source,
-        source_map,
-        comment,
-        current_code_column,
-        current_indent_column,
-    )
+
+    fn close_suffix_target_column(
+        &self,
+        source: &str,
+        source_map: &SourceMap<'_>,
+        comment: &SourceComment<'_>,
+        current_indent_column: usize,
+    ) -> Option<usize> {
+        if current_indent_column == self.source_indent_column {
+            return self.close_suffix_target_column;
+        }
+        aligned_close_suffix_comment_target_column(
+            source,
+            source_map,
+            comment,
+            current_indent_column,
+        )
+    }
 }
 
-fn aligned_close_suffix_comment_padding(
+fn aligned_close_suffix_comment_target_column(
     source: &str,
     source_map: &SourceMap<'_>,
     comment: &SourceComment<'_>,
-    current_code_column: usize,
     current_indent_column: usize,
 ) -> Option<usize> {
     let entries = close_suffix_comment_alignment_entries(source, source_map, comment)?;
@@ -269,22 +321,19 @@ fn aligned_close_suffix_comment_padding(
             .unwrap_or(1)
     }
     .max(1);
-    let target_column = entries
-        .iter()
-        .map(|entry| {
-            rendered_close_suffix_source_indent(
-                entry.source_indent,
-                current.source_indent,
-                current_indent_column,
-                source_indent_unit,
-            ) + entry.code_width
-        })
-        .max()?
-        + 1;
     Some(
-        target_column
-            .saturating_sub(current_indent_column + current_code_column)
-            .max(1),
+        entries
+            .iter()
+            .map(|entry| {
+                rendered_close_suffix_source_indent(
+                    entry.source_indent,
+                    current.source_indent,
+                    current_indent_column,
+                    source_indent_unit,
+                ) + entry.code_width
+            })
+            .max()?
+            + 1,
     )
 }
 

--- a/crates/shuck-formatter/src/streaming/compounds.rs
+++ b/crates/shuck-formatter/src/streaming/compounds.rs
@@ -399,7 +399,7 @@ where
         if comments.is_empty() {
             return;
         }
-        let disabled_branch_block = branch_prefix_comments_use_disabled_body_indent(&comments);
+        let disabled_branch_block = branch_prefix_comments_use_disabled_body_indent(comments);
         self.newline();
         for (index, comment) in comments.iter().enumerate() {
             if disabled_branch_block {

--- a/crates/shuck-formatter/src/streaming/compounds.rs
+++ b/crates/shuck-formatter/src/streaming/compounds.rs
@@ -246,7 +246,7 @@ where
             if_branch_upper_bound(command, 0, source, self.source_map(), self.facts());
         let then_site =
             CompoundBodySite::if_then_branch(command, &command.then_branch, then_upper_bound);
-        if !self.write_condition_separator_suffix_comment(&command.condition, then_span) {
+        if !self.write_condition_separator_suffix_comment(then_span) {
             self.write_compound_body_open_suffix(then_site);
         }
         self.format_if_branch_body_site_with_open_suffix(then_site, false)?;
@@ -394,11 +394,8 @@ where
         let Some((start, end)) = self.facts().if_next_branch_region(command, branch_index) else {
             return;
         };
-        let comments = self
-            .facts()
-            .branch_prefix_facts(start, end)
-            .comments()
-            .to_vec();
+        let branch_facts = self.facts().branch_prefix_facts(start, end);
+        let comments = branch_facts.comments();
         if comments.is_empty() {
             return;
         }
@@ -480,38 +477,12 @@ where
         self.write_suffix_comment_after_span(span, false);
     }
 
-    pub(super) fn write_condition_separator_suffix_comment(
-        &mut self,
-        condition: &StmtSeq,
-        then_span: Span,
-    ) -> bool {
-        let Some(comment) = self.condition_separator_suffix_comment(condition, then_span) else {
+    pub(super) fn write_condition_separator_suffix_comment(&mut self, then_span: Span) -> bool {
+        let Some(comment) = self.facts().suffix_comment_for_span(then_span) else {
             return false;
         };
-        self.write_comment_with_padding(&comment, trailing_comment_padding);
+        self.write_trailing_comment(&comment, false);
         true
-    }
-
-    pub(super) fn condition_separator_suffix_comment(
-        &self,
-        condition: &StmtSeq,
-        then_span: Span,
-    ) -> Option<SourceComment<'source>> {
-        let source_map = self.source_map();
-        let start = condition.last().map(condition_stmt_command_end)?;
-        let end = then_span.start.offset.min(source_map.source().len());
-        if start >= end {
-            return None;
-        }
-        let comment = source_map.first_source_comment_between(start, end)?;
-        let before_comment = source_map.slice_between(start, comment.span().start.offset)?;
-        if !before_comment
-            .chars()
-            .all(|ch| matches!(ch, ' ' | '\t' | '\r' | '\n' | ';'))
-        {
-            return None;
-        }
-        Some(comment)
     }
 
     pub(super) fn write_unmodeled_branch_background_terminator(
@@ -881,26 +852,7 @@ where
         }
         self.write_text(")");
         if let Some(comment) = &pattern_suffix_comment {
-            let current_code_column = self.column().saturating_sub(self.line_indent_column());
-            let mut padding = trailing_comment_padding(
-                self.source(),
-                self.source_map(),
-                comment,
-                current_code_column,
-                self.line_indent_column(),
-            );
-            if trailing_comment_alignment_column(
-                self.source(),
-                self.source_map(),
-                comment,
-                self.line_indent_column(),
-            )
-            .is_some()
-            {
-                padding += 1;
-            }
-            self.write_spaces(padding);
-            self.write_comment(comment);
+            self.write_trailing_comment(comment, true);
         }
 
         if item.body.is_empty() {
@@ -1028,7 +980,7 @@ where
     pub(super) fn write_case_terminator(&mut self, item: &CaseItem) {
         self.write_text(case_terminator(item.terminator));
         if let Some(comment) = self.facts().case_item(item).terminator_suffix_comment() {
-            self.write_comment_with_padding(&comment, trailing_comment_padding);
+            self.write_trailing_comment(&comment, false);
         }
     }
 

--- a/crates/shuck-formatter/src/streaming/mod.rs
+++ b/crates/shuck-formatter/src/streaming/mod.rs
@@ -14,7 +14,7 @@ use shuck_ast::{
 
 mod branches;
 mod case_layout;
-mod comments_alignment;
+pub(crate) mod comments_alignment;
 mod compounds;
 mod conditions;
 mod gaps;
@@ -79,14 +79,12 @@ use case_layout::{
     case_prefix_comment_uses_body_indent, comment_looks_like_disabled_case_pattern,
     trim_trailing_pattern_line_continuation,
 };
-use comments_alignment::{
-    inline_comment_code_width, trailing_comment_alignment_column, trailing_comment_padding,
-};
+use comments_alignment::inline_comment_code_width;
 use conditions::{
-    condition_keyword_on_previous_non_empty_line, condition_stmt_command_end,
-    elif_condition_has_explicit_statement_break, if_condition_has_explicit_statement_break,
-    if_condition_starts_after_keyword, loop_condition_starts_after_keyword,
-    raw_grouped_if_condition, stmt_sequence_renders_with_subshell_open,
+    condition_keyword_on_previous_non_empty_line, elif_condition_has_explicit_statement_break,
+    if_condition_has_explicit_statement_break, if_condition_starts_after_keyword,
+    loop_condition_starts_after_keyword, raw_grouped_if_condition,
+    stmt_sequence_renders_with_subshell_open,
 };
 use gaps::{
     gap_has_blank_line, group_close_offset, stmt_rendered_end_line_after_format,

--- a/crates/shuck-formatter/src/streaming/statements.rs
+++ b/crates/shuck-formatter/src/streaming/statements.rs
@@ -37,6 +37,24 @@ impl SimpleCommandPart<'_> {
 
 fn move_interspersed_redirects_after_arguments<'a>(parts: &mut Vec<SimpleCommandPart<'a>>) {
     let mut saw_argument = false;
+    let mut needs_reorder = false;
+
+    for part in parts.iter() {
+        match part {
+            SimpleCommandPart::Argument(_) => saw_argument = true,
+            SimpleCommandPart::Redirect(_) if saw_argument => {
+                needs_reorder = true;
+                break;
+            }
+            _ => {}
+        }
+    }
+
+    if !needs_reorder {
+        return;
+    }
+
+    saw_argument = false;
     let mut deferred_redirects = Vec::new();
     let mut reordered = Vec::with_capacity(parts.len());
 

--- a/crates/shuck-formatter/src/word/raw_rewrites.rs
+++ b/crates/shuck-formatter/src/word/raw_rewrites.rs
@@ -600,6 +600,9 @@ pub(super) fn render_inline_raw_command_substitution_as_block(
     if body.is_empty() {
         return None;
     }
+    if !raw_shell_body_may_render_as_block(body) {
+        return None;
+    }
 
     let fragment = FragmentFormatter::parse(body, options)?;
     let inline_multiline = fragment
@@ -633,6 +636,10 @@ pub(super) fn render_inline_raw_command_substitution_as_block(
         rendered.push_str("\n)");
     }
     Some(rendered)
+}
+
+fn raw_shell_body_may_render_as_block(body: &str) -> bool {
+    raw_shell_body_needs_structural_spacing(body) || raw_shell_body_has_async_separator(body)
 }
 
 pub(super) fn raw_body_contains_pipeline_multistatement_brace_group(body: &str) -> bool {
@@ -732,6 +739,40 @@ pub(super) fn raw_brace_group_has_multiple_commands(body_after_open: &str) -> bo
             _ => {}
         }
         index += 1;
+    }
+
+    false
+}
+
+fn raw_shell_body_has_async_separator(body: &str) -> bool {
+    let mut quote = QuoteState::default();
+    let mut index = 0usize;
+
+    while index < body.len() {
+        let rest = &body[index..];
+        let Some(ch) = rest.chars().next() else {
+            break;
+        };
+        let next_index = index + ch.len_utf8();
+
+        if quote.consume_raw_char(ch, true) {
+            index = next_index;
+            continue;
+        }
+
+        if rest.starts_with("$(")
+            && !rest.starts_with("$((")
+            && let Some(close_offset) = matching_raw_command_substitution_close(body, index + 2)
+        {
+            index = close_offset + 1;
+            continue;
+        }
+
+        if ch == '&' && !matches!(rest.as_bytes().get(1), Some(b'>')) {
+            return true;
+        }
+
+        index = next_index;
     }
 
     false

--- a/crates/shuck-formatter/src/word/raw_rewrites.rs
+++ b/crates/shuck-formatter/src/word/raw_rewrites.rs
@@ -891,18 +891,18 @@ pub(super) fn raw_shell_body_needs_structural_spacing(body: &str) -> bool {
 }
 
 pub(super) fn normalize_raw_command_substitution_padding(raw: &str) -> Option<String> {
-    let mut rendered = String::with_capacity(raw.len());
+    let mut rendered = None;
     let mut cursor = 0usize;
     let mut index = 0usize;
-    let mut changed = false;
 
     while let Some((open_offset, close_offset)) = next_raw_command_substitution(raw, index) {
         let body = &raw[open_offset + 2..close_offset];
         if !body.contains('\n') {
             let trimmed = trim_raw_command_substitution_horizontal_padding(body);
-            let normalized_body = normalize_raw_command_substitution_padding(trimmed)
-                .unwrap_or_else(|| trimmed.to_string());
+            let normalized_body = normalize_raw_command_substitution_padding(trimmed);
+            let normalized_body = normalized_body.as_deref().unwrap_or(trimmed);
             if trimmed.len() != body.len() || normalized_body != trimmed {
+                let rendered = rendered.get_or_insert_with(|| String::with_capacity(raw.len()));
                 rendered.push_str(&raw[cursor..open_offset]);
                 rendered.push_str("$(");
                 if normalized_body.starts_with('(') {
@@ -911,13 +911,15 @@ pub(super) fn normalize_raw_command_substitution_padding(raw: &str) -> Option<St
                 rendered.push_str(&normalized_body);
                 rendered.push(')');
                 cursor = close_offset + 1;
-                changed = true;
             }
         }
         index = close_offset + 1;
     }
 
-    finish_raw_rewrite(rendered, raw, cursor, changed)
+    rendered.map(|mut rendered| {
+        rendered.push_str(&raw[cursor..]);
+        rendered
+    })
 }
 
 pub(super) fn trim_raw_command_substitution_horizontal_padding(body: &str) -> &str {

--- a/crates/shuck-formatter/src/word/raw_rewrites.rs
+++ b/crates/shuck-formatter/src/word/raw_rewrites.rs
@@ -908,7 +908,7 @@ pub(super) fn normalize_raw_command_substitution_padding(raw: &str) -> Option<St
                 if normalized_body.starts_with('(') {
                     rendered.push(' ');
                 }
-                rendered.push_str(&normalized_body);
+                rendered.push_str(normalized_body);
                 rendered.push(')');
                 cursor = close_offset + 1;
             }

--- a/crates/shuck-formatter/tests/format_cases.rs
+++ b/crates/shuck-formatter/tests/format_cases.rs
@@ -1425,6 +1425,9 @@ default_format_ast_cases! {
     aligns_case_terminator_comments_after_pattern_pipe_spacing:
         "case \"$mac\" in\n  19|'6470028b2260') PORT=7534 ;; # first\n  16|'6470028b1ba2') PORT= ;; # second\n  8|'f4ec38c9c32c') PORT=7783 ;; # third\nesac\n"
         => "case \"$mac\" in\n19 | '6470028b2260') PORT=7534 ;; # first\n16 | '6470028b1ba2') PORT= ;;     # second\n8 | 'f4ec38c9c32c') PORT=7783 ;;  # third\nesac\n";
+    aligns_case_terminator_comments_when_single_digit_patterns_have_source_padding:
+        "case \"$mac\" in\n\t19|'6470028b2260') PORT=7534 ;; # first\n\t16|'6470028b1ba2') PORT= ;; # second\n\t 8|'f4ec38c9c32c') PORT=7783 ;; # third\n\t 6|'b2487abecab8') PORT=7528 ;; # fourth\nesac\n"
+        => "case \"$mac\" in\n19 | '6470028b2260') PORT=7534 ;; # first\n16 | '6470028b1ba2') PORT= ;;     # second\n8 | 'f4ec38c9c32c') PORT=7783 ;;  # third\n6 | 'b2487abecab8') PORT=7528 ;;  # fourth\nesac\n";
     preserves_case_suffix_comments_before_commented_compound_body:
         "case $x in\n*) # default branch\n# explain\nif test -n \"$x\"; then\n  echo \"$x\"\nfi\n;;\nesac\n"
         => "case $x in\n*) # default branch\n\t# explain\n\tif test -n \"$x\"; then\n\t\techo \"$x\"\n\tfi\n\t;;\nesac\n";


### PR DESCRIPTION
## Summary

- Lazily allocate formatter comment attachment buckets only when comments attach to a sequence child.
- Skip raw command-substitution fragment reparses when a cheap scan proves the body cannot render as a block.
- Avoid simple-command redirect reorder buffers when the existing part order is already stable.
- Delay raw command-substitution padding buffers until a rewrite is actually needed.

## Profiling

Measured the formatter large corpus before and after each candidate with the temporary allocation-counting harness. Four candidates improved both allocation counts and elapsed-time proxy; two were measured and rejected.

End-to-end from the original baseline to final: median formatter corpus elapsed went from 10.72s to 8.87s, and allocation count went from 57.46M to 46.50M.

## Validation

- `cargo fmt --check`
- `cargo test -p shuck-formatter`
- `make test-oracle-shfmt-large-corpus`