### PR TITLE
refactor(formatter): use structural close delimiters

### DIFF
--- a/crates/shuck-ast/src/ast.rs
+++ b/crates/shuck-ast/src/ast.rs
@@ -923,6 +923,7 @@ pub struct SelectCommand {
     pub variable_span: Span,
     pub words: Vec<Word>,
     pub body: StmtSeq,
+    pub done_span: Span,
     /// Source span of this command
     pub span: Span,
 }
@@ -954,6 +955,7 @@ pub struct ArithmeticForCommand {
     /// Typed arithmetic view of `step_span`.
     pub step_ast: Option<ArithmeticExprNode>,
     pub right_paren_span: Span,
+    pub done_span: Option<Span>,
     /// Loop body
     pub body: StmtSeq,
     /// Source span of this command
@@ -1089,6 +1091,7 @@ pub enum ArithmeticAssignOp {
 pub struct WhileCommand {
     pub condition: StmtSeq,
     pub body: StmtSeq,
+    pub done_span: Option<Span>,
     /// Source span of this command
     pub span: Span,
 }
@@ -1098,6 +1101,7 @@ pub struct WhileCommand {
 pub struct UntilCommand {
     pub condition: StmtSeq,
     pub body: StmtSeq,
+    pub done_span: Option<Span>,
     /// Source span of this command
     pub span: Span,
 }
@@ -1107,6 +1111,7 @@ pub struct UntilCommand {
 pub struct CaseCommand {
     pub word: Word,
     pub cases: Vec<CaseItem>,
+    pub esac_span: Span,
     /// Source span of this command
     pub span: Span,
 }
@@ -5451,6 +5456,7 @@ mod tests {
             step_span: Some(Span::new()),
             step_ast: None,
             right_paren_span: Span::new(),
+            done_span: Some(Span::new()),
             body: stmt_seq(vec![]),
             span: Span::new(),
         };

--- a/crates/shuck-formatter/src/command.rs
+++ b/crates/shuck-formatter/src/command.rs
@@ -7,8 +7,7 @@ use crate::raw_syntax::{
     refine_common_indent, shell_comment_can_start, skip_escaped_or_quoted,
 };
 use crate::scan::{
-    branch_keyword_offset, last_shell_keyword_start, last_uncommented_shell_keyword_before,
-    matching_done_close_start, matching_if_close_start, normalized_close_keyword_span,
+    branch_keyword_offset, last_uncommented_shell_keyword_before, normalized_close_keyword_span,
 };
 use crate::word::{render_arithmetic_expr_to_buf, render_word_syntax_to_buf};
 use shuck_ast::{
@@ -19,6 +18,7 @@ use shuck_ast::{
     SelectCommand, SimpleCommand, SourceText, Span, Stmt, StmtSeq, StmtTerminator, Subscript,
     UntilCommand, VarRef, WhileCommand, Word, WordPart,
 };
+use shuck_indexer::CloseDelimiterKind;
 
 mod arithmetic;
 mod assignments;

--- a/crates/shuck-formatter/src/command/body_site.rs
+++ b/crates/shuck-formatter/src/command/body_site.rs
@@ -71,28 +71,33 @@ impl<'a> CompoundBodySite<'a> {
         command: &'a WhileCommand,
         source_map: &crate::comments::SourceMap<'_>,
     ) -> Self {
-        Self::do_done(&command.body, command.span, None, source_map)
+        Self::do_done(&command.body, command.span, command.done_span, source_map)
     }
 
     pub(crate) fn until_command(
         command: &'a UntilCommand,
         source_map: &crate::comments::SourceMap<'_>,
     ) -> Self {
-        Self::do_done(&command.body, command.span, None, source_map)
+        Self::do_done(&command.body, command.span, command.done_span, source_map)
     }
 
     pub(crate) fn select_command(
         command: &'a SelectCommand,
         source_map: &crate::comments::SourceMap<'_>,
     ) -> Self {
-        Self::do_done(&command.body, command.span, None, source_map)
+        Self::do_done(
+            &command.body,
+            command.span,
+            Some(command.done_span),
+            source_map,
+        )
     }
 
     pub(crate) fn arithmetic_for_command(
         command: &'a ArithmeticForCommand,
         source_map: &crate::comments::SourceMap<'_>,
     ) -> Self {
-        Self::do_done(&command.body, command.span, None, source_map)
+        Self::do_done(&command.body, command.span, command.done_span, source_map)
     }
 
     pub(crate) fn if_then_branch(

--- a/crates/shuck-formatter/src/command/render_policy.rs
+++ b/crates/shuck-formatter/src/command/render_policy.rs
@@ -190,7 +190,7 @@ fn stmt_compound_close_span(
             }
             | ForSyntax::ParenBrace {
                 right_brace_span, ..
-            } => normalized_brace_close_span(source, source_map, right_brace_span),
+            } => normalized_brace_close_span(source, source_map, command.span, right_brace_span),
             ForSyntax::InDirect { .. } | ForSyntax::ParenDirect { .. } => None,
         },
         CompoundCommand::Repeat(command) => match command.syntax {
@@ -199,7 +199,7 @@ fn stmt_compound_close_span(
             }
             RepeatSyntax::Brace {
                 right_brace_span, ..
-            } => normalized_brace_close_span(source, source_map, right_brace_span),
+            } => normalized_brace_close_span(source, source_map, command.span, right_brace_span),
             RepeatSyntax::Direct => None,
         },
         CompoundCommand::Foreach(command) => match command.syntax {
@@ -208,16 +208,30 @@ fn stmt_compound_close_span(
             }
             ForeachSyntax::ParenBrace {
                 right_brace_span, ..
-            } => normalized_brace_close_span(source, source_map, right_brace_span),
+            } => normalized_brace_close_span(source, source_map, command.span, right_brace_span),
         },
         CompoundCommand::ArithmeticFor(command) => {
-            done_close_span(source, source_map, command.span, None)
+            done_close_span(source, source_map, command.span, command.done_span)
         }
-        CompoundCommand::While(command) => done_close_span(source, source_map, command.span, None),
-        CompoundCommand::Until(command) => done_close_span(source, source_map, command.span, None),
-        CompoundCommand::Select(command) => done_close_span(source, source_map, command.span, None),
-        CompoundCommand::Case(command) => last_shell_keyword_start(source, command.span, "esac")
-            .map(|start| source_map.span_for_offsets(start, start + "esac".len())),
+        CompoundCommand::While(command) => {
+            done_close_span(source, source_map, command.span, command.done_span)
+        }
+        CompoundCommand::Until(command) => {
+            done_close_span(source, source_map, command.span, command.done_span)
+        }
+        CompoundCommand::Select(command) => {
+            done_close_span(source, source_map, command.span, Some(command.done_span))
+        }
+        CompoundCommand::Case(command) => source_map
+            .close_delimiter_span(command.span, CloseDelimiterKind::Esac)
+            .or_else(|| {
+                Some(normalized_close_keyword_span(
+                    source,
+                    source_map,
+                    command.esac_span,
+                    "esac",
+                ))
+            }),
         _ => None,
     }
 }
