### PR TITLE
perf(formatter): reuse facts in render paths

### DIFF
--- a/crates/shuck-formatter/src/command.rs
+++ b/crates/shuck-formatter/src/command.rs
@@ -46,16 +46,16 @@ pub(crate) use self::compound_assignments::{
     multiline_compound_assignment_layout, multiline_compound_assignment_lines,
 };
 pub(crate) use self::groups::{
-    group_attachment_span, group_attachment_span_with_heredoc, group_open_suffix,
-    group_was_inline_in_source, matching_group_close,
-    stmt_group_attachment_or_verbatim_span_with_heredoc, stmt_start_after_operator,
+    group_attachment_span_with_heredoc, group_open_suffix, group_was_inline_in_source,
+    matching_group_close, stmt_group_attachment_or_verbatim_span_with_heredoc,
+    stmt_start_after_operator,
 };
 pub(crate) use self::render_policy::{
     case_item_body_upper_bound, case_item_was_inline_in_source, compound_close_span,
     done_close_span, if_close_span, line_gap_break_count, normalized_close_keyword_span,
-    rendered_stmt_end_line_with_heredoc, should_render_verbatim_with_heredoc, stmt_attachment_span,
+    rendered_stmt_end_line_with_heredoc, should_render_verbatim_with_heredoc,
     stmt_attachment_span_with_heredoc_and_compound_close, stmt_has_trailing_comment,
-    stmt_render_start_line,
+    stmt_render_start_line_with_heredoc,
 };
 pub(crate) use self::spans::{
     anonymous_function_attachment_span, anonymous_function_header_span, builtin_like_parts,

--- a/crates/shuck-formatter/src/command/render_policy.rs
+++ b/crates/shuck-formatter/src/command/render_policy.rs
@@ -100,21 +100,6 @@ pub(crate) fn should_render_verbatim_with_heredoc(
             && stmt_has_trailing_comment(stmt, source_map))
 }
 
-pub(crate) fn stmt_attachment_span(
-    stmt: &Stmt,
-    source: &str,
-    source_map: &crate::comments::SourceMap<'_>,
-    options: &crate::options::ResolvedShellFormatOptions,
-) -> Span {
-    stmt_attachment_span_with_heredoc(
-        stmt,
-        source,
-        source_map,
-        options,
-        classify_stmt_contains_heredoc,
-    )
-}
-
 pub(crate) fn stmt_attachment_span_with_heredoc<F>(
     stmt: &Stmt,
     source: &str,
@@ -171,7 +156,13 @@ where
     } else {
         complete_stmt_span(
             stmt,
-            command_attachment_span(&stmt.command, source, source_map, options),
+            command_attachment_span_with_heredoc(
+                &stmt.command,
+                source,
+                source_map,
+                options,
+                stmt_contains_heredoc,
+            ),
         )
     };
     extend_compound_close_suffix_attachment_span(span, compound_close_span, source_map)
@@ -301,56 +292,91 @@ fn span_starts_with_keyword(source: &str, span: Span, keyword: &str) -> bool {
     source.get(start..end) == Some(keyword)
 }
 
