### PR TITLE
refactor(formatter): finish compound body site bounds

### DIFF
--- a/crates/shuck-formatter/src/command/body_site.rs
+++ b/crates/shuck-formatter/src/command/body_site.rs
@@ -7,12 +7,45 @@ pub(crate) enum CompoundBodyOpen {
     Direct,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct CompoundBodyBounds {
+    facts_end: usize,
+    render_end: usize,
+}
+
+impl CompoundBodyBounds {
+    fn shared(end: usize) -> Self {
+        Self {
+            facts_end: end,
+            render_end: end,
+        }
+    }
+
+    fn split(facts_end: usize, render_end: usize) -> Self {
+        Self {
+            facts_end,
+            render_end,
+        }
+    }
+
+    pub(crate) fn facts_limit(self) -> Option<usize> {
+        Some(self.facts_end)
+    }
+
+    pub(crate) fn render_limit(self) -> Option<usize> {
+        Some(self.render_end)
+    }
+
+    pub(crate) fn render_end(self) -> usize {
+        self.render_end
+    }
+}
+
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct CompoundBodySite<'a> {
     body: &'a StmtSeq,
     enclosing_span: Span,
-    facts_upper_bound: usize,
-    renderer_upper_bound: usize,
+    bounds: CompoundBodyBounds,
     open: CompoundBodyOpen,
     close_span: Option<Span>,
 }
@@ -34,7 +67,7 @@ impl<'a> CompoundBodySite<'a> {
             }
             | ForSyntax::ParenBrace {
                 right_brace_span, ..
-            } => Self::brace(&command.body, command.span, right_brace_span),
+            } => Self::brace(&command.body, command.span, right_brace_span, source_map),
         }
     }
 
@@ -48,7 +81,7 @@ impl<'a> CompoundBodySite<'a> {
             }
             ForeachSyntax::ParenBrace {
                 right_brace_span, ..
-            } => Self::brace(&command.body, command.span, right_brace_span),
+            } => Self::brace(&command.body, command.span, right_brace_span, source_map),
         }
     }
 
@@ -63,7 +96,7 @@ impl<'a> CompoundBodySite<'a> {
             RepeatSyntax::Direct => Self::direct(&command.body, command.span),
             RepeatSyntax::Brace {
                 right_brace_span, ..
-            } => Self::brace(&command.body, command.span, right_brace_span),
+            } => Self::brace(&command.body, command.span, right_brace_span, source_map),
         }
     }
 
@@ -100,6 +133,24 @@ impl<'a> CompoundBodySite<'a> {
         Self::do_done(&command.body, command.span, command.done_span, source_map)
     }
 