@@ -225,9 +239,12 @@ fn stmt_compound_close_span(
 fn normalized_brace_close_span(
     source: &str,
     source_map: &crate::comments::SourceMap<'_>,
+    command_span: Span,
     span: Span,
 ) -> Option<Span> {
-    Some(normalized_close_keyword_span(source, source_map, span, "}"))
+    source_map
+        .close_delimiter_span(command_span, CloseDelimiterKind::RightBrace)
+        .or_else(|| Some(normalized_close_keyword_span(source, source_map, span, "}")))
 }
 
 pub(crate) fn if_close_span(
@@ -241,13 +258,15 @@ pub(crate) fn if_close_span(
             right_brace_span, ..
         } => (right_brace_span, "}"),
     };
-    let syntax_close = normalized_close_keyword_span(source, source_map, syntax_close, keyword);
-    if span_starts_with_keyword(source, syntax_close, keyword) {
-        return syntax_close;
+    let kind = match command.syntax {
+        IfSyntax::ThenFi { .. } => CloseDelimiterKind::Fi,
+        IfSyntax::Brace { .. } => CloseDelimiterKind::RightBrace,
+    };
+    if let Some(indexed_close) = source_map.close_delimiter_span(command.span, kind) {
+        return indexed_close;
     }
-    matching_if_close_start(source, command.span)
-        .map(|start| source_map.span_for_offsets(start, start + keyword.len()))
-        .unwrap_or(syntax_close)
+    let syntax_close = normalized_close_keyword_span(source, source_map, syntax_close, keyword);
+    syntax_close
 }
 
 pub(crate) fn done_close_span(
@@ -256,6 +275,10 @@ pub(crate) fn done_close_span(
     span: Span,
     fallback: Option<Span>,
 ) -> Option<Span> {
+    if let Some(indexed_close) = source_map.close_delimiter_span(span, CloseDelimiterKind::Done) {
+        return Some(indexed_close);
+    }
+
     if let Some(fallback) = fallback {
         let normalized = normalized_close_keyword_span(source, source_map, fallback, "done");
         if span_starts_with_keyword(source, normalized, "done") {
@@ -263,18 +286,21 @@ pub(crate) fn done_close_span(
         }
     }
 
-    let span_end = span.end.offset.min(source.len());
-    if let Some(start) = span_end.checked_sub("done".len())
-        && source.get(start..span_end) == Some("done")
-    {
-        return Some(source_map.span_for_offsets(start, span_end));
-    }
+    close_keyword_at_span_end(source, source_map, span, "done").or_else(|| {
+        fallback.map(|span| normalized_close_keyword_span(source, source_map, span, "done"))
+    })
+}
 
-    matching_done_close_start(source, span)
-        .map(|start| source_map.span_for_offsets(start, start + "done".len()))
-        .or_else(|| {
-            fallback.map(|span| normalized_close_keyword_span(source, source_map, span, "done"))
-        })
+fn close_keyword_at_span_end(
+    source: &str,
+    source_map: &crate::comments::SourceMap<'_>,
+    span: Span,
+    keyword: &str,
+) -> Option<Span> {
+    let span_end = span.end.offset.min(source.len());
+    let start = span_end.checked_sub(keyword.len())?;
+    (source.get(start..span_end) == Some(keyword))
+        .then(|| source_map.span_for_offsets(start, span_end))
 }
 
 fn span_starts_with_keyword(source: &str, span: Span, keyword: &str) -> bool {

--- a/crates/shuck-formatter/src/command/render_policy.rs
+++ b/crates/shuck-formatter/src/command/render_policy.rs
@@ -265,8 +265,7 @@ pub(crate) fn if_close_span(
     if let Some(indexed_close) = source_map.close_delimiter_span(command.span, kind) {
         return indexed_close;
     }
-    let syntax_close = normalized_close_keyword_span(source, source_map, syntax_close, keyword);
-    syntax_close
+    normalized_close_keyword_span(source, source_map, syntax_close, keyword)
 }
 
 pub(crate) fn done_close_span(

--- a/crates/shuck-formatter/src/comments.rs
+++ b/crates/shuck-formatter/src/comments.rs
@@ -1,7 +1,7 @@
 use std::sync::{Arc, OnceLock};
 
 use shuck_ast::{Comment, Position, Span, TextSize};
-use shuck_indexer::{IndexedComment, Indexer, LineIndex};
+use shuck_indexer::{CloseDelimiterIndex, CloseDelimiterKind, IndexedComment, Indexer, LineIndex};
 
 use crate::source::SourceView;
 
@@ -14,6 +14,7 @@ pub struct SourceMap<'a> {
 #[derive(Debug)]
 struct SourceMapData {
     line_index: LineIndex,
+    close_delimiters: CloseDelimiterIndex,
     first_non_whitespace: Vec<OnceLock<Option<usize>>>,
     hash_offsets: Vec<usize>,
     track_alignment: bool,
@@ -37,6 +38,7 @@ impl<'a> SourceMap<'a> {
         Self::with_line_index_and_comment_offsets(
             source,
             indexer.line_index().clone(),
+            indexer.close_delimiter_index().clone(),
             indexer
                 .comment_index()
                 .comments()
@@ -50,13 +52,20 @@ impl<'a> SourceMap<'a> {
     fn with_line_index_and_comment_offsets(
         source: &'a str,
         line_index: LineIndex,
+        close_delimiters: CloseDelimiterIndex,
         comment_offsets: impl IntoIterator<Item = usize>,
         track_alignment: bool,
     ) -> Self {
         let mut hash_offsets = comment_offsets.into_iter().collect::<Vec<_>>();
         hash_offsets.sort_unstable();
         hash_offsets.dedup();
-        Self::from_parts(source, line_index, hash_offsets, track_alignment)
+        Self::from_parts(
+            source,
+            line_index,
+            close_delimiters,
+            hash_offsets,
+            track_alignment,
+        )
     }
 
     #[cfg(test)]
@@ -72,6 +81,7 @@ impl<'a> SourceMap<'a> {
         Self::from_parts(
             source,
             LineIndex::new(source),
+            CloseDelimiterIndex::empty(),
             hash_offsets,
             track_alignment,
         )
@@ -80,6 +90,7 @@ impl<'a> SourceMap<'a> {
     fn from_parts(
         source: &'a str,
         line_index: LineIndex,
+        close_delimiters: CloseDelimiterIndex,
         hash_offsets: Vec<usize>,
         track_alignment: bool,
     ) -> Self {
@@ -91,6 +102,7 @@ impl<'a> SourceMap<'a> {
             source,
             data: Arc::new(SourceMapData {
                 line_index,
+                close_delimiters,
                 first_non_whitespace,
                 hash_offsets,
                 track_alignment,
@@ -150,6 +162,21 @@ impl<'a> SourceMap<'a> {
         let start = usize::from(comment.range.start());
         let end = usize::from(comment.range.end());
         self.source_comment_for_offsets(start, end)
+    }
+
+    #[must_use]
+    pub(crate) fn close_delimiter_span(
+        &self,
+        command_span: Span,
+        kind: CloseDelimiterKind,
+    ) -> Option<Span> {
+        let range = self
+            .data
+            .close_delimiters
+            .close_for_command(command_span.to_range(), kind)?;
+        let start = usize::from(range.start());
+        let end = usize::from(range.end());
+        Some(self.span_for_offsets(start, end))
     }
 
     #[must_use]

--- a/crates/shuck-formatter/src/facts.rs
+++ b/crates/shuck-formatter/src/facts.rs
@@ -12,7 +12,9 @@ use shuck_ast::{
     ZshGlobSegment,
 };
 use shuck_ast::{TextRange, TextSize};
-use shuck_indexer::{CommentIndex, IndexedComment, Indexer, IndexerOptions, LineIndex};
+use shuck_indexer::{
+    CloseDelimiterKind, CommentIndex, IndexedComment, Indexer, IndexerOptions, LineIndex,
+};
 
 use crate::command::{
     CompoundBodySite, array_elem_parts, builtin_like_parts, case_item_body_upper_bound,
@@ -30,9 +32,7 @@ use crate::comments::{
     CommentAttachmentModel, SequenceCommentAttachment, SourceComment, SourceMap,
 };
 use crate::options::{LineEnding, ResolvedShellFormatOptions};
-use crate::scan::{
-    BranchPrefixComment, last_shell_keyword_end, last_shell_keyword_start, source_between_offsets,
-};
+use crate::scan::{BranchPrefixComment, last_shell_keyword_end, source_between_offsets};
 use crate::source::{SourceView, command_substitution_source_starts_with_body_line};
 use crate::streaming::comments_alignment::CommentAlignmentFacts;
 use crate::visit::{self, AstVisitor};
@@ -3026,8 +3026,9 @@ fn sequence_comment_lower_bound(sequence: &StmtSeq, source_map: &SourceMap<'_>) 
 }
 
 fn case_close_span(command: &CaseCommand, source_map: &SourceMap<'_>) -> Option<Span> {
-    let start = last_shell_keyword_start(source_map.source(), command.span, "esac")?;
-    Some(source_map.span_for_offsets(start, start + "esac".len()))
+    source_map
+        .close_delimiter_span(command.span, CloseDelimiterKind::Esac)
+        .or_else(|| Some(command.esac_span))
 }
 
 fn group_close_offset(

--- a/crates/shuck-formatter/src/facts.rs
+++ b/crates/shuck-formatter/src/facts.rs
@@ -3028,7 +3028,7 @@ fn sequence_comment_lower_bound(sequence: &StmtSeq, source_map: &SourceMap<'_>) 
 fn case_close_span(command: &CaseCommand, source_map: &SourceMap<'_>) -> Option<Span> {
     source_map
         .close_delimiter_span(command.span, CloseDelimiterKind::Esac)
-        .or_else(|| Some(command.esac_span))
+        .or(Some(command.esac_span))
 }
 
 fn group_close_offset(

--- a/crates/shuck-formatter/src/scan.rs
+++ b/crates/shuck-formatter/src/scan.rs
@@ -71,11 +71,3 @@ pub(crate) fn normalized_close_keyword_span(
         span
     }
 }
-
-pub(crate) fn matching_if_close_start(source: &str, span: Span) -> Option<usize> {
-    SourceView::new(source).matching_if_close_start(span)
-}
-
-pub(crate) fn matching_done_close_start(source: &str, span: Span) -> Option<usize> {
-    SourceView::new(source).matching_done_close_start(span)
-}

--- a/crates/shuck-formatter/src/source.rs
+++ b/crates/shuck-formatter/src/source.rs
@@ -128,27 +128,6 @@ impl<'source> SourceView<'source> {
             && shell_keyword_boundaries_match(self.source, offset, end)
     }
 
-    pub(crate) fn matching_if_close_start(self, span: Span) -> Option<usize> {
-        self.matching_close_keyword_start(span, "fi", |source, offset, upper| {
-            shell_control_keyword_at(source, offset, upper, "if").then_some("if".len())
-        })
-    }
-
-    pub(crate) fn matching_done_close_start(self, span: Span) -> Option<usize> {
-        self.matching_close_keyword_start(span, "done", |source, offset, upper| {
-            ["for", "select", "while", "until", "foreach", "repeat"]
-                .iter()
-                .find(|keyword| shell_control_keyword_at(source, offset, upper, keyword))
-                .map(|_| {
-                    source[offset..]
-                        .chars()
-                        .take_while(char::is_ascii_alphabetic)
-                        .map(char::len_utf8)
-                        .sum()
-                })
-        })
-    }
-
     pub(crate) fn dollar_command_substitution(
         self,
     ) -> Option<DollarCommandSubstitutionSource<'source>> {
@@ -177,43 +156,6 @@ impl<'source> SourceView<'source> {
                 .rfind('\n')
                 .map_or(0, |newline| newline.saturating_add(1)),
         )
-    }
-
-    fn matching_close_keyword_start(
-        self,
-        span: Span,
-        close_keyword: &str,
-        mut open_len_at: impl FnMut(&str, usize, usize) -> Option<usize>,
-    ) -> Option<usize> {
-        let upper = span.end.offset.min(self.source.len());
-        let mut offset = span.start.offset.min(upper);
-        let mut depth = 0usize;
-        let scanner = RawShellScanner::bounded(self.source, upper);
-        while offset < upper {
-            let ch = self.source[offset..].chars().next()?;
-            if let Some(next) = scanner.skip_quoted_or_comment_at(offset) {
-                offset = next;
-                continue;
-            }
-
-            if let Some(open_len) = open_len_at(self.source, offset, upper) {
-                depth = depth.saturating_add(1);
-                offset += open_len;
-                continue;
-            }
-            if shell_control_keyword_at(self.source, offset, upper, close_keyword) {
-                if depth > 0 {
-                    depth -= 1;
-                    if depth == 0 {
-                        return Some(offset);
-                    }
-                }
-                offset += close_keyword.len();
-                continue;
-            }
-            offset += ch.len_utf8();
-        }
-        None
     }
 }
 
@@ -291,37 +233,6 @@ fn branch_keyword_candidate_matches(line: &str, start: usize, end: usize) -> boo
     before.is_empty() || before.ends_with(';') || before.ends_with('&')
 }
 
-fn shell_control_keyword_at(source: &str, offset: usize, upper: usize, keyword: &str) -> bool {
-    SourceView::new(source).shell_keyword_at(offset, upper, keyword)
-        && shell_keyword_has_command_prefix(source, offset)
-}
-
-fn shell_keyword_has_command_prefix(source: &str, offset: usize) -> bool {
-    let prefix = &source[..offset];
-    let Some((previous_offset, previous)) = prefix
-        .char_indices()
-        .rev()
-        .find(|(_, ch)| !matches!(ch, ' ' | '\t' | '\r'))
-    else {
-        return true;
-    };
-
-    if previous == '\n' || matches!(previous, ';' | '&' | '|' | '(' | ')' | '{' | '!') {
-        return true;
-    }
-
-    let word_end = previous_offset + previous.len_utf8();
-    let word_start = prefix[..word_end]
-        .char_indices()
-        .rev()
-        .find(|(_, ch)| !is_shell_keyword_char(*ch))
-        .map_or(0, |(index, ch)| index + ch.len_utf8());
-    matches!(
-        &prefix[word_start..word_end],
-        "do" | "then" | "else" | "elif" | "time" | "coproc"
-    )
-}
-
 fn shell_keyword_boundaries_match(text: &str, start: usize, end: usize) -> bool {
     let before = text[..start].chars().next_back();
     let after = text[end..].chars().next();
@@ -360,27 +271,5 @@ mod tests {
         assert!(command_substitution_source_prefers_continued_inline_body(
             "$(echo ok \\\n  && echo again)"
         ));
-    }
-
-    #[test]
-    fn source_view_skips_comments_when_matching_close_keywords() {
-        let source = "if true; then\n  echo fi # fi\nfi\n";
-        let span = Span {
-            start: shuck_ast::Position {
-                line: 1,
-                column: 1,
-                offset: 0,
-            },
-            end: shuck_ast::Position {
-                line: 3,
-                column: 3,
-                offset: source.len(),
-            },
-        };
-
-        assert_eq!(
-            SourceView::new(source).matching_if_close_start(span),
-            source.rfind("fi")
-        );
     }
 }

--- a/crates/shuck-indexer/src/close_delimiter_index.rs
+++ b/crates/shuck-indexer/src/close_delimiter_index.rs
@@ -1,0 +1,832 @@
+use shuck_ast::{
+    ArithmeticExpr, ArithmeticExprNode, ArithmeticLvalue, ArrayElem, Assignment, AssignmentValue,
+    BourneParameterExpansion, BuiltinCommand, Command, CompoundCommand, ConditionalExpr,
+    DeclOperand, File, ForSyntax, ForeachSyntax, HeredocBody, HeredocBodyPart, IfSyntax,
+    ParameterExpansion, ParameterExpansionSyntax, Pattern, PatternPart, Redirect, RedirectTarget,
+    RepeatSyntax, Span, Stmt, StmtSeq, TextRange, TextSize, VarRef, Word, WordPart,
+};
+
+/// The source delimiter that closes a parsed shell compound command.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum CloseDelimiterKind {
+    /// The `fi` delimiter for `if` commands.
+    Fi,
+    /// The `done` delimiter for loop bodies.
+    Done,
+    /// The `esac` delimiter for `case` commands.
+    Esac,
+    /// The `}` delimiter for brace-backed compound bodies.
+    RightBrace,
+}
+
+impl CloseDelimiterKind {
+    fn text(self) -> &'static str {
+        match self {
+            Self::Fi => "fi",
+            Self::Done => "done",
+            Self::Esac => "esac",
+            Self::RightBrace => "}",
+        }
+    }
+}
+
+/// One indexed close delimiter and the compound command span it belongs to.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct IndexedCloseDelimiter {
+    command_range: TextRange,
+    delimiter_range: TextRange,
+    kind: CloseDelimiterKind,
+}
+
+impl IndexedCloseDelimiter {
+    /// Return the parsed compound command range that owns this delimiter.
+    pub fn command_range(self) -> TextRange {
+        self.command_range
+    }
+
+    /// Return the source byte range for the close delimiter itself.
+    pub fn delimiter_range(self) -> TextRange {
+        self.delimiter_range
+    }
+
+    /// Return the delimiter kind.
+    pub fn kind(self) -> CloseDelimiterKind {
+        self.kind
+    }
+}
+
+/// Lookup table for structural close delimiters in parsed shell source.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct CloseDelimiterIndex {
+    delimiters: Vec<IndexedCloseDelimiter>,
+}
+
+impl CloseDelimiterIndex {
+    /// Build close-delimiter metadata from parser output.
+    ///
+    /// The index uses parser-owned syntax spans and ignores compound forms
+    /// without a concrete close delimiter in source.
+    pub fn new(source: &str, file: &File) -> Self {
+        let mut collector = CloseDelimiterCollector::new(source);
+        collector.visit_file(file);
+        collector.finish()
+    }
+
+    /// Return an empty close-delimiter index.
+    pub fn empty() -> Self {
+        Self::default()
+    }
+
+    /// Return all indexed close delimiters in source order.
+    pub fn delimiters(&self) -> &[IndexedCloseDelimiter] {
+        &self.delimiters
+    }
+
+    /// Return the close delimiter range for `command_range` and `kind`.
+    pub fn close_for_command(
+        &self,
+        command_range: TextRange,
+        kind: CloseDelimiterKind,
+    ) -> Option<TextRange> {
+        let start_index = self
+            .delimiters
+            .partition_point(|entry| entry.command_range.start() < command_range.start());
+        for entry in &self.delimiters[start_index..] {
+            if entry.command_range.start() != command_range.start() {
+                break;
+            }
+            if entry.command_range == command_range && entry.kind == kind {
+                return Some(entry.delimiter_range);
+            }
+        }
+        None
+    }
+}
+
+struct CloseDelimiterCollector<'source> {
+    source: &'source str,
+    delimiters: Vec<IndexedCloseDelimiter>,
+}
+
+impl<'source> CloseDelimiterCollector<'source> {
+    fn new(source: &'source str) -> Self {
+        Self {
+            source,
+            delimiters: Vec::new(),
+        }
+    }
+
+    fn finish(mut self) -> CloseDelimiterIndex {
+        self.delimiters.sort_unstable_by_key(|entry| {
+            (
+                entry.command_range.start().to_u32(),
+                entry.command_range.end().to_u32(),
+                entry.kind,
+                entry.delimiter_range.start().to_u32(),
+            )
+        });
+        self.delimiters
+            .dedup_by_key(|entry| (entry.command_range, entry.kind, entry.delimiter_range));
+        CloseDelimiterIndex {
+            delimiters: self.delimiters,
+        }
+    }
+
+    fn visit_file(&mut self, file: &File) {
+        self.visit_stmt_seq(&file.body);
+    }
+
+    fn visit_stmt_seq(&mut self, sequence: &StmtSeq) {
+        for stmt in sequence.iter() {
+            self.visit_stmt(stmt);
+        }
+    }
+
+    fn visit_stmt(&mut self, stmt: &Stmt) {
+        for redirect in &stmt.redirects {
+            self.visit_redirect(redirect);
+        }
+        self.visit_command(&stmt.command);
+    }
+
+    fn visit_command(&mut self, command: &Command) {
+        match command {
+            Command::Simple(command) => {
+                for assignment in &command.assignments {
+                    self.visit_assignment(assignment);
+                }
+                self.visit_word(&command.name);
+                for word in &command.args {
+                    self.visit_word(word);
+                }
+            }
+            Command::Builtin(command) => {
+                self.visit_builtin(command);
+            }
+            Command::Decl(command) => {
+                for assignment in &command.assignments {
+                    self.visit_assignment(assignment);
+                }
+                for operand in &command.operands {
+                    match operand {
+                        DeclOperand::Flag(word) | DeclOperand::Dynamic(word) => {
+                            self.visit_word(word);
+                        }
+                        DeclOperand::Name(reference) => self.visit_var_ref(reference),
+                        DeclOperand::Assignment(assignment) => self.visit_assignment(assignment),
+                    }
+                }
+            }
+            Command::Binary(command) => {
+                self.visit_stmt(&command.left);
+                self.visit_stmt(&command.right);
+            }
+            Command::Compound(command) => self.visit_compound(command),
+            Command::Function(function) => {
+                for entry in &function.header.entries {
+                    self.visit_word(&entry.word);
+                }
+                self.visit_stmt(&function.body);
+            }
+            Command::AnonymousFunction(function) => {
+                self.visit_stmt(&function.body);
+                for word in &function.args {
+                    self.visit_word(word);
+                }
+            }
+        }
+    }
+
+    fn visit_builtin(&mut self, command: &BuiltinCommand) {
+        match command {
+            BuiltinCommand::Break(command) => {
+                for assignment in &command.assignments {
+                    self.visit_assignment(assignment);
+                }
+                if let Some(depth) = &command.depth {
+                    self.visit_word(depth);
+                }
+                for word in &command.extra_args {
+                    self.visit_word(word);
+                }
+            }
+            BuiltinCommand::Continue(command) => {
+                for assignment in &command.assignments {
+                    self.visit_assignment(assignment);
+                }
+                if let Some(depth) = &command.depth {
+                    self.visit_word(depth);
+                }
+                for word in &command.extra_args {
+                    self.visit_word(word);
+                }
+            }
+            BuiltinCommand::Return(command) => {
+                for assignment in &command.assignments {
+                    self.visit_assignment(assignment);
+                }
+                if let Some(code) = &command.code {
+                    self.visit_word(code);
+                }
+                for word in &command.extra_args {
+                    self.visit_word(word);
+                }
+            }
+            BuiltinCommand::Exit(command) => {
+                for assignment in &command.assignments {
+                    self.visit_assignment(assignment);
+                }
+                if let Some(code) = &command.code {
+                    self.visit_word(code);
+                }
+                for word in &command.extra_args {
+                    self.visit_word(word);
+                }
+            }
+        }
+    }
+
+    fn visit_compound(&mut self, command: &CompoundCommand) {
+        match command {
+            CompoundCommand::If(command) => {
+                match command.syntax {
+                    IfSyntax::ThenFi { fi_span, .. } => {
+                        self.push_span(command.span, CloseDelimiterKind::Fi, fi_span);
+                    }
+                    IfSyntax::Brace {
+                        right_brace_span, ..
+                    } => {
+                        self.push_span(
+                            command.span,
+                            CloseDelimiterKind::RightBrace,
+                            right_brace_span,
+                        );
+                    }
+                }
+                self.visit_stmt_seq(&command.condition);
+                self.visit_stmt_seq(&command.then_branch);
+                for (condition, branch) in &command.elif_branches {
+                    self.visit_stmt_seq(condition);
+                    self.visit_stmt_seq(branch);
+                }
+                if let Some(branch) = &command.else_branch {
+                    self.visit_stmt_seq(branch);
+                }
+            }
+            CompoundCommand::For(command) => {
+                match command.syntax {
+                    ForSyntax::InDoDone { done_span, .. }
+                    | ForSyntax::ParenDoDone { done_span, .. } => {
+                        self.push_span(command.span, CloseDelimiterKind::Done, done_span);
+                    }
+                    ForSyntax::InBrace {
+                        right_brace_span, ..
+                    }
+                    | ForSyntax::ParenBrace {
+                        right_brace_span, ..
+                    } => {
+                        self.push_span(
+                            command.span,
+                            CloseDelimiterKind::RightBrace,
+                            right_brace_span,
+                        );
+                    }
+                    ForSyntax::InDirect { .. } | ForSyntax::ParenDirect { .. } => {}
+                }
+                if let Some(words) = &command.words {
+                    for word in words {
+                        self.visit_word(word);
+                    }
+                }
+                self.visit_stmt_seq(&command.body);
+            }
+            CompoundCommand::Repeat(command) => {
+                match command.syntax {
+                    RepeatSyntax::DoDone { done_span, .. } => {
+                        self.push_span(command.span, CloseDelimiterKind::Done, done_span);
+                    }
+                    RepeatSyntax::Brace {
+                        right_brace_span, ..
+                    } => {
+                        self.push_span(
+                            command.span,
+                            CloseDelimiterKind::RightBrace,
+                            right_brace_span,
+                        );
+                    }
+                    RepeatSyntax::Direct => {}
+                }
+                self.visit_word(&command.count);
+                self.visit_stmt_seq(&command.body);
+            }
+            CompoundCommand::Foreach(command) => {
+                match command.syntax {
+                    ForeachSyntax::InDoDone { done_span, .. } => {
+                        self.push_span(command.span, CloseDelimiterKind::Done, done_span);
+                    }
+                    ForeachSyntax::ParenBrace {
+                        right_brace_span, ..
+                    } => {
+                        self.push_span(
+                            command.span,
+                            CloseDelimiterKind::RightBrace,
+                            right_brace_span,
+                        );
+                    }
+                }
+                for word in &command.words {
+                    self.visit_word(word);
+                }
+                self.visit_stmt_seq(&command.body);
+            }
+            CompoundCommand::ArithmeticFor(command) => {
+                if let Some(done_span) = command.done_span {
+                    self.push_span(command.span, CloseDelimiterKind::Done, done_span);
+                }
+                if let Some(expr) = &command.init_ast {
+                    self.visit_arithmetic_expr(expr);
+                }
+                if let Some(expr) = &command.condition_ast {
+                    self.visit_arithmetic_expr(expr);
+                }
+                if let Some(expr) = &command.step_ast {
+                    self.visit_arithmetic_expr(expr);
+                }
+                self.visit_stmt_seq(&command.body);
+            }
+            CompoundCommand::While(command) => {
+                if let Some(done_span) = command.done_span {
+                    self.push_span(command.span, CloseDelimiterKind::Done, done_span);
+                }
+                self.visit_stmt_seq(&command.condition);
+                self.visit_stmt_seq(&command.body);
+            }
+            CompoundCommand::Until(command) => {
+                if let Some(done_span) = command.done_span {
+                    self.push_span(command.span, CloseDelimiterKind::Done, done_span);
+                }
+                self.visit_stmt_seq(&command.condition);
+                self.visit_stmt_seq(&command.body);
+            }
+            CompoundCommand::Case(command) => {
+                self.push_span(command.span, CloseDelimiterKind::Esac, command.esac_span);
+                self.visit_word(&command.word);
+                for item in &command.cases {
+                    for pattern in &item.patterns {
+                        self.visit_pattern(pattern);
+                    }
+                    self.visit_stmt_seq(&item.body);
+                }
+            }
+            CompoundCommand::Select(command) => {
+                self.push_span(command.span, CloseDelimiterKind::Done, command.done_span);
+                for word in &command.words {
+                    self.visit_word(word);
+                }
+                self.visit_stmt_seq(&command.body);
+            }
+            CompoundCommand::Subshell(sequence) | CompoundCommand::BraceGroup(sequence) => {
+                self.visit_stmt_seq(sequence);
+            }
+            CompoundCommand::Always(command) => {
+                self.visit_stmt_seq(&command.body);
+                self.visit_stmt_seq(&command.always_body);
+            }
+            CompoundCommand::Time(command) => {
+                if let Some(command) = &command.command {
+                    self.visit_stmt(command);
+                }
+            }
+            CompoundCommand::Conditional(command) => {
+                self.visit_conditional_expr(&command.expression);
+            }
+            CompoundCommand::Coproc(command) => self.visit_stmt(&command.body),
+            CompoundCommand::Arithmetic(command) => {
+                if let Some(expr) = &command.expr_ast {
+                    self.visit_arithmetic_expr(expr);
+                }
+            }
+        }
+    }
+
+    fn visit_assignment(&mut self, assignment: &Assignment) {
+        self.visit_var_ref(&assignment.target);
+        match &assignment.value {
+            AssignmentValue::Scalar(word) => self.visit_word(word),
+            AssignmentValue::Compound(array) => {
+                for element in &array.elements {
+                    match element {
+                        ArrayElem::Sequential(word) => self.visit_word(word),
+                        ArrayElem::Keyed { value, .. } | ArrayElem::KeyedAppend { value, .. } => {
+                            self.visit_word(value);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    fn visit_var_ref(&mut self, reference: &VarRef) {
+        if let Some(subscript) = reference.subscript.as_deref()
+            && let Some(word) = subscript.word_ast()
+        {
+            self.visit_word(word);
+        }
+        if let Some(subscript) = reference.subscript.as_deref()
+            && let Some(expr) = &subscript.arithmetic_ast
+        {
+            self.visit_arithmetic_expr(expr);
+        }
+    }
+
+    fn visit_pattern(&mut self, pattern: &Pattern) {
+        for part in &pattern.parts {
+            match &part.kind {
+                PatternPart::Group { patterns, .. } => {
+                    for pattern in patterns {
+                        self.visit_pattern(pattern);
+                    }
+                }
+                PatternPart::Word(word) => self.visit_word(word),
+                PatternPart::Literal(_)
+                | PatternPart::AnyString
+                | PatternPart::AnyChar
+                | PatternPart::CharClass(_) => {}
+            }
+        }
+    }
+
+    fn visit_conditional_expr(&mut self, expression: &ConditionalExpr) {
+        match expression {
+            ConditionalExpr::Binary(expression) => {
+                self.visit_conditional_expr(&expression.left);
+                self.visit_conditional_expr(&expression.right);
+            }
+            ConditionalExpr::Unary(expression) => self.visit_conditional_expr(&expression.expr),
+            ConditionalExpr::Parenthesized(expression) => {
+                self.visit_conditional_expr(&expression.expr);
+            }
+            ConditionalExpr::Word(word) | ConditionalExpr::Regex(word) => self.visit_word(word),
+            ConditionalExpr::Pattern(pattern) => self.visit_pattern(pattern),
+            ConditionalExpr::VarRef(reference) => self.visit_var_ref(reference),
+        }
+    }
+
+    fn visit_redirect(&mut self, redirect: &Redirect) {
+        match &redirect.target {
+            RedirectTarget::Word(word) => self.visit_word(word),
+            RedirectTarget::Heredoc(heredoc) => {
+                self.visit_word(&heredoc.delimiter.raw);
+                self.visit_heredoc_body(&heredoc.body);
+            }
+        }
+    }
+
+    fn visit_heredoc_body(&mut self, body: &HeredocBody) {
+        for part in &body.parts {
+            match &part.kind {
+                HeredocBodyPart::CommandSubstitution { body, .. } => self.visit_stmt_seq(body),
+                HeredocBodyPart::ArithmeticExpansion {
+                    expression_ast,
+                    expression_word_ast,
+                    ..
+                } => {
+                    if let Some(expr) = expression_ast {
+                        self.visit_arithmetic_expr(expr);
+                    }
+                    self.visit_word(expression_word_ast);
+                }
+                HeredocBodyPart::Parameter(parameter) => self.visit_parameter(parameter),
+                HeredocBodyPart::Literal(_) | HeredocBodyPart::Variable(_) => {}
+            }
+        }
+    }
+
+    fn visit_word(&mut self, word: &Word) {
+        for part in &word.parts {
+            self.visit_word_part(&part.kind);
+        }
+    }
+
+    fn visit_word_part(&mut self, part: &WordPart) {
+        match part {
+            WordPart::DoubleQuoted { parts, .. } => {
+                for nested in parts {
+                    self.visit_word_part(&nested.kind);
+                }
+            }
+            WordPart::CommandSubstitution { body, .. } => self.visit_stmt_seq(body),
+            WordPart::ArithmeticExpansion {
+                expression_ast,
+                expression_word_ast,
+                ..
+            } => {
+                if let Some(expr) = expression_ast.as_deref() {
+                    self.visit_arithmetic_expr(expr);
+                }
+                self.visit_word(expression_word_ast);
+            }
+            WordPart::Parameter(parameter) => self.visit_parameter(parameter),
+            WordPart::ParameterExpansion {
+                reference,
+                operator,
+                operand_word_ast,
+                ..
+            } => {
+                self.visit_var_ref(reference);
+                self.visit_parameter_operator(operator);
+                if let Some(operand) = operand_word_ast.as_deref() {
+                    self.visit_word(operand);
+                }
+            }
+            WordPart::IndirectExpansion {
+                reference,
+                operator,
+                operand_word_ast,
+                ..
+            } => {
+                self.visit_var_ref(reference);
+                if let Some(operator) = operator.as_deref() {
+                    self.visit_parameter_operator(operator);
+                }
+                if let Some(operand) = operand_word_ast.as_deref() {
+                    self.visit_word(operand);
+                }
+            }
+            WordPart::Substring {
+                reference,
+                offset_word_ast,
+                length_word_ast,
+                ..
+            }
+            | WordPart::ArraySlice {
+                reference,
+                offset_word_ast,
+                length_word_ast,
+                ..
+            } => {
+                self.visit_var_ref(reference);
+                self.visit_word(offset_word_ast);
+                if let Some(length) = length_word_ast.as_deref() {
+                    self.visit_word(length);
+                }
+            }
+            WordPart::ProcessSubstitution { body, .. } => self.visit_stmt_seq(body),
+            WordPart::Transformation { reference, .. }
+            | WordPart::Length(reference)
+            | WordPart::ArrayAccess(reference)
+            | WordPart::ArrayLength(reference)
+            | WordPart::ArrayIndices(reference) => self.visit_var_ref(reference),
+            WordPart::Variable(_)
+            | WordPart::Literal(_)
+            | WordPart::ZshQualifiedGlob(_)
+            | WordPart::SingleQuoted { .. }
+            | WordPart::PrefixMatch { .. } => {}
+        }
+    }
+
+    fn visit_parameter(&mut self, parameter: &ParameterExpansion) {
+        match &parameter.syntax {
+            ParameterExpansionSyntax::Bourne(syntax) => self.visit_bourne_parameter(syntax),
+            ParameterExpansionSyntax::Zsh(syntax) => {
+                match &syntax.target {
+                    shuck_ast::ZshExpansionTarget::Reference(reference) => {
+                        self.visit_var_ref(reference);
+                    }
+                    shuck_ast::ZshExpansionTarget::Nested(parameter) => {
+                        self.visit_parameter(parameter);
+                    }
+                    shuck_ast::ZshExpansionTarget::Word(word) => self.visit_word(word),
+                    shuck_ast::ZshExpansionTarget::Empty => {}
+                }
+                for modifier in &syntax.modifiers {
+                    if let Some(word) = modifier.argument_word_ast() {
+                        self.visit_word(word);
+                    }
+                }
+                if let Some(operation) = &syntax.operation {
+                    if let Some(word) = operation.operand_word_ast() {
+                        self.visit_word(word);
+                    }
+                    if let Some(word) = operation.pattern_word_ast() {
+                        self.visit_word(word);
+                    }
+                    if let Some(word) = operation.replacement_word_ast() {
+                        self.visit_word(word);
+                    }
+                    if let Some(word) = operation.offset_word_ast() {
+                        self.visit_word(word);
+                    }
+                    if let Some(word) = operation.length_word_ast() {
+                        self.visit_word(word);
+                    }
+                }
+            }
+        }
+    }
+
+    fn visit_bourne_parameter(&mut self, syntax: &BourneParameterExpansion) {
+        if let Some(word) = syntax.operand_word_ast() {
+            self.visit_word(word);
+        }
+        if let Some(word) = syntax.offset_word_ast() {
+            self.visit_word(word);
+        }
+        if let Some(word) = syntax.length_word_ast() {
+            self.visit_word(word);
+        }
+    }
+
+    fn visit_arithmetic_expr(&mut self, expr: &ArithmeticExprNode) {
+        match &expr.kind {
+            ArithmeticExpr::ShellWord(word) => self.visit_word(word),
+            ArithmeticExpr::Indexed { index, .. } => self.visit_arithmetic_expr(index),
+            ArithmeticExpr::Parenthesized { expression } => self.visit_arithmetic_expr(expression),
+            ArithmeticExpr::Unary { expr, .. } | ArithmeticExpr::Postfix { expr, .. } => {
+                self.visit_arithmetic_expr(expr);
+            }
+            ArithmeticExpr::Binary { left, right, .. } => {
+                self.visit_arithmetic_expr(left);
+                self.visit_arithmetic_expr(right);
+            }
+            ArithmeticExpr::Conditional {
+                condition,
+                then_expr,
+                else_expr,
+            } => {
+                self.visit_arithmetic_expr(condition);
+                self.visit_arithmetic_expr(then_expr);
+                self.visit_arithmetic_expr(else_expr);
+            }
+            ArithmeticExpr::Assignment { target, value, .. } => {
+                self.visit_arithmetic_lvalue(target);
+                self.visit_arithmetic_expr(value);
+            }
+            ArithmeticExpr::Number(_) | ArithmeticExpr::Variable(_) => {}
+        }
+    }
+
+    fn visit_arithmetic_lvalue(&mut self, target: &ArithmeticLvalue) {
+        match target {
+            ArithmeticLvalue::Indexed { index, .. } => self.visit_arithmetic_expr(index),
+            ArithmeticLvalue::Variable(_) => {}
+        }
+    }
+
+    fn visit_parameter_operator(&mut self, operator: &shuck_ast::ParameterOp) {
+        match operator {
+            shuck_ast::ParameterOp::RemovePrefixShort { pattern }
+            | shuck_ast::ParameterOp::RemovePrefixLong { pattern }
+            | shuck_ast::ParameterOp::RemoveSuffixShort { pattern }
+            | shuck_ast::ParameterOp::RemoveSuffixLong { pattern } => self.visit_pattern(pattern),
+            shuck_ast::ParameterOp::ReplaceFirst { pattern, .. }
+            | shuck_ast::ParameterOp::ReplaceAll { pattern, .. } => self.visit_pattern(pattern),
+            shuck_ast::ParameterOp::UseDefault
+            | shuck_ast::ParameterOp::AssignDefault
+            | shuck_ast::ParameterOp::UseReplacement
+            | shuck_ast::ParameterOp::Error
+            | shuck_ast::ParameterOp::UpperFirst
+            | shuck_ast::ParameterOp::UpperAll
+            | shuck_ast::ParameterOp::LowerFirst
+            | shuck_ast::ParameterOp::LowerAll => {}
+        }
+        if let Some(word) = operator.replacement_word_ast() {
+            self.visit_word(word);
+        }
+    }
+
+    fn push_span(&mut self, command_span: Span, kind: CloseDelimiterKind, delimiter_span: Span) {
+        let Some(delimiter_range) = self.delimiter_range_from_span(delimiter_span, kind.text())
+        else {
+            return;
+        };
+        self.push_range(command_span, kind, delimiter_range);
+    }
+
+    fn push_range(
+        &mut self,
+        command_span: Span,
+        kind: CloseDelimiterKind,
+        delimiter_range: TextRange,
+    ) {
+        let command_range = command_span.to_range();
+        if command_range.is_empty() || !self.range_is_valid(command_range) {
+            return;
+        }
+        self.delimiters.push(IndexedCloseDelimiter {
+            command_range,
+            delimiter_range,
+            kind,
+        });
+    }
+
+    fn delimiter_range_from_span(&self, span: Span, text: &str) -> Option<TextRange> {
+        let start = span.start.offset;
+        let start_end = start.checked_add(text.len())?;
+        if self.source.get(start..start_end) == Some(text) {
+            return Some(text_range(start, start_end));
+        }
+
+        let end = span.end.offset;
+        let end_start = end.checked_sub(text.len())?;
+        if self.source.get(end_start..end) == Some(text) {
+            return Some(text_range(end_start, end));
+        }
+
+        None
+    }
+
+    fn range_is_valid(&self, range: TextRange) -> bool {
+        let start = usize::from(range.start());
+        let end = usize::from(range.end());
+        start < end && end <= self.source.len()
+    }
+}
+
+fn text_range(start: usize, end: usize) -> TextRange {
+    TextRange::new(TextSize::new(start as u32), TextSize::new(end as u32))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{Indexer, IndexerOptions};
+    use shuck_parser::parser::Parser;
+
+    fn parse_with_close_index(source: &str) -> (File, CloseDelimiterIndex) {
+        let output = Parser::new(source).parse().unwrap();
+        let indexer = Indexer::new_with_options(
+            source,
+            &output,
+            IndexerOptions::new().with_source_layout_indexes(true),
+        );
+        (output.file, indexer.close_delimiter_index().clone())
+    }
+
+    fn compound_range(stmt: &Stmt) -> TextRange {
+        let Command::Compound(command) = &stmt.command else {
+            panic!("expected compound command");
+        };
+        match command {
+            CompoundCommand::If(command) => command.span.to_range(),
+            CompoundCommand::While(command) => command.span.to_range(),
+            CompoundCommand::Case(command) => command.span.to_range(),
+            other => panic!("unexpected compound command: {other:?}"),
+        }
+    }
+
+    fn keyword_range(source: &str, marker: &str, keyword: &str) -> TextRange {
+        let start = source.find(marker).unwrap();
+        text_range(start, start + keyword.len())
+    }
+
+    #[test]
+    fn indexes_close_keywords_without_following_command_bleed() {
+        let source = "\
+if true; then
+  echo fi
+fi # close
+echo after
+while true; do
+  echo done
+done # loop
+case $x in
+  a) echo esac ;;
+esac # case
+";
+        let (file, index) = parse_with_close_index(source);
+
+        assert_eq!(
+            index.close_for_command(compound_range(&file.body[0]), CloseDelimiterKind::Fi),
+            Some(keyword_range(source, "fi # close", "fi"))
+        );
+        assert_eq!(
+            index.close_for_command(compound_range(&file.body[2]), CloseDelimiterKind::Done),
+            Some(keyword_range(source, "done # loop", "done"))
+        );
+        assert_eq!(
+            index.close_for_command(compound_range(&file.body[3]), CloseDelimiterKind::Esac),
+            Some(keyword_range(source, "esac # case", "esac"))
+        );
+    }
+
+    #[test]
+    fn close_delimiters_are_source_layout_metadata() {
+        let source = "if true; then echo ok; fi\n";
+        let output = Parser::new(source).parse().unwrap();
+        let default_indexer = Indexer::new(source, &output);
+        let layout_indexer = Indexer::new_with_options(
+            source,
+            &output,
+            IndexerOptions::new().with_source_layout_indexes(true),
+        );
+
+        assert!(
+            default_indexer
+                .close_delimiter_index()
+                .delimiters()
+                .is_empty()
+        );
+        assert_eq!(layout_indexer.close_delimiter_index().delimiters().len(), 1);
+    }
+}

--- a/crates/shuck-indexer/src/lib.rs
+++ b/crates/shuck-indexer/src/lib.rs
@@ -18,10 +18,13 @@
 //! available. The lower-level indexes are also exported for integrations that
 //! only need line mapping or that already have an AST-shaped source of comments
 //! or regions.
+mod close_delimiter_index;
 mod comment_index;
 mod line_index;
 mod region_index;
 
+/// Structural close-delimiter lookup types derived from parser output.
+pub use close_delimiter_index::{CloseDelimiterIndex, CloseDelimiterKind, IndexedCloseDelimiter};
 /// Comment lookup types derived from parser output.
 pub use comment_index::{CommentIndex, IndexedComment};
 /// Line-based offset lookup utilities.
@@ -37,7 +40,8 @@ use shuck_parser::parser::ParseResult;
 ///
 /// The default options build the indexes used by linting and semantic analysis.
 /// Source-layout indexes retain formatter-oriented lookup tables such as raw
-/// continuation backslash offsets and heredoc closing-marker ranges.
+/// continuation backslash offsets, heredoc closing-marker ranges, and compound
+/// close delimiters.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub struct IndexerOptions {
     source_layout_indexes: bool,
@@ -52,10 +56,11 @@ impl IndexerOptions {
     /// Enable or disable formatter-oriented source-layout indexes.
     ///
     /// When enabled, [`LineIndex::raw_continuation_line_starts`],
-    /// [`LineIndex::raw_continuation_backslashes`], and
-    /// [`RegionIndex::heredoc_closing_marker_range`] retain their lookup data.
-    /// The default keeps those retained indexes disabled while still computing
-    /// semantic continuation lines for [`Indexer::continuation_line_starts`].
+    /// [`LineIndex::raw_continuation_backslashes`],
+    /// [`RegionIndex::heredoc_closing_marker_range`], and
+    /// [`CloseDelimiterIndex`] retain their lookup data. The default keeps
+    /// those retained indexes disabled while still computing semantic
+    /// continuation lines for [`Indexer::continuation_line_starts`].
     pub fn with_source_layout_indexes(mut self, enabled: bool) -> Self {
         self.source_layout_indexes = enabled;
         self
@@ -82,6 +87,7 @@ pub struct Indexer {
     line_index: LineIndex,
     comment_index: CommentIndex,
     region_index: RegionIndex,
+    close_delimiter_index: CloseDelimiterIndex,
     continuation_lines: Vec<TextSize>,
 }
 
@@ -129,6 +135,11 @@ impl Indexer {
             file,
             options.source_layout_indexes(),
         );
+        let close_delimiter_index = if options.source_layout_indexes() {
+            CloseDelimiterIndex::new(source, file)
+        } else {
+            CloseDelimiterIndex::empty()
+        };
         let continuation_lines =
             collect_continuation_lines(&raw_continuations, &comment_index, &region_index);
 
@@ -136,6 +147,7 @@ impl Indexer {
             line_index,
             comment_index,
             region_index,
+            close_delimiter_index,
             continuation_lines,
         }
     }
@@ -162,6 +174,14 @@ impl Indexer {
     /// interpreting bytes the same way in every syntactic context.
     pub fn region_index(&self) -> &RegionIndex {
         &self.region_index
+    }
+
+    /// Return the formatter-oriented close-delimiter index.
+    ///
+    /// This index is populated only when
+    /// [`IndexerOptions::with_source_layout_indexes`] is enabled.
+    pub fn close_delimiter_index(&self) -> &CloseDelimiterIndex {
+        &self.close_delimiter_index
     }
 
     /// Return byte offsets for the start of each semantic continuation line.

--- a/crates/shuck-parser/src/parser/commands/case.rs
+++ b/crates/shuck-parser/src/parser/commands/case.rs
@@ -55,12 +55,18 @@ impl<'a> Parser<'a> {
         }
 
         // Expect 'esac'
-        self.expect_keyword(Keyword::Esac)?;
+        if !self.is_keyword(Keyword::Esac) {
+            self.pop_depth();
+            return Err(self.error("expected 'esac'"));
+        }
+        let esac_span = self.current_span;
+        self.advance();
 
         self.pop_depth();
         Ok(CompoundCommand::Case(CaseCommand {
             word,
             cases,
+            esac_span,
             span: start_span.merge(self.current_span),
         }))
     }

--- a/crates/shuck-parser/src/parser/commands/compound.rs
+++ b/crates/shuck-parser/src/parser/commands/compound.rs
@@ -159,6 +159,14 @@ impl<'a> Parser<'a> {
         &mut self,
         context: BraceBodyContext,
     ) -> Result<CompoundCommand> {
+        let (compound, _) = self.parse_brace_group_with_close_span(context)?;
+        Ok(compound)
+    }
+
+    pub(super) fn parse_brace_group_with_close_span(
+        &mut self,
+        context: BraceBodyContext,
+    ) -> Result<(CompoundCommand, Span)> {
         self.push_depth()?;
         let (body, left_brace_span, right_brace_span) =
             self.parse_brace_enclosed_stmt_seq("syntax error: empty brace group", context)?;
@@ -168,7 +176,9 @@ impl<'a> Parser<'a> {
             self.record_zsh_always_span(span);
         }
 
-        let compound = if self.dialect.features().zsh_always && self.is_keyword(Keyword::Always) {
+        let (compound, close_span) = if self.dialect.features().zsh_always
+            && self.is_keyword(Keyword::Always)
+        {
             self.record_zsh_always_span(self.current_span);
             self.advance();
             self.skip_newlines()?;
@@ -180,18 +190,20 @@ impl<'a> Parser<'a> {
                 "syntax error: empty always clause",
                 BraceBodyContext::Ordinary,
             )?;
-            CompoundCommand::Always(AlwaysCommand {
-                body,
-                always_body,
-                span: left_brace_span.merge(always_right_brace_span),
-            })
+            (
+                CompoundCommand::Always(AlwaysCommand {
+                    body,
+                    always_body,
+                    span: left_brace_span.merge(always_right_brace_span),
+                }),
+                always_right_brace_span,
+            )
         } else {
-            let _ = right_brace_span;
-            CompoundCommand::BraceGroup(body)
+            (CompoundCommand::BraceGroup(body), right_brace_span)
         };
 
         self.pop_depth();
-        Ok(compound)
+        Ok((compound, close_span))
     }
 
     pub(super) fn parse_brace_enclosed_stmt_seq(

--- a/crates/shuck-parser/src/parser/commands/if_clause.rs
+++ b/crates/shuck-parser/src/parser/commands/if_clause.rs
@@ -185,12 +185,14 @@ impl<'a> Parser<'a> {
         };
 
         if !brace_style {
-            self.expect_keyword(Keyword::Fi)?;
+            if !self.is_keyword(Keyword::Fi) {
+                self.pop_depth();
+                return Err(self.error("expected 'fi'"));
+            }
+            let fi_span = self.current_span;
+            self.advance();
             if let IfSyntax::ThenFi { then_span, .. } = syntax {
-                syntax = IfSyntax::ThenFi {
-                    then_span,
-                    fi_span: self.current_span,
-                };
+                syntax = IfSyntax::ThenFi { then_span, fi_span };
             }
         }
 

--- a/crates/shuck-parser/src/parser/commands/loops.rs
+++ b/crates/shuck-parser/src/parser/commands/loops.rs
@@ -702,7 +702,12 @@ impl<'a> Parser<'a> {
         let body = Self::stmt_seq_with_span(body_span, body);
 
         // Expect 'done'
-        self.expect_keyword(Keyword::Done)?;
+        if !self.is_keyword(Keyword::Done) {
+            self.pop_depth();
+            return Err(self.error("expected 'done'"));
+        }
+        let done_span = self.current_span;
+        self.advance();
 
         self.pop_depth();
         Ok(CompoundCommand::Select(SelectCommand {
@@ -710,6 +715,7 @@ impl<'a> Parser<'a> {
             variable_span,
             words: words.into_vec(),
             body,
+            done_span,
             span: start_span.merge(self.current_span),
         }))
     }
@@ -826,7 +832,7 @@ impl<'a> Parser<'a> {
         }
         self.skip_newlines()?;
 
-        let (body, end_span) = if self.at(TokenKind::LeftBrace) {
+        let (body, done_span) = if self.at(TokenKind::LeftBrace) {
             let body = self.parse_brace_group(BraceBodyContext::Ordinary)?;
             let span = Self::compound_span(&body);
             (
@@ -837,7 +843,7 @@ impl<'a> Parser<'a> {
                         SmallVec::<[Redirect; 1]>::new(),
                     ))],
                 ),
-                self.current_span,
+                None,
             )
         } else {
             // Expect 'do'
@@ -860,7 +866,7 @@ impl<'a> Parser<'a> {
             }
             let done_span = self.current_span;
             self.advance();
-            (Self::stmt_seq_with_span(body_span, body), done_span)
+            (Self::stmt_seq_with_span(body_span, body), Some(done_span))
         };
 
         Ok(CompoundCommand::ArithmeticFor(Box::new(
@@ -875,8 +881,9 @@ impl<'a> Parser<'a> {
                 step_span,
                 step_ast,
                 right_paren_span,
+                done_span,
                 body,
-                span: start_span.merge(end_span),
+                span: start_span.merge(self.current_span),
             },
         )))
     }
@@ -895,7 +902,7 @@ impl<'a> Parser<'a> {
         let condition_span = Span::from_positions(condition_start, self.current_span.start);
         let condition = Self::stmt_seq_with_span(condition_span, condition);
 
-        let (body, end_span) = if allow_brace_body && self.at(TokenKind::LeftBrace) {
+        let (body, done_span) = if allow_brace_body && self.at(TokenKind::LeftBrace) {
             let body = self.parse_brace_group(BraceBodyContext::Ordinary)?;
             let span = Self::compound_span(&body);
             (
@@ -906,7 +913,7 @@ impl<'a> Parser<'a> {
                         SmallVec::<[Redirect; 1]>::new(),
                     ))],
                 ),
-                self.current_span,
+                None,
             )
         } else if let Some((body, left_brace_span, right_brace_span)) = allow_brace_body
             .then(|| self.try_parse_compact_zsh_brace_body(BraceBodyContext::Ordinary))
@@ -923,7 +930,7 @@ impl<'a> Parser<'a> {
                         SmallVec::<[Redirect; 1]>::new(),
                     ))],
                 ),
-                right_brace_span,
+                None,
             )
         } else {
             self.expect_keyword(Keyword::Do)?;
@@ -939,15 +946,21 @@ impl<'a> Parser<'a> {
             }
             let body = Self::stmt_seq_with_span(body_span, body);
 
-            self.expect_keyword(Keyword::Done)?;
-            (body, self.current_span)
+            if !self.is_keyword(Keyword::Done) {
+                self.pop_depth();
+                return Err(self.error("expected 'done'"));
+            }
+            let done_span = self.current_span;
+            self.advance();
+            (body, Some(done_span))
         };
 
         self.pop_depth();
         Ok(CompoundCommand::While(WhileCommand {
             condition,
             body,
-            span: start_span.merge(end_span),
+            done_span,
+            span: start_span.merge(self.current_span),
         }))
     }
 
@@ -965,7 +978,7 @@ impl<'a> Parser<'a> {
         let condition_span = Span::from_positions(condition_start, self.current_span.start);
         let condition = Self::stmt_seq_with_span(condition_span, condition);
 
-        let (body, end_span) = if allow_brace_body && self.at(TokenKind::LeftBrace) {
+        let (body, done_span) = if allow_brace_body && self.at(TokenKind::LeftBrace) {
             let body = self.parse_brace_group(BraceBodyContext::Ordinary)?;
             let span = Self::compound_span(&body);
             (
@@ -976,7 +989,7 @@ impl<'a> Parser<'a> {
                         SmallVec::<[Redirect; 1]>::new(),
                     ))],
                 ),
-                self.current_span,
+                None,
             )
         } else if let Some((body, left_brace_span, right_brace_span)) = allow_brace_body
             .then(|| self.try_parse_compact_zsh_brace_body(BraceBodyContext::Ordinary))
@@ -993,7 +1006,7 @@ impl<'a> Parser<'a> {
                         SmallVec::<[Redirect; 1]>::new(),
                     ))],
                 ),
-                right_brace_span,
+                None,
             )
         } else {
             self.expect_keyword(Keyword::Do)?;
@@ -1009,15 +1022,21 @@ impl<'a> Parser<'a> {
             }
             let body = Self::stmt_seq_with_span(body_span, body);
 
-            self.expect_keyword(Keyword::Done)?;
-            (body, self.current_span)
+            if !self.is_keyword(Keyword::Done) {
+                self.pop_depth();
+                return Err(self.error("expected 'done'"));
+            }
+            let done_span = self.current_span;
+            self.advance();
+            (body, Some(done_span))
         };
 
         self.pop_depth();
         Ok(CompoundCommand::Until(UntilCommand {
             condition,
             body,
-            span: start_span.merge(end_span),
+            done_span,
+            span: start_span.merge(self.current_span),
         }))
     }
 }

--- a/crates/shuck-parser/src/parser/commands/loops.rs
+++ b/crates/shuck-parser/src/parser/commands/loops.rs
@@ -959,7 +959,7 @@ impl<'a> Parser<'a> {
             }
             let done_span = self.current_span;
             self.advance();
-            (body, Some(done_span), done_span)
+            (body, Some(done_span), self.current_span)
         };
 
         self.pop_depth();
