### PR TITLE
refactor(formatter): add layout plans

### DIFF
--- a/crates/shuck-formatter/src/scan.rs
+++ b/crates/shuck-formatter/src/scan.rs
@@ -12,7 +12,7 @@ pub(crate) fn branch_keyword_offset(
     SourceView::new(source).branch_keyword_offset(start, end, keyword)
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct BranchPrefixComment {
     pub(crate) offset: usize,
     pub(crate) text: String,

--- a/crates/shuck-formatter/src/streaming/compounds.rs
+++ b/crates/shuck-formatter/src/streaming/compounds.rs
@@ -59,19 +59,18 @@ where
     }
 
     pub(super) fn format_then_fi_if(&mut self, command: &IfCommand) -> Result<()> {
-        let source = self.source();
-        let then_span = match command.syntax {
-            IfSyntax::ThenFi { then_span, .. } => then_span,
-            IfSyntax::Brace { .. } => unreachable!("brace if cannot be formatted as then/fi"),
-        };
-        let fi_span = command_if_close_span(command, source, self.source_map());
-        let layout = self.then_fi_if_layout(command, then_span, fi_span);
+        let plan = IfLayoutPlan::then_fi(command, self.render_context());
+        let IfLayoutPlan {
+            then_span,
+            fi_span,
+            style,
+        } = plan;
 
-        match layout {
-            ThenFiIfLayout::RawGroupedCondition { raw_condition } => {
+        match style {
+            IfLayoutStyle::RawGroupedCondition { raw_condition } => {
                 self.format_raw_grouped_then_fi_if(command, fi_span, &raw_condition)
             }
-            ThenFiIfLayout::SplitCondition => {
+            IfLayoutStyle::SplitCondition => {
                 self.format_split_condition_then_fi_if(command, then_span, fi_span)
             }
             layout => self.format_inline_condition_then_fi_if(command, then_span, fi_span, layout),
@@ -150,21 +149,21 @@ where
         command: &IfCommand,
         then_span: Span,
         fi_span: Span,
-        layout: ThenFiIfLayout,
+        layout: IfLayoutStyle,
     ) -> Result<()> {
         self.write_text("if ");
         self.format_inline_stmts(&command.condition)?;
         let then_separator = self.then_separator_for_condition(&command.condition);
 
         match layout {
-            ThenFiIfLayout::InlineThen => {
+            IfLayoutStyle::Inline(InlineIfLayout::Then) => {
                 self.write_text(then_separator);
                 self.write_space();
                 self.format_inline_stmts(&command.then_branch)?;
                 self.write_if_close("; fi", fi_span);
                 Ok(())
             }
-            ThenFiIfLayout::InlineThenElse => {
+            IfLayoutStyle::Inline(InlineIfLayout::ThenElse) => {
                 let Some(else_branch) = command.else_branch.as_ref() else {
                     unreachable!("inline then/else layout requires an else branch");
                 };
@@ -176,7 +175,7 @@ where
                 self.write_if_close("; fi", fi_span);
                 Ok(())
             }
-            ThenFiIfLayout::InlineThenMultilineElse => {
+            IfLayoutStyle::Inline(InlineIfLayout::ThenMultilineElse) => {
                 let Some(else_branch) = command.else_branch.as_ref() else {
                     unreachable!("inline then/multiline else layout requires an else branch");
                 };
@@ -197,14 +196,14 @@ where
                 self.finish_multiline_if_close(command, then_upper_bound, fi_span);
                 Ok(())
             }
-            ThenFiIfLayout::InlineThenNestedIf => {
+            IfLayoutStyle::Inline(InlineIfLayout::ThenNestedIf) => {
                 self.write_text(then_separator);
                 self.write_space();
                 self.format_stmt(&command.then_branch[0])?;
                 self.write_if_close("; fi", fi_span);
                 Ok(())
             }
-            ThenFiIfLayout::InlineChain => {
+            IfLayoutStyle::Inline(InlineIfLayout::Chain) => {
                 self.write_text(then_separator);
                 self.write_space();
                 self.format_inline_stmts(&command.then_branch)?;
@@ -222,10 +221,10 @@ where
                 self.write_if_close("; fi", fi_span);
                 Ok(())
             }
-            ThenFiIfLayout::Expanded(layout) => {
+            IfLayoutStyle::Expanded(layout) => {
                 self.format_expanded_then_fi_if(command, then_span, fi_span, then_separator, layout)
             }
-            ThenFiIfLayout::RawGroupedCondition { .. } | ThenFiIfLayout::SplitCondition => {
+            IfLayoutStyle::RawGroupedCondition { .. } | IfLayoutStyle::SplitCondition => {
                 unreachable!("non-inline if layout routed to inline emitter")
             }
         }
@@ -237,7 +236,7 @@ where
         then_span: Span,
         fi_span: Span,
         then_separator: &'static str,
-        layout: ExpandedThenFiIfLayout,
+        layout: ExpandedIfLayout,
     ) -> Result<()> {
         let source = self.source();
         let fi_upper_bound = fi_span.start.offset;
@@ -251,7 +250,7 @@ where
         }
         self.format_if_branch_body_site_with_open_suffix(then_site, false)?;
         for (index, (condition, body)) in command.elif_branches.iter().enumerate() {
-            if matches!(layout, ExpandedThenFiIfLayout::Compact) {
+            if matches!(layout, ExpandedIfLayout::Compact) {
                 self.write_text("; elif ");
                 self.format_inline_stmts(condition)?;
                 self.write_text(self.then_separator_for_condition(condition));
@@ -266,8 +265,8 @@ where
         }
         if let Some(body) = &command.else_branch {
             match layout {
-                ExpandedThenFiIfLayout::Compact => self.write_text("; else"),
-                ExpandedThenFiIfLayout::Multiline { inline_else_close } => {
+                ExpandedIfLayout::Compact => self.write_text("; else"),
+                ExpandedIfLayout::Multiline { inline_else_close } => {
                     self.write_if_branch_prefix(command, command.elif_branches.len(), source);
                     if inline_else_close {
                         self.write_text("else ");
@@ -282,8 +281,8 @@ where
             self.format_if_branch_body_site(site)?;
         }
         match layout {
-            ExpandedThenFiIfLayout::Compact => self.write_if_close("; fi", fi_span),
-            ExpandedThenFiIfLayout::Multiline { .. } => {
+            ExpandedIfLayout::Compact => self.write_if_close("; fi", fi_span),
+            ExpandedIfLayout::Multiline { .. } => {
                 self.finish_multiline_if_close(command, then_upper_bound, fi_span);
             }
         }
@@ -703,59 +702,66 @@ where
     }
 
     pub(super) fn format_case(&mut self, command: &CaseCommand) -> Result<()> {
-        if !self.options().compact_layout()
-            && case_command_was_inline_in_source(command, self.source())
-            && self.can_format_case_inline(command)
-        {
+        let plan = CaseLayoutPlan::for_command(command, self.render_context());
+        let CaseLayoutPlan {
+            style,
+            body_fallback_upper_bound,
+            esac_span,
+        } = plan;
+        if matches!(&style, CaseLayoutStyle::Inline) {
             return self.format_inline_case(command);
         }
 
-        let case_facts = self.facts().case_command(command);
-        let esac_span = case_facts.esac_span();
-        let case_body_fallback = case_facts.body_fallback_upper_bound();
-        let case_has_blank_line_after_in = case_facts.has_blank_line_after_in();
-        let case_has_blank_line_before_esac = case_facts.has_blank_line_before_esac();
-        let case_suffix_comments = case_facts.suffix_comments_before_esac().to_vec();
         self.write_text("case ");
         self.write_word(&command.word);
         self.write_text(" in");
         self.write_case_open_suffix(command);
-        if self.options().compact_layout() {
+        if matches!(&style, CaseLayoutStyle::Compact) {
             for item in &command.cases {
                 self.write_space();
-                self.format_case_item(item, case_item_body_upper_bound(item, case_body_fallback))?;
+                self.format_case_item(
+                    item,
+                    case_item_body_upper_bound(item, body_fallback_upper_bound),
+                )?;
             }
             self.write_text(" esac");
             self.write_close_suffix_after_span(esac_span);
-        } else {
-            let header_item_count =
-                self.format_case_items_on_header_line(command, case_body_fallback)?;
+        } else if let CaseLayoutStyle::Multiline {
+            header_item_count,
+            blank_line_after_in,
+            close,
+        } = style
+        {
+            self.format_case_items_on_header_line(
+                command,
+                body_fallback_upper_bound,
+                header_item_count,
+            )?;
             for (offset, item) in command.cases[header_item_count..].iter().enumerate() {
                 let index = header_item_count + offset;
                 self.newline();
-                if header_item_count == 0 && index == 0 && case_has_blank_line_after_in {
+                if header_item_count == 0 && index == 0 && blank_line_after_in {
                     self.newline();
                 }
                 if index > 0 && self.facts().case_item(item).has_blank_line_before() {
                     self.newline();
                 }
-                self.format_case_item(item, case_item_body_upper_bound(item, case_body_fallback))?;
+                self.format_case_item(
+                    item,
+                    case_item_body_upper_bound(item, body_fallback_upper_bound),
+                )?;
             }
-            if case_suffix_comments.is_empty() {
-                if case_close_shares_line_with_last_item(command, esac_span, self.source()) {
-                    self.write_space();
-                } else {
-                    if case_has_blank_line_before_esac {
+            match close {
+                CaseCloseLayout::SameLine => self.write_space(),
+                CaseCloseLayout::NextLine { blank_before } => {
+                    if blank_before {
                         self.newline();
                     }
                     self.newline();
                 }
-            } else {
-                self.emit_case_suffix_comments_before_esac(
-                    command,
-                    &case_suffix_comments,
-                    esac_span,
-                );
+                CaseCloseLayout::SuffixComments(comments) => {
+                    self.emit_case_suffix_comments_before_esac(command, &comments, esac_span);
+                }
             }
             self.write_text("esac");
             self.write_close_suffix_after_span(esac_span);
@@ -767,21 +773,14 @@ where
         &mut self,
         command: &CaseCommand,
         case_body_fallback: usize,
-    ) -> Result<usize> {
-        let mut item_count = 0;
-        for item in &command.cases {
-            if !case_item_pattern_starts_on_case_header(command, item) {
-                break;
-            }
+        item_count: usize,
+    ) -> Result<()> {
+        for item in command.cases.iter().take(item_count) {
             let upper_bound = case_item_body_upper_bound(item, case_body_fallback);
-            if !self.facts().case_item(item).prefix_comments().is_empty() {
-                break;
-            }
             self.write_space();
             self.format_case_item(item, upper_bound)?;
-            item_count += 1;
         }
-        Ok(item_count)
+        Ok(())
     }
 
     pub(super) fn write_case_open_suffix(&mut self, command: &CaseCommand) {

--- a/crates/shuck-formatter/src/streaming/layout_plan.rs
+++ b/crates/shuck-formatter/src/streaming/layout_plan.rs
@@ -1,0 +1,348 @@
+use super::case_layout::{
+    case_close_shares_line_with_last_item, case_command_was_inline_in_source,
+    case_item_body_was_inline_without_terminator,
+    case_item_pattern_body_terminator_was_inline_in_source,
+    case_item_pattern_starts_on_case_header,
+};
+use super::shape::{
+    can_inline_body_with_upper_bound, can_inline_else_branch_close, can_inline_if_chain,
+    then_branch_starts_with_inline_if,
+};
+use super::*;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct IfLayoutPlan {
+    pub(super) then_span: Span,
+    pub(super) fi_span: Span,
+    pub(super) style: IfLayoutStyle,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) enum IfLayoutStyle {
+    RawGroupedCondition { raw_condition: String },
+    SplitCondition,
+    Inline(InlineIfLayout),
+    Expanded(ExpandedIfLayout),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum InlineIfLayout {
+    Then,
+    ThenElse,
+    ThenMultilineElse,
+    ThenNestedIf,
+    Chain,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum ExpandedIfLayout {
+    Compact,
+    Multiline { inline_else_close: bool },
+}
+
+impl IfLayoutPlan {
+    pub(super) fn then_fi(command: &IfCommand, context: RenderContext<'_, '_>) -> Self {
+        let IfSyntax::ThenFi { then_span, .. } = command.syntax else {
+            unreachable!("brace if cannot be planned as then/fi");
+        };
+        let fi_span = command_if_close_span(command, context.source, context.source_map());
+        let style = then_fi_if_style(command, then_span, fi_span, context);
+
+        Self {
+            then_span,
+            fi_span,
+            style,
+        }
+    }
+}
+
+fn then_fi_if_style(
+    command: &IfCommand,
+    then_span: Span,
+    fi_span: Span,
+    context: RenderContext<'_, '_>,
+) -> IfLayoutStyle {
+    let fi_upper_bound = fi_span.start.offset;
+    let no_elifs = command.elif_branches.is_empty();
+
+    if no_elifs
+        && let Some(raw_condition) = raw_grouped_if_condition(
+            command,
+            then_span,
+            context.source,
+            context.source_map(),
+            context.options,
+            context.facts,
+        )
+    {
+        return IfLayoutStyle::RawGroupedCondition { raw_condition };
+    }
+
+    if if_condition_starts_after_keyword(
+        command,
+        then_span,
+        context.source,
+        context.source_map(),
+        context.options,
+        context.facts,
+    ) || if_condition_has_explicit_statement_break(
+        command,
+        then_span,
+        context.source,
+        context.source_map(),
+        context.facts,
+    ) {
+        return IfLayoutStyle::SplitCondition;
+    }
+
+    let can_inline_then = no_elifs
+        && can_inline_body_with_upper_bound(
+            context,
+            &command.then_branch,
+            command.span,
+            Some(fi_upper_bound),
+        );
+
+    if no_elifs && command.else_branch.is_none() && can_inline_then {
+        return IfLayoutStyle::Inline(InlineIfLayout::Then);
+    }
+
+    if can_inline_then && let Some(else_branch) = &command.else_branch {
+        let can_inline_else = can_inline_body_with_upper_bound(
+            context,
+            else_branch,
+            command.span,
+            Some(fi_upper_bound),
+        );
+        if can_inline_else {
+            return IfLayoutStyle::Inline(InlineIfLayout::ThenElse);
+        }
+        if !context.options.compact_layout() {
+            return IfLayoutStyle::Inline(InlineIfLayout::ThenMultilineElse);
+        }
+    }
+
+    if no_elifs
+        && command.else_branch.is_none()
+        && then_branch_starts_with_inline_if(context, command, then_span, fi_span)
+    {
+        return IfLayoutStyle::Inline(InlineIfLayout::ThenNestedIf);
+    }
+
+    if can_inline_if_chain(context, command, fi_span) {
+        return IfLayoutStyle::Inline(InlineIfLayout::Chain);
+    }
+
+    if context.options.compact_layout() {
+        IfLayoutStyle::Expanded(ExpandedIfLayout::Compact)
+    } else {
+        IfLayoutStyle::Expanded(ExpandedIfLayout::Multiline {
+            inline_else_close: command
+                .else_branch
+                .as_ref()
+                .is_some_and(|body| can_inline_else_branch_close(context, command, body, fi_span)),
+        })
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct CaseLayoutPlan {
+    pub(super) style: CaseLayoutStyle,
+    pub(super) body_fallback_upper_bound: usize,
+    pub(super) esac_span: Option<Span>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) enum CaseLayoutStyle {
+    Inline,
+    Compact,
+    Multiline {
+        header_item_count: usize,
+        blank_line_after_in: bool,
+        close: CaseCloseLayout,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) enum CaseCloseLayout {
+    SameLine,
+    NextLine { blank_before: bool },
+    SuffixComments(Vec<BranchPrefixComment>),
+}
+
+impl CaseLayoutPlan {
+    pub(super) fn for_command(command: &CaseCommand, context: RenderContext<'_, '_>) -> Self {
+        let case_facts = context.facts.case_command(command);
+        let body_fallback_upper_bound = case_facts.body_fallback_upper_bound();
+        let esac_span = case_facts.esac_span();
+        let style = if !context.options.compact_layout()
+            && case_command_was_inline_in_source(command, context.source)
+            && case_can_format_inline(command, context)
+        {
+            CaseLayoutStyle::Inline
+        } else if context.options.compact_layout() {
+            CaseLayoutStyle::Compact
+        } else {
+            CaseLayoutStyle::Multiline {
+                header_item_count: case_header_item_count(command, context),
+                blank_line_after_in: case_facts.has_blank_line_after_in(),
+                close: case_close_layout(command, context),
+            }
+        };
+
+        Self {
+            style,
+            body_fallback_upper_bound,
+            esac_span,
+        }
+    }
+}
+
+pub(super) fn case_can_format_inline(
+    command: &CaseCommand,
+    context: RenderContext<'_, '_>,
+) -> bool {
+    command.cases.iter().all(|item| {
+        item.body.is_empty()
+            || item.body.len() == 1
+                && (context.facts.case_item_was_inline_in_source(item)
+                    || case_item_pattern_body_terminator_was_inline_in_source(item, context.source)
+                    || case_item_body_was_inline_without_terminator(item))
+                && !context
+                    .facts
+                    .sequence(&item.body, Some(command.span.end.offset))
+                    .has_comments()
+    })
+}
+
+fn case_header_item_count(command: &CaseCommand, context: RenderContext<'_, '_>) -> usize {
+    let mut item_count = 0;
+    for item in &command.cases {
+        if !case_item_pattern_starts_on_case_header(command, item)
+            || !context.facts.case_item(item).prefix_comments().is_empty()
+        {
+            break;
+        }
+        item_count += 1;
+    }
+    item_count
+}
+
+fn case_close_layout(command: &CaseCommand, context: RenderContext<'_, '_>) -> CaseCloseLayout {
+    let case_facts = context.facts.case_command(command);
+    let case_suffix_comments = case_facts.suffix_comments_before_esac().to_vec();
+    if !case_suffix_comments.is_empty() {
+        return CaseCloseLayout::SuffixComments(case_suffix_comments);
+    }
+
+    if case_close_shares_line_with_last_item(command, case_facts.esac_span(), context.source) {
+        CaseCloseLayout::SameLine
+    } else {
+        CaseCloseLayout::NextLine {
+            blank_before: case_facts.has_blank_line_before_esac(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::options::ShellFormatOptions;
+    use shuck_parser::parser::Parser;
+
+    fn parse_with_facts<'source>(
+        source: &'source str,
+        options: &ShellFormatOptions,
+    ) -> (File, ResolvedShellFormatOptions, FormatterFacts<'source>) {
+        let resolved = options.resolve(source, None);
+        let file = Parser::with_dialect(source, resolved.dialect())
+            .parse()
+            .unwrap()
+            .file;
+        let facts = FormatterFacts::build(source, &file, &resolved);
+        (file, resolved, facts)
+    }
+
+    fn first_if_command(file: &File) -> &IfCommand {
+        let Command::Compound(CompoundCommand::If(command)) = &file.body[0].command else {
+            panic!("expected first statement to be if command");
+        };
+        command
+    }
+
+    fn first_case_command(file: &File) -> &CaseCommand {
+        let Command::Compound(CompoundCommand::Case(command)) = &file.body[0].command else {
+            panic!("expected first statement to be case command");
+        };
+        command
+    }
+
+    #[test]
+    fn plans_inline_then_if() {
+        let source = "if true; then echo yes; fi\n";
+        let (file, resolved, facts) = parse_with_facts(source, &ShellFormatOptions::default());
+        let context = RenderContext::new(source, &resolved, &facts);
+        let plan = IfLayoutPlan::then_fi(first_if_command(&file), context);
+
+        assert!(matches!(
+            plan.style,
+            IfLayoutStyle::Inline(InlineIfLayout::Then)
+        ));
+    }
+
+    #[test]
+    fn plans_split_condition_if() {
+        let source = "if\n  true\nthen\n  echo yes\nfi\n";
+        let (file, resolved, facts) = parse_with_facts(source, &ShellFormatOptions::default());
+        let context = RenderContext::new(source, &resolved, &facts);
+        let plan = IfLayoutPlan::then_fi(first_if_command(&file), context);
+
+        assert_eq!(plan.style, IfLayoutStyle::SplitCondition);
+    }
+
+    #[test]
+    fn plans_inline_source_case_as_inline() {
+        let source = "case $x in a) echo a ;; esac\n";
+        let (file, resolved, facts) = parse_with_facts(source, &ShellFormatOptions::default());
+        let context = RenderContext::new(source, &resolved, &facts);
+        let plan = CaseLayoutPlan::for_command(first_case_command(&file), context);
+
+        assert_eq!(plan.style, CaseLayoutStyle::Inline);
+    }
+
+    #[test]
+    fn plans_header_line_case_items_for_multiline_case() {
+        let source = "case $x in a) echo a ;;\nb) echo b ;;\nesac\n";
+        let (file, resolved, facts) = parse_with_facts(source, &ShellFormatOptions::default());
+        let context = RenderContext::new(source, &resolved, &facts);
+        let plan = CaseLayoutPlan::for_command(first_case_command(&file), context);
+
+        let CaseLayoutStyle::Multiline {
+            header_item_count,
+            blank_line_after_in,
+            close,
+        } = plan.style
+        else {
+            panic!("expected multiline case plan");
+        };
+        assert_eq!(header_item_count, 1);
+        assert!(!blank_line_after_in);
+        assert_eq!(
+            close,
+            CaseCloseLayout::NextLine {
+                blank_before: false
+            }
+        );
+    }
+
+    #[test]
+    fn plans_compact_case_when_never_split() {
+        let source = "case $x in\na) echo a ;;\nesac\n";
+        let options = ShellFormatOptions::default().with_never_split(true);
+        let (file, resolved, facts) = parse_with_facts(source, &options);
+        let context = RenderContext::new(source, &resolved, &facts);
+        let plan = CaseLayoutPlan::for_command(first_case_command(&file), context);
+
+        assert_eq!(plan.style, CaseLayoutStyle::Compact);
+    }
+}

--- a/crates/shuck-formatter/src/streaming/mod.rs
+++ b/crates/shuck-formatter/src/streaming/mod.rs
@@ -18,6 +18,7 @@ pub(crate) mod comments_alignment;
 mod compounds;
 mod conditions;
 mod gaps;
+mod layout_plan;
 mod redirects;
 mod shape;
 mod statements;
@@ -70,14 +71,12 @@ use branches::{
     unmodeled_branch_background_operator,
 };
 use case_layout::{
-    case_close_shares_line_with_last_item, case_command_was_inline_in_source,
     case_item_body_can_share_terminator, case_item_body_terminator_was_inline_in_source,
     case_item_body_was_inline_without_terminator, case_item_close_paren_shares_line_with_body,
     case_item_pattern_body_terminator_was_inline_in_source,
-    case_item_pattern_close_paren_on_own_line, case_item_pattern_starts_on_case_header,
-    case_item_single_body_stmt_can_inline, case_item_started_inline_without_terminator,
-    case_prefix_comment_uses_body_indent, comment_looks_like_disabled_case_pattern,
-    trim_trailing_pattern_line_continuation,
+    case_item_pattern_close_paren_on_own_line, case_item_single_body_stmt_can_inline,
+    case_item_started_inline_without_terminator, case_prefix_comment_uses_body_indent,
+    comment_looks_like_disabled_case_pattern, trim_trailing_pattern_line_continuation,
 };
 use comments_alignment::inline_comment_code_width;
 use conditions::{
@@ -90,11 +89,14 @@ use gaps::{
     gap_has_blank_line, group_close_offset, stmt_rendered_end_line_after_format,
     stmt_semicolon_terminator_starts_on_continuation_line, trim_trailing_gap_before_offset,
 };
+use layout_plan::{
+    CaseCloseLayout, CaseLayoutPlan, CaseLayoutStyle, ExpandedIfLayout, IfLayoutPlan,
+    IfLayoutStyle, InlineIfLayout, case_can_format_inline,
+};
 use redirects::{
     append_both_redirect_pair_matches_source, redirect_is_attached_process_substitution,
     redirect_list_needs_leading_space, redirect_list_starts_on_continuation_line,
 };
-use shape::{ExpandedThenFiIfLayout, ThenFiIfLayout};
 use substitutions::{
     assignment_source_has_command_substitution, conditional_binary_has_explicit_rhs_break,
     conditional_expr_contains_command_substitution, heredoc_body_contains_command_substitution,

--- a/crates/shuck-formatter/src/streaming/shape.rs
+++ b/crates/shuck-formatter/src/streaming/shape.rs
@@ -1,121 +1,177 @@
 use super::*;
 
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub(super) enum ThenFiIfLayout {
-    RawGroupedCondition { raw_condition: String },
-    SplitCondition,
-    InlineThen,
-    InlineThenElse,
-    InlineThenMultilineElse,
-    InlineThenNestedIf,
-    InlineChain,
-    Expanded(ExpandedThenFiIfLayout),
+pub(super) fn can_inline_body(
+    context: RenderContext<'_, '_>,
+    commands: &StmtSeq,
+    enclosing_span: Span,
+) -> bool {
+    can_inline_body_with_upper_bound(
+        context,
+        commands,
+        enclosing_span,
+        Some(enclosing_span.end.offset),
+    )
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(super) enum ExpandedThenFiIfLayout {
-    Compact,
-    Multiline { inline_else_close: bool },
+pub(super) fn can_inline_body_with_upper_bound(
+    context: RenderContext<'_, '_>,
+    commands: &StmtSeq,
+    enclosing_span: Span,
+    upper_bound: Option<usize>,
+) -> bool {
+    let [command] = commands.as_slice() else {
+        return false;
+    };
+    if matches!(command.terminator, Some(StmtTerminator::Background(_)))
+        || !can_inline_stmt(context, command)
+    {
+        return false;
+    }
+
+    if context.facts.sequence(commands, upper_bound).has_comments() {
+        return false;
+    }
+
+    context.options.compact_layout() || stmt_span(command).start.line == enclosing_span.start.line
+}
+
+pub(super) fn can_inline_stmt(context: RenderContext<'_, '_>, stmt: &Stmt) -> bool {
+    let stmt_facts = context.facts.stmt(stmt);
+    if stmt_facts.preserve_verbatim() || stmt_facts.has_trailing_comment() {
+        return false;
+    }
+
+    matches!(
+        &stmt.command,
+        Command::Simple(_)
+            | Command::Builtin(_)
+            | Command::Decl(_)
+            | Command::Function(_)
+            | Command::Binary(_)
+            | Command::Compound(
+                CompoundCommand::Conditional(_)
+                    | CompoundCommand::Arithmetic(_)
+                    | CompoundCommand::Time(_)
+            )
+    )
+}
+
+pub(super) fn can_inline_else_branch_close(
+    context: RenderContext<'_, '_>,
+    command: &IfCommand,
+    body: &StmtSeq,
+    fi_span: Span,
+) -> bool {
+    let [stmt] = body.as_slice() else {
+        return false;
+    };
+    if matches!(stmt.terminator, Some(StmtTerminator::Background(_)))
+        || !can_inline_stmt(context, stmt)
+        || context
+            .facts
+            .sequence(body, Some(fi_span.start.offset))
+            .has_comments()
+    {
+        return false;
+    };
+    let Some((_, else_offset)) = context
+        .facts
+        .if_next_branch_region(command, command.elif_branches.len())
+    else {
+        return false;
+    };
+    let else_line = context.source_map().line_number_for_offset(else_offset);
+    let body_line = stmt_span(stmt).start.line;
+    else_line == body_line && body_line == fi_span.start.line
+}
+
+pub(super) fn can_inline_if_chain(
+    context: RenderContext<'_, '_>,
+    command: &IfCommand,
+    fi_span: Span,
+) -> bool {
+    if command.elif_branches.is_empty() || command.span.start.line != fi_span.end.line {
+        return false;
+    }
+
+    if !can_inline_body_with_upper_bound(
+        context,
+        &command.then_branch,
+        command.span,
+        Some(if_branch_upper_bound(
+            command,
+            0,
+            context.source,
+            context.source_map(),
+            context.facts,
+        )),
+    ) {
+        return false;
+    }
+
+    for (index, (_, body)) in command.elif_branches.iter().enumerate() {
+        if !can_inline_body_with_upper_bound(
+            context,
+            body,
+            command.span,
+            Some(if_branch_upper_bound(
+                command,
+                index + 1,
+                context.source,
+                context.source_map(),
+                context.facts,
+            )),
+        ) {
+            return false;
+        }
+    }
+
+    command.else_branch.as_ref().is_none_or(|body| {
+        can_inline_body_with_upper_bound(context, body, command.span, Some(fi_span.start.offset))
+    })
+}
+
+pub(super) fn then_branch_starts_with_inline_if(
+    context: RenderContext<'_, '_>,
+    command: &IfCommand,
+    then_span: Span,
+    fi_span: Span,
+) -> bool {
+    if command.span.start.line != fi_span.end.line {
+        return false;
+    }
+    let [stmt] = command.then_branch.as_slice() else {
+        return false;
+    };
+    if stmt.negated || !stmt.redirects.is_empty() || stmt.terminator.is_some() {
+        return false;
+    }
+    let Command::Compound(CompoundCommand::If(inner)) = &stmt.command else {
+        return false;
+    };
+    matches!(inner.syntax, IfSyntax::ThenFi { .. })
+        && then_span.end.line == inner.span.start.line
+        && !context
+            .facts
+            .sequence(
+                &command.then_branch,
+                Some(if_branch_upper_bound(
+                    command,
+                    0,
+                    context.source,
+                    context.source_map(),
+                    context.facts,
+                )),
+            )
+            .has_comments()
 }
 
 impl<'source, 'facts, S> ShellRenderer<'source, 'facts, S>
 where
     S: StreamSink,
 {
-    pub(super) fn then_fi_if_layout(
-        &self,
-        command: &IfCommand,
-        then_span: Span,
-        fi_span: Span,
-    ) -> ThenFiIfLayout {
-        let source = self.source();
-        let fi_upper_bound = fi_span.start.offset;
-        let no_elifs = command.elif_branches.is_empty();
-
-        if no_elifs
-            && let Some(raw_condition) = raw_grouped_if_condition(
-                command,
-                then_span,
-                source,
-                self.source_map(),
-                self.options(),
-                self.facts(),
-            )
-        {
-            return ThenFiIfLayout::RawGroupedCondition { raw_condition };
-        }
-
-        if if_condition_starts_after_keyword(
-            command,
-            then_span,
-            source,
-            self.source_map(),
-            self.options(),
-            self.facts(),
-        ) || if_condition_has_explicit_statement_break(
-            command,
-            then_span,
-            source,
-            self.source_map(),
-            self.facts(),
-        ) {
-            return ThenFiIfLayout::SplitCondition;
-        }
-
-        let can_inline_then = no_elifs
-            && self.can_inline_body_with_upper_bound(
-                &command.then_branch,
-                command.span,
-                Some(fi_upper_bound),
-            );
-
-        if no_elifs && command.else_branch.is_none() && can_inline_then {
-            return ThenFiIfLayout::InlineThen;
-        }
-
-        if can_inline_then && let Some(else_branch) = &command.else_branch {
-            let can_inline_else = self.can_inline_body_with_upper_bound(
-                else_branch,
-                command.span,
-                Some(fi_upper_bound),
-            );
-            if can_inline_else {
-                return ThenFiIfLayout::InlineThenElse;
-            }
-            if !self.options().compact_layout() {
-                return ThenFiIfLayout::InlineThenMultilineElse;
-            }
-        }
-
-        if no_elifs
-            && command.else_branch.is_none()
-            && self.then_branch_starts_with_inline_if(command, then_span, fi_span)
-        {
-            return ThenFiIfLayout::InlineThenNestedIf;
-        }
-
-        if self.can_inline_if_chain(command, fi_span) {
-            return ThenFiIfLayout::InlineChain;
-        }
-
-        if self.options().compact_layout() {
-            ThenFiIfLayout::Expanded(ExpandedThenFiIfLayout::Compact)
-        } else {
-            ThenFiIfLayout::Expanded(ExpandedThenFiIfLayout::Multiline {
-                inline_else_close: command
-                    .else_branch
-                    .as_ref()
-                    .is_some_and(|body| self.can_inline_else_branch_close(command, body, fi_span)),
-            })
-        }
-    }
-
     pub(super) fn can_inline_body(&self, commands: &StmtSeq, enclosing_span: Span) -> bool {
-        self.can_inline_body_with_upper_bound(
-            commands,
-            enclosing_span,
-            Some(enclosing_span.end.offset),
-        )
+        can_inline_body(self.render_context(), commands, enclosing_span)
     }
 
     pub(super) fn can_inline_body_with_upper_bound(
@@ -124,21 +180,12 @@ where
         enclosing_span: Span,
         upper_bound: Option<usize>,
     ) -> bool {
-        let [command] = commands.as_slice() else {
-            return false;
-        };
-        if matches!(command.terminator, Some(StmtTerminator::Background(_)))
-            || !self.can_inline_stmt(command)
-        {
-            return false;
-        }
-
-        if self.facts().sequence(commands, upper_bound).has_comments() {
-            return false;
-        }
-
-        self.options().compact_layout()
-            || stmt_span(command).start.line == enclosing_span.start.line
+        can_inline_body_with_upper_bound(
+            self.render_context(),
+            commands,
+            enclosing_span,
+            upper_bound,
+        )
     }
 
     pub(super) fn can_inline_group(&self, commands: &StmtSeq, open_char: char) -> bool {
@@ -146,7 +193,7 @@ where
             return false;
         };
 
-        self.can_inline_stmt(command)
+        can_inline_stmt(self.render_context(), command)
             && self.can_inline_body(commands, stmt_span(command))
             && (stmt_span(command).start.line == stmt_span(command).end.line
                 || self.group_delimiters_attach_to_wrapped_body(commands, open_char))
@@ -253,131 +300,5 @@ where
         source
             .get(stmt_end..close_offset)
             .is_some_and(|between| !between.contains('\n'))
-    }
-
-    pub(super) fn can_inline_stmt(&self, stmt: &Stmt) -> bool {
-        let stmt_facts = self.facts().stmt(stmt);
-        if stmt_facts.preserve_verbatim() || stmt_facts.has_trailing_comment() {
-            return false;
-        }
-
-        matches!(
-            &stmt.command,
-            Command::Simple(_)
-                | Command::Builtin(_)
-                | Command::Decl(_)
-                | Command::Function(_)
-                | Command::Binary(_)
-                | Command::Compound(
-                    CompoundCommand::Conditional(_)
-                        | CompoundCommand::Arithmetic(_)
-                        | CompoundCommand::Time(_)
-                )
-        )
-    }
-
-    pub(super) fn can_inline_else_branch_close(
-        &self,
-        command: &IfCommand,
-        body: &StmtSeq,
-        fi_span: Span,
-    ) -> bool {
-        let [stmt] = body.as_slice() else {
-            return false;
-        };
-        if matches!(stmt.terminator, Some(StmtTerminator::Background(_)))
-            || !self.can_inline_stmt(stmt)
-            || self
-                .facts()
-                .sequence(body, Some(fi_span.start.offset))
-                .has_comments()
-        {
-            return false;
-        };
-        let Some((_, else_offset)) = self
-            .facts()
-            .if_next_branch_region(command, command.elif_branches.len())
-        else {
-            return false;
-        };
-        let else_line = self.source_map().line_number_for_offset(else_offset);
-        let body_line = stmt_span(stmt).start.line;
-        else_line == body_line && body_line == fi_span.start.line
-    }
-
-    pub(super) fn can_inline_if_chain(&self, command: &IfCommand, fi_span: Span) -> bool {
-        if command.elif_branches.is_empty() || command.span.start.line != fi_span.end.line {
-            return false;
-        }
-
-        let source = self.source();
-        if !self.can_inline_body_with_upper_bound(
-            &command.then_branch,
-            command.span,
-            Some(if_branch_upper_bound(
-                command,
-                0,
-                source,
-                self.source_map(),
-                self.facts(),
-            )),
-        ) {
-            return false;
-        }
-
-        for (index, (_, body)) in command.elif_branches.iter().enumerate() {
-            if !self.can_inline_body_with_upper_bound(
-                body,
-                command.span,
-                Some(if_branch_upper_bound(
-                    command,
-                    index + 1,
-                    source,
-                    self.source_map(),
-                    self.facts(),
-                )),
-            ) {
-                return false;
-            }
-        }
-
-        command.else_branch.as_ref().is_none_or(|body| {
-            self.can_inline_body_with_upper_bound(body, command.span, Some(fi_span.start.offset))
-        })
-    }
-
-    pub(super) fn then_branch_starts_with_inline_if(
-        &self,
-        command: &IfCommand,
-        then_span: Span,
-        fi_span: Span,
-    ) -> bool {
-        if command.span.start.line != fi_span.end.line {
-            return false;
-        }
-        let [stmt] = command.then_branch.as_slice() else {
-            return false;
-        };
-        if stmt.negated || !stmt.redirects.is_empty() || stmt.terminator.is_some() {
-            return false;
-        }
-        let Command::Compound(CompoundCommand::If(inner)) = &stmt.command else {
-            return false;
-        };
-        matches!(inner.syntax, IfSyntax::ThenFi { .. })
-            && then_span.end.line == inner.span.start.line
-            && !self
-                .facts()
-                .sequence(
-                    &command.then_branch,
-                    Some(if_branch_upper_bound(
-                        command,
-                        0,
-                        self.source(),
-                        self.source_map(),
-                        self.facts(),
-                    )),
-                )
-                .has_comments()
     }
 }

--- a/crates/shuck-formatter/src/streaming/statements.rs
+++ b/crates/shuck-formatter/src/streaming/statements.rs
@@ -1238,20 +1238,7 @@ where
     }
 
     pub(super) fn can_format_case_inline(&self, command: &CaseCommand) -> bool {
-        command.cases.iter().all(|item| {
-            item.body.is_empty()
-                || item.body.len() == 1
-                    && (self.facts().case_item_was_inline_in_source(item)
-                        || case_item_pattern_body_terminator_was_inline_in_source(
-                            item,
-                            self.source(),
-                        )
-                        || case_item_body_was_inline_without_terminator(item))
-                    && !self
-                        .facts()
-                        .sequence(&item.body, Some(command.span.end.offset))
-                        .has_comments()
-        })
+        case_can_format_inline(command, self.render_context())
     }
 
     pub(super) fn format_inline_case(&mut self, command: &CaseCommand) -> Result<()> {


### PR DESCRIPTION
## Summary
- Add a formatter layout-plan layer for `if` and `case` command shape decisions.
- Move the previous `then_fi_if_layout` policy and top-level case layout choices out of renderer methods.
- Add focused unit tests for layout-plan decisions while keeping renderer methods more mechanical.

## Validation
- `cargo test -p shuck-formatter`
- `cargo fmt --check`
- `git diff --check`

Note: I did not run the shfmt large-corpus oracle for this refactor pass.