+    pub(crate) fn single_body_command(
+        command: &'a CompoundCommand,
+        source_map: &crate::comments::SourceMap<'_>,
+    ) -> Option<Self> {
+        match command {
+            CompoundCommand::For(command) => Some(Self::for_command(command, source_map)),
+            CompoundCommand::Repeat(command) => Some(Self::repeat_command(command, source_map)),
+            CompoundCommand::Foreach(command) => Some(Self::foreach_command(command, source_map)),
+            CompoundCommand::ArithmeticFor(command) => {
+                Some(Self::arithmetic_for_command(command, source_map))
+            }
+            CompoundCommand::While(command) => Some(Self::while_command(command, source_map)),
+            CompoundCommand::Until(command) => Some(Self::until_command(command, source_map)),
+            CompoundCommand::Select(command) => Some(Self::select_command(command, source_map)),
+            _ => None,
+        }
+    }
+
     pub(crate) fn if_then_branch(
         command: &IfCommand,
         body: &'a StmtSeq,
@@ -132,8 +183,7 @@ impl<'a> CompoundBodySite<'a> {
         Some(Self {
             body: commands,
             enclosing_span: stmt_span(body),
-            facts_upper_bound: function_end_offset,
-            renderer_upper_bound: function_end_offset,
+            bounds: CompoundBodyBounds::shared(function_end_offset),
             open: CompoundBodyOpen::Group(open),
             close_span: None,
         })
@@ -147,12 +197,8 @@ impl<'a> CompoundBodySite<'a> {
         self.enclosing_span
     }
 
-    pub(crate) fn facts_upper_bound(self) -> usize {
-        self.facts_upper_bound
-    }
-
-    pub(crate) fn renderer_upper_bound(self) -> usize {
-        self.renderer_upper_bound
+    pub(crate) fn bounds(self) -> CompoundBodyBounds {
+        self.bounds
     }
 
     pub(crate) fn open(self) -> CompoundBodyOpen {
@@ -223,8 +269,7 @@ impl<'a> CompoundBodySite<'a> {
         Self {
             body,
             enclosing_span,
-            facts_upper_bound: upper_bound,
-            renderer_upper_bound: upper_bound,
+            bounds: CompoundBodyBounds::shared(upper_bound),
             open: CompoundBodyOpen::Keyword("do"),
             close_span,
         }
@@ -234,23 +279,37 @@ impl<'a> CompoundBodySite<'a> {
         Self {
             body,
             enclosing_span,
-            facts_upper_bound: enclosing_span.end.offset,
-            renderer_upper_bound: enclosing_span.end.offset,
+            bounds: CompoundBodyBounds::shared(enclosing_span.end.offset),
             open: CompoundBodyOpen::Direct,
             close_span: None,
         }
     }
 
-    fn brace(body: &'a StmtSeq, enclosing_span: Span, right_brace_span: Span) -> Self {
-        // Preserve the legacy split: facts are keyed at the closing brace, while
-        // renderer call sites ask for the enclosing command's full span.
+    fn brace(
+        body: &'a StmtSeq,
+        enclosing_span: Span,
+        right_brace_span: Span,
+        source_map: &crate::comments::SourceMap<'_>,
+    ) -> Self {
+        let close_span = source_map
+            .close_delimiter_span(enclosing_span, CloseDelimiterKind::RightBrace)
+            .unwrap_or_else(|| {
+                normalized_close_keyword_span(
+                    source_map.source(),
+                    source_map,
+                    right_brace_span,
+                    "}",
+                )
+            });
         Self {
             body,
             enclosing_span,
-            facts_upper_bound: right_brace_span.start.offset,
-            renderer_upper_bound: enclosing_span.end.offset,
+            bounds: CompoundBodyBounds::split(
+                right_brace_span.start.offset,
+                enclosing_span.end.offset,
+            ),
             open: CompoundBodyOpen::Group('{'),
-            close_span: None,
+            close_span: Some(close_span),
         }
     }
 
@@ -263,8 +322,7 @@ impl<'a> CompoundBodySite<'a> {
         Self {
             body,
             enclosing_span,
-            facts_upper_bound: upper_bound,
-            renderer_upper_bound: upper_bound,
+            bounds: CompoundBodyBounds::shared(upper_bound),
             open,
             close_span: None,
         }

--- a/crates/shuck-formatter/src/command/render_policy.rs
+++ b/crates/shuck-formatter/src/command/render_policy.rs
@@ -181,47 +181,6 @@ fn stmt_compound_close_span(
     };
     match command {
         CompoundCommand::If(command) => Some(if_close_span(command, source, source_map)),
-        CompoundCommand::For(command) => match command.syntax {
-            ForSyntax::InDoDone { done_span, .. } | ForSyntax::ParenDoDone { done_span, .. } => {
-                done_close_span(source, source_map, command.span, Some(done_span))
-            }
-            ForSyntax::InBrace {
-                right_brace_span, ..
-            }
-            | ForSyntax::ParenBrace {
-                right_brace_span, ..
-            } => normalized_brace_close_span(source, source_map, command.span, right_brace_span),
-            ForSyntax::InDirect { .. } | ForSyntax::ParenDirect { .. } => None,
-        },
-        CompoundCommand::Repeat(command) => match command.syntax {
-            RepeatSyntax::DoDone { done_span, .. } => {
-                done_close_span(source, source_map, command.span, Some(done_span))
-            }
-            RepeatSyntax::Brace {
-                right_brace_span, ..
-            } => normalized_brace_close_span(source, source_map, command.span, right_brace_span),
-            RepeatSyntax::Direct => None,
-        },
-        CompoundCommand::Foreach(command) => match command.syntax {
-            ForeachSyntax::InDoDone { done_span, .. } => {
-                done_close_span(source, source_map, command.span, Some(done_span))
-            }
-            ForeachSyntax::ParenBrace {
-                right_brace_span, ..
-            } => normalized_brace_close_span(source, source_map, command.span, right_brace_span),
-        },
-        CompoundCommand::ArithmeticFor(command) => {
-            done_close_span(source, source_map, command.span, command.done_span)
-        }
-        CompoundCommand::While(command) => {
-            done_close_span(source, source_map, command.span, command.done_span)
-        }
-        CompoundCommand::Until(command) => {
-            done_close_span(source, source_map, command.span, command.done_span)
-        }
-        CompoundCommand::Select(command) => {
-            done_close_span(source, source_map, command.span, Some(command.done_span))
-        }
         CompoundCommand::Case(command) => source_map
             .close_delimiter_span(command.span, CloseDelimiterKind::Esac)
             .or_else(|| {
@@ -232,19 +191,9 @@ fn stmt_compound_close_span(
                     "esac",
                 ))
             }),
-        _ => None,
+        _ => CompoundBodySite::single_body_command(command, source_map)
+            .and_then(|site| site.close_span()),
     }
-}
-
-fn normalized_brace_close_span(
-    source: &str,
-    source_map: &crate::comments::SourceMap<'_>,
-    command_span: Span,
-    span: Span,
-) -> Option<Span> {
-    source_map
-        .close_delimiter_span(command_span, CloseDelimiterKind::RightBrace)
-        .or_else(|| Some(normalized_close_keyword_span(source, source_map, span, "}")))
 }
 
 pub(crate) fn if_close_span(

--- a/crates/shuck-formatter/src/facts.rs
+++ b/crates/shuck-formatter/src/facts.rs
@@ -2147,7 +2147,7 @@ impl<'source, 'options> FormatterFactsBuilder<'source, 'options> {
         }
         let summary = self.visit_sequence_with_suffix(
             site.body(),
-            Some(site.facts_upper_bound()),
+            site.bounds().facts_limit(),
             site.group_open_char(),
             site.open_suffix_span(self.source_map()),
             site.open_end_offset(self.source),

--- a/crates/shuck-formatter/src/streaming/compounds.rs
+++ b/crates/shuck-formatter/src/streaming/compounds.rs
@@ -468,7 +468,7 @@ where
     pub(super) fn write_compound_body_open_suffix(&mut self, site: CompoundBodySite<'_>) {
         let Some(span) = self
             .facts()
-            .sequence(site.body(), Some(site.renderer_upper_bound()))
+            .sequence(site.body(), site.bounds().render_limit())
             .group_open_suffix_span()
         else {
             return;
@@ -507,7 +507,7 @@ where
         write_open_suffix: bool,
     ) -> Result<()> {
         let body = site.body();
-        let upper_bound = site.renderer_upper_bound();
+        let upper_bound = site.bounds().render_end();
         let preserve_open_blank = self
             .facts()
             .sequence(body, Some(upper_bound))
@@ -533,7 +533,7 @@ where
             if_branch_upper_bound(command, 0, source, self.source_map(), self.facts());
         let then_site =
             CompoundBodySite::if_then_branch(command, &command.then_branch, then_upper_bound);
-        self.format_brace_group(then_site.body(), Some(then_site.renderer_upper_bound()))?;
+        self.format_brace_group(then_site.body(), then_site.bounds().render_limit())?;
         for (index, (condition, body)) in command.elif_branches.iter().enumerate() {
             self.write_text(" elif ");
             self.format_inline_stmts(condition)?;
@@ -541,12 +541,12 @@ where
             let upper_bound =
                 if_branch_upper_bound(command, index + 1, source, self.source_map(), self.facts());
             let site = CompoundBodySite::if_then_branch(command, body, upper_bound);
-            self.format_brace_group(site.body(), Some(site.renderer_upper_bound()))?;
+            self.format_brace_group(site.body(), site.bounds().render_limit())?;
         }
         if let Some(body) = &command.else_branch {
             self.write_text(" else ");
             let site = CompoundBodySite::if_else_branch(command, body, command.span.end.offset);
-            self.format_brace_group(site.body(), Some(site.renderer_upper_bound()))?;
+            self.format_brace_group(site.body(), site.bounds().render_limit())?;
         }
         Ok(())
     }
@@ -574,21 +574,7 @@ where
         }
 
         let site = CompoundBodySite::for_command(command, self.source_map());
-        match site.open() {
-            CompoundBodyOpen::Keyword("do") => {
-                self.format_do_done_body(site, "done")?;
-            }
-            CompoundBodyOpen::Direct => {
-                self.write_space();
-                self.format_inline_stmts(site.body())?;
-            }
-            CompoundBodyOpen::Group('{') => {
-                self.write_text("; ");
-                self.format_brace_group(site.body(), Some(site.renderer_upper_bound()))?;
-            }
-            _ => unreachable!("for body uses do, direct, or brace syntax"),
-        }
-        Ok(())
+        self.format_loop_body_site(site, "; ", "for body uses do, direct, or brace syntax")
     }
 
     pub(super) fn write_for_in_words(&mut self, words: Option<&[Word]>, in_span: Option<Span>) {
@@ -622,6 +608,15 @@ where
         self.write_text("repeat ");
         self.write_word(&command.count);
         let site = CompoundBodySite::repeat_command(command, self.source_map());
+        self.format_loop_body_site(site, " ", "repeat body uses do, direct, or brace syntax")
+    }
+
+    pub(super) fn format_loop_body_site(
+        &mut self,
+        site: CompoundBodySite<'_>,
+        brace_prefix: &'static str,
+        invalid_body_kind: &'static str,
+    ) -> Result<()> {
         match site.open() {
             CompoundBodyOpen::Keyword("do") => {
                 self.format_do_done_body(site, "done")?;
@@ -631,10 +626,10 @@ where
                 self.format_inline_stmts(site.body())?;
             }
             CompoundBodyOpen::Group('{') => {
-                self.write_space();
-                self.format_brace_group(site.body(), Some(site.renderer_upper_bound()))?;
+                self.write_text(brace_prefix);
+                self.format_brace_group(site.body(), site.bounds().render_limit())?;
             }
-            _ => unreachable!("repeat body uses do, direct, or brace syntax"),
+            _ => unreachable!("{}", invalid_body_kind),
         }
         Ok(())
     }
@@ -647,7 +642,7 @@ where
             ForeachSyntax::ParenBrace { .. } => {
                 self.write_parenthesized_word_list(Some(&command.words));
                 self.write_space();
-                self.format_brace_group(site.body(), Some(site.renderer_upper_bound()))?;
+                self.format_brace_group(site.body(), site.bounds().render_limit())?;
             }
             ForeachSyntax::InDoDone { .. } => {
                 self.write_for_in_words(Some(&command.words), None);
@@ -1368,7 +1363,7 @@ where
                 if let Some((_, comment)) = header_comment {
                     return self.format_function_brace_group_with_header_comment(
                         site.body(),
-                        site.renderer_upper_bound(),
+                        site.bounds().render_end(),
                         &comment,
                     );
                 }
@@ -1382,7 +1377,7 @@ where
                     self.write_text("; }");
                     Ok(())
                 } else {
-                    self.format_brace_group(site.body(), Some(site.renderer_upper_bound()))
+                    self.format_brace_group(site.body(), site.bounds().render_limit())
                 }
             }
             Some(site) if site.group_open_char() == Some('(') => {
@@ -1395,7 +1390,7 @@ where
                     self.write_text(")");
                     Ok(())
                 } else {
-                    self.format_subshell(site.body(), Some(site.renderer_upper_bound()))
+                    self.format_subshell(site.body(), site.bounds().render_limit())
                 }
             }
             Some(_) => unreachable!("function body group uses brace or subshell syntax"),

--- a/crates/shuck-formatter/src/streaming/statements.rs
+++ b/crates/shuck-formatter/src/streaming/statements.rs
@@ -579,7 +579,7 @@ where
         close: &'static str,
     ) -> Result<()> {
         let body = site.body();
-        let body_upper_bound = site.renderer_upper_bound();
+        let body_upper_bound = site.bounds().render_end();
         let close_span = site.close_span();
         let enclosing_span = site.enclosing_span();
         let has_open_suffix = self
@@ -632,7 +632,7 @@ where
         open: &'static str,
     ) -> Result<()> {
         let body = site.body();
-        let body_upper_bound = site.renderer_upper_bound();
+        let body_upper_bound = site.bounds().render_end();
         let close_span = site.close_span();
 
         self.write_text(open);


### PR DESCRIPTION
## Summary
- add a named `CompoundBodyBounds` plan to `CompoundBodySite` so facts and renderer bounds are explicit
- centralize single-body compound close-span lookup through `CompoundBodySite`
- collapse repeated `for` and `repeat` body rendering into a shared formatter helper

## Test plan
- `cargo test -p shuck-formatter`