@@ -1037,7 +1037,7 @@ impl<'a> Parser<'a> {
             }
             let done_span = self.current_span;
             self.advance();
-            (body, Some(done_span), done_span)
+            (body, Some(done_span), self.current_span)
         };
 
         self.pop_depth();

--- a/crates/shuck-parser/src/parser/commands/loops.rs
+++ b/crates/shuck-parser/src/parser/commands/loops.rs
@@ -832,7 +832,7 @@ impl<'a> Parser<'a> {
         }
         self.skip_newlines()?;
 
-        let (body, done_span) = if self.at(TokenKind::LeftBrace) {
+        let (body, done_span, end_span) = if self.at(TokenKind::LeftBrace) {
             let body = self.parse_brace_group(BraceBodyContext::Ordinary)?;
             let span = Self::compound_span(&body);
             (
@@ -844,6 +844,7 @@ impl<'a> Parser<'a> {
                     ))],
                 ),
                 None,
+                self.current_span,
             )
         } else {
             // Expect 'do'
@@ -866,7 +867,11 @@ impl<'a> Parser<'a> {
             }
             let done_span = self.current_span;
             self.advance();
-            (Self::stmt_seq_with_span(body_span, body), Some(done_span))
+            (
+                Self::stmt_seq_with_span(body_span, body),
+                Some(done_span),
+                done_span,
+            )
         };
 
         Ok(CompoundCommand::ArithmeticFor(Box::new(
@@ -883,7 +888,7 @@ impl<'a> Parser<'a> {
                 right_paren_span,
                 done_span,
                 body,
-                span: start_span.merge(self.current_span),
+                span: start_span.merge(end_span),
             },
         )))
     }

