### PR TITLE
feat(config): fall back to global ~/.config/shuck config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1832,6 +1832,7 @@ version = "0.0.41"
 dependencies = [
  "anyhow",
  "clap",
+ "etcetera",
  "serde",
  "shuck-formatter",
  "shuck-run",

--- a/README.md
+++ b/README.md
@@ -256,7 +256,15 @@ YAML comments outside the `run:` scalar are not visible to the shell parser and 
 
 ## Configuration
 
-Project settings live in `.shuck.toml` or `shuck.toml`.
+Project settings live in `.shuck.toml` or `shuck.toml`. Shuck walks up from each
+input to find the nearest of these files and treats that directory as the project
+root.
+
+If no project config is found, Shuck falls back to a user-level global config at
+`~/.config/shuck/shuck.toml` (or `.shuck.toml`), honoring `XDG_CONFIG_HOME` when
+set. Set `SHUCK_CONFIG_HOME` to point at a different directory for the global
+config. A project config always takes precedence over the global one, and
+`--config <file>` or `--isolated` bypass global config entirely.
 
 Use the `[check]` section to control embedded-script extraction:
 

--- a/crates/shuck-cli/src/commands/check/watch.rs
+++ b/crates/shuck-cli/src/commands/check/watch.rs
@@ -7,7 +7,8 @@ use std::sync::mpsc::{Receiver, TryRecvError, channel};
 use anyhow::{Result, anyhow};
 use notify::{RecursiveMode, Watcher, recommended_watcher};
 use shuck_config::{
-    ConfigArguments, discovered_config_path_for_root, resolve_project_root_for_input,
+    ConfigArguments, discovered_config_path_for_root, global_config_path,
+    resolve_project_root_for_input,
 };
 
 use super::display::print_report;
@@ -334,7 +335,16 @@ fn watch_config_target(
 
     let project_root = resolve_project_root_for_input(resolved_input, true)?;
     let Some(config_path) = discovered_config_path_for_root(&project_root)? else {
-        return Ok(None);
+        // No project config: the run falls back to the user-level global
+        // config, so watch that location for edits instead.
+        let Some(global_path) = global_config_path()? else {
+            return Ok(None);
+        };
+        let resolved_path = normalize_path(&global_path);
+        return Ok(Some(WatchPath {
+            canonical_path: fs::canonicalize(&resolved_path).map_err(anyhow::Error::from)?,
+            resolved_path,
+        }));
     };
 
     let resolved_path = normalize_path(&config_path);

--- a/crates/shuck-config/Cargo.toml
+++ b/crates/shuck-config/Cargo.toml
@@ -11,6 +11,7 @@ description = "Configuration loading and project-root discovery for shuck"
 [dependencies]
 anyhow = { workspace = true }
 clap = { workspace = true }
+etcetera = { workspace = true }
 serde = { workspace = true }
 shuck-formatter = { workspace = true }
 shuck-run = { workspace = true }

--- a/crates/shuck-config/src/lib.rs
+++ b/crates/shuck-config/src/lib.rs
@@ -25,9 +25,6 @@ const CONFIG_FILENAMES: [&str; 2] = [".shuck.toml", "shuck.toml"];
 /// Environment variable that overrides the directory searched for the global
 /// (user-level) shuck config file. When set, only this directory is consulted
 /// for global configuration.
-///
-/// Unused in test builds, which drive the override through a thread-local seam.
-#[cfg_attr(test, allow(dead_code))]
 const GLOBAL_CONFIG_DIR_ENV: &str = "SHUCK_CONFIG_HOME";
 /// Error shown when users try to set formatter dialect in a config file.
 pub const CONFIG_DIALECT_UNSUPPORTED_ERROR: &str = "`[format].dialect` is not supported; formatter dialect is auto-discovered from the file name or shebang. Use `--dialect` for a per-run override";
@@ -1593,9 +1590,26 @@ pub fn resolve_project_root_for_file(
 }
 
 /// Load project configuration and apply command-line overrides.
+///
+/// When no project-level config is discovered, the user-level global config
+/// (see [`global_config_path`]) is used as a fallback.
 pub fn load_project_config(
     project_root: &Path,
     config_arguments: &ConfigArguments,
+) -> Result<ShuckConfig> {
+    let global_config = global_config_path()?;
+    load_project_config_with_global(project_root, config_arguments, global_config.as_deref())
+}
+
+/// Core config resolution with an explicitly provided global-config fallback.
+///
+/// The global fallback is injected rather than discovered here so that callers
+/// (and tests) control it directly; [`load_project_config`] supplies the
+/// ambient user-level location.
+fn load_project_config_with_global(
+    project_root: &Path,
+    config_arguments: &ConfigArguments,
+    global_config: Option<&Path>,
 ) -> Result<ShuckConfig> {
     let mut config = if config_arguments.isolated {
         ShuckConfig::default()
@@ -1603,8 +1617,8 @@ pub fn load_project_config(
         load_config_file(config_path)?
     } else if let Some(config_path) = config_path_for_root(project_root)? {
         load_config_file(&config_path)?
-    } else if let Some(global_path) = global_config_path()? {
-        load_config_file(&global_path)?
+    } else if let Some(global_path) = global_config {
+        load_config_file(global_path)?
     } else {
         return Ok(config_arguments.overrides.clone());
     };
@@ -2383,49 +2397,18 @@ pub fn discovered_config_path_for_root(root: &Path) -> io::Result<Option<PathBuf
 /// Directories searched, in precedence order, for a user-level global config.
 ///
 /// The `SHUCK_CONFIG_HOME` environment variable, when set, takes precedence and
-/// is the only directory consulted (useful for pinning behavior and for tests).
-/// Otherwise the XDG-style config directory is used on every platform:
-/// `$XDG_CONFIG_HOME/shuck` when that variable is set, and `~/.config/shuck`
-/// otherwise. This keeps the location consistent for a CLI config file rather
-/// than following per-OS GUI-app conventions.
+/// is the only directory consulted (useful for pinning behavior). Otherwise the
+/// XDG-style config directory is used on every platform: `$XDG_CONFIG_HOME/shuck`
+/// when that variable is set, and `~/.config/shuck` otherwise. This keeps the
+/// location consistent for a CLI config file rather than following per-OS
+/// GUI-app conventions.
 fn global_config_search_dirs() -> Vec<PathBuf> {
-    if let Some(dir) = global_config_dir_override() {
-        return vec![dir];
+    if let Some(explicit) = std::env::var_os(GLOBAL_CONFIG_DIR_ENV)
+        && !explicit.is_empty()
+    {
+        return vec![PathBuf::from(explicit)];
     }
 
-    default_global_config_dirs()
-}
-
-/// Explicit override for the global config directory.
-///
-/// In production this reads the `SHUCK_CONFIG_HOME` environment variable. Under
-/// this crate's own unit tests it reads a thread-local instead, so a test can
-/// set it without mutating shared process state (which would race the rest of
-/// the suite).
-#[cfg(not(test))]
-fn global_config_dir_override() -> Option<PathBuf> {
-    std::env::var_os(GLOBAL_CONFIG_DIR_ENV)
-        .filter(|value| !value.is_empty())
-        .map(PathBuf::from)
-}
-
-#[cfg(test)]
-fn global_config_dir_override() -> Option<PathBuf> {
-    tests::test_global_config_dir()
-}
-
-/// Default (non-overridden) global config directories.
-///
-/// Under unit tests this is empty so the suite never reads a real user-level
-/// config from the host machine; a test that wants a global config sets the
-/// thread-local override instead.
-#[cfg(test)]
-fn default_global_config_dirs() -> Vec<PathBuf> {
-    Vec::new()
-}
-
-#[cfg(not(test))]
-fn default_global_config_dirs() -> Vec<PathBuf> {
     let base = std::env::var_os("XDG_CONFIG_HOME")
         .filter(|value| !value.is_empty())
         .map(PathBuf::from)
@@ -2435,19 +2418,27 @@ fn default_global_config_dirs() -> Vec<PathBuf> {
         .unwrap_or_default()
 }
 
+/// Return the first existing config file across `dirs`, if any.
+///
+/// Kept separate from the ambient directory discovery so the precedence logic
+/// can be unit-tested against explicit directories.
+fn find_global_config(dirs: &[PathBuf]) -> io::Result<Option<PathBuf>> {
+    for dir in dirs {
+        if let Some(path) = config_path_for_root(dir)? {
+            return Ok(Some(path));
+        }
+    }
+    Ok(None)
+}
+
 /// Locate the user-level global config file, if one exists.
 ///
 /// Global configuration is used only as a fallback when no project-level
 /// `.shuck.toml`/`shuck.toml` is discovered and no explicit `--config` file or
 /// `--isolated` was requested. The first existing file across the search
-/// directories (see `global_config_search_dirs`) wins.
+/// directories wins.
 pub fn global_config_path() -> io::Result<Option<PathBuf>> {
-    for dir in global_config_search_dirs() {
-        if let Some(path) = config_path_for_root(&dir)? {
-            return Ok(Some(path));
-        }
-    }
-    Ok(None)
+    find_global_config(&global_config_search_dirs())
 }
 
 fn normalize_path(path: &Path) -> PathBuf {
@@ -3595,48 +3586,40 @@ mod tests {
         );
     }
 
-    thread_local! {
-        /// Per-thread override for the global config directory. Because each
-        /// test runs (together with the `load_project_config` call it drives) on
-        /// a single thread, setting this never races other tests in the suite.
-        static TEST_GLOBAL_CONFIG_DIR: std::cell::RefCell<Option<PathBuf>> =
-            const { std::cell::RefCell::new(None) };
+    /// Loads config the way the public API does, but with the global fallback
+    /// disabled, so unit tests never depend on a real user-level config file on
+    /// the host machine. This deliberately shadows the crate's public
+    /// `load_project_config` within the test module; the handful of tests that
+    /// exercise the global fallback call `load_project_config_with_global`
+    /// directly with an explicit path.
+    fn load_project_config(
+        project_root: &Path,
+        config_arguments: &ConfigArguments,
+    ) -> Result<ShuckConfig> {
+        load_project_config_with_global(project_root, config_arguments, None)
     }
 
-    /// Read the thread-local global config directory override, if set.
-    pub(super) fn test_global_config_dir() -> Option<PathBuf> {
-        TEST_GLOBAL_CONFIG_DIR.with(|dir| dir.borrow().clone())
-    }
-
-    /// Sets the thread-local global config directory and clears it on drop.
-    struct GlobalConfigHomeGuard;
-
-    impl GlobalConfigHomeGuard {
-        fn set(dir: &Path) -> Self {
-            TEST_GLOBAL_CONFIG_DIR.with(|slot| *slot.borrow_mut() = Some(dir.to_path_buf()));
-            Self
-        }
-    }
-
-    impl Drop for GlobalConfigHomeGuard {
-        fn drop(&mut self) {
-            TEST_GLOBAL_CONFIG_DIR.with(|slot| *slot.borrow_mut() = None);
-        }
+    /// Writes a `shuck.toml` into `dir` and returns its path.
+    fn write_global_config(dir: &Path, body: &str) -> PathBuf {
+        let path = dir.join("shuck.toml");
+        fs::write(&path, body).unwrap();
+        path
     }
 
     #[test]
     fn global_config_is_used_when_no_project_config_exists() {
         let global_dir = tempdir().unwrap();
-        fs::write(
-            global_dir.path().join("shuck.toml"),
-            "[format]\nfunction-next-line = true\n",
-        )
-        .unwrap();
-        let _guard = GlobalConfigHomeGuard::set(global_dir.path());
+        let global =
+            write_global_config(global_dir.path(), "[format]\nfunction-next-line = true\n");
 
         // A project directory with no local config file falls back to the global one.
         let project = tempdir().unwrap();
-        let loaded = load_project_config(project.path(), &ConfigArguments::default()).unwrap();
+        let loaded = load_project_config_with_global(
+            project.path(),
+            &ConfigArguments::default(),
+            Some(&global),
+        )
+        .unwrap();
 
         assert_eq!(loaded.format.function_next_line, Some(true));
     }
@@ -3644,12 +3627,8 @@ mod tests {
     #[test]
     fn project_config_takes_precedence_over_global_config() {
         let global_dir = tempdir().unwrap();
-        fs::write(
-            global_dir.path().join("shuck.toml"),
-            "[format]\nfunction-next-line = true\n",
-        )
-        .unwrap();
-        let _guard = GlobalConfigHomeGuard::set(global_dir.path());
+        let global =
+            write_global_config(global_dir.path(), "[format]\nfunction-next-line = true\n");
 
         let project = tempdir().unwrap();
         fs::write(
@@ -3658,7 +3637,12 @@ mod tests {
         )
         .unwrap();
 
-        let loaded = load_project_config(project.path(), &ConfigArguments::default()).unwrap();
+        let loaded = load_project_config_with_global(
+            project.path(),
+            &ConfigArguments::default(),
+            Some(&global),
+        )
+        .unwrap();
 
         assert_eq!(loaded.format.function_next_line, Some(false));
     }
@@ -3666,16 +3650,13 @@ mod tests {
     #[test]
     fn isolated_ignores_global_config() {
         let global_dir = tempdir().unwrap();
-        fs::write(
-            global_dir.path().join("shuck.toml"),
-            "[format]\nfunction-next-line = true\n",
-        )
-        .unwrap();
-        let _guard = GlobalConfigHomeGuard::set(global_dir.path());
+        let global =
+            write_global_config(global_dir.path(), "[format]\nfunction-next-line = true\n");
 
         let project = tempdir().unwrap();
         let config = ConfigArguments::from_cli(vec![], true).unwrap();
-        let loaded = load_project_config(project.path(), &config).unwrap();
+        let loaded =
+            load_project_config_with_global(project.path(), &config, Some(&global)).unwrap();
 
         assert_eq!(loaded.format.function_next_line, None);
     }
@@ -3683,12 +3664,8 @@ mod tests {
     #[test]
     fn explicit_config_file_takes_precedence_over_global_config() {
         let global_dir = tempdir().unwrap();
-        fs::write(
-            global_dir.path().join("shuck.toml"),
-            "[format]\nfunction-next-line = true\n",
-        )
-        .unwrap();
-        let _guard = GlobalConfigHomeGuard::set(global_dir.path());
+        let global =
+            write_global_config(global_dir.path(), "[format]\nfunction-next-line = true\n");
 
         let project = tempdir().unwrap();
         let explicit = project.path().join("explicit.toml");
@@ -3697,7 +3674,8 @@ mod tests {
         let config =
             ConfigArguments::from_cli(vec![SingleConfigArgument::FilePath(explicit)], false)
                 .unwrap();
-        let loaded = load_project_config(project.path(), &config).unwrap();
+        let loaded =
+            load_project_config_with_global(project.path(), &config, Some(&global)).unwrap();
 
         assert_eq!(loaded.format.function_next_line, Some(false));
     }
@@ -3705,12 +3683,8 @@ mod tests {
     #[test]
     fn cli_overrides_layer_on_top_of_global_config() {
         let global_dir = tempdir().unwrap();
-        fs::write(
-            global_dir.path().join("shuck.toml"),
-            "[format]\nfunction-next-line = true\n",
-        )
-        .unwrap();
-        let _guard = GlobalConfigHomeGuard::set(global_dir.path());
+        let global =
+            write_global_config(global_dir.path(), "[format]\nfunction-next-line = true\n");
 
         let project = tempdir().unwrap();
         let config = ConfigArguments::from_cli(
@@ -3720,22 +3694,44 @@ mod tests {
             false,
         )
         .unwrap();
-        let loaded = load_project_config(project.path(), &config).unwrap();
+        let loaded =
+            load_project_config_with_global(project.path(), &config, Some(&global)).unwrap();
 
         assert_eq!(loaded.format.function_next_line, Some(true));
         assert_eq!(loaded.format.indent_width, Some(2));
     }
 
     #[test]
-    fn global_config_absent_returns_only_overrides() {
-        let global_dir = tempdir().unwrap();
-        // Directory exists but contains no config file.
-        let _guard = GlobalConfigHomeGuard::set(global_dir.path());
-
+    fn global_config_missing_returns_only_overrides() {
         let project = tempdir().unwrap();
-        assert!(global_config_path().unwrap().is_none());
-
-        let loaded = load_project_config(project.path(), &ConfigArguments::default()).unwrap();
+        let loaded =
+            load_project_config_with_global(project.path(), &ConfigArguments::default(), None)
+                .unwrap();
         assert_eq!(loaded.format.function_next_line, None);
+    }
+
+    #[test]
+    fn find_global_config_returns_first_existing_file() {
+        let missing = tempdir().unwrap();
+        let present = tempdir().unwrap();
+        let later = tempdir().unwrap();
+        write_global_config(present.path(), "[format]\n");
+        fs::write(later.path().join(".shuck.toml"), "[format]\n").unwrap();
+
+        // An empty directory alone yields nothing.
+        assert!(
+            find_global_config(&[missing.path().to_path_buf()])
+                .unwrap()
+                .is_none()
+        );
+
+        // The first directory that contains a config file wins.
+        let found = find_global_config(&[
+            missing.path().to_path_buf(),
+            present.path().to_path_buf(),
+            later.path().to_path_buf(),
+        ])
+        .unwrap();
+        assert_eq!(found, Some(present.path().join("shuck.toml")));
     }
 }

--- a/crates/shuck-config/src/lib.rs
+++ b/crates/shuck-config/src/lib.rs
@@ -2440,7 +2440,7 @@ fn default_global_config_dirs() -> Vec<PathBuf> {
 /// Global configuration is used only as a fallback when no project-level
 /// `.shuck.toml`/`shuck.toml` is discovered and no explicit `--config` file or
 /// `--isolated` was requested. The first existing file across the search
-/// directories (see [`global_config_search_dirs`]) wins.
+/// directories (see `global_config_search_dirs`) wins.
 pub fn global_config_path() -> io::Result<Option<PathBuf>> {
     for dir in global_config_search_dirs() {
         if let Some(path) = config_path_for_root(&dir)? {

--- a/crates/shuck-config/src/lib.rs
+++ b/crates/shuck-config/src/lib.rs
@@ -1597,19 +1597,21 @@ pub fn load_project_config(
     project_root: &Path,
     config_arguments: &ConfigArguments,
 ) -> Result<ShuckConfig> {
-    let global_config = global_config_path()?;
-    load_project_config_with_global(project_root, config_arguments, global_config.as_deref())
+    load_project_config_with_global(project_root, config_arguments, global_config_path)
 }
 
-/// Core config resolution with an explicitly provided global-config fallback.
+/// Core config resolution with an injected global-config lookup.
 ///
 /// The global fallback is injected rather than discovered here so that callers
 /// (and tests) control it directly; [`load_project_config`] supplies the
-/// ambient user-level location.
+/// ambient user-level location. The lookup is lazy: `--isolated`, an explicit
+/// `--config` file, and a discovered project config all bypass the global
+/// location entirely, so a broken user-level config directory must not affect
+/// those modes.
 fn load_project_config_with_global(
     project_root: &Path,
     config_arguments: &ConfigArguments,
-    global_config: Option<&Path>,
+    global_config: impl FnOnce() -> io::Result<Option<PathBuf>>,
 ) -> Result<ShuckConfig> {
     let mut config = if config_arguments.isolated {
         ShuckConfig::default()
@@ -1617,8 +1619,8 @@ fn load_project_config_with_global(
         load_config_file(config_path)?
     } else if let Some(config_path) = config_path_for_root(project_root)? {
         load_config_file(&config_path)?
-    } else if let Some(global_path) = global_config {
-        load_config_file(global_path)?
+    } else if let Some(global_path) = global_config()? {
+        load_config_file(&global_path)?
     } else {
         return Ok(config_arguments.overrides.clone());
     };
@@ -2439,6 +2441,18 @@ fn find_global_config(dirs: &[PathBuf]) -> io::Result<Option<PathBuf>> {
 /// directories wins.
 pub fn global_config_path() -> io::Result<Option<PathBuf>> {
     find_global_config(&global_config_search_dirs())
+}
+
+/// Every file path where a user-level global config may live, existing or not.
+///
+/// Intended for file watchers that need to observe global config edits,
+/// creation, and deletion: watching only [`global_config_path`] would miss a
+/// config file created after the watcher starts.
+pub fn global_config_candidate_paths() -> Vec<PathBuf> {
+    global_config_search_dirs()
+        .iter()
+        .flat_map(|dir| CONFIG_FILENAMES.iter().map(|filename| dir.join(filename)))
+        .collect()
 }
 
 fn normalize_path(path: &Path) -> PathBuf {
@@ -3596,7 +3610,13 @@ mod tests {
         project_root: &Path,
         config_arguments: &ConfigArguments,
     ) -> Result<ShuckConfig> {
-        load_project_config_with_global(project_root, config_arguments, None)
+        load_project_config_with_global(project_root, config_arguments, || Ok(None))
+    }
+
+    /// A global-config lookup that must not run; branches that bypass the
+    /// global fallback should never evaluate it.
+    fn global_lookup_fails() -> io::Result<Option<PathBuf>> {
+        Err(io::Error::other("global config lookup should not run"))
     }
 
     /// Writes a `shuck.toml` into `dir` and returns its path.
@@ -3614,12 +3634,11 @@ mod tests {
 
         // A project directory with no local config file falls back to the global one.
         let project = tempdir().unwrap();
-        let loaded = load_project_config_with_global(
-            project.path(),
-            &ConfigArguments::default(),
-            Some(&global),
-        )
-        .unwrap();
+        let loaded =
+            load_project_config_with_global(project.path(), &ConfigArguments::default(), || {
+                Ok(Some(global.clone()))
+            })
+            .unwrap();
 
         assert_eq!(loaded.format.function_next_line, Some(true));
     }
@@ -3637,12 +3656,11 @@ mod tests {
         )
         .unwrap();
 
-        let loaded = load_project_config_with_global(
-            project.path(),
-            &ConfigArguments::default(),
-            Some(&global),
-        )
-        .unwrap();
+        let loaded =
+            load_project_config_with_global(project.path(), &ConfigArguments::default(), || {
+                Ok(Some(global.clone()))
+            })
+            .unwrap();
 
         assert_eq!(loaded.format.function_next_line, Some(false));
     }
@@ -3656,7 +3674,8 @@ mod tests {
         let project = tempdir().unwrap();
         let config = ConfigArguments::from_cli(vec![], true).unwrap();
         let loaded =
-            load_project_config_with_global(project.path(), &config, Some(&global)).unwrap();
+            load_project_config_with_global(project.path(), &config, || Ok(Some(global.clone())))
+                .unwrap();
 
         assert_eq!(loaded.format.function_next_line, None);
     }
@@ -3675,7 +3694,8 @@ mod tests {
             ConfigArguments::from_cli(vec![SingleConfigArgument::FilePath(explicit)], false)
                 .unwrap();
         let loaded =
-            load_project_config_with_global(project.path(), &config, Some(&global)).unwrap();
+            load_project_config_with_global(project.path(), &config, || Ok(Some(global.clone())))
+                .unwrap();
 
         assert_eq!(loaded.format.function_next_line, Some(false));
     }
@@ -3695,7 +3715,8 @@ mod tests {
         )
         .unwrap();
         let loaded =
-            load_project_config_with_global(project.path(), &config, Some(&global)).unwrap();
+            load_project_config_with_global(project.path(), &config, || Ok(Some(global.clone())))
+                .unwrap();
 
         assert_eq!(loaded.format.function_next_line, Some(true));
         assert_eq!(loaded.format.indent_width, Some(2));
@@ -3705,9 +3726,35 @@ mod tests {
     fn global_config_missing_returns_only_overrides() {
         let project = tempdir().unwrap();
         let loaded =
-            load_project_config_with_global(project.path(), &ConfigArguments::default(), None)
-                .unwrap();
+            load_project_config_with_global(project.path(), &ConfigArguments::default(), || {
+                Ok(None)
+            })
+            .unwrap();
         assert_eq!(loaded.format.function_next_line, None);
+    }
+
+    #[test]
+    fn global_config_lookup_is_skipped_when_a_higher_precedence_source_applies() {
+        let project = tempdir().unwrap();
+        fs::write(project.path().join(".shuck.toml"), "[format]\n").unwrap();
+        load_project_config_with_global(
+            project.path(),
+            &ConfigArguments::default(),
+            global_lookup_fails,
+        )
+        .expect("project config should not consult the global location");
+
+        let isolated = ConfigArguments::from_cli(vec![], true).unwrap();
+        load_project_config_with_global(project.path(), &isolated, global_lookup_fails)
+            .expect("--isolated should not consult the global location");
+
+        let explicit_path = project.path().join("explicit.toml");
+        fs::write(&explicit_path, "[format]\n").unwrap();
+        let explicit =
+            ConfigArguments::from_cli(vec![SingleConfigArgument::FilePath(explicit_path)], false)
+                .unwrap();
+        load_project_config_with_global(project.path(), &explicit, global_lookup_fails)
+            .expect("--config should not consult the global location");
     }
 
     #[test]

--- a/crates/shuck-config/src/lib.rs
+++ b/crates/shuck-config/src/lib.rs
@@ -3,8 +3,9 @@
 //! Configuration loading and override handling for Shuck commands.
 //!
 //! This crate owns the TOML shapes used by `.shuck.toml`, command-line
-//! `--config` overrides, project-root discovery, and the small metadata model
-//! used to render configuration reference docs.
+//! `--config` overrides, project-root discovery, an optional user-level global
+//! config file, and the small metadata model used to render configuration
+//! reference docs.
 
 use std::collections::BTreeMap;
 use std::ffi::OsStr;
@@ -21,6 +22,13 @@ use shuck_formatter::{IndentStyle, ShellDialect};
 use shuck_run::RunConfig;
 
 const CONFIG_FILENAMES: [&str; 2] = [".shuck.toml", "shuck.toml"];
+/// Environment variable that overrides the directory searched for the global
+/// (user-level) shuck config file. When set, only this directory is consulted
+/// for global configuration.
+///
+/// Unused in test builds, which drive the override through a thread-local seam.
+#[cfg_attr(test, allow(dead_code))]
+const GLOBAL_CONFIG_DIR_ENV: &str = "SHUCK_CONFIG_HOME";
 /// Error shown when users try to set formatter dialect in a config file.
 pub const CONFIG_DIALECT_UNSUPPORTED_ERROR: &str = "`[format].dialect` is not supported; formatter dialect is auto-discovered from the file name or shebang. Use `--dialect` for a per-run override";
 const CONFIG_OVERRIDE_ROOT_KEYS: &[&str] = &["check", "format", "lint", "run"];
@@ -1593,11 +1601,12 @@ pub fn load_project_config(
         ShuckConfig::default()
     } else if let Some(config_path) = &config_arguments.config_file {
         load_config_file(config_path)?
-    } else {
-        let Some(config_path) = config_path_for_root(project_root)? else {
-            return Ok(config_arguments.overrides.clone());
-        };
+    } else if let Some(config_path) = config_path_for_root(project_root)? {
         load_config_file(&config_path)?
+    } else if let Some(global_path) = global_config_path()? {
+        load_config_file(&global_path)?
+    } else {
+        return Ok(config_arguments.overrides.clone());
     };
 
     config.apply_overrides(config_arguments.overrides.clone());
@@ -2369,6 +2378,76 @@ fn config_path_for_root(root: &Path) -> io::Result<Option<PathBuf>> {
 /// Return the config file path located directly under `root`, if any.
 pub fn discovered_config_path_for_root(root: &Path) -> io::Result<Option<PathBuf>> {
     config_path_for_root(root)
+}
+
+/// Directories searched, in precedence order, for a user-level global config.
+///
+/// The `SHUCK_CONFIG_HOME` environment variable, when set, takes precedence and
+/// is the only directory consulted (useful for pinning behavior and for tests).
+/// Otherwise the XDG-style config directory is used on every platform:
+/// `$XDG_CONFIG_HOME/shuck` when that variable is set, and `~/.config/shuck`
+/// otherwise. This keeps the location consistent for a CLI config file rather
+/// than following per-OS GUI-app conventions.
+fn global_config_search_dirs() -> Vec<PathBuf> {
+    if let Some(dir) = global_config_dir_override() {
+        return vec![dir];
+    }
+
+    default_global_config_dirs()
+}
+
+/// Explicit override for the global config directory.
+///
+/// In production this reads the `SHUCK_CONFIG_HOME` environment variable. Under
+/// this crate's own unit tests it reads a thread-local instead, so a test can
+/// set it without mutating shared process state (which would race the rest of
+/// the suite).
+#[cfg(not(test))]
+fn global_config_dir_override() -> Option<PathBuf> {
+    std::env::var_os(GLOBAL_CONFIG_DIR_ENV)
+        .filter(|value| !value.is_empty())
+        .map(PathBuf::from)
+}
+
+#[cfg(test)]
+fn global_config_dir_override() -> Option<PathBuf> {
+    tests::test_global_config_dir()
+}
+
+/// Default (non-overridden) global config directories.
+///
+/// Under unit tests this is empty so the suite never reads a real user-level
+/// config from the host machine; a test that wants a global config sets the
+/// thread-local override instead.
+#[cfg(test)]
+fn default_global_config_dirs() -> Vec<PathBuf> {
+    Vec::new()
+}
+
+#[cfg(not(test))]
+fn default_global_config_dirs() -> Vec<PathBuf> {
+    let base = std::env::var_os("XDG_CONFIG_HOME")
+        .filter(|value| !value.is_empty())
+        .map(PathBuf::from)
+        .or_else(|| etcetera::home_dir().ok().map(|home| home.join(".config")));
+
+    base.map(|base| vec![base.join("shuck")])
+        .unwrap_or_default()
+}
+
+/// Locate the user-level global config file, if one exists.
+///
+/// Global configuration is used only as a fallback when no project-level
+/// `.shuck.toml`/`shuck.toml` is discovered and no explicit `--config` file or
+/// `--isolated` was requested. The first existing file across the search
+/// directories (see [`global_config_search_dirs`]) wins.
+pub fn global_config_path() -> io::Result<Option<PathBuf>> {
+    for dir in global_config_search_dirs() {
+        if let Some(path) = config_path_for_root(&dir)? {
+            return Ok(Some(path));
+        }
+    }
+    Ok(None)
 }
 
 fn normalize_path(path: &Path) -> PathBuf {
@@ -3514,5 +3593,149 @@ mod tests {
             resolve_project_root_for_input(&nested, false).unwrap(),
             nested
         );
+    }
+
+    thread_local! {
+        /// Per-thread override for the global config directory. Because each
+        /// test runs (together with the `load_project_config` call it drives) on
+        /// a single thread, setting this never races other tests in the suite.
+        static TEST_GLOBAL_CONFIG_DIR: std::cell::RefCell<Option<PathBuf>> =
+            const { std::cell::RefCell::new(None) };
+    }
+
+    /// Read the thread-local global config directory override, if set.
+    pub(super) fn test_global_config_dir() -> Option<PathBuf> {
+        TEST_GLOBAL_CONFIG_DIR.with(|dir| dir.borrow().clone())
+    }
+
+    /// Sets the thread-local global config directory and clears it on drop.
+    struct GlobalConfigHomeGuard;
+
+    impl GlobalConfigHomeGuard {
+        fn set(dir: &Path) -> Self {
+            TEST_GLOBAL_CONFIG_DIR.with(|slot| *slot.borrow_mut() = Some(dir.to_path_buf()));
+            Self
+        }
+    }
+
+    impl Drop for GlobalConfigHomeGuard {
+        fn drop(&mut self) {
+            TEST_GLOBAL_CONFIG_DIR.with(|slot| *slot.borrow_mut() = None);
+        }
+    }
+
+    #[test]
+    fn global_config_is_used_when_no_project_config_exists() {
+        let global_dir = tempdir().unwrap();
+        fs::write(
+            global_dir.path().join("shuck.toml"),
+            "[format]\nfunction-next-line = true\n",
+        )
+        .unwrap();
+        let _guard = GlobalConfigHomeGuard::set(global_dir.path());
+
+        // A project directory with no local config file falls back to the global one.
+        let project = tempdir().unwrap();
+        let loaded = load_project_config(project.path(), &ConfigArguments::default()).unwrap();
+
+        assert_eq!(loaded.format.function_next_line, Some(true));
+    }
+
+    #[test]
+    fn project_config_takes_precedence_over_global_config() {
+        let global_dir = tempdir().unwrap();
+        fs::write(
+            global_dir.path().join("shuck.toml"),
+            "[format]\nfunction-next-line = true\n",
+        )
+        .unwrap();
+        let _guard = GlobalConfigHomeGuard::set(global_dir.path());
+
+        let project = tempdir().unwrap();
+        fs::write(
+            project.path().join(".shuck.toml"),
+            "[format]\nfunction-next-line = false\n",
+        )
+        .unwrap();
+
+        let loaded = load_project_config(project.path(), &ConfigArguments::default()).unwrap();
+
+        assert_eq!(loaded.format.function_next_line, Some(false));
+    }
+
+    #[test]
+    fn isolated_ignores_global_config() {
+        let global_dir = tempdir().unwrap();
+        fs::write(
+            global_dir.path().join("shuck.toml"),
+            "[format]\nfunction-next-line = true\n",
+        )
+        .unwrap();
+        let _guard = GlobalConfigHomeGuard::set(global_dir.path());
+
+        let project = tempdir().unwrap();
+        let config = ConfigArguments::from_cli(vec![], true).unwrap();
+        let loaded = load_project_config(project.path(), &config).unwrap();
+
+        assert_eq!(loaded.format.function_next_line, None);
+    }
+
+    #[test]
+    fn explicit_config_file_takes_precedence_over_global_config() {
+        let global_dir = tempdir().unwrap();
+        fs::write(
+            global_dir.path().join("shuck.toml"),
+            "[format]\nfunction-next-line = true\n",
+        )
+        .unwrap();
+        let _guard = GlobalConfigHomeGuard::set(global_dir.path());
+
+        let project = tempdir().unwrap();
+        let explicit = project.path().join("explicit.toml");
+        fs::write(&explicit, "[format]\nfunction-next-line = false\n").unwrap();
+
+        let config =
+            ConfigArguments::from_cli(vec![SingleConfigArgument::FilePath(explicit)], false)
+                .unwrap();
+        let loaded = load_project_config(project.path(), &config).unwrap();
+
+        assert_eq!(loaded.format.function_next_line, Some(false));
+    }
+
+    #[test]
+    fn cli_overrides_layer_on_top_of_global_config() {
+        let global_dir = tempdir().unwrap();
+        fs::write(
+            global_dir.path().join("shuck.toml"),
+            "[format]\nfunction-next-line = true\n",
+        )
+        .unwrap();
+        let _guard = GlobalConfigHomeGuard::set(global_dir.path());
+
+        let project = tempdir().unwrap();
+        let config = ConfigArguments::from_cli(
+            vec![SingleConfigArgument::SettingsOverride(Box::new(
+                parse_config_override("format.indent-width = 2").unwrap(),
+            ))],
+            false,
+        )
+        .unwrap();
+        let loaded = load_project_config(project.path(), &config).unwrap();
+
+        assert_eq!(loaded.format.function_next_line, Some(true));
+        assert_eq!(loaded.format.indent_width, Some(2));
+    }
+
+    #[test]
+    fn global_config_absent_returns_only_overrides() {
+        let global_dir = tempdir().unwrap();
+        // Directory exists but contains no config file.
+        let _guard = GlobalConfigHomeGuard::set(global_dir.path());
+
+        let project = tempdir().unwrap();
+        assert!(global_config_path().unwrap().is_none());
+
+        let loaded = load_project_config(project.path(), &ConfigArguments::default()).unwrap();
+        assert_eq!(loaded.format.function_next_line, None);
     }
 }

--- a/crates/shuck-server/src/server/main_loop.rs
+++ b/crates/shuck-server/src/server/main_loop.rs
@@ -126,19 +126,31 @@ impl Server {
             return;
         }
 
+        let mut watchers = vec![
+            FileSystemWatcher {
+                glob_pattern: types::GlobPattern::String("**/.shuck.toml".into()),
+                kind: None,
+            },
+            FileSystemWatcher {
+                glob_pattern: types::GlobPattern::String("**/shuck.toml".into()),
+                kind: None,
+            },
+        ];
+        // The user-level global config lives outside the workspace, so the
+        // relative globs above never cover it; watch its candidate paths
+        // explicitly so projects using the global fallback observe edits.
+        watchers.extend(
+            shuck_config::global_config_candidate_paths()
+                .iter()
+                .filter_map(|path| path.to_str())
+                .map(|path| FileSystemWatcher {
+                    glob_pattern: types::GlobPattern::String(path.into()),
+                    kind: None,
+                }),
+        );
+
         let register_options =
-            match serde_json::to_value(DidChangeWatchedFilesRegistrationOptions {
-                watchers: vec![
-                    FileSystemWatcher {
-                        glob_pattern: types::GlobPattern::String("**/.shuck.toml".into()),
-                        kind: None,
-                    },
-                    FileSystemWatcher {
-                        glob_pattern: types::GlobPattern::String("**/shuck.toml".into()),
-                        kind: None,
-                    },
-                ],
-            }) {
+            match serde_json::to_value(DidChangeWatchedFilesRegistrationOptions { watchers }) {
                 Ok(value) => value,
                 Err(error) => {
                     tracing::error!("Failed to serialize config watcher registration: {error}");

--- a/crates/shuck-server/src/session/index.rs
+++ b/crates/shuck-server/src/session/index.rs
@@ -180,7 +180,7 @@ impl Index {
     }
 
     pub(super) fn reload_settings(&mut self, changes: &[FileEvent], _client: &Client) {
-        let changed_roots = changes
+        let changed_paths = changes
             .iter()
             .filter_map(|change| change.uri.to_file_path().ok())
             .filter(|path| {
@@ -189,11 +189,27 @@ impl Index {
                     Some(".shuck.toml" | "shuck.toml")
                 )
             })
-            .filter_map(|path| path.parent().map(Path::to_path_buf))
-            .collect::<FxHashSet<_>>();
-        if changed_roots.is_empty() {
+            .collect::<Vec<_>>();
+        if changed_paths.is_empty() {
             return;
         }
+
+        // A global config change can affect any project without a local
+        // config, and cache keys carry no record of which fallback was used,
+        // so drop the whole cache rather than matching by config root.
+        let global_candidates = shuck_config::global_config_candidate_paths();
+        if changed_paths
+            .iter()
+            .any(|path| global_candidates.contains(path))
+        {
+            self.clear_project_settings_cache();
+            return;
+        }
+
+        let changed_roots = changed_paths
+            .iter()
+            .filter_map(|path| path.parent().map(Path::to_path_buf))
+            .collect::<FxHashSet<_>>();
 
         self.project_settings_cache
             .write()


### PR DESCRIPTION

<!--
Thanks for contributing to shuck!

Before opening this PR, please confirm:

- [x] You have read CONTRIBUTING.md and CLEAN_ROOM.md.
- [x] The PR title follows Conventional Commits (e.g. `feat(linter): add C042`, `fix(parser): handle nested heredocs`). The title is what lands on `main` and drives release-please.
- [x] No ShellCheck source, wiki content, or verbatim diagnostic text has been copied into this change.
-->

Summary

Closes #1117. Config discovery only searches upward from each input today, so a personal config can't reliably apply to scripts outside a project tree (e.g. on an external mount), and there's no tidy home for user-wide defaults. This adds a user-level global config: when no project-level .shuck.toml/shuck.toml is found by walking up, shuck falls back to ~/.config/shuck/shuck.toml (or .shuck.toml) if it exists.

The location follows XDG conventions on every platform (honoring XDG_CONFIG_HOME) rather than per-OS GUI-app directories, since that's the right convention for a CLI config file. SHUCK_CONFIG_HOME overrides the directory. Existing precedence is unchanged: --config <file> and --isolated bypass global config, a discovered project config takes precedence over the global onestill layer on top. The LSP server inherits the behavior forfree (same load_project_config path).    
                                                                                                                  
Changes                                                                                                                                                    

- Add a user-level global config fallback in shuck-config: load_project_config now consults ~/.config/shuck/shuck.toml (or .shuck.toml) when no project config is discovered.
- Location resolves XDG-style on all platforms — $XDG_CONFIG_HOME/shuck when set, else ~/.config/shuck — with SHUCK_CONFIG_HOME as an explicit override.
- Precedence preserved: --isolated and explicit --config bypasig wins over global; inline --config overrides still apply ontop. 
- Document the fallback and its precedence in the README config
- Add etcetera to shuck-config for home-dir resolution (already a workspace dependency; Cargo.lock grows by one line — no new crates enter the tree).      

Test plan                                                                                                                                                  

- [x] make check (fmt + clippy + cargo-shear) — also ran cargo doc --all --no-deps (0 warnings) and check-scripts                                           - [x] make test (cargo test --workspace --all-features)
- [ ] make test-large-corpus — N/A, no rule or conformance changes
- [x] Added or updated unit / integration / insta snapshot tes used as fallback, project precedence, --isolated bypass,explicit---config precedence, override layering, missing-global → defaults, and a pure directory-precedence test)
- [x] Manually exercised the CLI where relevant — verified shu8-space global via SHUCK_CONFIG_HOME, a 6-space global viaXDG_CONFIG_HOME/shuck, and falls back to the tab default with no global config; also confirmed a project .shuck.toml overrides the global one

Notes for reviewers                                                                                                                                        

- Test seam is dependency injection, not cfg(test). The public load_project_config resolves the ambient user-level location and delegates to a private      load_project_config_with_global(root, args, Option<&Path>). Prme code path — no #[cfg(test)] divergence, no thread-local, noenvironment mutation. Unit tests inject an explicit path (or None), and the directory-precedence logic is a pure find_global_config(&[dirs]) covered by its own test.
- Hermeticity: the crate's existing loader tests use a small documented helper in the test module that delegates with None, so the suite never reads a real user-level config from the host machine.
- Platform choice: unlike the cache (which uses the native OS cache dir), the global config deliberately uses ~/.config/shuck on all platforms rather than ~/Library/Application Support on macOS — the XDG path is the e file. Happy to revisit if you'd prefer the native config_dir().