### PR TITLE
refactor(formatter): consolidate comment planning

### DIFF
--- a/crates/shuck-formatter/src/facts.rs
+++ b/crates/shuck-formatter/src/facts.rs
@@ -252,6 +252,210 @@ impl<'source> CaseItemFacts<'source> {
 }
 
 #[derive(Debug, Clone)]
+pub(crate) struct CommentPlan<'source> {
+    alignment: HashMap<FactSpan, CommentAlignmentFacts>,
+    suffix_comments: HashMap<FactSpan, SourceComment<'source>>,
+    close_suffix_comments: HashMap<FactSpan, SourceComment<'source>>,
+    branch_prefix_facts: HashMap<OffsetRegionKey, BranchPrefixFacts>,
+    case_facts: HashMap<FactSpan, CaseCommandFacts>,
+    case_item_facts: HashMap<FactSpan, CaseItemFacts<'source>>,
+}
+
+impl<'source> CommentPlan<'source> {
+    fn new(
+        source: &'source str,
+        source_map: &SourceMap<'source>,
+        comment_attachments: &CommentAttachmentModel<'source>,
+    ) -> Self {
+        let alignment = comment_attachments
+            .comments()
+            .iter()
+            .map(|comment| {
+                (
+                    FactSpan::from(comment.span()),
+                    CommentAlignmentFacts::new(source, source_map, comment),
+                )
+            })
+            .collect();
+
+        Self {
+            alignment,
+            suffix_comments: HashMap::default(),
+            close_suffix_comments: HashMap::default(),
+            branch_prefix_facts: HashMap::default(),
+            case_facts: HashMap::default(),
+            case_item_facts: HashMap::default(),
+        }
+    }
+
+    fn trailing_comment(
+        &self,
+        source_map: &SourceMap<'source>,
+        comment: SourceComment<'source>,
+    ) -> InlineCommentPlan<'source> {
+        InlineCommentPlan::new(
+            comment,
+            self.alignment_for(source_map, comment),
+            InlineCommentPlacement::Trailing,
+        )
+    }
+
+    fn suffix_comment_for_span(
+        &self,
+        source_map: &SourceMap<'source>,
+        span: Span,
+    ) -> Option<InlineCommentPlan<'source>> {
+        self.suffix_comments
+            .get(&FactSpan::from(span))
+            .copied()
+            .map(|comment| self.trailing_comment(source_map, comment))
+    }
+
+    fn close_suffix_comment_after_span(
+        &self,
+        source_map: &SourceMap<'source>,
+        span: Span,
+    ) -> Option<InlineCommentPlan<'source>> {
+        let comment = self
+            .close_suffix_comments
+            .get(&FactSpan::from(span))
+            .copied()
+            .or_else(|| source_map.suffix_comment_after_span(span))?;
+        Some(InlineCommentPlan::new(
+            comment,
+            self.alignment_for(source_map, comment),
+            InlineCommentPlacement::CloseSuffix,
+        ))
+    }
+
+    fn branch_prefix_facts(&self, start: usize, end: usize) -> Option<&BranchPrefixFacts> {
+        self.branch_prefix_facts
+            .get(&OffsetRegionKey::new(start, end))
+    }
+
+    fn case_command(&self, command: &CaseCommand) -> Option<&CaseCommandFacts> {
+        self.case_facts.get(&FactSpan::from(command.span))
+    }
+
+    fn case_item(&self, item: &CaseItem) -> Option<&CaseItemFacts<'source>> {
+        self.case_item_facts.get(&case_item_key(item))
+    }
+
+    fn insert_suffix_comment(&mut self, span: Span, comment: SourceComment<'source>) {
+        self.suffix_comments.insert(FactSpan::from(span), comment);
+    }
+
+    fn insert_close_suffix_comment(&mut self, span: Span, comment: SourceComment<'source>) {
+        self.close_suffix_comments
+            .insert(FactSpan::from(span), comment);
+    }
+
+    fn insert_branch_prefix_facts(&mut self, start: usize, end: usize, facts: BranchPrefixFacts) {
+        self.branch_prefix_facts
+            .insert(OffsetRegionKey::new(start, end), facts);
+    }
+
+    fn insert_case_command(&mut self, command: &CaseCommand, facts: CaseCommandFacts) {
+        self.case_facts.insert(FactSpan::from(command.span), facts);
+    }
+
+    fn insert_case_item(&mut self, item: &CaseItem, facts: CaseItemFacts<'source>) {
+        self.case_item_facts.insert(case_item_key(item), facts);
+    }
+
+    fn alignment_for(
+        &self,
+        source_map: &SourceMap<'source>,
+        comment: SourceComment<'source>,
+    ) -> CommentAlignmentFacts {
+        self.alignment
+            .get(&FactSpan::from(comment.span()))
+            .copied()
+            .unwrap_or_else(|| {
+                CommentAlignmentFacts::new(source_map.source(), source_map, &comment)
+            })
+    }
+
+    #[cfg(feature = "benchmarking")]
+    fn len(&self) -> usize {
+        self.alignment.len()
+            + self.suffix_comments.len()
+            + self.close_suffix_comments.len()
+            + self.branch_prefix_facts.len()
+            + self.case_facts.len()
+            + self.case_item_facts.len()
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct InlineCommentPlan<'source> {
+    comment: SourceComment<'source>,
+    alignment: CommentAlignmentFacts,
+    placement: InlineCommentPlacement,
+}
+
+impl<'source> InlineCommentPlan<'source> {
+    fn new(
+        comment: SourceComment<'source>,
+        alignment: CommentAlignmentFacts,
+        placement: InlineCommentPlacement,
+    ) -> Self {
+        Self {
+            comment,
+            alignment,
+            placement,
+        }
+    }
+
+    pub(crate) fn comment(self) -> SourceComment<'source> {
+        self.comment
+    }
+
+    pub(crate) fn padding(
+        self,
+        source_map: &SourceMap<'_>,
+        current_code_column: usize,
+        current_indent_column: usize,
+    ) -> usize {
+        match self.placement {
+            InlineCommentPlacement::Trailing => self.alignment.trailing_padding(
+                source_map.source(),
+                source_map,
+                &self.comment,
+                current_code_column,
+                current_indent_column,
+            ),
+            InlineCommentPlacement::CloseSuffix => self.alignment.close_suffix_padding(
+                source_map.source(),
+                source_map,
+                &self.comment,
+                current_code_column,
+                current_indent_column,
+            ),
+        }
+    }
+
+    pub(crate) fn has_alignment(
+        self,
+        source_map: &SourceMap<'_>,
+        current_indent_column: usize,
+    ) -> bool {
+        self.alignment.has_trailing_alignment(
+            source_map.source(),
+            source_map,
+            &self.comment,
+            current_indent_column,
+        )
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+enum InlineCommentPlacement {
+    Trailing,
+    CloseSuffix,
+}
+
+#[derive(Debug, Clone)]
 pub(crate) struct StmtFacts {
     attachment_span: Span,
     render_span: Span,
@@ -1304,12 +1508,7 @@ pub(crate) struct FormatterFacts<'source> {
     background_breaks: HashSet<FactSpan>,
     inline_group_sequences: HashSet<FactSpan>,
     inline_case_item_bodies: HashSet<FactSpan>,
-    branch_prefix_facts: HashMap<OffsetRegionKey, BranchPrefixFacts>,
-    comment_alignment: HashMap<FactSpan, CommentAlignmentFacts>,
-    suffix_comments: HashMap<FactSpan, SourceComment<'source>>,
-    close_suffix_comments: HashMap<FactSpan, SourceComment<'source>>,
-    case_facts: HashMap<FactSpan, CaseCommandFacts>,
-    case_item_facts: HashMap<FactSpan, CaseItemFacts<'source>>,
+    comment_plan: CommentPlan<'source>,
     indexer: Indexer,
 }
 
@@ -1446,76 +1645,33 @@ impl<'source> FormatterFacts<'source> {
             .contains(&FactSpan::from(item.body.span))
     }
 
-    pub(crate) fn close_suffix_comment_after_span(
+    pub(crate) fn close_suffix_comment_plan_after_span(
         &self,
         span: Span,
-    ) -> Option<SourceComment<'source>> {
-        self.close_suffix_comments
-            .get(&FactSpan::from(span))
-            .copied()
-            .or_else(|| self.source_map.suffix_comment_after_span(span))
+    ) -> Option<InlineCommentPlan<'source>> {
+        self.comment_plan
+            .close_suffix_comment_after_span(&self.source_map, span)
     }
 