--- a/crates/shuck-parser/src/parser/commands/loops.rs
+++ b/crates/shuck-parser/src/parser/commands/loops.rs
@@ -907,7 +907,7 @@ impl<'a> Parser<'a> {
         let condition_span = Span::from_positions(condition_start, self.current_span.start);
         let condition = Self::stmt_seq_with_span(condition_span, condition);
 
-        let (body, done_span) = if allow_brace_body && self.at(TokenKind::LeftBrace) {
+        let (body, done_span, end_span) = if allow_brace_body && self.at(TokenKind::LeftBrace) {
             let body = self.parse_brace_group(BraceBodyContext::Ordinary)?;
             let span = Self::compound_span(&body);
             (
@@ -919,6 +919,7 @@ impl<'a> Parser<'a> {
                     ))],
                 ),
                 None,
+                span,
             )
         } else if let Some((body, left_brace_span, right_brace_span)) = allow_brace_body
             .then(|| self.try_parse_compact_zsh_brace_body(BraceBodyContext::Ordinary))
@@ -936,6 +937,7 @@ impl<'a> Parser<'a> {
                     ))],
                 ),
                 None,
+                right_brace_span,
             )
         } else {
             self.expect_keyword(Keyword::Do)?;
@@ -957,7 +959,7 @@ impl<'a> Parser<'a> {
             }
             let done_span = self.current_span;
             self.advance();
-            (body, Some(done_span))
+            (body, Some(done_span), done_span)
         };
 
         self.pop_depth();