-fn command_attachment_span(
+fn command_attachment_span_with_heredoc<F>(
     command: &Command,
     source: &str,
     source_map: &crate::comments::SourceMap<'_>,
     options: &crate::options::ResolvedShellFormatOptions,
-) -> Span {
+    stmt_contains_heredoc: F,
+) -> Span
+where
+    F: Fn(&Stmt) -> bool + Copy,
+{
     match command {
-        Command::Binary(command) => {
-            stmt_attachment_span(&command.left, source, source_map, options).merge(
-                stmt_attachment_span(&command.right, source, source_map, options),
-            )
-        }
+        Command::Binary(command) => stmt_attachment_span_with_heredoc(
+            &command.left,
+            source,
+            source_map,
+            options,
+            stmt_contains_heredoc,
+        )
+        .merge(stmt_attachment_span_with_heredoc(
+            &command.right,
+            source,
+            source_map,
+            options,
+            stmt_contains_heredoc,
+        )),
         _ => command_format_span(command),
     }
 }
 
-pub(crate) fn stmt_render_start_line(
+pub(crate) fn stmt_render_start_line_with_heredoc<F>(
     stmt: &Stmt,
     source: &str,
     source_map: &crate::comments::SourceMap<'_>,
     options: &crate::options::ResolvedShellFormatOptions,
-) -> usize {
+    stmt_contains_heredoc: F,
+) -> usize
+where
+    F: Fn(&Stmt) -> bool + Copy,
+{
     if let Some((commands, open)) = command_group_commands(&stmt.command) {
-        group_render_start_line(stmt, commands.as_slice(), source, source_map, open, options)
+        group_render_start_line_with_heredoc(
+            stmt,
+            commands.as_slice(),
+            source,
+            source_map,
+            open,
+            options,
+            stmt_contains_heredoc,
+        )
     } else {
-        stmt_attachment_span(stmt, source, source_map, options)
+        stmt_attachment_span_with_heredoc(stmt, source, source_map, options, stmt_contains_heredoc)
             .start
             .line
     }
 }
 
-fn group_render_start_line(
+fn group_render_start_line_with_heredoc<F>(
     stmt: &Stmt,
     commands: &[Stmt],
     source: &str,
     source_map: &crate::comments::SourceMap<'_>,
     open: char,
     options: &crate::options::ResolvedShellFormatOptions,
-) -> usize {
-    group_attachment_span(commands, source_map, open, matching_group_close(open))
-        .map(|span| span.start.line)
-        .or_else(|| {
-            find_empty_group_open_offset(source, stmt_span(stmt).start.offset, open)
-                .map(|offset| source_map.line_number_for_offset(offset))
-        })
-        .unwrap_or_else(|| {
-            stmt_attachment_span(stmt, source, source_map, options)
-                .start
-                .line
-        })
+    stmt_contains_heredoc: F,
+) -> usize
+where
+    F: Fn(&Stmt) -> bool + Copy,
+{
+    group_attachment_span_with_heredoc(
+        commands,
+        source_map,
+        open,
+        matching_group_close(open),
+        stmt_contains_heredoc,
+    )
+    .map(|span| span.start.line)
+    .or_else(|| {
+        find_empty_group_open_offset(source, stmt_span(stmt).start.offset, open)
+            .map(|offset| source_map.line_number_for_offset(offset))
+    })
+    .unwrap_or_else(|| {
+        stmt_attachment_span_with_heredoc(stmt, source, source_map, options, stmt_contains_heredoc)
+            .start
+            .line
+    })
 }
 
 fn stmt_has_alignment_sensitive_padding(

--- a/crates/shuck-formatter/src/facts.rs
+++ b/crates/shuck-formatter/src/facts.rs
@@ -35,8 +35,9 @@ use crate::command::{
     if_next_branch_region_with_body_end, matching_group_close, rendered_stmt_end_line_with_heredoc,
     should_render_verbatim_with_heredoc, stmt_attachment_span_with_heredoc_and_compound_close,
     stmt_format_span, stmt_group_attachment_or_verbatim_span_with_heredoc,
-    stmt_has_trailing_comment, stmt_render_start_line, stmt_span, stmt_start_after_operator,
-    stmt_verbatim_span_with_source_map, trim_unescaped_trailing_whitespace,
+    stmt_has_trailing_comment, stmt_render_start_line_with_heredoc, stmt_span,
+    stmt_start_after_operator, stmt_verbatim_span_with_source_map,
+    trim_unescaped_trailing_whitespace,
 };
 use crate::comments::{BranchPrefixComment, CommentAttachmentModel, SourceComment, SourceMap};
 use crate::options::{LineEnding, ResolvedShellFormatOptions};
@@ -223,15 +224,6 @@ struct LayoutAnnotations {
 }
 
 impl LayoutAnnotations {
-    fn build_for_sequence(source: &str, sequence: &StmtSeq) -> Self {
-        let mut annotations = Self::default();
-        {
-            let mut pass = LayoutAnnotationPass::new(source, &mut annotations);
-            pass.visit_stmt_seq(sequence);
-        }
-        annotations
-    }
-
     fn build_for_stmt(source: &str, stmt: &Stmt) -> Self {
         let mut annotations = Self::default();
         {
@@ -1454,24 +1446,9 @@ pub(crate) fn classify_word_has_multiline_literal_source(word: &Word, source: &s
         .has_multiline_literal_source()
 }
 
-pub(crate) fn classify_sequence_contains_multiline_literal_source(
-    sequence: &StmtSeq,
-    source: &str,
-) -> bool {
-    LayoutAnnotations::build_for_sequence(source, sequence)
-        .sequence(sequence)
-        .contains_multiline_literal_source
-}
-
 pub(crate) fn classify_stmt_contains_heredoc(stmt: &Stmt) -> bool {
     LayoutAnnotations::build_for_stmt("", stmt)
         .stmt(stmt)
-        .contains_heredoc
-}
-
-pub(crate) fn classify_sequence_contains_heredoc(sequence: &StmtSeq) -> bool {
-    LayoutAnnotations::build_for_sequence("", sequence)
-        .sequence(sequence)
         .contains_heredoc
 }
 
@@ -1939,12 +1916,7 @@ impl<'source, 'options> FormatterFactsBuilder<'source, 'options> {
                     .leading_for(index)
                     .first()
                     .map(SourceComment::line)
-                    .unwrap_or(stmt_render_start_line(
-                        stmt,
-                        self.source,
-                        self.source_map(),
-                        self.options,
-                    ));
+                    .unwrap_or_else(|| self.facts.stmt(stmt).rendered_start_line());
             }
         }
 
@@ -2041,11 +2013,19 @@ impl<'source, 'options> FormatterFactsBuilder<'source, 'options> {
             self.source_map(),
             stmt_contains_heredoc,
         );
+        let rendered_start_line = stmt_render_start_line_with_heredoc(
+            stmt,
+            self.source,
+            self.source_map(),
+            self.options,
+            stmt_contains_heredoc,
+        );
         self.facts.layout_facts.statements.insert(
             site.key,
             StmtFacts {
                 attachment_span,
                 render_span,
+                rendered_start_line,
                 rendered_end_line,
                 has_trailing_comment: stmt_has_trailing_comment(stmt, self.source_map()),
                 preserve_verbatim,
@@ -3087,7 +3067,7 @@ impl<'source, 'options> FormatterFactsBuilder<'source, 'options> {
         let first_body_stmt_line = item
             .body
             .first()
-            .map(|stmt| stmt_render_start_line(stmt, self.source, self.source_map(), self.options))
+            .map(|stmt| self.facts.stmt(stmt).rendered_start_line())
             .unwrap_or(first_body_line);
         let first_pattern_start = item
             .patterns
@@ -3749,7 +3729,7 @@ mod tests {
     use shuck_parser::parser::Parser;
 
     use super::*;
-    use crate::command::group_attachment_span;
+    use crate::command::group_attachment_span_with_heredoc;
     use crate::{ShellDialect, ShellFormatOptions};
 
     fn parse(source: &str) -> shuck_ast::File {
@@ -3785,9 +3765,15 @@ mod tests {
         open: char,
         close: char,
     ) -> &'source str {
-        group_attachment_span(commands.as_slice(), facts.source_map(), open, close)
-            .expect("expected group attachment span")
-            .slice(source)
+        group_attachment_span_with_heredoc(
+            commands.as_slice(),
+            facts.source_map(),
+            open,
+            close,
+            |stmt| facts.stmt(stmt).contains_heredoc(),
+        )
+        .expect("expected group attachment span")
+        .slice(source)
     }
 
     #[test]
@@ -4096,9 +4082,14 @@ mod tests {
         };
 
         let sequence = facts.sequence(subshell, Some(stmt_span(condition_stmt).end.offset));
-        let attachment_span =
-            group_attachment_span(subshell.as_slice(), facts.source_map(), '(', ')')
-                .expect("expected subshell attachment span");
+        let attachment_span = group_attachment_span_with_heredoc(
+            subshell.as_slice(),
+            facts.source_map(),
+            '(',
+            ')',
+            |stmt| facts.stmt(stmt).contains_heredoc(),
+        )
+        .expect("expected subshell attachment span");
         assert!(!sequence.has_comments());
         assert!(facts.group_was_inline_in_source(subshell));
         assert_eq!(
@@ -4152,9 +4143,14 @@ mod tests {
             Command::Compound(CompoundCommand::Subshell(commands)) => commands,
             _ => panic!("expected subshell"),
         };
-        let attachment_span =
-            group_attachment_span(subshell.as_slice(), facts.source_map(), '(', ')')
-                .expect("expected subshell attachment span");
+        let attachment_span = group_attachment_span_with_heredoc(
+            subshell.as_slice(),
+            facts.source_map(),
+            '(',
+            ')',
+            |stmt| facts.stmt(stmt).contains_heredoc(),
+        )
+        .expect("expected subshell attachment span");
 
         assert_eq!(
             attachment_span.slice(source),

--- a/crates/shuck-formatter/src/facts/layout.rs
+++ b/crates/shuck-formatter/src/facts/layout.rs
@@ -21,6 +21,7 @@ impl LayoutFacts {
 pub(crate) struct StmtFacts {
     pub(super) attachment_span: Span,
     pub(super) render_span: Span,
+    pub(super) rendered_start_line: usize,
     pub(super) rendered_end_line: usize,
     pub(super) has_trailing_comment: bool,
     pub(super) preserve_verbatim: bool,
@@ -34,6 +35,10 @@ impl StmtFacts {
 
     pub(crate) fn render_span(&self) -> Span {
         self.render_span
+    }
+
+    pub(crate) fn rendered_start_line(&self) -> usize {
+        self.rendered_start_line
     }
 
     pub(crate) fn rendered_end_line(&self) -> usize {

--- a/crates/shuck-formatter/src/render_plan/conditions.rs
+++ b/crates/shuck-formatter/src/render_plan/conditions.rs
@@ -1,27 +1,23 @@
 use shuck_ast::{Command, CompoundCommand, IfCommand, Span, Stmt, StmtSeq};
 
-use crate::command::{
-    branch_open_keyword_start, command_format_span, stmt_render_start_line, stmt_span,
-};
+use crate::command::{branch_open_keyword_start, command_format_span, stmt_span};
 use crate::comments::SourceMap;
 use crate::facts::FormatterFacts;
-use crate::options::ResolvedShellFormatOptions;
 use crate::raw_syntax::{skip_double_quoted, skip_single_quoted};
 
 pub(crate) fn if_condition_starts_after_keyword(
     command: &IfCommand,
     then_span: Span,
     source: &str,
-    source_map: &SourceMap<'_>,
-    options: &ResolvedShellFormatOptions,
     facts: &FormatterFacts,
 ) -> bool {
     if raw_if_condition_starts_with_negation_continuation(command, then_span, source, facts) {
         return false;
     }
-    command.condition.first().is_some_and(|stmt| {
-        stmt_render_start_line(stmt, source, source_map, options) > command.span.start.line
-    })
+    command
+        .condition
+        .first()
+        .is_some_and(|stmt| facts.stmt(stmt).rendered_start_line() > command.span.start.line)
 }
 
 pub(crate) fn if_condition_has_explicit_statement_break(
@@ -183,10 +179,9 @@ pub(crate) fn raw_grouped_if_condition(
     then_span: Span,
     source: &str,
     source_map: &SourceMap<'_>,
-    options: &ResolvedShellFormatOptions,
     facts: &FormatterFacts,
 ) -> Option<String> {
-    if !if_condition_starts_after_keyword(command, then_span, source, source_map, options, facts) {
+    if !if_condition_starts_after_keyword(command, then_span, source, facts) {
         return None;
     }
     let start = command.span.start.offset.checked_add("if".len())?;

--- a/crates/shuck-formatter/src/render_plan/if_case.rs
+++ b/crates/shuck-formatter/src/render_plan/if_case.rs
@@ -85,27 +85,21 @@ fn then_fi_if_style(
             then_span,
             context.source,
             context.source_map(),
-            context.options,
             context.facts,
         )
     {
         return IfLayoutStyle::RawGroupedCondition { raw_condition };
     }
 
-    if if_condition_starts_after_keyword(
-        command,
-        then_span,
-        context.source,
-        context.source_map(),
-        context.options,
-        context.facts,
-    ) || if_condition_has_explicit_statement_break(
-        command,
-        then_span,
-        context.source,
-        context.source_map(),
-        context.facts,
-    ) {
+    if if_condition_starts_after_keyword(command, then_span, context.source, context.facts)
+        || if_condition_has_explicit_statement_break(
+            command,
+            then_span,
+            context.source,
+            context.source_map(),
+            context.facts,
+        )
+    {
         return IfLayoutStyle::SplitCondition;
     }
 

--- a/crates/shuck-formatter/src/streaming/comments_alignment.rs
+++ b/crates/shuck-formatter/src/streaming/comments_alignment.rs
@@ -87,6 +87,7 @@ where
             stmt,
             self.source(),
             self.source_map(),
+            self.facts(),
             self.facts().stmt(stmt).rendered_end_line(),
         )
     }
@@ -100,12 +101,9 @@ where
         attachments
             .map(|attachment| attachment.first_rendered_line_for(index + 1))
             .unwrap_or_else(|| {
-                stmt_render_start_line(
-                    &statements[index + 1],
-                    self.source(),
-                    self.source_map(),
-                    self.options(),
-                )
+                self.facts()
+                    .stmt(&statements[index + 1])
+                    .rendered_start_line()
             })
     }
 

--- a/crates/shuck-formatter/src/streaming/gaps.rs
+++ b/crates/shuck-formatter/src/streaming/gaps.rs
@@ -19,6 +19,7 @@ pub(super) fn stmt_rendered_end_line_after_format(
     stmt: &Stmt,
     source: &str,
     source_map: &SourceMap<'_>,
+    facts: &FormatterFacts,
     fallback: usize,
 ) -> usize {
     if matches!(stmt.terminator, Some(StmtTerminator::Semicolon))
@@ -33,17 +34,15 @@ pub(super) fn stmt_rendered_end_line_after_format(
                 command.right.as_ref(),
                 source,
                 source_map,
+                facts,
                 fallback,
             );
         }
         _ if stmt.redirects.is_empty() && stmt.terminator.is_none() => {
             if let Some((commands, open)) = command_group_commands(&stmt.command)
-                && let Some(span) = group_attachment_span(
-                    commands.as_slice(),
-                    source_map,
-                    open,
-                    matching_group_close(open),
-                )
+                && let Some(span) = facts
+                    .sequence(commands, Some(stmt_span(stmt).end.offset))
+                    .group_attachment_span()
             {
                 let close = matching_group_close(open);
                 let close_offset = group_close_offset(

--- a/crates/shuck-formatter/src/streaming/mod.rs
+++ b/crates/shuck-formatter/src/streaming/mod.rs
@@ -26,19 +26,18 @@ use crate::command::{
     array_elem_parts, binary_operator, builtin_like_parts, case_item_body_upper_bound,
     case_terminator, collect_binary_list_first as collect_binary_list_first_with,
     collect_pipeline_parts, command_format_span, command_group_commands,
-    format_arithmetic_command_source, format_arithmetic_for_clause_source, group_attachment_span,
+    format_arithmetic_command_source, format_arithmetic_for_clause_source,
     if_next_branch_region_with_body_end, line_gap_break_count, matching_group_close,
     multiline_compound_assignment_command_substitution_body_prefix,
     multiline_compound_assignment_layout, multiline_compound_assignment_lines,
     render_assignment_head_to_buf, render_assignment_to_buf, render_background_operator,
     render_subscript_to_buf, render_var_ref_to_buf, simple_command_uses_synthetic_words,
-    slice_span, stmt_attachment_span, stmt_format_span, stmt_render_start_line, stmt_span,
-    stmt_start_after_operator, stmt_verbatim_span_with_source_map,
-    trim_unescaped_trailing_whitespace,
+    slice_span, stmt_format_span, stmt_span, stmt_start_after_operator,
+    stmt_verbatim_span_with_source_map, trim_unescaped_trailing_whitespace,
 };
 use crate::comments::{BranchPrefixComment, SourceComment, SourceMap};
 use crate::context::RenderContext;
-use crate::facts::{FormatterFacts, classify_sequence_contains_heredoc};
+use crate::facts::FormatterFacts;
 use crate::options::{IndentStyle, ResolvedShellFormatOptions};
 use crate::raw_syntax::{
     CommandSubstitutionPipelineContinuation, RawLineQuoteState, RawShellText, RenderedHeredocTail,

--- a/crates/shuck-formatter/src/streaming/statements.rs
+++ b/crates/shuck-formatter/src/streaming/statements.rs
@@ -163,8 +163,7 @@ where
 
         for (index, stmt) in statements.iter().enumerate() {
             if let Some(attachment) = attachments.as_ref() {
-                let next_line =
-                    stmt_render_start_line(stmt, self.source(), self.source_map(), self.options());
+                let next_line = self.facts().stmt(stmt).rendered_start_line();
                 if index == 0
                     && let Some(min_offset) = first_leading_min_offset
                 {
@@ -898,12 +897,9 @@ where
         stmt: &Stmt,
         min_comment_start: Option<usize>,
     ) -> Result<()> {
-        let statement_start =
-            stmt_attachment_span(stmt, self.source(), self.source_map(), self.options())
-                .start
-                .offset;
-        let next_line =
-            stmt_render_start_line(stmt, self.source(), self.source_map(), self.options());
+        let stmt_facts = self.facts().stmt(stmt);
+        let statement_start = stmt_facts.attachment_span().start.offset;
+        let next_line = stmt_facts.rendered_start_line();
         let leading = stmt
             .leading_comments
             .iter()

--- a/crates/shuck-formatter/src/streaming/substitutions.rs
+++ b/crates/shuck-formatter/src/streaming/substitutions.rs
@@ -19,13 +19,16 @@ enum RenderedFragment<'text> {
     },
 }
 
-pub(super) fn assignment_contains_command_heredoc(assignment: &Assignment) -> bool {
+pub(super) fn assignment_contains_command_heredoc(
+    assignment: &Assignment,
+    facts: &FormatterFacts<'_>,
+) -> bool {
     match &assignment.value {
-        AssignmentValue::Scalar(word) => word_contains_command_heredoc(word),
+        AssignmentValue::Scalar(word) => word_contains_command_heredoc(word, facts),
         AssignmentValue::Compound(array) => array
             .elements
             .iter()
-            .any(|element| word_contains_command_heredoc(array_elem_parts(element).1)),
+            .any(|element| word_contains_command_heredoc(array_elem_parts(element).1, facts)),
     }
 }
 
@@ -53,10 +56,10 @@ pub(super) fn compound_assignment_is_single_case_command_substitution(
     )
 }
 
-pub(super) fn word_contains_command_heredoc(word: &Word) -> bool {
+pub(super) fn word_contains_command_heredoc(word: &Word, facts: &FormatterFacts<'_>) -> bool {
     word.parts
         .iter()
-        .any(|part| word_part_contains_command_heredoc(&part.kind))
+        .any(|part| word_part_contains_command_heredoc(&part.kind, facts))
 }
 
 pub(super) fn heredoc_body_contains_command_substitution(body: &HeredocBody) -> bool {
@@ -65,14 +68,14 @@ pub(super) fn heredoc_body_contains_command_substitution(body: &HeredocBody) -> 
         .any(|part| matches!(part.kind, HeredocBodyPart::CommandSubstitution { .. }))
 }
 
-fn word_part_contains_command_heredoc(part: &WordPart) -> bool {
+fn word_part_contains_command_heredoc(part: &WordPart, facts: &FormatterFacts<'_>) -> bool {
     match part {
         WordPart::CommandSubstitution { body, .. } | WordPart::ProcessSubstitution { body, .. } => {
-            classify_sequence_contains_heredoc(body)
+            facts.sequence_contains_heredoc(body)
         }
         WordPart::DoubleQuoted { parts, .. } => parts
             .iter()
-            .any(|part| word_part_contains_command_heredoc(&part.kind)),
+            .any(|part| word_part_contains_command_heredoc(&part.kind, facts)),
         _ => false,
     }
 }
@@ -970,7 +973,7 @@ where
         };
 
         if rendered_shell_text_has_heredoc_tail(rendered)
-            && (word_contains_command_heredoc(word)
+            && (word_contains_command_heredoc(word, self.facts())
                 || word_source_has_shell_substitution(word, self.source())
                 || rendered_has_shell_substitution())
         {
@@ -1042,7 +1045,7 @@ where
         };
 
         if rendered_shell_text_has_heredoc_tail(rendered)
-            && (assignment_contains_command_heredoc(assignment)
+            && (assignment_contains_command_heredoc(assignment, self.facts())
                 || assignment_has_command_substitution()
                 || rendered_has_shell_substitution())
         {

--- a/crates/shuck-formatter/src/word/command_substitution.rs
+++ b/crates/shuck-formatter/src/word/command_substitution.rs
@@ -1074,10 +1074,6 @@ pub(super) fn command_substitution_layout(
         if command_substitution_source_closes_on_own_line(raw) {
             return CommandSubstitutionLayout::Block;
         }
-        if command_substitution_source_parses_as_multiple_statements(raw, context.options.dialect())
-        {
-            return CommandSubstitutionLayout::Block;
-        }
         if command_substitution_source_prefers_continued_inline_body(raw) {
             return CommandSubstitutionLayout::InlineContinued;
         }
@@ -1097,26 +1093,6 @@ pub(super) fn command_substitution_layout(
     } else {
         CommandSubstitutionLayout::Inline
     }
-}
-
-pub(super) fn command_substitution_source_parses_as_multiple_statements(
-    raw: &str,
-    dialect: shuck_parser::ShellDialect,
-) -> bool {
-    if raw.contains('\n') || !raw.contains(';') {
-        return false;
-    }
-
-    let Some(body) = raw_dollar_command_substitution_body(raw) else {
-        return false;
-    };
-    let body = body.trim();
-    if body.is_empty() {
-        return false;
-    }
-
-    let parsed = shuck_parser::parser::Parser::with_dialect(body, dialect).parse();
-    !parsed.is_err() && parsed.file.body.len() > 1
 }
 
 pub(super) fn push_inline_raw_command_substitution_as_block(

--- a/crates/shuck-formatter/src/word/core.rs
+++ b/crates/shuck-formatter/src/word/core.rs
@@ -158,7 +158,7 @@ impl<'source> WordRenderDecision<'source> {
             && let Some(raw) = raw
             && (word_has_multiline_double_quoted_source(word, source)
                 || (raw.starts_with('"') && raw.contains("\\\n")))
-            && !word_is_quoted_formattable_command_substitution_only(word, source)
+            && !word_is_quoted_formattable_command_substitution_only_with_facts(word, context.facts)
             && (preserve_escaped_multiline_words || !raw_escaped_multiline_double_quoted_word(raw))
             && could_need_preserve_raw_syntax(raw)
         {
@@ -384,14 +384,6 @@ pub(super) fn word_has_multiline_double_quoted_source(word: &Word, source: &str)
         matches!(&part.kind, WordPart::DoubleQuoted { .. })
             && raw_source_slice(part.span, source).is_some_and(|raw| raw.contains('\n'))
     })
-}
-
-pub(crate) fn word_is_quoted_formattable_command_substitution_only(
-    word: &Word,
-    source: &str,
-) -> bool {
-    quoted_command_substitution_only_body(word)
-        .is_some_and(|body| !classify_sequence_contains_multiline_literal_source(body, source))
 }
 
 pub(crate) fn word_is_quoted_formattable_command_substitution_only_with_facts(

--- a/crates/shuck-formatter/src/word/mod.rs
+++ b/crates/shuck-formatter/src/word/mod.rs
@@ -2,7 +2,7 @@ use std::fmt::Write as _;
 
 use crate::command::trim_unescaped_trailing_whitespace;
 use crate::context::{FragmentFormatter, RenderContext};
-use crate::facts::{FormatterFacts, classify_sequence_contains_multiline_literal_source};
+use crate::facts::FormatterFacts;
 use crate::options::{IndentStyle, ResolvedShellFormatOptions};
 use crate::raw_syntax::{
     QuoteState, RawShellScanner, RawShellText, common_nonempty_shell_indent, heredoc_start,


### PR DESCRIPTION
## Summary

- Reuse `FormatterFacts` for render start/end, heredoc, and comment-sensitive decisions in formatter streaming paths.
- Remove an inline command-substitution reparse that only rediscovered information already present in the parsed body.
- Keep raw-fragment formatting where the formatter intentionally needs the narrower fragment context instead of full-file comment attachment.

## Why

The formatter was doing extra classification work after facts had already been built. This keeps those render paths on the shared fact model and avoids redundant AST walks or reparsing where the existing AST/facts are the correct source of truth.

## Validation

- `cargo fmt --check`
- `cargo test -p shuck-formatter`
- `make test-oracle-shfmt-large-corpus`