-    pub(crate) fn suffix_comment_for_span(&self, span: Span) -> Option<SourceComment<'source>> {
-        self.suffix_comments.get(&FactSpan::from(span)).copied()
-    }
-
-    pub(crate) fn trailing_comment_padding(
+    pub(crate) fn suffix_comment_plan_for_span(
         &self,
-        comment: &SourceComment<'_>,
-        current_code_column: usize,
-        current_indent_column: usize,
-    ) -> usize {
-        self.comment_alignment_for(comment).trailing_padding(
-            self.source_map.source(),
-            &self.source_map,
-            comment,
-            current_code_column,
-            current_indent_column,
-        )
+        span: Span,
+    ) -> Option<InlineCommentPlan<'source>> {
+        self.comment_plan
+            .suffix_comment_for_span(&self.source_map, span)
     }
 
-    pub(crate) fn trailing_comment_has_alignment(
+    pub(crate) fn trailing_comment_plan(
         &self,
-        comment: &SourceComment<'_>,
-        current_indent_column: usize,
-    ) -> bool {
-        self.comment_alignment_for(comment).has_trailing_alignment(
-            self.source_map.source(),
-            &self.source_map,
-            comment,
-            current_indent_column,
-        )
-    }
-
-    pub(crate) fn close_suffix_comment_padding(
-        &self,
-        comment: &SourceComment<'_>,
-        current_code_column: usize,
-        current_indent_column: usize,
-    ) -> usize {
-        self.comment_alignment_for(comment).close_suffix_padding(
-            self.source_map.source(),
-            &self.source_map,
-            comment,
-            current_code_column,
-            current_indent_column,
-        )
-    }
-
-    fn comment_alignment_for(&self, comment: &SourceComment<'_>) -> CommentAlignmentFacts {
-        self.comment_alignment
-            .get(&FactSpan::from(comment.span()))
-            .copied()
-            .unwrap_or_else(|| {
-                CommentAlignmentFacts::new(self.source_map.source(), &self.source_map, comment)
-            })
+        comment: SourceComment<'source>,
+    ) -> InlineCommentPlan<'source> {
+        self.comment_plan
+            .trailing_comment(&self.source_map, comment)
     }
 
     pub(crate) fn branch_prefix_facts(&self, start: usize, end: usize) -> BranchPrefixFacts {
-        let key = OffsetRegionKey::new(start, end);
-        self.branch_prefix_facts
-            .get(&key)
+        self.comment_plan
+            .branch_prefix_facts(start, end)
             .cloned()
             .unwrap_or_else(|| {
                 BranchPrefixFacts::new(
@@ -1553,14 +1709,14 @@ impl<'source> FormatterFacts<'source> {
     }
 
     pub(crate) fn case_command(&self, command: &CaseCommand) -> &CaseCommandFacts {
-        self.case_facts
-            .get(&FactSpan::from(command.span))
+        self.comment_plan
+            .case_command(command)
             .unwrap_or_else(|| unreachable!("missing case command facts"))
     }
 
     pub(crate) fn case_item(&self, item: &CaseItem) -> &CaseItemFacts<'source> {
-        self.case_item_facts
-            .get(&case_item_key(item))
+        self.comment_plan
+            .case_item(item)
             .unwrap_or_else(|| unreachable!("missing case item facts"))
     }
 
@@ -1671,12 +1827,7 @@ impl<'source> FormatterFacts<'source> {
             + self.background_breaks.len()
             + self.inline_group_sequences.len()
             + self.inline_case_item_bodies.len()
-            + self.branch_prefix_facts.len()
-            + self.comment_alignment.len()
-            + self.suffix_comments.len()
-            + self.close_suffix_comments.len()
-            + self.case_facts.len()
-            + self.case_item_facts.len()
+            + self.comment_plan.len()
             + self.indexer.region_index().heredoc_ranges().len()
     }
 }
@@ -1952,16 +2103,7 @@ impl<'source, 'options> FormatterFactsBuilder<'source, 'options> {
     ) -> Self {
         let source_map = SourceMap::from_indexer(source, &indexer, options.keep_padding());
         let comment_attachments = CommentAttachmentModel::from_indexer(&source_map, &indexer);
-        let comment_alignment = comment_attachments
-            .comments()
-            .iter()
-            .map(|comment| {
-                (
-                    FactSpan::from(comment.span()),
-                    CommentAlignmentFacts::new(source, &source_map, comment),
-                )
-            })
-            .collect();
+        let comment_plan = CommentPlan::new(source, &source_map, &comment_attachments);
 
         Self {
             source,
@@ -1977,12 +2119,7 @@ impl<'source, 'options> FormatterFactsBuilder<'source, 'options> {
                 background_breaks: HashSet::default(),
                 inline_group_sequences: HashSet::default(),
                 inline_case_item_bodies: HashSet::default(),
-                branch_prefix_facts: HashMap::default(),
-                comment_alignment,
-                suffix_comments: HashMap::default(),
-                close_suffix_comments: HashMap::default(),
-                case_facts: HashMap::default(),
-                case_item_facts: HashMap::default(),
+                comment_plan,
                 indexer,
             },
             layout: LayoutAnnotations::default(),
@@ -2479,8 +2616,8 @@ impl<'source, 'options> FormatterFactsBuilder<'source, 'options> {
             )
         {
             self.facts
-                .suffix_comments
-                .insert(FactSpan::from(then_span), comment);
+                .comment_plan
+                .insert_suffix_comment(then_span, comment);
         }
         let then_upper_bound =
             if_branch_upper_bound(command, 0, self.source, self.source_map(), &self.facts);
@@ -2586,14 +2723,12 @@ impl<'source, 'options> FormatterFactsBuilder<'source, 'options> {
                 case_item_body_upper_bound(item, case_command_facts.body_fallback_upper_bound());
             summary.merge(self.visit_sequence(&item.body, upper_bound, None));
             let item_facts = self.build_case_item_facts(item, previous_item, upper_bound);
-            self.facts
-                .case_item_facts
-                .insert(case_item_key(item), item_facts);
+            self.facts.comment_plan.insert_case_item(item, item_facts);
             previous_item = Some(item);
         }
         self.facts
-            .case_facts
-            .insert(FactSpan::from(command.span), case_command_facts);
+            .comment_plan
+            .insert_case_command(command, case_command_facts);
         summary
     }
 
@@ -3190,16 +3325,14 @@ impl<'source, 'options> FormatterFactsBuilder<'source, 'options> {
         };
         if let Some(comment) = self.source_map().suffix_comment_after_span(span) {
             self.facts
-                .close_suffix_comments
-                .insert(FactSpan::from(span), comment);
+                .comment_plan
+                .insert_close_suffix_comment(span, comment);
         }
     }
 
     fn record_suffix_attachment(&mut self, span: Span) {
         if let Some(comment) = suffix_comment_from_span(self.source, self.source_map(), span) {
-            self.facts
-                .suffix_comments
-                .insert(FactSpan::from(span), comment);
+            self.facts.comment_plan.insert_suffix_comment(span, comment);
         }
     }
 
@@ -3227,8 +3360,9 @@ impl<'source, 'options> FormatterFactsBuilder<'source, 'options> {
         .into_iter()
         .filter(|comment| !self.facts.offset_is_in_heredoc_body(comment.offset))
         .collect();
-        self.facts.branch_prefix_facts.insert(
-            OffsetRegionKey::new(start, end),
+        self.facts.comment_plan.insert_branch_prefix_facts(
+            start,
+            end,
             BranchPrefixFacts::new(self.source, start, end, comments),
         );
     }
@@ -4055,7 +4189,8 @@ mod tests {
             .group_open_suffix_span()
             .expect("expected group open suffix span");
         let comment = facts
-            .suffix_comment_for_span(span)
+            .suffix_comment_plan_for_span(span)
+            .map(InlineCommentPlan::comment)
             .expect("expected suffix comment attachment");
         assert_eq!(comment.text(), "# note");
         assert!(sequence.leading_for(0).is_empty());
@@ -4070,9 +4205,10 @@ mod tests {
             .trailing_for(0)
             .first()
             .expect("expected first trailing comment");
+        let plan = facts.trailing_comment_plan(*comment);
 
-        assert!(facts.trailing_comment_has_alignment(comment, 0));
-        assert_eq!(facts.trailing_comment_padding(comment, "one".len(), 0), 6);
+        assert!(plan.has_alignment(facts.source_map(), 0));
+        assert_eq!(plan.padding(facts.source_map(), "one".len(), 0), 6);
     }
 
     #[test]
@@ -4211,7 +4347,7 @@ mod tests {
         );
         assert!(
             facts
-                .close_suffix_comment_after_span(case_facts.esac_span().unwrap())
+                .close_suffix_comment_plan_after_span(case_facts.esac_span().unwrap())
                 .is_some()
         );
     }

--- a/crates/shuck-formatter/src/streaming/comments_alignment.rs
+++ b/crates/shuck-formatter/src/streaming/comments_alignment.rs
@@ -51,16 +51,9 @@ where
         }
     }
 
-    pub(super) fn emit_trailing_comments_for_stmt(&mut self, comments: &[SourceComment<'_>]) {
+    pub(super) fn emit_trailing_comments_for_stmt(&mut self, comments: &[SourceComment<'source>]) {
         for comment in comments {
-            let current_code_column = self.column().saturating_sub(self.line_indent_column());
-            let padding = self.facts().trailing_comment_padding(
-                comment,
-                current_code_column,
-                self.line_indent_column(),
-            );
-            self.write_spaces(padding);
-            self.write_comment(comment);
+            self.write_trailing_comment(comment, false);
         }
     }
 
@@ -133,50 +126,48 @@ where
     }
 
     pub(super) fn write_close_suffix_after_span(&mut self, close_span: Option<Span>) {
-        let Some(comment) =
-            close_span.and_then(|span| self.facts().close_suffix_comment_after_span(span))
+        let Some(plan) =
+            close_span.and_then(|span| self.facts().close_suffix_comment_plan_after_span(span))
         else {
             return;
         };
+        self.write_inline_comment_plan(plan, false);
+    }
+
+    pub(super) fn write_inline_comment_plan(
+        &mut self,
+        plan: crate::facts::InlineCommentPlan<'source>,
+        nudge_aligned: bool,
+    ) {
         let current_code_column = self.column().saturating_sub(self.line_indent_column());
-        let padding = self.facts().close_suffix_comment_padding(
-            &comment,
+        let mut padding = plan.padding(
+            self.source_map(),
             current_code_column,
             self.line_indent_column(),
         );
+        if nudge_aligned && plan.has_alignment(self.source_map(), self.line_indent_column()) {
+            padding += 1;
+        }
         self.write_spaces(padding);
-        self.write_comment(&comment);
+        self.write_comment(&plan.comment());
     }
 
     pub(super) fn write_trailing_comment(
         &mut self,
-        comment: &SourceComment<'_>,
+        comment: &SourceComment<'source>,
         nudge_aligned: bool,
     ) {
-        let current_code_column = self.column().saturating_sub(self.line_indent_column());
-        let mut padding = self.facts().trailing_comment_padding(
-            comment,
-            current_code_column,
-            self.line_indent_column(),
-        );
-        if nudge_aligned
-            && self
-                .facts()
-                .trailing_comment_has_alignment(comment, self.line_indent_column())
-        {
-            padding += 1;
-        }
-        self.write_spaces(padding);
-        self.write_comment(comment);
+        let plan = self.facts().trailing_comment_plan(*comment);
+        self.write_inline_comment_plan(plan, nudge_aligned);
     }
 
     pub(super) fn write_suffix_comment_after_span(&mut self, span: Span, nudge_aligned: bool) {
-        let Some(comment) = self.facts().suffix_comment_for_span(span) else {
+        let Some(plan) = self.facts().suffix_comment_plan_for_span(span) else {
             self.write_space();
             self.write_text(span.slice(self.source()).trim_start());
             return;
         };
-        self.write_trailing_comment(&comment, nudge_aligned);
+        self.write_inline_comment_plan(plan, nudge_aligned);
     }
 }
 

--- a/crates/shuck-formatter/src/streaming/compounds.rs
+++ b/crates/shuck-formatter/src/streaming/compounds.rs
@@ -477,10 +477,10 @@ where
     }
 
     pub(super) fn write_condition_separator_suffix_comment(&mut self, then_span: Span) -> bool {
-        let Some(comment) = self.facts().suffix_comment_for_span(then_span) else {
+        let Some(plan) = self.facts().suffix_comment_plan_for_span(then_span) else {
             return false;
         };
-        self.write_trailing_comment(&comment, false);
+        self.write_inline_comment_plan(plan, false);
         true
     }
 
@@ -1244,7 +1244,8 @@ where
         }
         let Some(comment) = self
             .facts()
-            .close_suffix_comment_after_span(stmt_format_span(stmt))
+            .close_suffix_comment_plan_after_span(stmt_format_span(stmt))
+            .map(|plan| plan.comment())
         else {
             return;
         };


### PR DESCRIPTION
## Summary
- consolidate formatter comment attachment/alignment maps behind a typed `CommentPlan`
- route suffix, close-suffix, and trailing inline comment rendering through `InlineCommentPlan`
- keep existing comment attachment behavior while narrowing renderer-facing APIs

## Validation
- `cargo fmt`
- `cargo test -p shuck-formatter`