@@ -965,7 +967,7 @@ impl<'a> Parser<'a> {
             condition,
             body,
             done_span,
-            span: start_span.merge(self.current_span),
+            span: start_span.merge(end_span),
         }))
     }
 
@@ -983,7 +985,7 @@ impl<'a> Parser<'a> {
         let condition_span = Span::from_positions(condition_start, self.current_span.start);
         let condition = Self::stmt_seq_with_span(condition_span, condition);
 
-        let (body, done_span) = if allow_brace_body && self.at(TokenKind::LeftBrace) {
+        let (body, done_span, end_span) = if allow_brace_body && self.at(TokenKind::LeftBrace) {
             let body = self.parse_brace_group(BraceBodyContext::Ordinary)?;
             let span = Self::compound_span(&body);
             (
@@ -995,6 +997,7 @@ impl<'a> Parser<'a> {
                     ))],
                 ),
                 None,
+                span,
             )
         } else if let Some((body, left_brace_span, right_brace_span)) = allow_brace_body
             .then(|| self.try_parse_compact_zsh_brace_body(BraceBodyContext::Ordinary))
@@ -1012,6 +1015,7 @@ impl<'a> Parser<'a> {
                     ))],
                 ),
                 None,
+                right_brace_span,
             )
         } else {
             self.expect_keyword(Keyword::Do)?;
@@ -1033,7 +1037,7 @@ impl<'a> Parser<'a> {
             }
             let done_span = self.current_span;
             self.advance();
-            (body, Some(done_span))
+            (body, Some(done_span), done_span)
         };
 
         self.pop_depth();
@@ -1041,7 +1045,7 @@ impl<'a> Parser<'a> {
             condition,
             body,
             done_span,
-            span: start_span.merge(self.current_span),
+            span: start_span.merge(end_span),
         }))
     }
 }

--- a/crates/shuck-parser/src/parser/commands/loops.rs
+++ b/crates/shuck-parser/src/parser/commands/loops.rs
@@ -908,7 +908,8 @@ impl<'a> Parser<'a> {
         let condition = Self::stmt_seq_with_span(condition_span, condition);
 
         let (body, done_span, end_span) = if allow_brace_body && self.at(TokenKind::LeftBrace) {
-            let body = self.parse_brace_group(BraceBodyContext::Ordinary)?;
+            let (body, close_span) =
+                self.parse_brace_group_with_close_span(BraceBodyContext::Ordinary)?;
             let span = Self::compound_span(&body);
             (
                 Self::stmt_seq_with_span(
@@ -919,7 +920,7 @@ impl<'a> Parser<'a> {
                     ))],
                 ),
                 None,
-                span,
+                close_span,
             )
         } else if let Some((body, left_brace_span, right_brace_span)) = allow_brace_body
             .then(|| self.try_parse_compact_zsh_brace_body(BraceBodyContext::Ordinary))
@@ -986,7 +987,8 @@ impl<'a> Parser<'a> {
         let condition = Self::stmt_seq_with_span(condition_span, condition);
 
         let (body, done_span, end_span) = if allow_brace_body && self.at(TokenKind::LeftBrace) {
-            let body = self.parse_brace_group(BraceBodyContext::Ordinary)?;
+            let (body, close_span) =
+                self.parse_brace_group_with_close_span(BraceBodyContext::Ordinary)?;
             let span = Self::compound_span(&body);
             (
                 Self::stmt_seq_with_span(
@@ -997,7 +999,7 @@ impl<'a> Parser<'a> {
                     ))],
                 ),
                 None,
-                span,
+                close_span,
             )
         } else if let Some((body, left_brace_span, right_brace_span)) = allow_brace_body
             .then(|| self.try_parse_compact_zsh_brace_body(BraceBodyContext::Ordinary))

--- a/crates/shuck-parser/src/parser/source_tree.rs
+++ b/crates/shuck-parser/src/parser/source_tree.rs
@@ -444,20 +444,24 @@ impl<'a> Parser<'a> {
                     Self::rebase_arithmetic_expr(expr, base);
                 }
                 command.right_paren_span = command.right_paren_span.rebased(base);
+                command.done_span = command.done_span.map(|span| span.rebased(base));
                 Self::rebase_stmt_seq(&mut command.body, base);
             }
             CompoundCommand::While(command) => {
                 command.span = command.span.rebased(base);
+                command.done_span = command.done_span.map(|span| span.rebased(base));
                 Self::rebase_stmt_seq(&mut command.condition, base);
                 Self::rebase_stmt_seq(&mut command.body, base);
             }
             CompoundCommand::Until(command) => {
                 command.span = command.span.rebased(base);
+                command.done_span = command.done_span.map(|span| span.rebased(base));
                 Self::rebase_stmt_seq(&mut command.condition, base);
                 Self::rebase_stmt_seq(&mut command.body, base);
             }
             CompoundCommand::Case(command) => {
                 command.span = command.span.rebased(base);
+                command.esac_span = command.esac_span.rebased(base);
                 Self::rebase_word(&mut command.word, base);
                 for case in &mut command.cases {
                     Self::rebase_patterns(&mut case.patterns, base);
@@ -467,6 +471,7 @@ impl<'a> Parser<'a> {
             CompoundCommand::Select(command) => {
                 command.span = command.span.rebased(base);
                 command.variable_span = command.variable_span.rebased(base);
+                command.done_span = command.done_span.rebased(base);
                 Self::rebase_words(&mut command.words, base);
                 Self::rebase_stmt_seq(&mut command.body, base);
             }

--- a/crates/shuck-parser/src/parser/tests/commands/loops.rs
+++ b/crates/shuck-parser/src/parser/tests/commands/loops.rs
@@ -517,6 +517,10 @@ fn test_parse_zsh_while_loop_with_brace_body() {
     };
 
     assert!(redirects.is_empty());
+    assert_eq!(
+        command.span.slice(input),
+        "while (( -- count + 1 )) {\n  echo hi\n}"
+    );
     assert_eq!(command.body.len(), 1);
     let (body_compound, body_redirects) = expect_compound(&command.body[0]);
     let AstCompoundCommand::BraceGroup(body) = body_compound else {
@@ -524,6 +528,28 @@ fn test_parse_zsh_while_loop_with_brace_body() {
     };
     assert!(body_redirects.is_empty());
     assert_eq!(body.len(), 1);
+}
+
+#[test]
+fn test_parse_zsh_until_brace_body_span_stops_at_closing_brace() {
+    let input = "until (( ready )) {\n  echo hi\n}\necho next\n";
+    let script = Parser::with_dialect(input, ShellDialect::Zsh)
+        .parse()
+        .unwrap()
+        .file;
+
+    assert_eq!(script.body.len(), 2);
+    let (compound, redirects) = expect_compound(&script.body[0]);
+    let AstCompoundCommand::Until(command) = compound else {
+        panic!("expected until loop");
+    };
+
+    assert!(redirects.is_empty());
+    assert_eq!(
+        command.span.slice(input),
+        "until (( ready )) {\n  echo hi\n}"
+    );
+    assert_eq!(expect_simple(&script.body[1]).name.render(input), "echo");
 }
 
 #[test]

--- a/crates/shuck-parser/src/parser/tests/commands/loops.rs
+++ b/crates/shuck-parser/src/parser/tests/commands/loops.rs
@@ -527,6 +527,44 @@ fn test_parse_zsh_while_loop_with_brace_body() {
 }
 
 #[test]
+fn test_parse_zsh_while_compact_brace_body_span_stops_before_next_command() {
+    let input = "while (( count )){echo;}; echo next\n";
+    let script = Parser::with_dialect(input, ShellDialect::Zsh)
+        .parse()
+        .unwrap()
+        .file;
+
+    assert_eq!(script.body.len(), 2);
+    let (compound, redirects) = expect_compound(&script.body[0]);
+    let AstCompoundCommand::While(command) = compound else {
+        panic!("expected while loop");
+    };
+
+    assert!(redirects.is_empty());
+    assert_eq!(command.span.slice(input), "while (( count )){echo;}");
+    assert_eq!(expect_simple(&script.body[1]).name.render(input), "echo");
+}
+
+#[test]
+fn test_parse_zsh_until_compact_brace_body_span_stops_before_next_command() {
+    let input = "until (( ready )){echo;}; echo next\n";
+    let script = Parser::with_dialect(input, ShellDialect::Zsh)
+        .parse()
+        .unwrap()
+        .file;
+
+    assert_eq!(script.body.len(), 2);
+    let (compound, redirects) = expect_compound(&script.body[0]);
+    let AstCompoundCommand::Until(command) = compound else {
+        panic!("expected until loop");
+    };
+
+    assert!(redirects.is_empty());
+    assert_eq!(command.span.slice(input), "until (( ready )){echo;}");
+    assert_eq!(expect_simple(&script.body[1]).name.render(input), "echo");
+}
+
+#[test]
 fn test_parse_zsh_while_loop_with_brace_body_after_setopt_noshortloops() {
     let input = "f() {\n  setopt noshortloops\n  while (( count )) {\n    break\n  }\n}\n";
     Parser::with_dialect(input, ShellDialect::Zsh)


### PR DESCRIPTION
## Summary

- add a source-layout close delimiter index in `shuck-indexer`
- preserve parser-owned close spans for `fi`, `done`, and `esac` without narrowing existing command spans
- route formatter close-suffix and body-site decisions through `SourceMap` instead of raw close-keyword searches

## Validation

- `cargo test -p shuck-parser -p shuck-indexer -p shuck-formatter`
- `make test-oracle-shfmt-large-corpus` (`blocking_mismatches=0`, `shuck_errors=0`)