### PR TITLE
feat(server): cross-file call hierarchy over a workspace call-graph index

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,6 +315,32 @@ source-paths = ["lib", "scripts"]
 lint-sources = true
 ```
 
+### Resolving a file that isn't next to the script
+
+When the target lives somewhere the annotating file can't reach relatively — a
+shared `lib/` while the script sits in `scripts/` — give the hint just the
+**file name** and add its directory to `source-paths`:
+
+```sh
+# scripts/deploy.sh
+# shuck: follow-source=util.sh
+source "$SHARED_DIR/util.sh"
+greet   # defined in lib/util.sh
+```
+
+```toml
+# .shuck.toml (at the project root)
+[lint]
+source-paths = ["lib"]
+```
+
+Resolution tries the hint against the annotating file's own directory first
+(`scripts/util.sh`), then each `source-paths` root (`lib/util.sh` — found). The
+hint may be a bare name (`util.sh`), a subpath (`net/http.sh`, joined onto each
+root), or an absolute path (used as-is). `source-paths` roots are relative to
+the project root; the token `SCRIPTDIR` means the annotating file's directory.
+This works the same in `shuck check` and in the editor (LSP call hierarchy).
+
 ## Configuration
 
 Project settings live in `.shuck.toml` or `shuck.toml`. Shuck walks up from each

--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ Shuck ships with a first-party Language Server Protocol (LSP) server in the main
 shuck server
 ```
 
-The server analyzes the editor's in-memory buffer, publishes diagnostics as you edit, and reuses the same parser, lint rules, formatter settings, configuration, and fix machinery as the CLI. It currently supports incremental document sync, real-time diagnostics, quick fixes, `source.fixAll.shuck`, disable-this-line actions, whole-document and range formatting, hover help for rule codes in `# shuck:` and `# shellcheck` directives, completion, go-to-definition, references, document highlights, call hierarchy (incoming and outgoing calls for functions, across files connected by `source` and `assume-source`/`follow-source` hints), document symbols, and workspace symbols.
+The server analyzes the editor's in-memory buffer, publishes diagnostics as you edit, and reuses the same parser, lint rules, formatter settings, configuration, and fix machinery as the CLI. It currently supports incremental document sync, real-time diagnostics, quick fixes, `source.fixAll.shuck`, disable-this-line actions, whole-document and range formatting, hover help for rule codes in `# shuck:` and `# shellcheck` directives, completion, go-to-definition, references, document highlights, call hierarchy (incoming and outgoing calls for functions, across files connected by `source` statements and `# shuck: source=` directives), document symbols, and workspace symbols.
 
 Any editor that can launch a stdio LSP server can use Shuck by pointing shell buffers at `shuck server`. See the [editor integration guide](https://ewhauser.github.io/shuck/docs/editors/) for setup examples.
 
@@ -323,7 +323,7 @@ shared `lib/` while the script sits in `scripts/` — give the hint just the
 
 ```sh
 # scripts/deploy.sh
-# shuck: follow-source=util.sh
+# shuck: source=util.sh lint=true
 source "$SHARED_DIR/util.sh"
 greet   # defined in lib/util.sh
 ```

--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ Shuck ships with a first-party Language Server Protocol (LSP) server in the main
 shuck server
 ```
 
-The server analyzes the editor's in-memory buffer, publishes diagnostics as you edit, and reuses the same parser, lint rules, formatter settings, configuration, and fix machinery as the CLI. It currently supports incremental document sync, real-time diagnostics, quick fixes, `source.fixAll.shuck`, disable-this-line actions, whole-document and range formatting, hover help for rule codes in `# shuck:` and `# shellcheck` directives, completion, go-to-definition, references, document highlights, call hierarchy (incoming and outgoing calls for functions), document symbols, and workspace symbols.
+The server analyzes the editor's in-memory buffer, publishes diagnostics as you edit, and reuses the same parser, lint rules, formatter settings, configuration, and fix machinery as the CLI. It currently supports incremental document sync, real-time diagnostics, quick fixes, `source.fixAll.shuck`, disable-this-line actions, whole-document and range formatting, hover help for rule codes in `# shuck:` and `# shellcheck` directives, completion, go-to-definition, references, document highlights, call hierarchy (incoming and outgoing calls for functions, across files connected by `source` and `assume-source`/`follow-source` hints), document symbols, and workspace symbols.
 
 Any editor that can launch a stdio LSP server can use Shuck by pointing shell buffers at `shuck server`. See the [editor integration guide](https://ewhauser.github.io/shuck/docs/editors/) for setup examples.
 

--- a/crates/shuck-semantic/src/call_facts.rs
+++ b/crates/shuck-semantic/src/call_facts.rs
@@ -11,7 +11,6 @@
 //! outside this module; callers supply already-resolved `source_edges`, so this
 //! layer stays pure graph logic and is unit-testable without a filesystem.
 
-use std::collections::VecDeque;
 use std::path::{Path, PathBuf};
 
 use rustc_hash::{FxHashMap, FxHashSet};
@@ -19,6 +18,8 @@ use shuck_ast::{Name, Span};
 
 use crate::editor::binding_definition_span;
 use crate::{ScopeId, SemanticModel};
+
+type SourceResolution = Option<(PathBuf, Span)>;
 
 /// Identity of a call-graph node within a file: a named function, or the file's
 /// top-level (module) body.
@@ -50,11 +51,20 @@ pub struct CallFactSite {
     pub name_span: Span,
     /// Innermost enclosing function, or the file top level.
     pub enclosing: CallNodeKind,
-    /// Whether the semantic model resolved this call to a function binding
-    /// visible in this file (honoring definition order and shadowing). Sites
-    /// that do not resolve locally are candidates for cross-file resolution
-    /// through source edges; sites that do must not be re-resolved by name.
-    pub locally_resolved: bool,
+    /// Definition span when the semantic model resolved this call to a function
+    /// binding visible in this file. Retaining the span lets later source edges
+    /// override that binding while preserving in-file definition order.
+    pub local_definition_span: Option<Span>,
+}
+
+/// One statically resolved `source` edge, retaining its execution position in
+/// the referring file so shadowing can follow shell source order.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct CallFactSourceEdge {
+    /// Resolved target path.
+    pub path: PathBuf,
+    /// Span of the `source` reference in the referring file.
+    pub span: Span,
 }
 
 /// Call-relevant facts projected from one file, plus its resolved source edges.
@@ -65,8 +75,8 @@ pub struct FileCallFacts {
     /// Call sites contained in this file.
     pub call_sites: Vec<CallFactSite>,
     /// Resolved on-disk paths of this file's determinable source edges (literal
-    /// resolvable paths plus `assume-source` / `follow-source` targets).
-    pub source_edges: Vec<PathBuf>,
+    /// resolvable paths plus `source=` directive targets).
+    pub source_edges: Vec<CallFactSourceEdge>,
 }
 
 impl FileCallFacts {
@@ -74,9 +84,27 @@ impl FileCallFacts {
     /// target paths of the file's determinable source edges, supplied by the
     /// caller (path resolution is not a semantic-layer concern).
     pub fn project(model: &SemanticModel, source_edges: Vec<PathBuf>) -> Self {
-        let analysis = model.analysis();
+        Self::project_with_source_edges(
+            model,
+            source_edges
+                .into_iter()
+                .map(|path| CallFactSourceEdge {
+                    path,
+                    span: Span::new(),
+                })
+                .collect(),
+        )
+    }
 
-        let mut function_name_by_scope: FxHashMap<ScopeId, Name> = FxHashMap::default();
+    /// Projects call facts while preserving each source edge's position.
+    pub fn project_with_source_edges(
+        model: &SemanticModel,
+        mut source_edges: Vec<CallFactSourceEdge>,
+    ) -> Self {
+        let analysis = model.analysis();
+        source_edges.sort_by_key(|edge| edge.span.start.offset);
+
+        let mut function_names_by_scope: FxHashMap<ScopeId, Vec<Name>> = FxHashMap::default();
         let mut definitions = Vec::new();
         for binding in model.function_definition_bindings() {
             definitions.push(CallFactDefinition {
@@ -85,28 +113,38 @@ impl FileCallFacts {
                 selection_span: binding.span,
             });
             if let Some(scope) = analysis.function_scope_for_binding(binding.id) {
-                function_name_by_scope
+                function_names_by_scope
                     .entry(scope)
-                    .or_insert_with(|| binding.name.clone());
+                    .or_default()
+                    .push(binding.name.clone());
             }
         }
 
         let mut call_sites = Vec::new();
         for site in model.all_call_sites() {
-            let enclosing = model
+            let enclosing_functions = model
                 .ancestor_scopes(site.scope)
-                .find_map(|scope| function_name_by_scope.get(&scope).cloned())
-                .map(CallNodeKind::Function)
-                .unwrap_or(CallNodeKind::TopLevel);
-            let locally_resolved = analysis
+                .find_map(|scope| function_names_by_scope.get(&scope));
+            let local_definition_span = analysis
                 .visible_function_binding_at_call(&site.callee, site.name_span)
-                .is_some();
-            call_sites.push(CallFactSite {
-                callee: site.callee.clone(),
-                name_span: site.name_span,
-                enclosing,
-                locally_resolved,
-            });
+                .map(|binding_id| binding_definition_span(model.binding(binding_id)));
+            if let Some(enclosing_functions) = enclosing_functions {
+                for enclosing in enclosing_functions {
+                    call_sites.push(CallFactSite {
+                        callee: site.callee.clone(),
+                        name_span: site.name_span,
+                        enclosing: CallNodeKind::Function(enclosing.clone()),
+                        local_definition_span,
+                    });
+                }
+            } else {
+                call_sites.push(CallFactSite {
+                    callee: site.callee.clone(),
+                    name_span: site.name_span,
+                    enclosing: CallNodeKind::TopLevel,
+                    local_definition_span,
+                });
+            }
         }
 
         Self {
@@ -195,44 +233,85 @@ impl WorkspaceCallIndex {
     /// (nearest definition wins). Returns `None` for names with no reachable
     /// definition (builtins, external commands, unresolved dynamic sources).
     pub fn resolve(&self, from_path: &Path, callee: &Name) -> Option<PathBuf> {
-        if let Some(facts) = self.files.get(from_path)
-            && facts.definition(callee).is_some()
-        {
-            return Some(from_path.to_path_buf());
-        }
-
-        self.resolve_through_edges(from_path, callee)
+        let facts = self.files.get(from_path)?;
+        let local = facts
+            .definitions
+            .iter()
+            .rev()
+            .find(|definition| &definition.name == callee)
+            .map(|definition| definition.def_span);
+        let sourced = self.resolve_through_edges_before(from_path, callee, None);
+        choose_resolved_target(from_path, local, sourced)
     }
 
-    /// Resolves `callee` through `from_path`'s transitive source edges only,
-    /// skipping the file's own definitions. Used for call sites the semantic
-    /// model did not bind locally: a same-named local definition that is not
-    /// visible at the site (defined later, or shadowed) must not capture it.
-    fn resolve_through_edges(&self, from_path: &Path, callee: &Name) -> Option<PathBuf> {
-        let mut visited: FxHashSet<PathBuf> = FxHashSet::default();
-        visited.insert(from_path.to_path_buf());
-        let mut queue: VecDeque<PathBuf> = self
-            .files
-            .get(from_path)
-            .map(|facts| facts.source_edges.iter().cloned().collect())
-            .unwrap_or_default();
+    /// Resolves through source edges that execute before `cutoff`. A `None`
+    /// cutoff represents the file's final sourced environment, which is also
+    /// the conservative model for calls inside deferred function bodies.
+    fn resolve_through_edges_before(
+        &self,
+        from_path: &Path,
+        callee: &Name,
+        cutoff: Option<usize>,
+    ) -> SourceResolution {
+        let facts = self.files.get(from_path)?;
+        let mut stack = FxHashSet::default();
+        stack.insert(from_path.to_path_buf());
+        facts
+            .source_edges
+            .iter()
+            .rev()
+            .filter(|edge| {
+                edge.span == Span::new()
+                    || cutoff.is_none_or(|offset| edge.span.start.offset < offset)
+            })
+            .find_map(|edge| {
+                self.resolve_exported(&edge.path, callee, &mut stack)
+                    .map(|path| (path, edge.span))
+            })
+    }
 
-        while let Some(path) = queue.pop_front() {
-            if !visited.insert(path.clone()) {
-                continue;
-            }
-            let Some(facts) = self.files.get(&path) else {
-                continue;
+    /// Resolves the final exported binding from one sourced file. Definitions
+    /// and nested source edges are evaluated in reverse execution order, so the
+    /// first successful event is the binding shell execution leaves visible.
+    fn resolve_exported(
+        &self,
+        path: &Path,
+        callee: &Name,
+        stack: &mut FxHashSet<PathBuf>,
+    ) -> Option<PathBuf> {
+        if !stack.insert(path.to_path_buf()) {
+            return None;
+        }
+        let Some(facts) = self.files.get(path) else {
+            stack.remove(path);
+            return None;
+        };
+
+        enum Event<'a> {
+            Definition,
+            Source(&'a CallFactSourceEdge),
+        }
+
+        let mut events = Vec::new();
+        for definition in facts.definitions.iter().filter(|def| &def.name == callee) {
+            events.push((definition.def_span.start.offset, Event::Definition));
+        }
+        for edge in &facts.source_edges {
+            events.push((edge.span.start.offset, Event::Source(edge)));
+        }
+        events.sort_by_key(|(offset, _)| *offset);
+
+        for (_, event) in events.into_iter().rev() {
+            let resolved = match event {
+                Event::Definition => Some(path.to_path_buf()),
+                Event::Source(edge) => self.resolve_exported(&edge.path, callee, stack),
             };
-            if facts.definition(callee).is_some() {
-                return Some(path);
-            }
-            for edge in &facts.source_edges {
-                if !visited.contains(edge) {
-                    queue.push_back(edge.clone());
-                }
+            if resolved.is_some() {
+                stack.remove(path);
+                return resolved;
             }
         }
+        stack.remove(path);
         None
     }
 
@@ -248,20 +327,22 @@ impl WorkspaceCallIndex {
         let mut spans: FxHashMap<(PathBuf, Name), Vec<Span>> = FxHashMap::default();
         // Resolution is per-callee, not per-site: memoize it so repeated calls
         // to the same helper do not re-run the source-edge search.
-        let mut resolved: FxHashMap<Name, Option<PathBuf>> = FxHashMap::default();
+        let mut resolved: FxHashMap<(Name, Option<usize>), SourceResolution> = FxHashMap::default();
         for site in &facts.call_sites {
             if &site.enclosing != from_kind {
                 continue;
             }
-            let target = if site.locally_resolved {
-                // The semantic model already bound this call in-file.
-                Some(from_path.to_path_buf())
-            } else {
-                resolved
-                    .entry(site.callee.clone())
-                    .or_insert_with(|| self.resolve_through_edges(from_path, &site.callee))
-                    .clone()
+            let cutoff = match site.enclosing {
+                CallNodeKind::TopLevel => Some(site.name_span.start.offset),
+                CallNodeKind::Function(_) => None,
             };
+            let sourced = resolved
+                .entry((site.callee.clone(), cutoff))
+                .or_insert_with(|| {
+                    self.resolve_through_edges_before(from_path, &site.callee, cutoff)
+                })
+                .clone();
+            let target = choose_resolved_target(from_path, site.local_definition_span, sourced);
             let Some(target_path) = target else {
                 continue;
             };
@@ -309,22 +390,24 @@ impl WorkspaceCallIndex {
             let facts = &self.files[caller_path];
             // Edge resolution is independent of the site, so compute it at
             // most once per caller file rather than per call site.
-            let mut edges_resolve: Option<bool> = None;
+            let mut edge_resolutions: FxHashMap<Option<usize>, SourceResolution> =
+                FxHashMap::default();
             for site in &facts.call_sites {
                 if &site.callee != name {
                     continue;
                 }
-                let resolves = if site.locally_resolved {
-                    // A locally bound call belongs to this edge only when the
-                    // queried function lives in the caller's own file.
-                    caller_path.as_path() == target_path
-                } else {
-                    caller_path.as_path() != target_path
-                        && *edges_resolve.get_or_insert_with(|| {
-                            self.resolve_through_edges(caller_path, name).as_deref()
-                                == Some(target_path)
-                        })
+                let cutoff = match site.enclosing {
+                    CallNodeKind::TopLevel => Some(site.name_span.start.offset),
+                    CallNodeKind::Function(_) => None,
                 };
+                let sourced = edge_resolutions
+                    .entry(cutoff)
+                    .or_insert_with(|| self.resolve_through_edges_before(caller_path, name, cutoff))
+                    .clone();
+                let resolves =
+                    choose_resolved_target(caller_path, site.local_definition_span, sourced)
+                        .as_deref()
+                        == Some(target_path);
                 if !resolves {
                     continue;
                 }
@@ -361,6 +444,23 @@ impl WorkspaceCallIndex {
                 }
             })
             .collect()
+    }
+}
+
+fn choose_resolved_target(
+    from_path: &Path,
+    local_definition: Option<Span>,
+    sourced: SourceResolution,
+) -> Option<PathBuf> {
+    match (local_definition, sourced) {
+        (Some(definition), Some((path, source_span)))
+            if source_span != Span::new() && source_span.start.offset > definition.start.offset =>
+        {
+            Some(path)
+        }
+        (Some(_), _) => Some(from_path.to_path_buf()),
+        (None, Some((path, _))) => Some(path),
+        (None, None) => None,
     }
 }
 
@@ -506,6 +606,125 @@ mod tests {
             index
                 .incoming(Path::new("/w/a.sh"), &name("greet"))
                 .is_empty()
+        );
+    }
+
+    #[test]
+    fn source_order_controls_cross_file_resolution_at_each_top_level_call() {
+        let caller_source = "greet\nsource a.sh\ngreet\nsource c.sh\ngreet\n";
+        let output = Parser::with_dialect(caller_source, ShellDialect::Bash)
+            .parse()
+            .unwrap();
+        let indexer = Indexer::new(caller_source, &output);
+        let caller = SemanticModel::build(&output.file, caller_source, &indexer);
+        let edges = caller
+            .source_refs()
+            .iter()
+            .zip(["/w/a.sh", "/w/c.sh"])
+            .map(|(source_ref, path)| CallFactSourceEdge {
+                path: PathBuf::from(path),
+                span: source_ref.span,
+            })
+            .collect();
+
+        let caller_path = PathBuf::from("/w/main.sh");
+        let a_path = PathBuf::from("/w/a.sh");
+        let c_path = PathBuf::from("/w/c.sh");
+        let mut index = WorkspaceCallIndex::new();
+        index.insert(
+            caller_path.clone(),
+            FileCallFacts::project_with_source_edges(&caller, edges),
+        );
+        index.insert(a_path.clone(), facts("greet() { echo a; }\n", &[]));
+        index.insert(c_path.clone(), facts("greet() { echo c; }\n", &[]));
+
+        // Before the first source there is no edge. Between the sources the
+        // call lands in a.sh; after the second source its definition wins.
+        let outgoing = index.outgoing(&caller_path, &CallNodeKind::TopLevel);
+        assert_eq!(outgoing.len(), 2);
+        assert_eq!(outgoing[0].path, a_path);
+        assert_eq!(outgoing[0].call_spans.len(), 1);
+        assert_eq!(outgoing[1].path, c_path);
+        assert_eq!(outgoing[1].call_spans.len(), 1);
+        assert_eq!(
+            index.resolve(&caller_path, &name("greet")),
+            Some(c_path.clone()),
+            "the later sourced definition is the final visible binding"
+        );
+
+        let incoming_a = index.incoming(&a_path, &name("greet"));
+        assert_eq!(incoming_a.len(), 1);
+        assert_eq!(incoming_a[0].call_spans.len(), 1);
+        let incoming_c = index.incoming(&c_path, &name("greet"));
+        assert_eq!(incoming_c.len(), 1);
+        assert_eq!(incoming_c[0].call_spans.len(), 1);
+    }
+
+    #[test]
+    fn later_source_and_local_definitions_override_each_other_in_order() {
+        let caller_source =
+            "greet() { echo local; }\nsource a.sh\ngreet\ngreet() { echo final; }\ngreet\n";
+        let output = Parser::with_dialect(caller_source, ShellDialect::Bash)
+            .parse()
+            .unwrap();
+        let indexer = Indexer::new(caller_source, &output);
+        let caller = SemanticModel::build(&output.file, caller_source, &indexer);
+        let edge = CallFactSourceEdge {
+            path: PathBuf::from("/w/a.sh"),
+            span: caller.source_refs()[0].span,
+        };
+
+        let caller_path = PathBuf::from("/w/main.sh");
+        let a_path = PathBuf::from("/w/a.sh");
+        let mut index = WorkspaceCallIndex::new();
+        index.insert(
+            caller_path.clone(),
+            FileCallFacts::project_with_source_edges(&caller, vec![edge]),
+        );
+        index.insert(a_path.clone(), facts("greet() { echo sourced; }\n", &[]));
+
+        let outgoing = index.outgoing(&caller_path, &CallNodeKind::TopLevel);
+        assert_eq!(outgoing.len(), 2);
+        assert_eq!(
+            outgoing[0].path, a_path,
+            "source overrides the first local definition"
+        );
+        assert_eq!(outgoing[0].call_spans.len(), 1);
+        assert_eq!(
+            outgoing[1].path, caller_path,
+            "the final local definition overrides the earlier source"
+        );
+        assert_eq!(outgoing[1].call_spans.len(), 1);
+    }
+
+    #[test]
+    fn workspace_index_preserves_zsh_multi_name_function_bodies() {
+        let source = "function music itunes() { helper; }\nhelper() { :; }\nitunes\n";
+        let output = Parser::with_dialect(source, ShellDialect::Zsh)
+            .parse()
+            .unwrap();
+        let indexer = Indexer::new(source, &output);
+        let model = SemanticModel::build(&output.file, source, &indexer);
+        let path = PathBuf::from("/w/script.zsh");
+        let mut index = WorkspaceCallIndex::new();
+        index.insert(path.clone(), FileCallFacts::project(&model, Vec::new()));
+
+        let outgoing = index.outgoing(&path, &CallNodeKind::Function(name("itunes")));
+        assert_eq!(outgoing.len(), 1);
+        assert_eq!(outgoing[0].node, CallNodeKind::Function(name("helper")));
+
+        let mut callers = index
+            .incoming(&path, &name("helper"))
+            .into_iter()
+            .map(|call| call.node)
+            .collect::<Vec<_>>();
+        callers.sort_by_key(|node| format!("{node:?}"));
+        assert_eq!(
+            callers,
+            [
+                CallNodeKind::Function(name("itunes")),
+                CallNodeKind::Function(name("music")),
+            ]
         );
     }
 }

--- a/crates/shuck-semantic/src/call_facts.rs
+++ b/crates/shuck-semantic/src/call_facts.rs
@@ -50,6 +50,11 @@ pub struct CallFactSite {
     pub name_span: Span,
     /// Innermost enclosing function, or the file top level.
     pub enclosing: CallNodeKind,
+    /// Whether the semantic model resolved this call to a function binding
+    /// visible in this file (honoring definition order and shadowing). Sites
+    /// that do not resolve locally are candidates for cross-file resolution
+    /// through source edges; sites that do must not be re-resolved by name.
+    pub locally_resolved: bool,
 }
 
 /// Call-relevant facts projected from one file, plus its resolved source edges.
@@ -93,10 +98,14 @@ impl FileCallFacts {
                 .find_map(|scope| function_name_by_scope.get(&scope).cloned())
                 .map(CallNodeKind::Function)
                 .unwrap_or(CallNodeKind::TopLevel);
+            let locally_resolved = analysis
+                .visible_function_binding_at_call(&site.callee, site.name_span)
+                .is_some();
             call_sites.push(CallFactSite {
                 callee: site.callee.clone(),
                 name_span: site.name_span,
                 enclosing,
+                locally_resolved,
             });
         }
 
@@ -164,6 +173,23 @@ impl WorkspaceCallIndex {
         self.files.get(path)
     }
 
+    /// Iterates all indexed files and their facts (unordered).
+    pub fn files(&self) -> impl Iterator<Item = (&Path, &FileCallFacts)> {
+        self.files
+            .iter()
+            .map(|(path, facts)| (path.as_path(), facts))
+    }
+
+    /// Number of indexed files.
+    pub fn len(&self) -> usize {
+        self.files.len()
+    }
+
+    /// Returns whether the index holds no files.
+    pub fn is_empty(&self) -> bool {
+        self.files.is_empty()
+    }
+
     /// Resolves `callee`, as seen from `from_path`, to the file that defines it:
     /// the file's own definitions first, then its transitive source edges
     /// (nearest definition wins). Returns `None` for names with no reachable
@@ -175,6 +201,14 @@ impl WorkspaceCallIndex {
             return Some(from_path.to_path_buf());
         }
 
+        self.resolve_through_edges(from_path, callee)
+    }
+
+    /// Resolves `callee` through `from_path`'s transitive source edges only,
+    /// skipping the file's own definitions. Used for call sites the semantic
+    /// model did not bind locally: a same-named local definition that is not
+    /// visible at the site (defined later, or shadowed) must not capture it.
+    fn resolve_through_edges(&self, from_path: &Path, callee: &Name) -> Option<PathBuf> {
         let mut visited: FxHashSet<PathBuf> = FxHashSet::default();
         visited.insert(from_path.to_path_buf());
         let mut queue: VecDeque<PathBuf> = self
@@ -212,11 +246,23 @@ impl WorkspaceCallIndex {
 
         let mut order: Vec<(PathBuf, Name)> = Vec::new();
         let mut spans: FxHashMap<(PathBuf, Name), Vec<Span>> = FxHashMap::default();
+        // Resolution is per-callee, not per-site: memoize it so repeated calls
+        // to the same helper do not re-run the source-edge search.
+        let mut resolved: FxHashMap<Name, Option<PathBuf>> = FxHashMap::default();
         for site in &facts.call_sites {
             if &site.enclosing != from_kind {
                 continue;
             }
-            let Some(target_path) = self.resolve(from_path, &site.callee) else {
+            let target = if site.locally_resolved {
+                // The semantic model already bound this call in-file.
+                Some(from_path.to_path_buf())
+            } else {
+                resolved
+                    .entry(site.callee.clone())
+                    .or_insert_with(|| self.resolve_through_edges(from_path, &site.callee))
+                    .clone()
+            };
+            let Some(target_path) = target else {
                 continue;
             };
             let key = (target_path, site.callee.clone());
@@ -261,11 +307,25 @@ impl WorkspaceCallIndex {
         caller_paths.sort();
         for caller_path in caller_paths {
             let facts = &self.files[caller_path];
+            // Edge resolution is independent of the site, so compute it at
+            // most once per caller file rather than per call site.
+            let mut edges_resolve: Option<bool> = None;
             for site in &facts.call_sites {
                 if &site.callee != name {
                     continue;
                 }
-                if self.resolve(caller_path, name).as_deref() != Some(target_path) {
+                let resolves = if site.locally_resolved {
+                    // A locally bound call belongs to this edge only when the
+                    // queried function lives in the caller's own file.
+                    caller_path.as_path() == target_path
+                } else {
+                    caller_path.as_path() != target_path
+                        && *edges_resolve.get_or_insert_with(|| {
+                            self.resolve_through_edges(caller_path, name).as_deref()
+                                == Some(target_path)
+                        })
+                };
+                if !resolves {
                     continue;
                 }
                 let key = (caller_path.clone(), site.enclosing.clone());

--- a/crates/shuck-semantic/src/call_facts.rs
+++ b/crates/shuck-semantic/src/call_facts.rs
@@ -1,0 +1,451 @@
+//! Workspace call-graph index for cross-file call hierarchy (spec 025).
+//!
+//! Each file contributes a compact [`FileCallFacts`] projection: the functions
+//! it defines, the call sites it contains (tagged with their enclosing
+//! function), and the resolved paths of its determinable source edges. A
+//! [`WorkspaceCallIndex`] holds those projections keyed by path and answers
+//! outgoing/incoming call-hierarchy queries as symmetric traversals of one
+//! resolvable call graph.
+//!
+//! Path resolution (turning a `source`/hint operand into an on-disk path) lives
+//! outside this module; callers supply already-resolved `source_edges`, so this
+//! layer stays pure graph logic and is unit-testable without a filesystem.
+
+use std::collections::VecDeque;
+use std::path::{Path, PathBuf};
+
+use rustc_hash::{FxHashMap, FxHashSet};
+use shuck_ast::{Name, Span};
+
+use crate::editor::binding_definition_span;
+use crate::{ScopeId, SemanticModel};
+
+/// Identity of a call-graph node within a file: a named function, or the file's
+/// top-level (module) body.
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub enum CallNodeKind {
+    /// A named function defined in the file.
+    Function(Name),
+    /// The file's top-level statements.
+    TopLevel,
+}
+
+/// A function definition discovered in a file.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct CallFactDefinition {
+    /// Function name.
+    pub name: Name,
+    /// Span covering the whole definition.
+    pub def_span: Span,
+    /// Span to select when navigating to the definition (the name token).
+    pub selection_span: Span,
+}
+
+/// A call site discovered in a file.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct CallFactSite {
+    /// Callee name as written at the site.
+    pub callee: Name,
+    /// Span of the callee token.
+    pub name_span: Span,
+    /// Innermost enclosing function, or the file top level.
+    pub enclosing: CallNodeKind,
+}
+
+/// Call-relevant facts projected from one file, plus its resolved source edges.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct FileCallFacts {
+    /// Functions defined in this file.
+    pub definitions: Vec<CallFactDefinition>,
+    /// Call sites contained in this file.
+    pub call_sites: Vec<CallFactSite>,
+    /// Resolved on-disk paths of this file's determinable source edges (literal
+    /// resolvable paths plus `assume-source` / `follow-source` targets).
+    pub source_edges: Vec<PathBuf>,
+}
+
+impl FileCallFacts {
+    /// Projects call facts from a semantic model. `source_edges` are the resolved
+    /// target paths of the file's determinable source edges, supplied by the
+    /// caller (path resolution is not a semantic-layer concern).
+    pub fn project(model: &SemanticModel, source_edges: Vec<PathBuf>) -> Self {
+        let analysis = model.analysis();
+
+        let mut function_name_by_scope: FxHashMap<ScopeId, Name> = FxHashMap::default();
+        let mut definitions = Vec::new();
+        for binding in model.function_definition_bindings() {
+            definitions.push(CallFactDefinition {
+                name: binding.name.clone(),
+                def_span: binding_definition_span(binding),
+                selection_span: binding.span,
+            });
+            if let Some(scope) = analysis.function_scope_for_binding(binding.id) {
+                function_name_by_scope
+                    .entry(scope)
+                    .or_insert_with(|| binding.name.clone());
+            }
+        }
+
+        let mut call_sites = Vec::new();
+        for site in model.all_call_sites() {
+            let enclosing = model
+                .ancestor_scopes(site.scope)
+                .find_map(|scope| function_name_by_scope.get(&scope).cloned())
+                .map(CallNodeKind::Function)
+                .unwrap_or(CallNodeKind::TopLevel);
+            call_sites.push(CallFactSite {
+                callee: site.callee.clone(),
+                name_span: site.name_span,
+                enclosing,
+            });
+        }
+
+        Self {
+            definitions,
+            call_sites,
+            source_edges,
+        }
+    }
+
+    /// Returns the definition of `name` in this file, if any (first wins).
+    pub fn definition(&self, name: &Name) -> Option<&CallFactDefinition> {
+        self.definitions.iter().find(|def| &def.name == name)
+    }
+}
+
+/// One end of a cross-file call edge, with the call-token spans that realize it.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct CrossFileCall {
+    /// File of the node at this end of the edge (the callee for outgoing, the
+    /// caller for incoming).
+    pub path: PathBuf,
+    /// Which node in `path`.
+    pub node: CallNodeKind,
+    /// Definition span of the node's function; `None` for a top-level node.
+    pub def_span: Option<Span>,
+    /// Selection span of the node's function; `None` for a top-level node.
+    pub selection_span: Option<Span>,
+    /// Spans of the callee tokens that realize the edge.
+    ///
+    /// For an outgoing edge these live in the *queried* file; for an incoming
+    /// edge they live in `path` (the caller's file).
+    pub call_spans: Vec<Span>,
+}
+
+/// A workspace-wide index of per-file call facts.
+#[derive(Debug, Default)]
+pub struct WorkspaceCallIndex {
+    files: FxHashMap<PathBuf, FileCallFacts>,
+}
+
+impl WorkspaceCallIndex {
+    /// Creates an empty index.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Inserts or replaces the facts for `path`.
+    pub fn insert(&mut self, path: PathBuf, facts: FileCallFacts) {
+        self.files.insert(path, facts);
+    }
+
+    /// Removes a file from the index.
+    pub fn remove(&mut self, path: &Path) {
+        self.files.remove(path);
+    }
+
+    /// Returns whether `path` is indexed.
+    pub fn contains(&self, path: &Path) -> bool {
+        self.files.contains_key(path)
+    }
+
+    /// Returns the facts for `path`, if indexed.
+    pub fn facts(&self, path: &Path) -> Option<&FileCallFacts> {
+        self.files.get(path)
+    }
+
+    /// Resolves `callee`, as seen from `from_path`, to the file that defines it:
+    /// the file's own definitions first, then its transitive source edges
+    /// (nearest definition wins). Returns `None` for names with no reachable
+    /// definition (builtins, external commands, unresolved dynamic sources).
+    pub fn resolve(&self, from_path: &Path, callee: &Name) -> Option<PathBuf> {
+        if let Some(facts) = self.files.get(from_path)
+            && facts.definition(callee).is_some()
+        {
+            return Some(from_path.to_path_buf());
+        }
+
+        let mut visited: FxHashSet<PathBuf> = FxHashSet::default();
+        visited.insert(from_path.to_path_buf());
+        let mut queue: VecDeque<PathBuf> = self
+            .files
+            .get(from_path)
+            .map(|facts| facts.source_edges.iter().cloned().collect())
+            .unwrap_or_default();
+
+        while let Some(path) = queue.pop_front() {
+            if !visited.insert(path.clone()) {
+                continue;
+            }
+            let Some(facts) = self.files.get(&path) else {
+                continue;
+            };
+            if facts.definition(callee).is_some() {
+                return Some(path);
+            }
+            for edge in &facts.source_edges {
+                if !visited.contains(edge) {
+                    queue.push_back(edge.clone());
+                }
+            }
+        }
+        None
+    }
+
+    /// Returns the functions that the node `from_kind` in `from_path` calls,
+    /// grouped by callee. Callees that do not resolve to a defined function
+    /// (builtins, external commands) are omitted.
+    pub fn outgoing(&self, from_path: &Path, from_kind: &CallNodeKind) -> Vec<CrossFileCall> {
+        let Some(facts) = self.files.get(from_path) else {
+            return Vec::new();
+        };
+
+        let mut order: Vec<(PathBuf, Name)> = Vec::new();
+        let mut spans: FxHashMap<(PathBuf, Name), Vec<Span>> = FxHashMap::default();
+        for site in &facts.call_sites {
+            if &site.enclosing != from_kind {
+                continue;
+            }
+            let Some(target_path) = self.resolve(from_path, &site.callee) else {
+                continue;
+            };
+            let key = (target_path, site.callee.clone());
+            spans
+                .entry(key.clone())
+                .or_insert_with(|| {
+                    order.push(key);
+                    Vec::new()
+                })
+                .push(site.name_span);
+        }
+
+        order
+            .into_iter()
+            .map(|(target_path, name)| {
+                let definition = self
+                    .files
+                    .get(&target_path)
+                    .and_then(|facts| facts.definition(&name));
+                let call_spans = spans
+                    .remove(&(target_path.clone(), name.clone()))
+                    .unwrap_or_default();
+                CrossFileCall {
+                    path: target_path,
+                    def_span: definition.map(|def| def.def_span),
+                    selection_span: definition.map(|def| def.selection_span),
+                    node: CallNodeKind::Function(name),
+                    call_spans,
+                }
+            })
+            .collect()
+    }
+
+    /// Returns the callers of the function `name` defined in `target_path`,
+    /// grouped by caller node. A caller is any file that transitively sources
+    /// `target_path` and calls `name` without a nearer shadowing definition.
+    pub fn incoming(&self, target_path: &Path, name: &Name) -> Vec<CrossFileCall> {
+        let mut order: Vec<(PathBuf, CallNodeKind)> = Vec::new();
+        let mut spans: FxHashMap<(PathBuf, CallNodeKind), Vec<Span>> = FxHashMap::default();
+
+        let mut caller_paths: Vec<&PathBuf> = self.files.keys().collect();
+        caller_paths.sort();
+        for caller_path in caller_paths {
+            let facts = &self.files[caller_path];
+            for site in &facts.call_sites {
+                if &site.callee != name {
+                    continue;
+                }
+                if self.resolve(caller_path, name).as_deref() != Some(target_path) {
+                    continue;
+                }
+                let key = (caller_path.clone(), site.enclosing.clone());
+                spans
+                    .entry(key.clone())
+                    .or_insert_with(|| {
+                        order.push(key);
+                        Vec::new()
+                    })
+                    .push(site.name_span);
+            }
+        }
+
+        order
+            .into_iter()
+            .map(|(caller_path, node)| {
+                let definition = match &node {
+                    CallNodeKind::Function(function) => self
+                        .files
+                        .get(&caller_path)
+                        .and_then(|facts| facts.definition(function)),
+                    CallNodeKind::TopLevel => None,
+                };
+                let call_spans = spans
+                    .remove(&(caller_path.clone(), node.clone()))
+                    .unwrap_or_default();
+                CrossFileCall {
+                    path: caller_path,
+                    node,
+                    def_span: definition.map(|def| def.def_span),
+                    selection_span: definition.map(|def| def.selection_span),
+                    call_spans,
+                }
+            })
+            .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use shuck_indexer::Indexer;
+    use shuck_parser::parser::{Parser, ShellDialect};
+
+    use super::*;
+
+    fn facts(source: &str, edges: &[&str]) -> FileCallFacts {
+        let output = Parser::with_dialect(source, ShellDialect::Bash)
+            .parse()
+            .unwrap();
+        let indexer = Indexer::new(source, &output);
+        let model = SemanticModel::build(&output.file, source, &indexer);
+        FileCallFacts::project(&model, edges.iter().map(PathBuf::from).collect())
+    }
+
+    fn name(text: &str) -> Name {
+        Name::from(text)
+    }
+
+    #[test]
+    fn projects_definitions_call_sites_and_enclosing() {
+        let facts = facts(
+            "inner() { :; }\nouter() {\n  inner\n  nested() { inner; }\n}\nouter\n",
+            &[],
+        );
+        let def_names: Vec<_> = facts
+            .definitions
+            .iter()
+            .map(|def| def.name.to_string())
+            .collect();
+        assert!(def_names.contains(&"inner".to_owned()));
+        assert!(def_names.contains(&"outer".to_owned()));
+
+        // `outer` calls `inner`; the `inner` in `nested` is enclosed by `nested`;
+        // the trailing `outer` call is top level.
+        let enclosings: Vec<_> = facts
+            .call_sites
+            .iter()
+            .map(|site| (site.callee.to_string(), site.enclosing.clone()))
+            .collect();
+        assert!(enclosings.contains(&("inner".to_owned(), CallNodeKind::Function(name("outer")))));
+        assert!(enclosings.contains(&("inner".to_owned(), CallNodeKind::Function(name("nested")))));
+        assert!(enclosings.contains(&("outer".to_owned(), CallNodeKind::TopLevel)));
+    }
+
+    fn three_file_index() -> WorkspaceCallIndex {
+        // a.sh defines greet; b.sh follows a and calls greet; c.sh assumes a and
+        // calls greet. Edges are supplied pre-resolved (as the server would).
+        let mut index = WorkspaceCallIndex::new();
+        index.insert(
+            PathBuf::from("/w/a.sh"),
+            facts("greet() { echo hi; }\n", &[]),
+        );
+        index.insert(
+            PathBuf::from("/w/b.sh"),
+            facts("run() {\n  greet\n}\nrun\n", &["/w/a.sh"]),
+        );
+        index.insert(PathBuf::from("/w/c.sh"), facts("greet\n", &["/w/a.sh"]));
+        index
+    }
+
+    #[test]
+    fn resolve_finds_definition_through_source_edge() {
+        let index = three_file_index();
+        assert_eq!(
+            index.resolve(Path::new("/w/b.sh"), &name("greet")),
+            Some(PathBuf::from("/w/a.sh"))
+        );
+        // A builtin/external name resolves nowhere.
+        assert_eq!(index.resolve(Path::new("/w/b.sh"), &name("echo")), None);
+    }
+
+    #[test]
+    fn incoming_collects_callers_across_files_including_assume_and_top_level() {
+        let index = three_file_index();
+        let incoming = index.incoming(Path::new("/w/a.sh"), &name("greet"));
+        let mut callers: Vec<String> = incoming
+            .iter()
+            .map(|call| format!("{}:{:?}", call.path.to_string_lossy(), call.node))
+            .collect();
+        callers.sort();
+        // b.sh's `run` (follow edge) and c.sh's top level (assume edge).
+        assert_eq!(
+            callers,
+            vec![
+                format!("/w/b.sh:{:?}", CallNodeKind::Function(name("run"))),
+                format!("/w/c.sh:{:?}", CallNodeKind::TopLevel),
+            ]
+        );
+    }
+
+    #[test]
+    fn outgoing_descends_into_followed_file() {
+        let index = three_file_index();
+        let outgoing = index.outgoing(Path::new("/w/b.sh"), &CallNodeKind::Function(name("run")));
+        assert_eq!(outgoing.len(), 1);
+        assert_eq!(outgoing[0].path, PathBuf::from("/w/a.sh"));
+        assert_eq!(outgoing[0].node, CallNodeKind::Function(name("greet")));
+        assert_eq!(outgoing[0].call_spans.len(), 1);
+        assert!(outgoing[0].def_span.is_some());
+    }
+
+    #[test]
+    fn local_definition_shadows_cross_file_one() {
+        let mut index = WorkspaceCallIndex::new();
+        index.insert(
+            PathBuf::from("/w/a.sh"),
+            facts("greet() { echo a; }\n", &[]),
+        );
+        // b defines its own greet, so its call resolves locally, not to a.sh.
+        index.insert(
+            PathBuf::from("/w/b.sh"),
+            facts("greet() { echo b; }\ngreet\n", &["/w/a.sh"]),
+        );
+        assert_eq!(
+            index.resolve(Path::new("/w/b.sh"), &name("greet")),
+            Some(PathBuf::from("/w/b.sh"))
+        );
+        // a.sh's greet therefore has no incoming call from b.sh.
+        assert!(
+            index
+                .incoming(Path::new("/w/a.sh"), &name("greet"))
+                .is_empty()
+        );
+    }
+
+    #[test]
+    fn unresolved_dynamic_source_yields_no_cross_file_edge() {
+        // b sources a computed path with no hint: no edge is supplied, so greet
+        // stays unresolved and a.sh sees no caller.
+        let mut index = WorkspaceCallIndex::new();
+        index.insert(
+            PathBuf::from("/w/a.sh"),
+            facts("greet() { echo hi; }\n", &[]),
+        );
+        index.insert(PathBuf::from("/w/b.sh"), facts("greet\n", &[]));
+        assert_eq!(index.resolve(Path::new("/w/b.sh"), &name("greet")), None);
+        assert!(
+            index
+                .incoming(Path::new("/w/a.sh"), &name("greet"))
+                .is_empty()
+        );
+    }
+}

--- a/crates/shuck-semantic/src/editor.rs
+++ b/crates/shuck-semantic/src/editor.rs
@@ -1694,7 +1694,7 @@ fn declaration_operand_ranges_by_definition_span(
     ranges
 }
 
-fn binding_definition_span(binding: &Binding) -> Span {
+pub(crate) fn binding_definition_span(binding: &Binding) -> Span {
     match binding.origin {
         crate::BindingOrigin::Assignment {
             definition_span, ..

--- a/crates/shuck-semantic/src/lib.rs
+++ b/crates/shuck-semantic/src/lib.rs
@@ -9,6 +9,7 @@ mod analysis;
 mod array_use;
 mod binding;
 mod builder;
+mod call_facts;
 mod call_graph;
 mod cfg;
 mod command_topology;
@@ -40,6 +41,11 @@ pub use binding::{
     BuiltinBindingTargetKind, LoopValueOrigin,
 };
 /// Call-graph structures derived from the analyzed script.
+/// Workspace call-graph index types for cross-file call hierarchy.
+pub use call_facts::{
+    CallFactDefinition, CallFactSite, CallNodeKind, CrossFileCall, FileCallFacts,
+    WorkspaceCallIndex,
+};
 pub use call_graph::{
     CallGraph, CallSite, OverwrittenFunction, UnreachedFunction, UnreachedFunctionReason,
 };

--- a/crates/shuck-semantic/src/lib.rs
+++ b/crates/shuck-semantic/src/lib.rs
@@ -43,8 +43,8 @@ pub use binding::{
 /// Call-graph structures derived from the analyzed script.
 /// Workspace call-graph index types for cross-file call hierarchy.
 pub use call_facts::{
-    CallFactDefinition, CallFactSite, CallNodeKind, CrossFileCall, FileCallFacts,
-    WorkspaceCallIndex,
+    CallFactDefinition, CallFactSite, CallFactSourceEdge, CallNodeKind, CrossFileCall,
+    FileCallFacts, WorkspaceCallIndex,
 };
 pub use call_graph::{
     CallGraph, CallSite, OverwrittenFunction, UnreachedFunction, UnreachedFunctionReason,

--- a/crates/shuck-semantic/src/tests.rs
+++ b/crates/shuck-semantic/src/tests.rs
@@ -333,7 +333,7 @@ build
 }
 
 #[test]
-fn editor_call_hierarchy_attributes_calls_by_enclosing_function() {
+fn call_index_attributes_calls_by_enclosing_function() {
     let source = "\
 inner() { :; }
 outer() {
@@ -343,44 +343,38 @@ outer() {
 outer
 ";
     let model = model(source);
-    let query = model.editor_query();
-
-    // Prepare on the `outer` definition name.
-    let outer_def = span_for_nth(source, "outer", 0);
-    let outer = query
-        .prepare_call_hierarchy(outer_def.start.offset)
-        .expect("outer should resolve to a function node");
-    assert_eq!(outer.name.as_str(), "outer");
+    let path = std::path::PathBuf::from("/ws/script.sh");
+    let mut index = WorkspaceCallIndex::new();
+    index.insert(path.clone(), FileCallFacts::project(&model, Vec::new()));
 
     // `outer` calls `inner` directly once; the `inner` inside `nested` belongs
     // to `nested`, not to `outer`.
-    let outgoing = query
-        .outgoing_calls(&outer)
+    let outgoing = index
+        .outgoing(&path, &CallNodeKind::Function(Name::from("outer")))
         .into_iter()
-        .map(|call| (call.to.name.to_string(), call.call_spans.len()))
+        .map(|call| (call.node.clone(), call.call_spans.len()))
         .collect::<Vec<_>>();
-    assert_eq!(outgoing, [("inner".to_owned(), 1)]);
+    assert_eq!(outgoing, [(CallNodeKind::Function(Name::from("inner")), 1)]);
 
     // `inner` is called from both `outer` and the nested `nested` function.
-    let inner_def = span_for_nth(source, "inner", 0);
-    let inner = query
-        .prepare_call_hierarchy(inner_def.start.offset)
-        .expect("inner should resolve to a function node");
-    let mut callers = query
-        .incoming_calls(&inner)
+    let mut callers = index
+        .incoming(&path, &Name::from("inner"))
         .into_iter()
-        .map(|call| call.from.name.to_string())
+        .map(|call| call.node)
         .collect::<Vec<_>>();
-    callers.sort();
-    assert_eq!(callers, ["nested", "outer"]);
+    callers.sort_by_key(|node| format!("{node:?}"));
+    assert_eq!(
+        callers,
+        [
+            CallNodeKind::Function(Name::from("nested")),
+            CallNodeKind::Function(Name::from("outer")),
+        ]
+    );
 
     // `outer` itself is called once, from the script top level.
-    let incoming_outer = query.incoming_calls(&outer);
+    let incoming_outer = index.incoming(&path, &Name::from("outer"));
     assert_eq!(incoming_outer.len(), 1);
-    assert!(matches!(
-        incoming_outer[0].from.target,
-        EditorCallHierarchyTarget::TopLevel
-    ));
+    assert_eq!(incoming_outer[0].node, CallNodeKind::TopLevel);
     assert_eq!(incoming_outer[0].call_spans.len(), 1);
 }
 
@@ -518,6 +512,65 @@ fn unrelated_shuck_directives_do_not_become_source_directives() {
         SourceRefKind::Dynamic | SourceRefKind::SingleVariableStaticTail { .. }
     ));
     assert_eq!(refs[0].directive, None);
+}
+
+#[test]
+fn call_index_honors_binding_visibility_over_name_matching() {
+    // `main` calls `grep` before any function of that name is visible; the
+    // later local definition must not capture the call, and a sourced file
+    // defining `helper` must only receive calls the model left unresolved.
+    //
+    // The top-level `grep` runs before the function of that name is defined,
+    // so it invokes the external command (function-body calls, by contrast,
+    // resolve at runtime and may bind to later definitions).
+    let caller_source = "\
+grep pattern file
+grep() { :; }
+main() {
+  helper
+}
+";
+    let lib_source = "helper() { :; }\n";
+    let caller = model(caller_source);
+    let lib = model(lib_source);
+
+    let caller_path = std::path::PathBuf::from("/ws/main.sh");
+    let lib_path = std::path::PathBuf::from("/ws/lib.sh");
+    let mut index = WorkspaceCallIndex::new();
+    index.insert(
+        caller_path.clone(),
+        FileCallFacts::project(&caller, vec![lib_path.clone()]),
+    );
+    index.insert(lib_path.clone(), FileCallFacts::project(&lib, Vec::new()));
+
+    // The top level's `grep` call precedes the definition, so it resolves to
+    // the external command: no edge from the top level.
+    let top_level_outgoing = index.outgoing(&caller_path, &CallNodeKind::TopLevel);
+    assert!(
+        top_level_outgoing.is_empty(),
+        "expected no top-level edges, got {top_level_outgoing:?}"
+    );
+    // Symmetrically, the local `grep` function has no callers.
+    assert!(index.incoming(&caller_path, &Name::from("grep")).is_empty());
+
+    // `main` resolves `helper` through the source edge.
+    let outgoing = index
+        .outgoing(&caller_path, &CallNodeKind::Function(Name::from("main")))
+        .into_iter()
+        .map(|call| (call.path.clone(), call.node.clone()))
+        .collect::<Vec<_>>();
+    assert_eq!(
+        outgoing,
+        [(
+            lib_path.clone(),
+            CallNodeKind::Function(Name::from("helper"))
+        )]
+    );
+    // And `helper`'s caller is `main` in the sourcing file.
+    let incoming = index.incoming(&lib_path, &Name::from("helper"));
+    assert_eq!(incoming.len(), 1);
+    assert_eq!(incoming[0].path, caller_path);
+    assert_eq!(incoming[0].node, CallNodeKind::Function(Name::from("main")));
 }
 
 #[test]

--- a/crates/shuck-server/src/call_hierarchy.rs
+++ b/crates/shuck-server/src/call_hierarchy.rs
@@ -13,9 +13,9 @@
 //! document, workspace folder, or configuration changes, so expanding a call
 //! tree re-uses one build instead of re-analyzing the workspace per request.
 //!
-//! Call sites the semantic model binds in-file stay binding-accurate
-//! (definition order and shadowing are honored); only calls it leaves
-//! unresolved are matched by name across source edges. Known limitation:
+//! Call sites combine binding-accurate in-file definitions with positioned
+//! source edges, so later sourced and local definitions override earlier ones
+//! in shell execution order. Known limitation:
 //! nodes are keyed by function *name* within a file, so two same-named
 //! definitions in one file collapse onto the first.
 
@@ -30,7 +30,8 @@ use shuck_config::{ConfigArguments, load_project_config, resolve_project_root_fo
 use shuck_indexer::LineIndex;
 use shuck_linter::ShellDialect;
 use shuck_semantic::{
-    CallNodeKind, CrossFileCall, FileCallFacts, WorkspaceCallIndex, resolve_source_ref_targets,
+    CallFactSourceEdge, CallNodeKind, CrossFileCall, FileCallFacts, WorkspaceCallIndex,
+    resolve_source_ref_targets,
 };
 
 use crate::PositionEncoding;
@@ -288,7 +289,7 @@ impl BuiltIndex {
         'expand: loop {
             let missing: Vec<PathBuf> = index
                 .files()
-                .flat_map(|(_, facts)| facts.source_edges.iter().cloned())
+                .flat_map(|(_, facts)| facts.source_edges.iter().map(|edge| edge.path.clone()))
                 .filter(|target| !index.contains(target))
                 .collect::<std::collections::BTreeSet<_>>()
                 .into_iter()
@@ -380,12 +381,19 @@ fn insert_file(
     let edges = model
         .source_refs()
         .iter()
-        .flat_map(|source_ref| {
-            resolve_source_ref_targets(path, source_ref, source_path_roots, source_path_base)
+        .filter_map(|source_ref| {
+            resolve_source_ref_targets(path, source_ref, source_path_roots, source_path_base).map(
+                |target| CallFactSourceEdge {
+                    path: canonical(&target),
+                    span: source_ref.span,
+                },
+            )
         })
-        .map(|target| canonical(&target))
         .collect::<Vec<_>>();
-    index.insert(key.clone(), FileCallFacts::project(&model, edges));
+    index.insert(
+        key.clone(),
+        FileCallFacts::project_with_source_edges(&model, edges),
+    );
     texts.insert(
         key,
         FileText {

--- a/crates/shuck-server/src/call_hierarchy.rs
+++ b/crates/shuck-server/src/call_hierarchy.rs
@@ -234,27 +234,45 @@ impl BuiltIndex {
         let mut index = WorkspaceCallIndex::new();
         let mut texts: BTreeMap<PathBuf, FileText> = BTreeMap::new();
 
+        // `max_files` is a hard bound on the total index size. One budget is
+        // shared by all three population phases — open buffers, closed-file
+        // discovery, and source-edge expansion — and every insertion checks it.
+        let max_files = context.max_files;
         let mut source_paths = SourcePathsCache::default();
-        let mut open_paths = Vec::new();
-        for open in &context.open_documents {
-            let Some(path) = open.uri.to_file_path().ok().map(|path| canonical(&path)) else {
-                continue;
-            };
-            open_paths.push(path.clone());
-            let (roots, base) = source_paths.resolve(&path, &context.workspace_roots);
+        // Resolve every open path up front (even ones over budget) so
+        // discovery below never re-reads an open buffer's stale on-disk
+        // contents.
+        let open_docs: Vec<(PathBuf, &WorkspaceOpenDocument)> = context
+            .open_documents
+            .iter()
+            .filter_map(|open| {
+                let path = canonical(&open.uri.to_file_path().ok()?);
+                Some((path, open))
+            })
+            .collect();
+        let open_paths: Vec<PathBuf> = open_docs.iter().map(|(path, _)| path.clone()).collect();
+        for (path, open) in &open_docs {
+            if index.len() >= max_files {
+                tracing::warn!(
+                    "call hierarchy: open documents exceed the {max_files}-file limit; \
+                     indexing only the first {max_files}"
+                );
+                break;
+            }
+            let (roots, base) = source_paths.resolve(path, &context.workspace_roots);
             insert_file(
                 &mut index,
                 &mut texts,
-                &path,
+                path,
                 open.document.contents(),
                 &roots,
                 &base,
             );
         }
 
-        for file in
-            discover_closed_shell_files(&context.workspace_roots, &open_paths, context.max_files)
-        {
+        // Discovery is capped to the budget the open buffers left over.
+        let remaining = max_files.saturating_sub(index.len());
+        for file in discover_closed_shell_files(&context.workspace_roots, &open_paths, remaining) {
             let Ok(source) = std::fs::read_to_string(&file) else {
                 continue;
             };
@@ -265,8 +283,9 @@ impl BuiltIndex {
         // Resolved source edges may point outside discovery (gitignored
         // vendored files, targets outside the workspace roots). Index those
         // files too — otherwise their definitions are invisible to the graph —
-        // following edges of newly added files to a fixpoint.
-        loop {
+        // following edges of newly added files to a fixpoint, re-checking the
+        // budget before every insertion.
+        'expand: loop {
             let missing: Vec<PathBuf> = index
                 .files()
                 .flat_map(|(_, facts)| facts.source_edges.iter().cloned())
@@ -274,10 +293,17 @@ impl BuiltIndex {
                 .collect::<std::collections::BTreeSet<_>>()
                 .into_iter()
                 .collect();
-            if missing.is_empty() || index.len() >= context.max_files {
+            if missing.is_empty() {
                 break;
             }
             for target in missing {
+                if index.len() >= max_files {
+                    tracing::warn!(
+                        "call hierarchy: source-edge targets exceed the {max_files}-file \
+                         limit; the call graph may be missing edges"
+                    );
+                    break 'expand;
+                }
                 let Ok(source) = std::fs::read_to_string(&target) else {
                     // Unreadable target: record an empty entry so the loop
                     // terminates instead of retrying it forever.
@@ -419,4 +445,99 @@ fn discover_closed_shell_files(
 
 fn canonical(path: &Path) -> PathBuf {
     std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use crate::edit::TextDocument;
+
+    use super::*;
+
+    /// Builds a workspace exercising all three index-population phases: open
+    /// buffers, closed-file discovery, and source-edge expansion to a target
+    /// outside the discovered set.
+    fn context_for(workspace: &Path, max_files: usize) -> CallHierarchyContext {
+        let open_path = workspace.join("open_a.sh");
+        let open_doc = WorkspaceOpenDocument {
+            uri: types::Url::from_file_path(&open_path).unwrap(),
+            document: Arc::new(
+                TextDocument::new(
+                    "# shuck: source=vendored/edge.sh\nsource \"$DIR/edge.sh\"\nedge_fn\n"
+                        .to_owned(),
+                    1,
+                )
+                .with_language_id("shellscript"),
+            ),
+        };
+        let open_b = WorkspaceOpenDocument {
+            uri: types::Url::from_file_path(workspace.join("open_b.sh")).unwrap(),
+            document: Arc::new(
+                TextDocument::new("b() { :; }\n".to_owned(), 1).with_language_id("shellscript"),
+            ),
+        };
+        CallHierarchyContext {
+            workspace_roots: vec![workspace.to_path_buf()],
+            open_documents: vec![open_doc, open_b],
+            encoding: PositionEncoding::UTF16,
+            max_files,
+            cache: Arc::new(CallIndexCache::default()),
+            epoch: 0,
+        }
+    }
+
+    fn populate_workspace(workspace: &Path) {
+        // Open buffers (also present on disk with different content).
+        std::fs::write(workspace.join("open_a.sh"), "stale() { :; }\n").unwrap();
+        std::fs::write(workspace.join("open_b.sh"), "stale() { :; }\n").unwrap();
+        // Closed files picked up by discovery.
+        for index in 0..4 {
+            std::fs::write(
+                workspace.join(format!("closed_{index}.sh")),
+                "closed() { :; }\n",
+            )
+            .unwrap();
+        }
+        // Edge target hidden from discovery by gitignore, reachable only
+        // through open_a.sh's source directive.
+        std::fs::create_dir_all(workspace.join("vendored")).unwrap();
+        std::fs::write(workspace.join(".gitignore"), "vendored/\n").unwrap();
+        std::fs::write(workspace.join("vendored/edge.sh"), "edge_fn() { :; }\n").unwrap();
+    }
+
+    #[test]
+    fn max_files_is_a_hard_bound_across_all_population_phases() {
+        let tempdir = tempfile::tempdir().unwrap();
+        let workspace = std::fs::canonicalize(tempdir.path()).unwrap();
+        populate_workspace(&workspace);
+
+        // 2 open + 4 discovered + 1 edge target = 7 candidates; the limit
+        // must cap the total, not any single phase.
+        for max_files in [1, 3, 5] {
+            let built = BuiltIndex::build(&context_for(&workspace, max_files));
+            assert!(
+                built.index.len() <= max_files,
+                "index size {} exceeds max_files {max_files}",
+                built.index.len()
+            );
+        }
+    }
+
+    #[test]
+    fn generous_max_files_indexes_open_discovered_and_edge_targets() {
+        let tempdir = tempfile::tempdir().unwrap();
+        let workspace = std::fs::canonicalize(tempdir.path()).unwrap();
+        populate_workspace(&workspace);
+
+        let built = BuiltIndex::build(&context_for(&workspace, 100));
+        assert_eq!(
+            built.index.len(),
+            7,
+            "2 open buffers + 4 discovered + 1 edge target"
+        );
+        // The edge target joined the graph through the source directive, so
+        // the open buffer's call resolves into it.
+        assert!(built.index.contains(&workspace.join("vendored/edge.sh")));
+    }
 }

--- a/crates/shuck-server/src/call_hierarchy.rs
+++ b/crates/shuck-server/src/call_hierarchy.rs
@@ -1,15 +1,28 @@
 //! Cross-file call hierarchy (spec 025).
 //!
 //! `incomingCalls` / `outgoingCalls` answer across the whole workspace by
-//! building a [`WorkspaceCallIndex`] per request: every workspace shell file
-//! (open buffer preferred over disk) is parsed and projected into call facts,
-//! its determinable source edges resolved, and the two directions answered as
+//! building a [`WorkspaceCallIndex`]: every workspace shell file (open buffer
+//! preferred over disk) is parsed and projected into call facts, its
+//! determinable source edges resolved, and the two directions answered as
 //! traversals of the resulting call graph. `prepareCallHierarchy` stays a
-//! single-file identity step; the item it returns (name + file URI) is enough
-//! for the index queries to locate the node.
+//! single-file identity step; the item it returns (name + file URI + a
+//! [`CallHierarchyData`] payload distinguishing top-level nodes) is enough for
+//! the index queries to locate the node.
+//!
+//! The built index is cached on the session and invalidated whenever a
+//! document, workspace folder, or configuration changes, so expanding a call
+//! tree re-uses one build instead of re-analyzing the workspace per request.
+//!
+//! Call sites the semantic model binds in-file stay binding-accurate
+//! (definition order and shadowing are honored); only calls it leaves
+//! unresolved are matched by name across source edges. Known limitation:
+//! nodes are keyed by function *name* within a file, so two same-named
+//! definitions in one file collapse onto the first.
 
 use std::collections::{BTreeMap, HashMap};
 use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Mutex};
 
 use lsp_types as types;
 use shuck_ast::{Name, Span};
@@ -22,6 +35,7 @@ use shuck_semantic::{
 
 use crate::PositionEncoding;
 use crate::editor::analyze_editor_document;
+use crate::editor_features::CallHierarchyData;
 use crate::symbols::WorkspaceOpenDocument;
 
 /// Resolves and memoizes `[lint] source-paths` per project root, so cross-file
@@ -65,6 +79,66 @@ pub(crate) struct CallHierarchyContext {
     pub(crate) workspace_roots: Vec<PathBuf>,
     pub(crate) open_documents: Vec<WorkspaceOpenDocument>,
     pub(crate) encoding: PositionEncoding,
+    /// Upper bound on indexed files (`server.callHierarchy.maxFiles`): a
+    /// runaway workspace degrades to a partial graph, not an unbounded scan.
+    pub(crate) max_files: usize,
+    pub(crate) cache: Arc<CallIndexCache>,
+    pub(crate) epoch: u64,
+}
+
+/// Session-lifetime cache of the built workspace call index.
+///
+/// Every document, workspace, or configuration change bumps the epoch and
+/// drops the cached build. Requests capture the epoch when they snapshot the
+/// session; a build finished after a concurrent change carries a stale epoch
+/// and is never served to later requests.
+#[derive(Default)]
+pub(crate) struct CallIndexCache {
+    epoch: AtomicU64,
+    built: Mutex<Option<(u64, Arc<BuiltIndex>)>>,
+}
+
+impl CallIndexCache {
+    /// Drops any cached index and marks in-flight builds stale.
+    pub(crate) fn invalidate(&self) {
+        self.epoch.fetch_add(1, Ordering::SeqCst);
+        if let Ok(mut slot) = self.built.lock() {
+            *slot = None;
+        }
+    }
+
+    pub(crate) fn current_epoch(&self) -> u64 {
+        self.epoch.load(Ordering::SeqCst)
+    }
+
+    fn get(&self, epoch: u64) -> Option<Arc<BuiltIndex>> {
+        let slot = self.built.lock().ok()?;
+        slot.as_ref()
+            .filter(|(built_epoch, _)| *built_epoch == epoch)
+            .map(|(_, built)| built.clone())
+    }
+
+    fn store(&self, epoch: u64, built: Arc<BuiltIndex>) {
+        // A build raced by an invalidation is tagged with a stale epoch; skip
+        // storing it so it cannot displace a fresher build. (If it slips past
+        // this check, `get`'s epoch comparison still refuses to serve it.)
+        if epoch != self.current_epoch() {
+            return;
+        }
+        if let Ok(mut slot) = self.built.lock() {
+            *slot = Some((epoch, built));
+        }
+    }
+}
+
+/// Returns the cached index for this context's epoch, building it on a miss.
+fn cached_index(context: &CallHierarchyContext) -> Arc<BuiltIndex> {
+    if let Some(built) = context.cache.get(context.epoch) {
+        return built;
+    }
+    let built = Arc::new(BuiltIndex::build(context));
+    context.cache.store(context.epoch, built.clone());
+    built
 }
 
 /// Source text and line index for one indexed file, retained for span→range
@@ -85,10 +159,14 @@ pub(crate) fn incoming_calls(
     context: CallHierarchyContext,
     params: types::CallHierarchyIncomingCallsParams,
 ) -> crate::server::Result<IncomingResponse> {
-    let Some((path, name)) = item_identity(&params.item) else {
+    let Some((path, node)) = item_identity(&params.item) else {
         return Ok(None);
     };
-    let built = BuiltIndex::build(&context);
+    let CallNodeKind::Function(name) = node else {
+        // Nothing "calls" a script's top level in this model.
+        return Ok(Some(Vec::new()));
+    };
+    let built = cached_index(&context);
     let calls = built
         .index
         .incoming(&path, &name)
@@ -108,14 +186,14 @@ pub(crate) fn outgoing_calls(
     context: CallHierarchyContext,
     params: types::CallHierarchyOutgoingCallsParams,
 ) -> crate::server::Result<OutgoingResponse> {
-    let Some((path, name)) = item_identity(&params.item) else {
+    let Some((path, node)) = item_identity(&params.item) else {
         return Ok(None);
     };
-    let built = BuiltIndex::build(&context);
+    let built = cached_index(&context);
     // Outgoing call-token spans live in the queried file.
     let calls = built
         .index
-        .outgoing(&path, &CallNodeKind::Function(name))
+        .outgoing(&path, &node)
         .into_iter()
         .filter_map(|call| {
             let to = built.item_for(&call)?;
@@ -128,12 +206,27 @@ pub(crate) fn outgoing_calls(
     Ok(Some(calls))
 }
 
-/// The queried node's identity: its file path and function name. The single-file
-/// `prepare` step already stamped the item with the function name and its file
-/// URI, so no `data` round-trip is required.
-fn item_identity(item: &types::CallHierarchyItem) -> Option<(PathBuf, Name)> {
+/// The queried node's identity: its file path plus which node in that file.
+///
+/// The `data` payload stamped by `prepare` (and by [`BuiltIndex::item_for`])
+/// distinguishes a script top-level MODULE node from a function; without it a
+/// top-level item would be misread as a function named after the file's label.
+/// Items from clients that drop `data` fall back to the LSP `kind`.
+fn item_identity(item: &types::CallHierarchyItem) -> Option<(PathBuf, CallNodeKind)> {
     let path = canonical(&item.uri.to_file_path().ok()?);
-    Some((path, Name::from(item.name.as_str())))
+    let data = item
+        .data
+        .clone()
+        .and_then(|value| serde_json::from_value::<CallHierarchyData>(value).ok());
+    let node = match data {
+        Some(CallHierarchyData::TopLevel) => CallNodeKind::TopLevel,
+        Some(CallHierarchyData::Function { .. }) => {
+            CallNodeKind::Function(Name::from(item.name.as_str()))
+        }
+        None if item.kind == types::SymbolKind::MODULE => CallNodeKind::TopLevel,
+        None => CallNodeKind::Function(Name::from(item.name.as_str())),
+    };
+    Some((path, node))
 }
 
 impl BuiltIndex {
@@ -159,12 +252,41 @@ impl BuiltIndex {
             );
         }
 
-        for file in discover_closed_shell_files(&context.workspace_roots, &open_paths) {
+        for file in
+            discover_closed_shell_files(&context.workspace_roots, &open_paths, context.max_files)
+        {
             let Ok(source) = std::fs::read_to_string(&file) else {
                 continue;
             };
             let (roots, base) = source_paths.resolve(&file, &context.workspace_roots);
             insert_file(&mut index, &mut texts, &file, &source, &roots, &base);
+        }
+
+        // Resolved source edges may point outside discovery (gitignored
+        // vendored files, targets outside the workspace roots). Index those
+        // files too — otherwise their definitions are invisible to the graph —
+        // following edges of newly added files to a fixpoint.
+        loop {
+            let missing: Vec<PathBuf> = index
+                .files()
+                .flat_map(|(_, facts)| facts.source_edges.iter().cloned())
+                .filter(|target| !index.contains(target))
+                .collect::<std::collections::BTreeSet<_>>()
+                .into_iter()
+                .collect();
+            if missing.is_empty() || index.len() >= context.max_files {
+                break;
+            }
+            for target in missing {
+                let Ok(source) = std::fs::read_to_string(&target) else {
+                    // Unreadable target: record an empty entry so the loop
+                    // terminates instead of retrying it forever.
+                    index.insert(target.clone(), FileCallFacts::default());
+                    continue;
+                };
+                let (roots, base) = source_paths.resolve(&target, &context.workspace_roots);
+                insert_file(&mut index, &mut texts, &target, &source, &roots, &base);
+            }
         }
 
         Self {
@@ -180,37 +302,20 @@ impl BuiltIndex {
         let uri = types::Url::from_file_path(&call.path).ok()?;
         match &call.node {
             CallNodeKind::Function(name) => {
-                let text = self.texts.get(&call.path)?;
                 let range = self.range_of(&call.path, call.def_span?)?;
                 let selection_range = call
                     .selection_span
                     .and_then(|span| self.range_of(&call.path, span))
                     .unwrap_or(range);
-                let _ = text;
-                Some(types::CallHierarchyItem {
-                    name: name.to_string(),
-                    kind: types::SymbolKind::FUNCTION,
-                    tags: None,
-                    detail: None,
+                Some(crate::editor_features::call_hierarchy_function_item(
+                    name.to_string(),
                     uri,
                     range,
                     selection_range,
-                    data: None,
-                })
+                ))
             }
             CallNodeKind::TopLevel => {
-                let start = types::Position::new(0, 0);
-                let range = types::Range { start, end: start };
-                Some(types::CallHierarchyItem {
-                    name: top_level_label(&call.path),
-                    kind: types::SymbolKind::MODULE,
-                    tags: None,
-                    detail: Some("script top level".to_owned()),
-                    uri,
-                    range,
-                    selection_range: range,
-                    data: None,
-                })
+                Some(crate::editor_features::call_hierarchy_top_level_item(uri))
             }
         }
     }
@@ -264,7 +369,11 @@ fn insert_file(
     );
 }
 
-fn discover_closed_shell_files(roots: &[PathBuf], open_paths: &[PathBuf]) -> Vec<PathBuf> {
+fn discover_closed_shell_files(
+    roots: &[PathBuf],
+    open_paths: &[PathBuf],
+    max_files: usize,
+) -> Vec<PathBuf> {
     use shuck_discover::{DiscoveryOptions, FileKind, discover_files};
 
     let mut files: BTreeMap<PathBuf, ()> = BTreeMap::new();
@@ -299,15 +408,15 @@ fn discover_closed_shell_files(roots: &[PathBuf], open_paths: &[PathBuf]) -> Vec
             files.entry(path).or_default();
         }
     }
-    files.into_keys().collect()
+    if files.len() > max_files {
+        tracing::warn!(
+            "call hierarchy: workspace has {} shell files; indexing only {max_files}",
+            files.len()
+        );
+    }
+    files.into_keys().take(max_files).collect()
 }
 
 fn canonical(path: &Path) -> PathBuf {
     std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf())
-}
-
-fn top_level_label(path: &Path) -> String {
-    path.file_name()
-        .map(|name| name.to_string_lossy().into_owned())
-        .unwrap_or_else(|| "script".to_owned())
 }

--- a/crates/shuck-server/src/call_hierarchy.rs
+++ b/crates/shuck-server/src/call_hierarchy.rs
@@ -1,0 +1,265 @@
+//! Cross-file call hierarchy (spec 025).
+//!
+//! `incomingCalls` / `outgoingCalls` answer across the whole workspace by
+//! building a [`WorkspaceCallIndex`] per request: every workspace shell file
+//! (open buffer preferred over disk) is parsed and projected into call facts,
+//! its determinable source edges resolved, and the two directions answered as
+//! traversals of the resulting call graph. `prepareCallHierarchy` stays a
+//! single-file identity step; the item it returns (name + file URI) is enough
+//! for the index queries to locate the node.
+
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+
+use lsp_types as types;
+use shuck_ast::{Name, Span};
+use shuck_indexer::LineIndex;
+use shuck_linter::ShellDialect;
+use shuck_semantic::{
+    CallNodeKind, CrossFileCall, FileCallFacts, WorkspaceCallIndex, resolve_source_ref_targets,
+};
+
+use crate::PositionEncoding;
+use crate::editor::analyze_editor_document;
+use crate::symbols::WorkspaceOpenDocument;
+
+pub(crate) type IncomingResponse = Option<Vec<types::CallHierarchyIncomingCall>>;
+pub(crate) type OutgoingResponse = Option<Vec<types::CallHierarchyOutgoingCall>>;
+
+/// Workspace state needed to build the call index for one request.
+pub(crate) struct CallHierarchyContext {
+    pub(crate) workspace_roots: Vec<PathBuf>,
+    pub(crate) open_documents: Vec<WorkspaceOpenDocument>,
+    pub(crate) encoding: PositionEncoding,
+}
+
+/// Source text and line index for one indexed file, retained for span→range
+/// mapping of cross-file results.
+struct FileText {
+    source: String,
+    line_index: LineIndex,
+}
+
+/// The per-request index plus the text needed to render results.
+struct BuiltIndex {
+    index: WorkspaceCallIndex,
+    texts: BTreeMap<PathBuf, FileText>,
+    encoding: PositionEncoding,
+}
+
+pub(crate) fn incoming_calls(
+    context: CallHierarchyContext,
+    params: types::CallHierarchyIncomingCallsParams,
+) -> crate::server::Result<IncomingResponse> {
+    let Some((path, name)) = item_identity(&params.item) else {
+        return Ok(None);
+    };
+    let built = BuiltIndex::build(&context);
+    let calls = built
+        .index
+        .incoming(&path, &name)
+        .into_iter()
+        .filter_map(|call| {
+            let from = built.item_for(&call)?;
+            Some(types::CallHierarchyIncomingCall {
+                from_ranges: built.ranges_in(&call.path, &call.call_spans),
+                from,
+            })
+        })
+        .collect();
+    Ok(Some(calls))
+}
+
+pub(crate) fn outgoing_calls(
+    context: CallHierarchyContext,
+    params: types::CallHierarchyOutgoingCallsParams,
+) -> crate::server::Result<OutgoingResponse> {
+    let Some((path, name)) = item_identity(&params.item) else {
+        return Ok(None);
+    };
+    let built = BuiltIndex::build(&context);
+    // Outgoing call-token spans live in the queried file.
+    let calls = built
+        .index
+        .outgoing(&path, &CallNodeKind::Function(name))
+        .into_iter()
+        .filter_map(|call| {
+            let to = built.item_for(&call)?;
+            Some(types::CallHierarchyOutgoingCall {
+                from_ranges: built.ranges_in(&path, &call.call_spans),
+                to,
+            })
+        })
+        .collect();
+    Ok(Some(calls))
+}
+
+/// The queried node's identity: its file path and function name. The single-file
+/// `prepare` step already stamped the item with the function name and its file
+/// URI, so no `data` round-trip is required.
+fn item_identity(item: &types::CallHierarchyItem) -> Option<(PathBuf, Name)> {
+    let path = canonical(&item.uri.to_file_path().ok()?);
+    Some((path, Name::from(item.name.as_str())))
+}
+
+impl BuiltIndex {
+    fn build(context: &CallHierarchyContext) -> Self {
+        let mut index = WorkspaceCallIndex::new();
+        let mut texts: BTreeMap<PathBuf, FileText> = BTreeMap::new();
+
+        let mut open_paths = Vec::new();
+        for open in &context.open_documents {
+            let Some(path) = open.uri.to_file_path().ok().map(|path| canonical(&path)) else {
+                continue;
+            };
+            open_paths.push(path.clone());
+            insert_file(&mut index, &mut texts, &path, open.document.contents());
+        }
+
+        for file in discover_closed_shell_files(&context.workspace_roots, &open_paths) {
+            let Ok(source) = std::fs::read_to_string(&file) else {
+                continue;
+            };
+            insert_file(&mut index, &mut texts, &file, &source);
+        }
+
+        Self {
+            index,
+            texts,
+            encoding: context.encoding,
+        }
+    }
+
+    /// Builds an LSP item for one end of a cross-file edge. Functions carry their
+    /// file URI and definition ranges; a top-level caller becomes a MODULE node.
+    fn item_for(&self, call: &CrossFileCall) -> Option<types::CallHierarchyItem> {
+        let uri = types::Url::from_file_path(&call.path).ok()?;
+        match &call.node {
+            CallNodeKind::Function(name) => {
+                let text = self.texts.get(&call.path)?;
+                let range = self.range_of(&call.path, call.def_span?)?;
+                let selection_range = call
+                    .selection_span
+                    .and_then(|span| self.range_of(&call.path, span))
+                    .unwrap_or(range);
+                let _ = text;
+                Some(types::CallHierarchyItem {
+                    name: name.to_string(),
+                    kind: types::SymbolKind::FUNCTION,
+                    tags: None,
+                    detail: None,
+                    uri,
+                    range,
+                    selection_range,
+                    data: None,
+                })
+            }
+            CallNodeKind::TopLevel => {
+                let start = types::Position::new(0, 0);
+                let range = types::Range { start, end: start };
+                Some(types::CallHierarchyItem {
+                    name: top_level_label(&call.path),
+                    kind: types::SymbolKind::MODULE,
+                    tags: None,
+                    detail: Some("script top level".to_owned()),
+                    uri,
+                    range,
+                    selection_range: range,
+                    data: None,
+                })
+            }
+        }
+    }
+
+    fn ranges_in(&self, path: &Path, spans: &[Span]) -> Vec<types::Range> {
+        spans
+            .iter()
+            .filter_map(|span| self.range_of(path, *span))
+            .collect()
+    }
+
+    fn range_of(&self, path: &Path, span: Span) -> Option<types::Range> {
+        let text = self.texts.get(path)?;
+        Some(crate::edit::to_lsp_range(
+            span.to_range(),
+            &text.source,
+            &text.line_index,
+            self.encoding,
+        ))
+    }
+}
+
+fn insert_file(
+    index: &mut WorkspaceCallIndex,
+    texts: &mut BTreeMap<PathBuf, FileText>,
+    path: &Path,
+    source: &str,
+) {
+    let key = canonical(path);
+    let shell = ShellDialect::infer(source, Some(path));
+    let model = analyze_editor_document(source, Some(path), shell);
+    // Base-directory resolution covers relative hints and literal includes;
+    // configured `source-paths` roots are a follow-up.
+    let edges = model
+        .source_refs()
+        .iter()
+        .flat_map(|source_ref| resolve_source_ref_targets(path, source_ref, &[], Path::new("")))
+        .map(|target| canonical(&target))
+        .collect::<Vec<_>>();
+    index.insert(key.clone(), FileCallFacts::project(&model, edges));
+    texts.insert(
+        key,
+        FileText {
+            source: source.to_owned(),
+            line_index: LineIndex::new(source),
+        },
+    );
+}
+
+fn discover_closed_shell_files(roots: &[PathBuf], open_paths: &[PathBuf]) -> Vec<PathBuf> {
+    use shuck_discover::{DiscoveryOptions, FileKind, discover_files};
+
+    let mut files: BTreeMap<PathBuf, ()> = BTreeMap::new();
+    for root in roots {
+        let discovered = match discover_files(
+            std::slice::from_ref(root),
+            root,
+            &DiscoveryOptions {
+                respect_gitignore: true,
+                parallel: true,
+                use_config_roots: true,
+                ..DiscoveryOptions::default()
+            },
+        ) {
+            Ok(files) => files,
+            Err(error) => {
+                tracing::warn!(
+                    "call hierarchy: failed to discover files in {}: {error}",
+                    root.display()
+                );
+                continue;
+            }
+        };
+        for file in discovered {
+            if file.kind != FileKind::Shell {
+                continue;
+            }
+            let path = canonical(&file.absolute_path);
+            if open_paths.contains(&path) {
+                continue;
+            }
+            files.entry(path).or_default();
+        }
+    }
+    files.into_keys().collect()
+}
+
+fn canonical(path: &Path) -> PathBuf {
+    std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf())
+}
+
+fn top_level_label(path: &Path) -> String {
+    path.file_name()
+        .map(|name| name.to_string_lossy().into_owned())
+        .unwrap_or_else(|| "script".to_owned())
+}

--- a/crates/shuck-server/src/call_hierarchy.rs
+++ b/crates/shuck-server/src/call_hierarchy.rs
@@ -8,11 +8,12 @@
 //! single-file identity step; the item it returns (name + file URI) is enough
 //! for the index queries to locate the node.
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashMap};
 use std::path::{Path, PathBuf};
 
 use lsp_types as types;
 use shuck_ast::{Name, Span};
+use shuck_config::{ConfigArguments, load_project_config, resolve_project_root_for_file};
 use shuck_indexer::LineIndex;
 use shuck_linter::ShellDialect;
 use shuck_semantic::{
@@ -22,6 +23,39 @@ use shuck_semantic::{
 use crate::PositionEncoding;
 use crate::editor::analyze_editor_document;
 use crate::symbols::WorkspaceOpenDocument;
+
+/// Resolves and memoizes `[lint] source-paths` per project root, so cross-file
+/// hint resolution honors configured search roots the same way `shuck check`
+/// does. Relative roots are resolved against the project root.
+#[derive(Default)]
+struct SourcePathsCache {
+    by_project_root: HashMap<PathBuf, Vec<String>>,
+}
+
+impl SourcePathsCache {
+    /// Returns the configured source-path roots for `path` and the project root
+    /// that relative roots are resolved against.
+    fn resolve(&mut self, path: &Path, workspace_roots: &[PathBuf]) -> (Vec<String>, PathBuf) {
+        let fallback = workspace_roots
+            .iter()
+            .filter(|root| path.starts_with(root))
+            .max_by_key(|root| root.components().count())
+            .cloned()
+            .or_else(|| path.parent().map(Path::to_path_buf))
+            .unwrap_or_else(|| PathBuf::from("."));
+        let project_root = resolve_project_root_for_file(path, &fallback, true).unwrap_or(fallback);
+        let roots = self
+            .by_project_root
+            .entry(project_root.clone())
+            .or_insert_with(|| {
+                load_project_config(&project_root, &ConfigArguments::default())
+                    .map(|config| config.lint.source_paths.unwrap_or_default())
+                    .unwrap_or_default()
+            })
+            .clone();
+        (roots, project_root)
+    }
+}
 
 pub(crate) type IncomingResponse = Option<Vec<types::CallHierarchyIncomingCall>>;
 pub(crate) type OutgoingResponse = Option<Vec<types::CallHierarchyOutgoingCall>>;
@@ -107,20 +141,30 @@ impl BuiltIndex {
         let mut index = WorkspaceCallIndex::new();
         let mut texts: BTreeMap<PathBuf, FileText> = BTreeMap::new();
 
+        let mut source_paths = SourcePathsCache::default();
         let mut open_paths = Vec::new();
         for open in &context.open_documents {
             let Some(path) = open.uri.to_file_path().ok().map(|path| canonical(&path)) else {
                 continue;
             };
             open_paths.push(path.clone());
-            insert_file(&mut index, &mut texts, &path, open.document.contents());
+            let (roots, base) = source_paths.resolve(&path, &context.workspace_roots);
+            insert_file(
+                &mut index,
+                &mut texts,
+                &path,
+                open.document.contents(),
+                &roots,
+                &base,
+            );
         }
 
         for file in discover_closed_shell_files(&context.workspace_roots, &open_paths) {
             let Ok(source) = std::fs::read_to_string(&file) else {
                 continue;
             };
-            insert_file(&mut index, &mut texts, &file, &source);
+            let (roots, base) = source_paths.resolve(&file, &context.workspace_roots);
+            insert_file(&mut index, &mut texts, &file, &source, &roots, &base);
         }
 
         Self {
@@ -194,16 +238,20 @@ fn insert_file(
     texts: &mut BTreeMap<PathBuf, FileText>,
     path: &Path,
     source: &str,
+    source_path_roots: &[String],
+    source_path_base: &Path,
 ) {
     let key = canonical(path);
     let shell = ShellDialect::infer(source, Some(path));
     let model = analyze_editor_document(source, Some(path), shell);
-    // Base-directory resolution covers relative hints and literal includes;
-    // configured `source-paths` roots are a follow-up.
+    // Resolve each determinable source edge against the file's own directory
+    // first, then the configured `[lint] source-paths` roots.
     let edges = model
         .source_refs()
         .iter()
-        .flat_map(|source_ref| resolve_source_ref_targets(path, source_ref, &[], Path::new("")))
+        .flat_map(|source_ref| {
+            resolve_source_ref_targets(path, source_ref, source_path_roots, source_path_base)
+        })
         .map(|target| canonical(&target))
         .collect::<Vec<_>>();
     index.insert(key.clone(), FileCallFacts::project(&model, edges));

--- a/crates/shuck-server/src/editor_features.rs
+++ b/crates/shuck-server/src/editor_features.rs
@@ -20,8 +20,6 @@ pub(crate) type DocumentHighlightResponse = Option<Vec<types::DocumentHighlight>
 pub(crate) type PrepareRenameResponse = Option<types::PrepareRenameResponse>;
 pub(crate) type RenameResponse = Option<types::WorkspaceEdit>;
 pub(crate) type CallHierarchyPrepareResponse = Option<Vec<types::CallHierarchyItem>>;
-pub(crate) type CallHierarchyIncomingResponse = Option<Vec<types::CallHierarchyIncomingCall>>;
-pub(crate) type CallHierarchyOutgoingResponse = Option<Vec<types::CallHierarchyOutgoingCall>>;
 
 /// Round-trip payload stored in `CallHierarchyItem.data` so the incoming/outgoing
 /// requests can re-resolve the node on a freshly analyzed document.
@@ -213,115 +211,6 @@ pub(crate) fn prepare_call_hierarchy(
     )]))
 }
 
-pub(crate) fn call_hierarchy_incoming_calls(
-    snapshot: DocumentSnapshot,
-    _client: &Client,
-    params: types::CallHierarchyIncomingCallsParams,
-) -> crate::server::Result<CallHierarchyIncomingResponse> {
-    let Some(analysis) = snapshot.analysis() else {
-        return Ok(None);
-    };
-    let source = analysis.source();
-    let query = analysis.semantic().editor_query();
-    let Some(item) = resolve_call_hierarchy_item(
-        &snapshot,
-        source,
-        analysis.line_index(),
-        &query,
-        &params.item,
-    ) else {
-        return Ok(None);
-    };
-    let calls = query
-        .incoming_calls(&item)
-        .into_iter()
-        .map(|incoming| types::CallHierarchyIncomingCall {
-            from: to_lsp_call_hierarchy_item(
-                &snapshot,
-                source,
-                analysis.line_index(),
-                incoming.from,
-            ),
-            from_ranges: spans_to_ranges(
-                &snapshot,
-                source,
-                analysis.line_index(),
-                &incoming.call_spans,
-            ),
-        })
-        .collect();
-    Ok(Some(calls))
-}
-
-pub(crate) fn call_hierarchy_outgoing_calls(
-    snapshot: DocumentSnapshot,
-    _client: &Client,
-    params: types::CallHierarchyOutgoingCallsParams,
-) -> crate::server::Result<CallHierarchyOutgoingResponse> {
-    let Some(analysis) = snapshot.analysis() else {
-        return Ok(None);
-    };
-    let source = analysis.source();
-    let query = analysis.semantic().editor_query();
-    let Some(item) = resolve_call_hierarchy_item(
-        &snapshot,
-        source,
-        analysis.line_index(),
-        &query,
-        &params.item,
-    ) else {
-        return Ok(None);
-    };
-    let calls = query
-        .outgoing_calls(&item)
-        .into_iter()
-        .map(|outgoing| types::CallHierarchyOutgoingCall {
-            to: to_lsp_call_hierarchy_item(&snapshot, source, analysis.line_index(), outgoing.to),
-            from_ranges: spans_to_ranges(
-                &snapshot,
-                source,
-                analysis.line_index(),
-                &outgoing.call_spans,
-            ),
-        })
-        .collect();
-    Ok(Some(calls))
-}
-
-/// Re-resolves the semantic node identified by an incoming LSP `CallHierarchyItem`.
-///
-/// Prefers the `data` payload we attached during `prepare`; falls back to the
-/// item's selection-range position when a client does not round-trip it.
-fn resolve_call_hierarchy_item(
-    snapshot: &DocumentSnapshot,
-    source: &str,
-    line_index: &shuck_indexer::LineIndex,
-    query: &shuck_semantic::EditorQuery<'_>,
-    item: &types::CallHierarchyItem,
-) -> Option<EditorCallHierarchyItem> {
-    let data = item
-        .data
-        .clone()
-        .and_then(|value| serde_json::from_value::<CallHierarchyData>(value).ok());
-    match data {
-        Some(CallHierarchyData::TopLevel) => Some(query.top_level_call_hierarchy_item()),
-        Some(CallHierarchyData::Function { line, character }) => {
-            let offset = offset_for_position(
-                snapshot,
-                source,
-                line_index,
-                types::Position { line, character },
-            );
-            query.prepare_call_hierarchy(offset)
-        }
-        None => {
-            let offset =
-                offset_for_position(snapshot, source, line_index, item.selection_range.start);
-            query.prepare_call_hierarchy(offset)
-        }
-    }
-}
-
 fn to_lsp_call_hierarchy_item(
     snapshot: &DocumentSnapshot,
     source: &str,
@@ -383,20 +272,6 @@ fn to_lsp_call_hierarchy_item(
             }
         }
     }
-}
-
-fn spans_to_ranges(
-    snapshot: &DocumentSnapshot,
-    source: &str,
-    line_index: &shuck_indexer::LineIndex,
-    spans: &[shuck_ast::Span],
-) -> Vec<types::Range> {
-    spans
-        .iter()
-        .map(|span| {
-            crate::edit::to_lsp_range(span.to_range(), source, line_index, snapshot.encoding())
-        })
-        .collect()
 }
 
 fn top_level_label(uri: &types::Url) -> String {
@@ -965,11 +840,14 @@ mod tests {
     }
 
     #[test]
-    fn call_hierarchy_prepare_incoming_and_outgoing() {
+    fn call_hierarchy_prepare_resolves_function_under_cursor() {
+        // prepare identifies the function node; incoming/outgoing (single- and
+        // cross-file) are covered by the semantic call-facts tests and the
+        // call_hierarchy module's black-box coverage.
         let source = "helper() {\n  echo hi\n}\n\nmain() {\n  helper\n  helper\n}\n\nmain\n";
         let (snapshot, client, uri) = make_snapshot(source);
 
-        // Prepare on the `main` definition name.
+        // On the `main` definition name.
         let main_item = prepare_item(
             &snapshot,
             &client,
@@ -979,61 +857,15 @@ mod tests {
         assert_eq!(main_item.name, "main");
         assert_eq!(main_item.kind, types::SymbolKind::FUNCTION);
 
-        // main() calls helper twice.
-        let outgoing = call_hierarchy_outgoing_calls(
-            snapshot.clone(),
-            &client,
-            types::CallHierarchyOutgoingCallsParams {
-                item: main_item.clone(),
-                work_done_progress_params: WorkDoneProgressParams::default(),
-                partial_result_params: PartialResultParams::default(),
-            },
-        )
-        .expect("outgoing should succeed")
-        .expect("outgoing should return calls");
-        assert_eq!(outgoing.len(), 1);
-        assert_eq!(outgoing[0].to.name, "helper");
-        assert_eq!(outgoing[0].from_ranges.len(), 2);
-
-        // main() is called once, from the script top level.
-        let incoming_main = call_hierarchy_incoming_calls(
-            snapshot.clone(),
-            &client,
-            types::CallHierarchyIncomingCallsParams {
-                item: main_item,
-                work_done_progress_params: WorkDoneProgressParams::default(),
-                partial_result_params: PartialResultParams::default(),
-            },
-        )
-        .expect("incoming should succeed")
-        .expect("incoming should return calls");
-        assert_eq!(incoming_main.len(), 1);
-        assert_eq!(incoming_main[0].from.kind, types::SymbolKind::MODULE);
-        assert_eq!(incoming_main[0].from_ranges.len(), 1);
-
-        // Prepare on `helper`; its callers are the enclosing function `main`.
+        // On a call to `helper`, prepare resolves to the `helper` definition.
         let helper_item = prepare_item(
             &snapshot,
             &client,
             &uri,
-            position_for_nth(source, "helper", 0),
+            position_for_nth(source, "helper", 1),
         );
         assert_eq!(helper_item.name, "helper");
-        let incoming_helper = call_hierarchy_incoming_calls(
-            snapshot,
-            &client,
-            types::CallHierarchyIncomingCallsParams {
-                item: helper_item,
-                work_done_progress_params: WorkDoneProgressParams::default(),
-                partial_result_params: PartialResultParams::default(),
-            },
-        )
-        .expect("incoming should succeed")
-        .expect("incoming should return calls");
-        assert_eq!(incoming_helper.len(), 1);
-        assert_eq!(incoming_helper[0].from.name, "main");
-        assert_eq!(incoming_helper[0].from.kind, types::SymbolKind::FUNCTION);
-        assert_eq!(incoming_helper[0].from_ranges.len(), 2);
+        assert_eq!(helper_item.kind, types::SymbolKind::FUNCTION);
     }
 
     #[test]

--- a/crates/shuck-server/src/editor_features.rs
+++ b/crates/shuck-server/src/editor_features.rs
@@ -22,10 +22,11 @@ pub(crate) type RenameResponse = Option<types::WorkspaceEdit>;
 pub(crate) type CallHierarchyPrepareResponse = Option<Vec<types::CallHierarchyItem>>;
 
 /// Round-trip payload stored in `CallHierarchyItem.data` so the incoming/outgoing
-/// requests can re-resolve the node on a freshly analyzed document.
+/// requests can distinguish a script top-level node from a function that happens
+/// to share the file's label.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase", tag = "kind")]
-enum CallHierarchyData {
+pub(crate) enum CallHierarchyData {
     Function { line: u32, character: u32 },
     TopLevel,
 }
@@ -242,35 +243,51 @@ fn to_lsp_call_hierarchy_item(
                     )
                 })
                 .unwrap_or(full_range);
-            types::CallHierarchyItem {
-                name: item.name.to_string(),
-                kind: types::SymbolKind::FUNCTION,
-                tags: None,
-                detail: None,
-                uri,
-                range: full_range,
-                selection_range,
-                data: serde_json::to_value(CallHierarchyData::Function {
-                    line: selection_range.start.line,
-                    character: selection_range.start.character,
-                })
-                .ok(),
-            }
+            call_hierarchy_function_item(item.name.to_string(), uri, full_range, selection_range)
         }
-        EditorCallHierarchyTarget::TopLevel => {
-            let start = types::Position::new(0, 0);
-            let range = types::Range { start, end: start };
-            types::CallHierarchyItem {
-                name: top_level_label(&uri),
-                kind: types::SymbolKind::MODULE,
-                tags: None,
-                detail: Some("script top level".to_owned()),
-                uri,
-                range,
-                selection_range: range,
-                data: serde_json::to_value(CallHierarchyData::TopLevel).ok(),
-            }
-        }
+        EditorCallHierarchyTarget::TopLevel => call_hierarchy_top_level_item(uri),
+    }
+}
+
+/// The one place a FUNCTION call-hierarchy node is shaped, shared by `prepare`
+/// and the cross-file incoming/outgoing item builder so the three requests
+/// return identical items for the same node.
+pub(crate) fn call_hierarchy_function_item(
+    name: String,
+    uri: types::Url,
+    range: types::Range,
+    selection_range: types::Range,
+) -> types::CallHierarchyItem {
+    types::CallHierarchyItem {
+        name,
+        kind: types::SymbolKind::FUNCTION,
+        tags: None,
+        detail: None,
+        uri,
+        range,
+        selection_range,
+        data: serde_json::to_value(CallHierarchyData::Function {
+            line: selection_range.start.line,
+            character: selection_range.start.character,
+        })
+        .ok(),
+    }
+}
+
+/// The one place a script-top-level MODULE node is shaped; see
+/// [`call_hierarchy_function_item`].
+pub(crate) fn call_hierarchy_top_level_item(uri: types::Url) -> types::CallHierarchyItem {
+    let start = types::Position::new(0, 0);
+    let range = types::Range { start, end: start };
+    types::CallHierarchyItem {
+        name: top_level_label(&uri),
+        kind: types::SymbolKind::MODULE,
+        tags: None,
+        detail: Some("script top level".to_owned()),
+        uri,
+        range,
+        selection_range: range,
+        data: serde_json::to_value(CallHierarchyData::TopLevel).ok(),
     }
 }
 

--- a/crates/shuck-server/src/lib.rs
+++ b/crates/shuck-server/src/lib.rs
@@ -17,6 +17,7 @@ pub use session::{Client, ClientOptions, DocumentQuery, DocumentSnapshot, Global
 pub use workspace::{Workspace, Workspaces};
 
 mod analysis;
+mod call_hierarchy;
 mod edit;
 mod editor;
 mod editor_features;

--- a/crates/shuck-server/src/server/api.rs
+++ b/crates/shuck-server/src/server/api.rs
@@ -39,10 +39,10 @@ pub(super) fn request(req: server::Request) -> Task {
         request::CallHierarchyPrepare::METHOD => {
             background_request_task::<request::CallHierarchyPrepare>(req, BackgroundSchedule::Worker)
         }
-        request::CallHierarchyIncomingCalls::METHOD => background_request_task::<
+        request::CallHierarchyIncomingCalls::METHOD => background_session_request_task::<
             request::CallHierarchyIncomingCalls,
         >(req, BackgroundSchedule::Worker),
-        request::CallHierarchyOutgoingCalls::METHOD => background_request_task::<
+        request::CallHierarchyOutgoingCalls::METHOD => background_session_request_task::<
             request::CallHierarchyOutgoingCalls,
         >(req, BackgroundSchedule::Worker),
         request::CodeActions::METHOD => {

--- a/crates/shuck-server/src/server/api/requests/call_hierarchy_incoming.rs
+++ b/crates/shuck-server/src/server/api/requests/call_hierarchy_incoming.rs
@@ -1,7 +1,8 @@
 use lsp_types::{self as types, request as req};
 
-use crate::editor_features;
-use crate::session::{Client, DocumentSnapshot};
+use crate::call_hierarchy::{self, CallHierarchyContext};
+use crate::server::Result;
+use crate::session::{Client, Session};
 
 pub(crate) struct CallHierarchyIncomingCalls;
 
@@ -9,25 +10,21 @@ impl super::RequestHandler for CallHierarchyIncomingCalls {
     type RequestType = req::CallHierarchyIncomingCalls;
 }
 
-impl super::BackgroundDocumentRequestHandler for CallHierarchyIncomingCalls {
-    fn document_url(
-        params: &types::CallHierarchyIncomingCallsParams,
-    ) -> std::borrow::Cow<'_, types::Url> {
-        std::borrow::Cow::Borrowed(&params.item.uri)
-    }
+impl super::super::traits::BackgroundRequestHandler for CallHierarchyIncomingCalls {
+    type Snapshot = CallHierarchyContext;
 
-    fn run_without_snapshot(
-        _client: &Client,
-        _params: types::CallHierarchyIncomingCallsParams,
-    ) -> crate::server::Result<editor_features::CallHierarchyIncomingResponse> {
-        Ok(None)
+    fn snapshot(
+        session: &Session,
+        _params: &types::CallHierarchyIncomingCallsParams,
+    ) -> Result<Self::Snapshot> {
+        Ok(session.call_hierarchy_context())
     }
 
     fn run_with_snapshot(
-        snapshot: DocumentSnapshot,
-        client: &Client,
+        snapshot: Self::Snapshot,
+        _client: &Client,
         params: types::CallHierarchyIncomingCallsParams,
-    ) -> crate::server::Result<editor_features::CallHierarchyIncomingResponse> {
-        editor_features::call_hierarchy_incoming_calls(snapshot, client, params)
+    ) -> Result<call_hierarchy::IncomingResponse> {
+        call_hierarchy::incoming_calls(snapshot, params)
     }
 }

--- a/crates/shuck-server/src/server/api/requests/call_hierarchy_outgoing.rs
+++ b/crates/shuck-server/src/server/api/requests/call_hierarchy_outgoing.rs
@@ -1,7 +1,8 @@
 use lsp_types::{self as types, request as req};
 
-use crate::editor_features;
-use crate::session::{Client, DocumentSnapshot};
+use crate::call_hierarchy::{self, CallHierarchyContext};
+use crate::server::Result;
+use crate::session::{Client, Session};
 
 pub(crate) struct CallHierarchyOutgoingCalls;
 
@@ -9,25 +10,21 @@ impl super::RequestHandler for CallHierarchyOutgoingCalls {
     type RequestType = req::CallHierarchyOutgoingCalls;
 }
 
-impl super::BackgroundDocumentRequestHandler for CallHierarchyOutgoingCalls {
-    fn document_url(
-        params: &types::CallHierarchyOutgoingCallsParams,
-    ) -> std::borrow::Cow<'_, types::Url> {
-        std::borrow::Cow::Borrowed(&params.item.uri)
-    }
+impl super::super::traits::BackgroundRequestHandler for CallHierarchyOutgoingCalls {
+    type Snapshot = CallHierarchyContext;
 
-    fn run_without_snapshot(
-        _client: &Client,
-        _params: types::CallHierarchyOutgoingCallsParams,
-    ) -> crate::server::Result<editor_features::CallHierarchyOutgoingResponse> {
-        Ok(None)
+    fn snapshot(
+        session: &Session,
+        _params: &types::CallHierarchyOutgoingCallsParams,
+    ) -> Result<Self::Snapshot> {
+        Ok(session.call_hierarchy_context())
     }
 
     fn run_with_snapshot(
-        snapshot: DocumentSnapshot,
-        client: &Client,
+        snapshot: Self::Snapshot,
+        _client: &Client,
         params: types::CallHierarchyOutgoingCallsParams,
-    ) -> crate::server::Result<editor_features::CallHierarchyOutgoingResponse> {
-        editor_features::call_hierarchy_outgoing_calls(snapshot, client, params)
+    ) -> Result<call_hierarchy::OutgoingResponse> {
+        call_hierarchy::outgoing_calls(snapshot, params)
     }
 }

--- a/crates/shuck-server/src/server/main_loop.rs
+++ b/crates/shuck-server/src/server/main_loop.rs
@@ -121,39 +121,18 @@ impl Server {
 
         if !dynamic_registration {
             tracing::warn!(
-                "LSP client does not support dynamic watched-file registration; config reloads are disabled"
+                "LSP client does not support dynamic watched-file registration; closed-file index updates and config reloads are disabled"
             );
             return;
         }
 
-        let mut watchers = vec![
-            FileSystemWatcher {
-                glob_pattern: types::GlobPattern::String("**/.shuck.toml".into()),
-                kind: None,
-            },
-            FileSystemWatcher {
-                glob_pattern: types::GlobPattern::String("**/shuck.toml".into()),
-                kind: None,
-            },
-        ];
-        // The user-level global config lives outside the workspace, so the
-        // relative globs above never cover it; watch its candidate paths
-        // explicitly so projects using the global fallback observe edits.
-        watchers.extend(
-            shuck_config::global_config_candidate_paths()
-                .iter()
-                .filter_map(|path| path.to_str())
-                .map(|path| FileSystemWatcher {
-                    glob_pattern: types::GlobPattern::String(path.into()),
-                    kind: None,
-                }),
-        );
+        let watchers = watched_files();
 
         let register_options =
             match serde_json::to_value(DidChangeWatchedFilesRegistrationOptions { watchers }) {
                 Ok(value) => value,
                 Err(error) => {
-                    tracing::error!("Failed to serialize config watcher registration: {error}");
+                    tracing::error!("Failed to serialize workspace watcher registration: {error}");
                     return;
                 }
             };
@@ -168,7 +147,7 @@ impl Server {
 
         let response_handler = |_: &Client, session: &mut crate::Session, ()| {
             session.set_project_settings_cache_enabled(true);
-            tracing::info!("Registered configuration file watcher");
+            tracing::info!("Registered workspace file watcher");
         };
 
         if let Err(err) = client.send_request::<lsp_types::request::RegisterCapability>(
@@ -176,13 +155,68 @@ impl Server {
             params,
             response_handler,
         ) {
-            tracing::error!("Failed to register configuration file watcher: {err}");
+            tracing::error!("Failed to register workspace file watcher: {err}");
         }
     }
+}
+
+fn watched_files() -> Vec<FileSystemWatcher> {
+    let mut watchers = vec![
+        // Call-hierarchy and workspace-symbol indexes include every discovered
+        // shell file, including extensionless shebang and zsh startup files.
+        // Watch the workspace broadly so closed-file edits, creates, deletes,
+        // and VCS updates invalidate those indexes.
+        FileSystemWatcher {
+            glob_pattern: types::GlobPattern::String("**/*".into()),
+            kind: None,
+        },
+        // Keep explicit config globs because some client glob implementations
+        // do not let a wildcard match leading-dot path components.
+        FileSystemWatcher {
+            glob_pattern: types::GlobPattern::String("**/.shuck.toml".into()),
+            kind: None,
+        },
+        FileSystemWatcher {
+            glob_pattern: types::GlobPattern::String("**/shuck.toml".into()),
+            kind: None,
+        },
+    ];
+    // The user-level global config lives outside the workspace, so the
+    // relative globs above never cover it; watch its candidate paths
+    // explicitly so projects using the global fallback observe edits.
+    watchers.extend(
+        shuck_config::global_config_candidate_paths()
+            .iter()
+            .filter_map(|path| path.to_str())
+            .map(|path| FileSystemWatcher {
+                glob_pattern: types::GlobPattern::String(path.into()),
+                kind: None,
+            }),
+    );
+    watchers
 }
 
 #[derive(Debug)]
 pub enum Event {
     Message(lsp_server::Message),
     SendResponse(lsp_server::Response),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn watched_files_include_all_workspace_paths_and_config_dotfiles() {
+        let patterns = watched_files()
+            .into_iter()
+            .filter_map(|watcher| match watcher.glob_pattern {
+                types::GlobPattern::String(pattern) => Some(pattern),
+                types::GlobPattern::Relative(_) => None,
+            })
+            .collect::<Vec<_>>();
+        assert!(patterns.iter().any(|pattern| pattern == "**/*"));
+        assert!(patterns.iter().any(|pattern| pattern == "**/.shuck.toml"));
+        assert!(patterns.iter().any(|pattern| pattern == "**/shuck.toml"));
+    }
 }

--- a/crates/shuck-server/src/session.rs
+++ b/crates/shuck-server/src/session.rs
@@ -38,6 +38,7 @@ pub struct Session {
     resolved_client_capabilities: Arc<ResolvedClientCapabilities>,
     workspace_symbols: Arc<crate::symbols::WorkspaceSymbolIndex>,
     analysis_cache: Arc<DocumentAnalysisCache>,
+    call_index_cache: Arc<crate::call_hierarchy::CallIndexCache>,
     request_queue: RequestQueue,
     shutdown_requested: bool,
 }
@@ -71,6 +72,7 @@ impl Session {
             )),
             workspace_symbols: Arc::new(crate::symbols::WorkspaceSymbolIndex::default()),
             analysis_cache: Arc::new(DocumentAnalysisCache::new()),
+            call_index_cache: Arc::new(crate::call_hierarchy::CallIndexCache::default()),
             request_queue: RequestQueue::new(),
             shutdown_requested: false,
         })
@@ -124,6 +126,7 @@ impl Session {
                 .update_text_document(key, content_changes, new_version, self.encoding());
         if result.is_ok() {
             self.analysis_cache.invalidate_uri(&key.clone().into_url());
+            self.call_index_cache.invalidate();
         }
         result
     }
@@ -131,12 +134,14 @@ impl Session {
     /// Open or replace an in-memory text document.
     pub fn open_text_document(&mut self, url: Url, document: TextDocument) {
         self.analysis_cache.invalidate_uri(&url);
+        self.call_index_cache.invalidate();
         self.index.open_text_document(url, document);
     }
 
     pub(crate) fn close_document(&mut self, key: &DocumentKey) -> crate::Result<()> {
         self.index.close_document(key)?;
         self.analysis_cache.invalidate_uri(&key.clone().into_url());
+        self.call_index_cache.invalidate();
         self.workspace_symbols
             .invalidate_uri(&key.clone().into_url());
         Ok(())
@@ -145,6 +150,7 @@ impl Session {
     pub(crate) fn reload_settings(&mut self, changes: &[FileEvent], client: &Client) {
         self.index.reload_settings(changes, client);
         self.analysis_cache.clear();
+        self.call_index_cache.invalidate();
         self.workspace_symbols.invalidate_file_events(changes);
     }
 
@@ -152,6 +158,7 @@ impl Session {
         self.index
             .open_workspace_folder(url, &self.global_settings, client)?;
         self.analysis_cache.clear();
+        self.call_index_cache.invalidate();
         self.workspace_symbols.invalidate_all();
         Ok(())
     }
@@ -159,6 +166,7 @@ impl Session {
     pub(crate) fn close_workspace_folder(&mut self, url: &Url) -> crate::Result<()> {
         self.index.close_workspace_folder(url)?;
         self.analysis_cache.clear();
+        self.call_index_cache.invalidate();
         self.workspace_symbols.invalidate_all();
         Ok(())
     }
@@ -181,6 +189,7 @@ impl Session {
 
     pub(crate) fn update_client_options(&mut self, options: ClientOptions) {
         self.analysis_cache.clear();
+        self.call_index_cache.invalidate();
         self.workspace_symbols.invalidate_all();
         self.global_settings.update_options(options);
         self.index.clear_project_settings_cache();
@@ -192,6 +201,7 @@ impl Session {
         workspace_options: Option<WorkspaceOptionsMap>,
     ) {
         self.analysis_cache.clear();
+        self.call_index_cache.invalidate();
         self.workspace_symbols.invalidate_all();
         self.global_settings.update_options(options);
         if let Some(workspace_options) = workspace_options {
@@ -245,6 +255,14 @@ impl Session {
             workspace_roots: self.index.workspace_roots().to_vec(),
             open_documents: self.index.open_documents_snapshot(),
             encoding: self.position_encoding,
+            max_files: self
+                .global_settings
+                .options()
+                .server
+                .call_hierarchy
+                .max_files,
+            epoch: self.call_index_cache.current_epoch(),
+            cache: self.call_index_cache.clone(),
         }
     }
 }

--- a/crates/shuck-server/src/session.rs
+++ b/crates/shuck-server/src/session.rs
@@ -302,7 +302,7 @@ impl DocumentSnapshot {
 mod tests {
     use crossbeam::channel;
     use lsp_types::{
-        ClientCapabilities, DidChangeWatchedFilesClientCapabilities,
+        ClientCapabilities, DidChangeWatchedFilesClientCapabilities, FileChangeType, FileEvent,
         TextDocumentContentChangeEvent, Url, WorkspaceClientCapabilities,
     };
 
@@ -396,6 +396,27 @@ mod tests {
 
         assert!(!Arc::ptr_eq(&before, &after));
         assert!(after.source().contains("other=value"));
+    }
+
+    #[test]
+    fn call_index_cache_invalidates_after_closed_file_event() {
+        let (workspace, mut session, _uri) = make_test_session();
+        let before = session.call_hierarchy_context().epoch;
+        let (main_loop_sender, _main_loop_receiver) = channel::unbounded();
+        let (client_sender, _client_receiver) = channel::unbounded();
+        let client = Client::new(main_loop_sender, client_sender);
+        let closed_uri = Url::from_file_path(workspace.path().join("closed.sh"))
+            .expect("closed file path should convert to a URL");
+
+        session.reload_settings(
+            &[FileEvent {
+                uri: closed_uri,
+                typ: FileChangeType::CHANGED,
+            }],
+            &client,
+        );
+
+        assert!(session.call_hierarchy_context().epoch > before);
     }
 
     #[test]

--- a/crates/shuck-server/src/session.rs
+++ b/crates/shuck-server/src/session.rs
@@ -236,6 +236,17 @@ impl Session {
             encoding: self.position_encoding,
         }
     }
+
+    /// Build the workspace context used to answer cross-file call-hierarchy
+    /// requests: the workspace roots, a snapshot of open documents, and the
+    /// negotiated position encoding.
+    pub(crate) fn call_hierarchy_context(&self) -> crate::call_hierarchy::CallHierarchyContext {
+        crate::call_hierarchy::CallHierarchyContext {
+            workspace_roots: self.index.workspace_roots().to_vec(),
+            open_documents: self.index.open_documents_snapshot(),
+            encoding: self.position_encoding,
+        }
+    }
 }
 
 impl DocumentSnapshot {

--- a/crates/shuck-server/src/session/options.rs
+++ b/crates/shuck-server/src/session/options.rs
@@ -68,9 +68,12 @@ pub struct ServerOptions {
     pub completion: CompletionFeatureOptions,
     /// Rename configuration.
     pub rename: RenameFeatureOptions,
+    /// Cross-file call hierarchy configuration.
+    pub call_hierarchy: CallHierarchyFeatureOptions,
     workspace_symbols_overrides: WorkspaceSymbolFeatureOptionsOverrides,
     completion_overrides: CompletionFeatureOptionsOverrides,
     rename_overrides: RenameFeatureOptionsOverrides,
+    call_hierarchy_overrides: CallHierarchyFeatureOptionsOverrides,
 }
 
 impl ServerOptions {
@@ -109,6 +112,19 @@ impl ServerOptions {
             base
         }
     }
+
+    pub(crate) fn call_hierarchy_layered_over(
+        &self,
+        base: CallHierarchyFeatureOptions,
+    ) -> CallHierarchyFeatureOptions {
+        if self.call_hierarchy_overrides.has_overrides() {
+            self.call_hierarchy_overrides.apply_to(base)
+        } else if self.call_hierarchy != CallHierarchyFeatureOptions::default() {
+            self.call_hierarchy
+        } else {
+            base
+        }
+    }
 }
 
 impl<'de> Deserialize<'de> for ServerOptions {
@@ -125,6 +141,8 @@ impl<'de> Deserialize<'de> for ServerOptions {
             completion: CompletionFeatureOptionsOverrides,
             #[serde(default)]
             rename: RenameFeatureOptionsOverrides,
+            #[serde(default)]
+            call_hierarchy: CallHierarchyFeatureOptionsOverrides,
         }
 
         let raw = RawServerOptions::deserialize(deserializer)?;
@@ -134,9 +152,13 @@ impl<'de> Deserialize<'de> for ServerOptions {
                 .apply_to(WorkspaceSymbolFeatureOptions::default()),
             completion: raw.completion.apply_to(CompletionFeatureOptions::default()),
             rename: raw.rename.apply_to(RenameFeatureOptions::default()),
+            call_hierarchy: raw
+                .call_hierarchy
+                .apply_to(CallHierarchyFeatureOptions::default()),
             workspace_symbols_overrides: raw.workspace_symbols,
             completion_overrides: raw.completion,
             rename_overrides: raw.rename,
+            call_hierarchy_overrides: raw.call_hierarchy,
         })
     }
 }
@@ -259,6 +281,46 @@ impl Default for WorkspaceSymbolFeatureOptions {
 
 fn default_workspace_symbols_enabled() -> bool {
     true
+}
+
+#[derive(Clone, Copy, Debug, Default, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+struct CallHierarchyFeatureOptionsOverrides {
+    #[serde(default)]
+    max_files: Option<usize>,
+}
+
+impl CallHierarchyFeatureOptionsOverrides {
+    fn has_overrides(self) -> bool {
+        self.max_files.is_some()
+    }
+
+    fn apply_to(self, base: CallHierarchyFeatureOptions) -> CallHierarchyFeatureOptions {
+        CallHierarchyFeatureOptions {
+            max_files: self.max_files.unwrap_or(base.max_files),
+        }
+    }
+}
+
+/// Configuration for cross-file call hierarchy.
+#[derive(Clone, Copy, Debug, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct CallHierarchyFeatureOptions {
+    /// Maximum number of workspace files to index for the call graph.
+    #[serde(default = "default_call_hierarchy_max_files")]
+    pub max_files: usize,
+}
+
+impl Default for CallHierarchyFeatureOptions {
+    fn default() -> Self {
+        Self {
+            max_files: default_call_hierarchy_max_files(),
+        }
+    }
+}
+
+fn default_call_hierarchy_max_files() -> usize {
+    10_000
 }
 
 fn default_workspace_symbols_max_files() -> usize {

--- a/crates/shuck-server/src/symbols.rs
+++ b/crates/shuck-server/src/symbols.rs
@@ -34,8 +34,8 @@ pub(crate) struct WorkspaceSymbolContext {
 
 #[derive(Clone)]
 pub(crate) struct WorkspaceOpenDocument {
-    uri: types::Url,
-    document: Arc<TextDocument>,
+    pub(crate) uri: types::Url,
+    pub(crate) document: Arc<TextDocument>,
 }
 
 pub(crate) struct WorkspaceSymbolIndex {

--- a/crates/shuck-server/tests/manual.rs
+++ b/crates/shuck-server/tests/manual.rs
@@ -415,3 +415,95 @@ fn cross_file_call_hierarchy_spans_source_edges() {
         .expect("server thread should join")
         .expect("server should exit cleanly");
 }
+
+#[test]
+fn cross_file_call_hierarchy_honors_configured_source_paths() {
+    let (server_connection, client_connection) = Connection::memory();
+    let server_thread = thread::spawn(move || shuck_server::run_connection(server_connection));
+
+    let workspace = tempfile::tempdir().expect("tempdir should be created");
+    // The helper lives under lib/, reachable from scripts/main.sh ONLY via the
+    // configured [lint] source-paths root — not relative to the annotating file.
+    std::fs::write(
+        workspace.path().join("shuck.toml"),
+        "[lint]\nsource-paths = [\"lib\"]\n",
+    )
+    .unwrap();
+    std::fs::create_dir(workspace.path().join("lib")).unwrap();
+    std::fs::create_dir(workspace.path().join("scripts")).unwrap();
+    std::fs::write(
+        workspace.path().join("lib/util.sh"),
+        "greet() {\n  echo hi\n}\n",
+    )
+    .unwrap();
+    std::fs::write(
+        workspace.path().join("scripts/main.sh"),
+        "run() {\n  # shuck: follow-source=util.sh\n  source \"$X/util.sh\"\n  greet\n}\nrun\n",
+    )
+    .unwrap();
+    let util_uri = Url::from_file_path(workspace.path().join("lib/util.sh")).unwrap();
+
+    send_request(
+        &client_connection,
+        1,
+        "initialize",
+        serde_json::json!({
+            "capabilities": replay_capabilities(),
+            "rootUri": Url::from_file_path(workspace.path()).unwrap(),
+        }),
+    );
+    let _ = recv_response(&client_connection, 1);
+    client_connection
+        .sender
+        .send(Message::Notification(Notification::new(
+            "initialized".to_owned(),
+            serde_json::json!({}),
+        )))
+        .expect("initialized should send");
+    open_document(&client_connection, &util_uri, "greet() {\n  echo hi\n}\n");
+
+    send_request(
+        &client_connection,
+        2,
+        "textDocument/prepareCallHierarchy",
+        serde_json::json!({
+            "textDocument": { "uri": util_uri },
+            "position": { "line": 0, "character": 0 },
+        }),
+    );
+    let greet_item = recv_response(&client_connection, 2).as_array().unwrap()[0].clone();
+    assert_eq!(greet_item["name"], serde_json::json!("greet"));
+
+    send_request(
+        &client_connection,
+        3,
+        "callHierarchy/incomingCalls",
+        serde_json::json!({ "item": greet_item }),
+    );
+    let incoming = recv_response(&client_connection, 3);
+    let incoming = incoming.as_array().unwrap();
+    // Without source-paths, main.sh's follow-source=util.sh would not resolve and
+    // greet would have no caller; with it, `run` shows up.
+    assert_eq!(incoming.len(), 1);
+    assert_eq!(incoming[0]["from"]["name"], serde_json::json!("run"));
+    assert!(
+        incoming[0]["from"]["uri"]
+            .as_str()
+            .unwrap()
+            .ends_with("scripts/main.sh")
+    );
+
+    send_request(&client_connection, 99, "shutdown", serde_json::json!(null));
+    let _ = recv_response(&client_connection, 99);
+    client_connection
+        .sender
+        .send(Message::Notification(Notification::new(
+            "exit".to_owned(),
+            serde_json::json!({}),
+        )))
+        .expect("exit notification should send");
+    server_thread
+        .join()
+        .expect("server thread should join")
+        .expect("server should exit cleanly");
+}

--- a/crates/shuck-server/tests/manual.rs
+++ b/crates/shuck-server/tests/manual.rs
@@ -294,17 +294,17 @@ fn cross_file_call_hierarchy_spans_source_edges() {
     let server_thread = thread::spawn(move || shuck_server::run_connection(server_connection));
 
     let workspace = tempfile::tempdir().expect("tempdir should be created");
-    // a.sh defines greet; b.sh follows a and calls greet inside `run`; c.sh
-    // assumes a and calls greet at top level.
+    // a.sh defines greet; b.sh sources a (lint=true) and calls greet inside
+    // `run`; c.sh sources a (import only) and calls greet at top level.
     std::fs::write(workspace.path().join("a.sh"), "greet() {\n  echo hi\n}\n").unwrap();
     std::fs::write(
         workspace.path().join("b.sh"),
-        "run() {\n  # shuck: follow-source=a.sh\n  source \"$DIR/a.sh\"\n  greet\n}\nrun\n",
+        "run() {\n  # shuck: source=a.sh lint=true\n  source \"$DIR/a.sh\"\n  greet\n}\nrun\n",
     )
     .unwrap();
     std::fs::write(
         workspace.path().join("c.sh"),
-        "# shuck: assume-source=a.sh\nsource \"$DIR/a.sh\"\ngreet\n",
+        "# shuck: source=a.sh\nsource \"$DIR/a.sh\"\ngreet\n",
     )
     .unwrap();
     let a_uri = Url::from_file_path(workspace.path().join("a.sh")).unwrap();
@@ -348,7 +348,8 @@ fn cross_file_call_hierarchy_spans_source_edges() {
     let greet_item = prepared.as_array().unwrap()[0].clone();
     assert_eq!(greet_item["name"], serde_json::json!("greet"));
 
-    // incoming: callers across files — b.sh's `run` (follow) and c.sh top level (assume)
+    // incoming: callers across files — b.sh's `run` (lint=true edge) and
+    // c.sh top level (import-only edge)
     send_request(
         &client_connection,
         3,
@@ -376,7 +377,7 @@ fn cross_file_call_hierarchy_spans_source_edges() {
     open_document(
         &client_connection,
         &b_uri,
-        "run() {\n  # shuck: follow-source=a.sh\n  source \"$DIR/a.sh\"\n  greet\n}\nrun\n",
+        "run() {\n  # shuck: source=a.sh lint=true\n  source \"$DIR/a.sh\"\n  greet\n}\nrun\n",
     );
     send_request(
         &client_connection,
@@ -438,7 +439,7 @@ fn cross_file_call_hierarchy_honors_configured_source_paths() {
     .unwrap();
     std::fs::write(
         workspace.path().join("scripts/main.sh"),
-        "run() {\n  # shuck: follow-source=util.sh\n  source \"$X/util.sh\"\n  greet\n}\nrun\n",
+        "run() {\n  # shuck: source=util.sh lint=true\n  source \"$X/util.sh\"\n  greet\n}\nrun\n",
     )
     .unwrap();
     let util_uri = Url::from_file_path(workspace.path().join("lib/util.sh")).unwrap();
@@ -482,7 +483,7 @@ fn cross_file_call_hierarchy_honors_configured_source_paths() {
     );
     let incoming = recv_response(&client_connection, 3);
     let incoming = incoming.as_array().unwrap();
-    // Without source-paths, main.sh's follow-source=util.sh would not resolve and
+    // Without source-paths, main.sh's source=util.sh directive would not resolve and
     // greet would have no caller; with it, `run` shows up.
     assert_eq!(incoming.len(), 1);
     assert_eq!(incoming[0]["from"]["name"], serde_json::json!("run"));

--- a/crates/shuck-server/tests/manual.rs
+++ b/crates/shuck-server/tests/manual.rs
@@ -270,3 +270,148 @@ fn replays_a_small_lsp_session() {
         .expect("server thread should join")
         .expect("server should exit cleanly");
 }
+
+fn open_document(connection: &Connection, uri: &Url, text: &str) {
+    connection
+        .sender
+        .send(Message::Notification(Notification::new(
+            "textDocument/didOpen".to_owned(),
+            serde_json::json!({
+                "textDocument": {
+                    "uri": uri,
+                    "languageId": "shellscript",
+                    "version": 1,
+                    "text": text,
+                }
+            }),
+        )))
+        .expect("didOpen should send");
+}
+
+#[test]
+fn cross_file_call_hierarchy_spans_source_edges() {
+    let (server_connection, client_connection) = Connection::memory();
+    let server_thread = thread::spawn(move || shuck_server::run_connection(server_connection));
+
+    let workspace = tempfile::tempdir().expect("tempdir should be created");
+    // a.sh defines greet; b.sh follows a and calls greet inside `run`; c.sh
+    // assumes a and calls greet at top level.
+    std::fs::write(workspace.path().join("a.sh"), "greet() {\n  echo hi\n}\n").unwrap();
+    std::fs::write(
+        workspace.path().join("b.sh"),
+        "run() {\n  # shuck: follow-source=a.sh\n  source \"$DIR/a.sh\"\n  greet\n}\nrun\n",
+    )
+    .unwrap();
+    std::fs::write(
+        workspace.path().join("c.sh"),
+        "# shuck: assume-source=a.sh\nsource \"$DIR/a.sh\"\ngreet\n",
+    )
+    .unwrap();
+    let a_uri = Url::from_file_path(workspace.path().join("a.sh")).unwrap();
+    let b_uri = Url::from_file_path(workspace.path().join("b.sh")).unwrap();
+
+    send_request(
+        &client_connection,
+        1,
+        "initialize",
+        serde_json::json!({
+            "capabilities": replay_capabilities(),
+            "rootUri": Url::from_file_path(workspace.path()).unwrap(),
+        }),
+    );
+    let initialize = recv_response(&client_connection, 1);
+    assert_eq!(
+        initialize["capabilities"]["callHierarchyProvider"],
+        serde_json::json!(true)
+    );
+    client_connection
+        .sender
+        .send(Message::Notification(Notification::new(
+            "initialized".to_owned(),
+            serde_json::json!({}),
+        )))
+        .expect("initialized should send");
+
+    open_document(&client_connection, &a_uri, "greet() {\n  echo hi\n}\n");
+
+    // prepare on greet's definition in a.sh
+    send_request(
+        &client_connection,
+        2,
+        "textDocument/prepareCallHierarchy",
+        serde_json::json!({
+            "textDocument": { "uri": a_uri },
+            "position": { "line": 0, "character": 0 },
+        }),
+    );
+    let prepared = recv_response(&client_connection, 2);
+    let greet_item = prepared.as_array().unwrap()[0].clone();
+    assert_eq!(greet_item["name"], serde_json::json!("greet"));
+
+    // incoming: callers across files — b.sh's `run` (follow) and c.sh top level (assume)
+    send_request(
+        &client_connection,
+        3,
+        "callHierarchy/incomingCalls",
+        serde_json::json!({ "item": greet_item }),
+    );
+    let incoming = recv_response(&client_connection, 3);
+    let mut callers: Vec<String> = incoming
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|call| {
+            let from = &call["from"];
+            format!(
+                "{}:{}",
+                from["uri"].as_str().unwrap().rsplit('/').next().unwrap(),
+                from["name"].as_str().unwrap()
+            )
+        })
+        .collect();
+    callers.sort();
+    assert_eq!(callers, vec!["b.sh:run".to_owned(), "c.sh:c.sh".to_owned()]);
+
+    // outgoing from run in b.sh descends into a.sh's greet
+    open_document(
+        &client_connection,
+        &b_uri,
+        "run() {\n  # shuck: follow-source=a.sh\n  source \"$DIR/a.sh\"\n  greet\n}\nrun\n",
+    );
+    send_request(
+        &client_connection,
+        4,
+        "textDocument/prepareCallHierarchy",
+        serde_json::json!({
+            "textDocument": { "uri": b_uri },
+            "position": { "line": 0, "character": 0 },
+        }),
+    );
+    let run_item = recv_response(&client_connection, 4).as_array().unwrap()[0].clone();
+    assert_eq!(run_item["name"], serde_json::json!("run"));
+    send_request(
+        &client_connection,
+        5,
+        "callHierarchy/outgoingCalls",
+        serde_json::json!({ "item": run_item }),
+    );
+    let outgoing = recv_response(&client_connection, 5);
+    let outgoing = outgoing.as_array().unwrap();
+    assert_eq!(outgoing.len(), 1);
+    assert_eq!(outgoing[0]["to"]["name"], serde_json::json!("greet"));
+    assert!(outgoing[0]["to"]["uri"].as_str().unwrap().ends_with("a.sh"));
+
+    send_request(&client_connection, 99, "shutdown", serde_json::json!(null));
+    let _ = recv_response(&client_connection, 99);
+    client_connection
+        .sender
+        .send(Message::Notification(Notification::new(
+            "exit".to_owned(),
+            serde_json::json!({}),
+        )))
+        .expect("exit notification should send");
+    server_thread
+        .join()
+        .expect("server thread should join")
+        .expect("server should exit cleanly");
+}

--- a/specs/025-cross-file-call-hierarchy.md
+++ b/specs/025-cross-file-call-hierarchy.md
@@ -2,7 +2,20 @@
 
 ## Status
 
-Proposed
+Implemented (v1).
+
+Delivered: the workspace call-graph index (`FileCallFacts` / `WorkspaceCallIndex`
+in `shuck-semantic`), the shared source-edge resolver, and session-scoped
+`incomingCalls` / `outgoingCalls` handlers that build the index per request over
+open buffers plus discovered workspace files and answer both directions across
+files. Edges come from all determinable sources (literal-resolvable,
+`assume-source`, `follow-source`). Covered by semantic unit tests and a black-box
+multi-file LSP test.
+
+Deferred (noted follow-ups, not blocking): configured `[lint] source-paths`
+roots in the LSP resolver (base-directory resolution only for now), and a
+persistent incrementally-invalidated index (the index is rebuilt per request,
+matching how `workspace/symbol` already works).
 
 ## Summary
 

--- a/specs/025-cross-file-call-hierarchy.md
+++ b/specs/025-cross-file-call-hierarchy.md
@@ -6,17 +6,26 @@ Implemented (v1).
 
 Delivered: the workspace call-graph index (`FileCallFacts` / `WorkspaceCallIndex`
 in `shuck-semantic`), the shared source-edge resolver, and session-scoped
-`incomingCalls` / `outgoingCalls` handlers that build the index per request over
-open buffers plus discovered workspace files and answer both directions across
-files. Edges come from all determinable sources (literal-resolvable,
-`assume-source`, `follow-source`), resolved against the annotating file's own
-directory and the configured `[lint] source-paths` roots (memoized per project
-root, matching `shuck check`). Covered by semantic unit tests and black-box
-multi-file LSP tests (including one that resolves only via `source-paths`).
+`incomingCalls` / `outgoingCalls` handlers that build the index over open
+buffers plus discovered workspace files (plus files reachable only through
+resolved source edges, e.g. gitignored vendored targets) and answer both
+directions across files. The built index is cached on the session behind an
+epoch counter and invalidated by any document, workspace, or configuration
+change, so expanding a call tree reuses one build. Call sites the semantic
+model binds in-file stay binding-accurate (definition order and shadowing are
+honored); only sites it leaves unresolved are matched by name across source
+edges. Top-level MODULE nodes round-trip through `CallHierarchyItem.data`, so
+their outgoing calls expand. Edges come from all determinable sources
+(literal-resolvable, `assume-source`, `follow-source`), resolved against the
+annotating file's own directory and the configured `[lint] source-paths` roots
+(memoized per project root, matching `shuck check`). The indexed-file count is
+bounded by `server.callHierarchy.maxFiles` (default 10k). Covered by semantic
+unit tests and black-box multi-file LSP tests (including one that resolves only
+via `source-paths`).
 
-Deferred (noted follow-up, not blocking): a persistent incrementally-invalidated
-index (the index is rebuilt per request, matching how `workspace/symbol` already
-works).
+Known limitation (noted follow-up, not blocking): nodes are keyed by function
+name within a file, so two same-named definitions in one file collapse onto the
+first.
 
 ## Summary
 

--- a/specs/025-cross-file-call-hierarchy.md
+++ b/specs/025-cross-file-call-hierarchy.md
@@ -16,12 +16,16 @@ model binds in-file stay binding-accurate (definition order and shadowing are
 honored); only sites it leaves unresolved are matched by name across source
 edges. Top-level MODULE nodes round-trip through `CallHierarchyItem.data`, so
 their outgoing calls expand. Edges come from all determinable sources
-(literal-resolvable, `assume-source`, `follow-source`), resolved against the
-annotating file's own directory and the configured `[lint] source-paths` roots
-(memoized per project root, matching `shuck check`). The indexed-file count is
-bounded by `server.callHierarchy.maxFiles` (default 10k). Covered by semantic
-unit tests and black-box multi-file LSP tests (including one that resolves only
-via `source-paths`).
+(literal-resolvable paths and `source=` directives with and without
+`lint=true`), resolved against the annotating file's own directory and the
+configured `[lint] source-paths` roots (memoized per project root, matching
+`shuck check`). The indexed-file count is hard-bounded by
+`server.callHierarchy.maxFiles` (default 10k): one budget is shared by all
+three population phases — open buffers, closed-file discovery, and source-edge
+expansion — and every insertion checks it, so a runaway workspace degrades to a
+partial graph (with a warning) rather than an unbounded scan. Covered by
+semantic unit tests, an index-size bound test, and black-box multi-file LSP
+tests (including one that resolves only via `source-paths`).
 
 Known limitation (noted follow-up, not blocking): nodes are keyed by function
 name within a file, so two same-named definitions in one file collapse onto the
@@ -31,8 +35,8 @@ first.
 
 Make LSP call hierarchy complete across files. Building on the single-file
 engine (spec 023's `prepareCallHierarchy` / `incomingCalls` / `outgoingCalls`)
-and the computed-source resolution from spec 024 (`assume-source` /
-`follow-source`), this spec introduces a **workspace call-graph index**: for
+and the computed-source resolution from spec 024 (the
+`# shuck: source=` directive), this spec introduces a **workspace call-graph index**: for
 every shell file the server knows about, the functions it defines, the call sites
 it contains, and the source edges that connect files. Both directions of the
 hierarchy — "what does this function call" and "who calls this function" — are
@@ -80,21 +84,21 @@ resolvable graph; it simply does not model runtime-only dispatch.
 A call site in file `B` resolves to a function `F` defined in file `A` when `B`
 can statically be shown to source `A` (directly or transitively) and no nearer
 definition of `F` shadows it. "Statically shown to source" covers every
-*determinable* source edge, not only `follow-source`:
+*determinable* source edge, not only linted (`lint=true`) edges:
 
 | Source form in `B` | Contributes a resolvable edge `B → A`? |
 | --- | --- |
 | Literal path that resolves on disk (`source ./lib/a.sh`) | yes |
-| Computed path with `# shuck: assume-source=a.sh` (resolves) | yes |
-| Computed path with `# shuck: follow-source=a.sh` (resolves) | yes |
+| Computed path with `# shuck: source=a.sh` (resolves) | yes |
+| Computed path with `# shuck: source=a.sh lint=true` (resolves) | yes |
 | Computed path, no hint, unresolvable | no (runtime-only) |
-| `assume-source=/dev/null` | no (explicitly nothing) |
+| `source=/dev/null` | no (explicitly nothing) |
 
 **Decision:** the call graph uses *all* determinable edges — resolvable literal
-sources and both hint kinds, `assume-source` and `follow-source`. Incoming
+sources and directive-asserted edges with or without `lint=true`. Incoming
 completeness, the property this spec exists to guarantee, requires counting every
-real caller, so a caller annotated with `assume-source` must contribute an edge
-just as `follow-source` does. Within the workspace graph the two hints are
+real caller, so a caller whose directive omits `lint=true` must contribute an edge
+just as a linted one does. Within the workspace graph the lint policy is
 therefore equivalent; this supersedes the 023-era rule that only `follow`
 participates. The `assume` vs `follow` difference persists where it began — in
 per-document analysis cost and in whether `shuck check` lints the target (spec
@@ -181,17 +185,17 @@ callers inside that closure, silently missing callers elsewhere in the
 workspace. Partial incoming in a navigation tool is a correctness bug, and the
 user requirement is explicit: both directions complete, or neither.
 
-### Follow-only edges (exclude `assume-source` from the graph)
+### Lint-only edges (exclude import-only directives from the graph)
 
-Rejected. It would preserve the 023-era "follow participates, assume does not"
-distinction crisply — cross-file hierarchy would require `follow-source`
-everywhere and `assume-source` would mean "symbols only, never in the graph" —
-but it loses incoming completeness for any project that annotated a caller with
-`assume-source`, which directly contradicts the completeness requirement. Both
-hint kinds contribute edges; the assume/follow distinction survives in
-per-document cost and CLI linting. If a future need arises for "resolve symbols
-but stay out of the call graph," that is a new, separately named mode, not a
-reinterpretation of `assume-source`.
+Rejected. It would preserve the 023-era "linted targets participate, imported
+ones do not" distinction crisply — cross-file hierarchy would require
+`lint=true` everywhere and a plain `source=` would mean "symbols only, never in
+the graph" — but it loses incoming completeness for any project whose caller
+directives omit `lint=true`, which directly contradicts the completeness
+requirement. All directive-asserted edges contribute; the lint policy survives
+where it began — in per-document cost and CLI linting. If a future need arises
+for "resolve symbols but stay out of the call graph," that is a new, separately
+named mode, not a reinterpretation of the plain `source=` directive.
 
 ### Merged multi-file semantic model
 
@@ -242,10 +246,10 @@ process:
 
 - **Projection** (`shuck-semantic`): `FileCallFacts` for a file lists its
   function definitions, call sites with enclosing function, and resolved source
-  edges (literal, `assume-source`, `follow-source`); `/dev/null` and unresolvable
+  edges (literal, `source=` directives with and without `lint=true`); `/dev/null` and unresolvable
   dynamic sources contribute no edge.
 - **Index** (`shuck-semantic`): over a three-file graph `a.sh` (defines `greet`)
-  ← `b.sh` (`follow-source=a.sh`, calls `greet`) ← `c.sh` (`assume-source=a.sh`,
+  ← `b.sh` (`source=a.sh lint=true`, calls `greet`) ← `c.sh` (`source=a.sh`,
   calls `greet`), `incoming(greet in a.sh)` returns both `b.sh` and `c.sh` call
   sites; `outgoing` from `b.sh`'s caller lands on `a.sh`'s `greet`. A nearer
   local `greet` in `b.sh` shadows the cross-file one.
@@ -258,7 +262,7 @@ process:
   without restart.
 - **Completeness guard**: a caller reachable only through an unresolvable dynamic
   source is *absent* (documented limitation), while the same caller with an
-  `assume-source`/`follow-source` hint *appears* — demonstrating hints maximize
+  `# shuck: source=` directive *appears* — demonstrating hints maximize
   the resolvable graph.
 - **Regression**: single-file call hierarchy (023) and all 024 behaviors
   unchanged; `make test` and the black-box LSP suite green.

--- a/specs/025-cross-file-call-hierarchy.md
+++ b/specs/025-cross-file-call-hierarchy.md
@@ -9,13 +9,14 @@ in `shuck-semantic`), the shared source-edge resolver, and session-scoped
 `incomingCalls` / `outgoingCalls` handlers that build the index per request over
 open buffers plus discovered workspace files and answer both directions across
 files. Edges come from all determinable sources (literal-resolvable,
-`assume-source`, `follow-source`). Covered by semantic unit tests and a black-box
-multi-file LSP test.
+`assume-source`, `follow-source`), resolved against the annotating file's own
+directory and the configured `[lint] source-paths` roots (memoized per project
+root, matching `shuck check`). Covered by semantic unit tests and black-box
+multi-file LSP tests (including one that resolves only via `source-paths`).
 
-Deferred (noted follow-ups, not blocking): configured `[lint] source-paths`
-roots in the LSP resolver (base-directory resolution only for now), and a
-persistent incrementally-invalidated index (the index is rebuilt per request,
-matching how `workspace/symbol` already works).
+Deferred (noted follow-up, not blocking): a persistent incrementally-invalidated
+index (the index is rebuilt per request, matching how `workspace/symbol` already
+works).
 
 ## Summary
 

--- a/specs/025-cross-file-call-hierarchy.md
+++ b/specs/025-cross-file-call-hierarchy.md
@@ -1,0 +1,220 @@
+# 025: Cross-File Call Hierarchy
+
+## Status
+
+Proposed
+
+## Summary
+
+Extend the single-file LSP call hierarchy (spec 023's navigation family, plus
+the `prepareCallHierarchy` / `incomingCalls` / `outgoingCalls` engine) so that
+functions reached through a `follow-source` hint (spec 024) participate in the
+hierarchy. When a script sources a helper by a computed path and annotates it
+with `# shuck: follow-source=lib/util.sh`, "outgoing calls" from a function
+should descend into `util.sh`, and a function *defined in* `util.sh` should offer
+its call sites back in the caller as "incoming calls". This is the payoff that
+specs 023 (engine) and 024 (resolution) were built to enable, and the concrete
+ask in issue #1144.
+
+## Motivation
+
+Today the two foundations exist but do not meet:
+
+- **Spec 024** resolves computed `source` paths via `assume-source` /
+  `follow-source`, and `follow-source` already lints the target during
+  `shuck check`. But that following is CLI-only; the LSP server never sees it.
+- **Spec 023 / call hierarchy** answers incoming/outgoing calls, but only within
+  one file: the server builds each document's semantic model with
+  `resolve_source_closure: false` (`crates/shuck-server/src/analysis.rs`,
+  `.../editor.rs`), and every `CallHierarchyItem` is addressed with the current
+  document's URI (`crates/shuck-server/src/editor_features.rs`,
+  `to_lsp_call_hierarchy_item`).
+
+The result: a cursor on `main` that calls `helper` (defined in a followed file)
+gets no outgoing edge to `helper`, and a cursor on `helper` gets no incoming edge
+from `main`. For real shell projects — plugin loaders, relative includes — this
+is exactly where navigation matters most. `follow-source` is the user-supplied
+bridge across the computed-path gap; this spec teaches call hierarchy to walk it.
+
+## Design
+
+### Directive scope: follow, not assume
+
+Only `follow-source` targets join the call hierarchy. `assume-source` remains
+"import symbols to resolve references" and deliberately does **not** contribute
+call sites or definitions to the hierarchy. This matches the split chosen in 024
+and the issue wording ("fully parse for lsp hierarchy" vs. "just use to
+disambiguate missing symbols"):
+
+| Directive | References resolve | Symbols in completion/hover | In call hierarchy |
+| --- | --- | --- | --- |
+| `assume-source` | yes | yes | no |
+| `follow-source` | yes | yes | **yes** |
+
+### The asymmetry: outgoing is natural, incoming is not
+
+Following a file's sources is a *directed* operation, and call hierarchy's two
+directions are not symmetric under it:
+
+- **Outgoing** ("what does `F` call") is naturally answerable. From `F`'s file we
+  follow its `follow-source` edges, parse the targets, and resolve `F`'s call
+  tokens against the union of function definitions in the file plus its followed
+  closure. Everything needed is reachable by walking *outward* from `F`.
+- **Incoming** ("who calls `F`") is not. If `F` is defined in `util.sh`, a caller
+  lives in some file `B` that does `follow-source=util.sh` — but nothing in
+  `util.sh` or its own closure points back to `B`. Discovering `B` requires a
+  *reverse* index: which workspace files follow/source/call into this one. The
+  closure does not provide that.
+
+This asymmetry drives the phasing below. v1 delivers complete outgoing edges and
+the incoming edges that are reachable within the *querying document's* closure;
+workspace-wide incoming is deferred to a reverse-index phase.
+
+### Semantic layer: retain the followed closure
+
+The closure today (`crates/shuck-semantic/src/source_closure/`) parses each
+sourced file to extract *contracts* (imported bindings/functions) and then
+discards the per-file model — so call sites and function-body scopes from
+followed files survive nowhere. Two ways to fix that:
+
+- **(A) Merged multi-file model.** Build one `SemanticModel` spanning the whole
+  follow closure, with call sites and scopes from every file in a shared arena.
+  Cleanest query surface, but a large, invasive change to model construction and
+  every span→file mapping.
+- **(B) Retained per-file models + a cross-file overlay** *(recommended)*. Keep
+  today's per-file models, but for `follow-source` edges retain the target's
+  model (or a compact "call-facts" projection: function-definition bindings with
+  spans, and resolved call sites with callee + name-span + enclosing function)
+  keyed by resolved path. A `CrossFileCallGraph` overlay links a call token to a
+  function definition in another retained file. Call hierarchy queries walk the
+  overlay; single-file queries are unchanged.
+
+Recommend (B): it is additive, leaves the existing single-file path untouched,
+and mirrors how the closure already parses each file once. The projection keeps
+retention cheap (no need to hold whole models if only call facts are needed).
+
+New semantic surface (sketch):
+
+```rust
+// A function-definition target in a specific file of the closure.
+pub struct CrossFileFunction { pub path: PathBuf, pub binding: BindingId, pub name: Name, ... }
+
+impl EditorQuery<'_> {
+    // Outgoing edges that resolve into followed files, keyed by target file.
+    fn cross_file_outgoing(&self, item: &EditorCallHierarchyItem, closure: &FollowClosure) -> Vec<EditorOutgoingCall>;
+    // Incoming edges discoverable within the querying document's own closure.
+    fn cross_file_incoming(&self, item: &EditorCallHierarchyItem, closure: &FollowClosure) -> Vec<EditorIncomingCall>;
+}
+```
+
+The existing `EditorCallHierarchyItem` gains a file identity (its resolved path)
+so items can address functions outside the active document; `EditorIncomingCall`
+/ `EditorOutgoingCall` already carry the call spans.
+
+### Server layer: enable the closure and address by file
+
+1. **Turn the closure on for call hierarchy.** The LSP analysis path currently
+   forces `resolve_source_closure: false`. Enable it for the call-hierarchy
+   requests (either always, or lazily when the document contains `follow-source`
+   hints, to avoid paying for closure resolution on documents that have none).
+   This is the one place 024's resolution feeds the server.
+2. **Read followed targets.** Followed files may not be open buffers. The server
+   resolves each `follow-source` path (reusing 024's `NativeSourceResolver` logic,
+   promoted to a shared crate so both `shuck check` and the server use one
+   resolver) and reads the file — preferring the open in-memory buffer when the
+   editor has it, falling back to disk. Transitive follows use a visited set, as
+   in the CLI.
+3. **Address items by their file.** `to_lsp_call_hierarchy_item` must stamp each
+   item with the *target file's* `Url`, not the active document's. Items for
+   followed files carry their resolved path's URI; the round-trip `data` payload
+   (currently a position in the current doc) becomes `{ uri, line, character }`.
+4. **Advertise nothing new.** `callHierarchyProvider` is already advertised by
+   spec 023's work; this spec only widens what the existing requests return.
+
+### Phasing
+
+- **Phase 1 — outgoing cross-file.** Retain follow-closure call facts; answer
+  outgoing calls that descend into followed files; address items by file. This
+  alone makes "step into the helper's function" work and is the bulk of the
+  value.
+- **Phase 2 — closure-local incoming.** Answer incoming calls whose callers live
+  in files already in the querying document's follow closure. (Complete for the
+  common "main follows helpers" shape.)
+- **Phase 3 — workspace incoming (optional / later).** A workspace-wide reverse
+  index (which files follow/call which) to answer "who calls `F`" across files
+  that the current document does not itself follow. Larger; may reuse the
+  workspace-symbol indexing machinery. Explicitly out of scope for the first PR.
+
+### Caching and invalidation
+
+The document analysis cache must track the resolved follow-target paths as
+dependencies, so editing a followed file invalidates the caller's call-hierarchy
+results. This mirrors `imported_dependency_paths` already produced by the closure
+and the `dependency_paths` the CLI check path records.
+
+## Alternatives Considered
+
+### Merged multi-file model (approach A above)
+
+Rejected for v1. A single arena spanning the closure gives the simplest query
+surface, but it is a deep change to model construction, span ownership, and every
+consumer that assumes one model = one file. The overlay (B) delivers the same
+navigation with an additive change; a merged model can come later if multiple
+features need it.
+
+### Feed `assume-source` into the hierarchy too
+
+Rejected. It would blur the 024 distinction users just gained: `assume-source`
+means "I only want symbols resolved, don't pull this file in." Overriding that to
+also add call edges removes the cheap "just silence the noise" option.
+
+### Workspace-index-first (incoming before outgoing)
+
+Rejected as the starting point. Incoming across the workspace needs a reverse
+call index that does not exist yet, while outgoing is reachable today via the
+follow closure. Shipping outgoing first delivers most of the value at a fraction
+of the cost and defers the index to when incoming demands it.
+
+### Always resolve the closure in the LSP path
+
+Considered. Simpler than gating on the presence of `follow-source` hints, but it
+makes every hover/definition/symbol request pay closure-resolution cost even for
+documents with no hints. Prefer lazy enablement keyed on hint presence, measured
+against the latency budget from spec 018.
+
+## Security Considerations
+
+Enabling the closure in the server means the LSP server **reads files named by
+the document under edit** (the `follow-source` targets), transitively. This is the
+same trust posture as 024's CLI following and ShellCheck's `-x`, now in an
+always-on editor process:
+
+- Resolution stays confined to the annotating file's directory plus configured
+  `source-paths`; targets outside those roots are not followed.
+- The server only reads and parses; it never executes sourced content.
+- Transitive following uses a visited set to bound fan-out and prevent cycles.
+- Reads prefer open buffers, so unsaved editor state is honored over stale disk
+  content and the server does not race the user's edits.
+
+## Verification
+
+- **Semantic** (`shuck-semantic`): given a caller model with a `follow-source`
+  edge to a helper defining `greet`, `cross_file_outgoing` for a function that
+  calls `greet` returns an edge whose target item carries the helper's path; and
+  a helper-local query surfaces the caller's call span via `cross_file_incoming`
+  when the caller is in the closure.
+- **Server** (`shuck-server`): a black-box LSP session over two files — `main.sh`
+  with `# shuck: follow-source=helper.sh` and `helper.sh` defining `greet` —
+  where `prepareCallHierarchy` on `main`'s call to `greet` plus `outgoingCalls`
+  returns an item with `helper.sh`'s URI, and `incomingCalls` on `greet` returns
+  `main`'s call site. Verify the followed file is read from disk when not open and
+  from the buffer when open.
+- **Invalidation**: editing `helper.sh` (buffer change) updates the caller's
+  outgoing/incoming results without a server restart.
+- **Scope guard**: an `assume-source` edge does *not* produce cross-file call
+  edges.
+- **Regression**: single-file call hierarchy (spec 023) and all 024 behaviors are
+  unchanged; `make test` and the black-box LSP suite stay green.
+
+Clean-room: all directive names, types, and documentation are authored in-repo;
+no ShellCheck source or wiki text is referenced.

--- a/specs/025-cross-file-call-hierarchy.md
+++ b/specs/025-cross-file-call-hierarchy.md
@@ -40,15 +40,15 @@ complete or it should not ship; therefore the design commits to a workspace-wide
 index from the start, which — usefully — also makes outgoing fall out of the same
 structure.
 
-### Honesty boundary
+### What "complete" covers
 
-"Complete" means complete over the **statically-resolvable call graph**. Shell
-has runtime-only dispatch (`eval`, indirect expansion, `$1`-driven case
-dispatch, sourcing a path shuck cannot determine even with hints). Those edges
-are unknowable statically and are out of scope; call hierarchy captures every
-edge the resolver can determine, and the 024 hints exist precisely to maximize
-what is determinable. The server should never present partial results *within*
-the resolvable graph, but it does not claim to model runtime dispatch.
+"Complete" here means complete over the **statically-resolvable call graph**.
+Shell also dispatches at runtime — `eval`, indirect expansion, `$1`-driven
+`case` dispatch, or sourcing a path that stays unresolvable even with a hint —
+and those edges cannot be known without running the script. They are out of
+scope. Call hierarchy returns every edge the resolver can determine (the 024
+hints exist to widen that set) and never returns *partial* results within the
+resolvable graph; it simply does not model runtime-only dispatch.
 
 ## Design
 
@@ -67,17 +67,17 @@ definition of `F` shadows it. "Statically shown to source" covers every
 | Computed path, no hint, unresolvable | no (runtime-only) |
 | `assume-source=/dev/null` | no (explicitly nothing) |
 
-**Recommendation:** the call graph uses *all* determinable edges, including
-`assume-source`. Rationale: incoming completeness — the property this spec
-exists to guarantee — requires counting every real caller; excluding
-`assume-source` callers would make "who calls `F`" wrong for any project that
-used `assume-source` on a caller. Under this model the 023-era distinction
-"`follow` participates in the hierarchy, `assume` does not" is superseded for the
-*workspace graph*: both hints, and plain resolvable literals, contribute edges.
-The `assume` vs `follow` difference remains meaningful where it began — in
+**Decision:** the call graph uses *all* determinable edges — resolvable literal
+sources and both hint kinds, `assume-source` and `follow-source`. Incoming
+completeness, the property this spec exists to guarantee, requires counting every
+real caller, so a caller annotated with `assume-source` must contribute an edge
+just as `follow-source` does. Within the workspace graph the two hints are
+therefore equivalent; this supersedes the 023-era rule that only `follow`
+participates. The `assume` vs `follow` difference persists where it began — in
 per-document analysis cost and in whether `shuck check` lints the target (spec
-024) — just not in what the global call graph contains. (See Alternatives for the
-stricter follow-only option.)
+024) — not in graph membership. Hinted edges are the whole point: computed source
+lines are exactly where the resolvable graph would otherwise have holes, and the
+hints fill them.
 
 ### The workspace call-graph index
 
@@ -160,14 +160,15 @@ user requirement is explicit: both directions complete, or neither.
 
 ### Follow-only edges (exclude `assume-source` from the graph)
 
-Considered. Preserves the 023-era "follow participates, assume does not"
-distinction crisply: cross-file hierarchy would require `follow-source`
-everywhere, and `assume-source` would mean "symbols only, never in the graph." It
-loses incoming completeness for projects that annotated callers with
-`assume-source`, which conflicts with the completeness requirement. Chosen model
-instead counts all determinable edges; the assume/follow distinction survives in
-per-document cost and CLI linting. Revisit if users want an explicit "resolve
-symbols but keep out of the call graph" mode.
+Rejected. It would preserve the 023-era "follow participates, assume does not"
+distinction crisply — cross-file hierarchy would require `follow-source`
+everywhere and `assume-source` would mean "symbols only, never in the graph" —
+but it loses incoming completeness for any project that annotated a caller with
+`assume-source`, which directly contradicts the completeness requirement. Both
+hint kinds contribute edges; the assume/follow distinction survives in
+per-document cost and CLI linting. If a future need arises for "resolve symbols
+but stay out of the call graph," that is a new, separately named mode, not a
+reinterpretation of `assume-source`.
 
 ### Merged multi-file semantic model
 

--- a/specs/025-cross-file-call-hierarchy.md
+++ b/specs/025-cross-file-call-hierarchy.md
@@ -13,8 +13,10 @@ directions across files. The built index is cached on the session behind an
 epoch counter and invalidated by any document, workspace, or configuration
 change, so expanding a call tree reuses one build. Call sites the semantic
 model binds in-file stay binding-accurate (definition order and shadowing are
-honored); only sites it leaves unresolved are matched by name across source
-edges. Top-level MODULE nodes round-trip through `CallHierarchyItem.data`, so
+honored), while source edges retain their positions so later sourced and local
+definitions override earlier ones; only sites without an effective local
+binding are matched by name across source edges. Top-level MODULE nodes
+round-trip through `CallHierarchyItem.data`, so
 their outgoing calls expand. Edges come from all determinable sources
 (literal-resolvable paths and `source=` directives with and without
 `lint=true`), resolved against the annotating file's own directory and the
@@ -117,14 +119,15 @@ WorkspaceCallIndex
 FileCallFacts
   definitions: [{ name, binding, def_span, selection_span }]   // functions defined here
   call_sites:  [{ callee_name, name_span, enclosing_function }] // calls made here
-  source_edges:[{ resolved_path, kind }]      // determinable sources this file has
+  source_edges:[{ resolved_path, span }]      // determinable sources in execution order
 ```
 
 Cross-file resolution layered on top:
 
-- `resolve(call_site in B) -> Option<(A, definition)>`: search `B`'s own
-  definitions first, then walk `B`'s transitive `source_edges` (visited-set
-  bounded), returning the nearest definition of `callee_name`.
+- `resolve(call_site in B) -> Option<(A, definition)>`: combine `B`'s visible
+  local definition with its transitive `source_edges` (visited-set bounded) in
+  shell execution order. Edges after a top-level call do not participate; later
+  sourced or local definitions override earlier ones.
 - `outgoing(F in A)`: for each call site enclosed by `F`, `resolve` it; group by
   target definition. (Targets may be in `A` or any followed file.)
 - `incoming(F in A)`: scan the index for call sites whose `resolve` lands on

--- a/specs/025-cross-file-call-hierarchy.md
+++ b/specs/025-cross-file-call-hierarchy.md
@@ -6,215 +6,238 @@ Proposed
 
 ## Summary
 
-Extend the single-file LSP call hierarchy (spec 023's navigation family, plus
-the `prepareCallHierarchy` / `incomingCalls` / `outgoingCalls` engine) so that
-functions reached through a `follow-source` hint (spec 024) participate in the
-hierarchy. When a script sources a helper by a computed path and annotates it
-with `# shuck: follow-source=lib/util.sh`, "outgoing calls" from a function
-should descend into `util.sh`, and a function *defined in* `util.sh` should offer
-its call sites back in the caller as "incoming calls". This is the payoff that
-specs 023 (engine) and 024 (resolution) were built to enable, and the concrete
-ask in issue #1144.
+Make LSP call hierarchy complete across files. Building on the single-file
+engine (spec 023's `prepareCallHierarchy` / `incomingCalls` / `outgoingCalls`)
+and the computed-source resolution from spec 024 (`assume-source` /
+`follow-source`), this spec introduces a **workspace call-graph index**: for
+every shell file the server knows about, the functions it defines, the call sites
+it contains, and the source edges that connect files. Both directions of the
+hierarchy — "what does this function call" and "who calls this function" — are
+answered as symmetric traversals of that one index, across the whole workspace,
+not just the file under the cursor. This is the payoff specs 023 and 024 were
+built to enable and the concrete ask in issue #1144.
 
 ## Motivation
 
-Today the two foundations exist but do not meet:
+The two foundations exist but do not meet, and the naive way to join them is
+wrong:
 
-- **Spec 024** resolves computed `source` paths via `assume-source` /
-  `follow-source`, and `follow-source` already lints the target during
-  `shuck check`. But that following is CLI-only; the LSP server never sees it.
-- **Spec 023 / call hierarchy** answers incoming/outgoing calls, but only within
-  one file: the server builds each document's semantic model with
-  `resolve_source_closure: false` (`crates/shuck-server/src/analysis.rs`,
-  `.../editor.rs`), and every `CallHierarchyItem` is addressed with the current
-  document's URI (`crates/shuck-server/src/editor_features.rs`,
-  `to_lsp_call_hierarchy_item`).
+- **Spec 024** makes computed `source` paths statically determinable via hints,
+  but that resolution is confined to the CLI and to a file's own outward closure.
+- **Spec 023 / call hierarchy** answers incoming/outgoing, but per file: the
+  server builds each document with `resolve_source_closure: false`
+  (`crates/shuck-server/src/analysis.rs`, `.../editor.rs`) and stamps every
+  `CallHierarchyItem` with the active document's URI
+  (`crates/shuck-server/src/editor_features.rs`).
 
-The result: a cursor on `main` that calls `helper` (defined in a followed file)
-gets no outgoing edge to `helper`, and a cursor on `helper` gets no incoming edge
-from `main`. For real shell projects — plugin loaders, relative includes — this
-is exactly where navigation matters most. `follow-source` is the user-supplied
-bridge across the computed-path gap; this spec teaches call hierarchy to walk it.
+A tempting shortcut is to answer cross-file calls by walking only the *querying
+document's* follow closure. That gives correct **outgoing** edges (a file's own
+sources are reachable outward) but **incorrect incoming** edges: "who calls `F`"
+where `F` is defined in `util.sh` depends on every workspace file that sources
+`util.sh` — information absent from `util.sh` or its closure. A call hierarchy
+that silently under-reports callers is a refactoring hazard. Incoming must be
+complete or it should not ship; therefore the design commits to a workspace-wide
+index from the start, which — usefully — also makes outgoing fall out of the same
+structure.
+
+### Honesty boundary
+
+"Complete" means complete over the **statically-resolvable call graph**. Shell
+has runtime-only dispatch (`eval`, indirect expansion, `$1`-driven case
+dispatch, sourcing a path shuck cannot determine even with hints). Those edges
+are unknowable statically and are out of scope; call hierarchy captures every
+edge the resolver can determine, and the 024 hints exist precisely to maximize
+what is determinable. The server should never present partial results *within*
+the resolvable graph, but it does not claim to model runtime dispatch.
 
 ## Design
 
-### Directive scope: follow, not assume
+### Which source edges resolve
 
-Only `follow-source` targets join the call hierarchy. `assume-source` remains
-"import symbols to resolve references" and deliberately does **not** contribute
-call sites or definitions to the hierarchy. This matches the split chosen in 024
-and the issue wording ("fully parse for lsp hierarchy" vs. "just use to
-disambiguate missing symbols"):
+A call site in file `B` resolves to a function `F` defined in file `A` when `B`
+can statically be shown to source `A` (directly or transitively) and no nearer
+definition of `F` shadows it. "Statically shown to source" covers every
+*determinable* source edge, not only `follow-source`:
 
-| Directive | References resolve | Symbols in completion/hover | In call hierarchy |
-| --- | --- | --- | --- |
-| `assume-source` | yes | yes | no |
-| `follow-source` | yes | yes | **yes** |
+| Source form in `B` | Contributes a resolvable edge `B → A`? |
+| --- | --- |
+| Literal path that resolves on disk (`source ./lib/a.sh`) | yes |
+| Computed path with `# shuck: assume-source=a.sh` (resolves) | yes |
+| Computed path with `# shuck: follow-source=a.sh` (resolves) | yes |
+| Computed path, no hint, unresolvable | no (runtime-only) |
+| `assume-source=/dev/null` | no (explicitly nothing) |
 
-### The asymmetry: outgoing is natural, incoming is not
+**Recommendation:** the call graph uses *all* determinable edges, including
+`assume-source`. Rationale: incoming completeness — the property this spec
+exists to guarantee — requires counting every real caller; excluding
+`assume-source` callers would make "who calls `F`" wrong for any project that
+used `assume-source` on a caller. Under this model the 023-era distinction
+"`follow` participates in the hierarchy, `assume` does not" is superseded for the
+*workspace graph*: both hints, and plain resolvable literals, contribute edges.
+The `assume` vs `follow` difference remains meaningful where it began — in
+per-document analysis cost and in whether `shuck check` lints the target (spec
+024) — just not in what the global call graph contains. (See Alternatives for the
+stricter follow-only option.)
 
-Following a file's sources is a *directed* operation, and call hierarchy's two
-directions are not symmetric under it:
+### The workspace call-graph index
 
-- **Outgoing** ("what does `F` call") is naturally answerable. From `F`'s file we
-  follow its `follow-source` edges, parse the targets, and resolve `F`'s call
-  tokens against the union of function definitions in the file plus its followed
-  closure. Everything needed is reachable by walking *outward* from `F`.
-- **Incoming** ("who calls `F`") is not. If `F` is defined in `util.sh`, a caller
-  lives in some file `B` that does `follow-source=util.sh` — but nothing in
-  `util.sh` or its own closure points back to `B`. Discovering `B` requires a
-  *reverse* index: which workspace files follow/source/call into this one. The
-  closure does not provide that.
+The core new structure. Over the shell files in the server's workspace folders:
 
-This asymmetry drives the phasing below. v1 delivers complete outgoing edges and
-the incoming edges that are reachable within the *querying document's* closure;
-workspace-wide incoming is deferred to a reverse-index phase.
-
-### Semantic layer: retain the followed closure
-
-The closure today (`crates/shuck-semantic/src/source_closure/`) parses each
-sourced file to extract *contracts* (imported bindings/functions) and then
-discards the per-file model — so call sites and function-body scopes from
-followed files survive nowhere. Two ways to fix that:
-
-- **(A) Merged multi-file model.** Build one `SemanticModel` spanning the whole
-  follow closure, with call sites and scopes from every file in a shared arena.
-  Cleanest query surface, but a large, invasive change to model construction and
-  every span→file mapping.
-- **(B) Retained per-file models + a cross-file overlay** *(recommended)*. Keep
-  today's per-file models, but for `follow-source` edges retain the target's
-  model (or a compact "call-facts" projection: function-definition bindings with
-  spans, and resolved call sites with callee + name-span + enclosing function)
-  keyed by resolved path. A `CrossFileCallGraph` overlay links a call token to a
-  function definition in another retained file. Call hierarchy queries walk the
-  overlay; single-file queries are unchanged.
-
-Recommend (B): it is additive, leaves the existing single-file path untouched,
-and mirrors how the closure already parses each file once. The projection keeps
-retention cheap (no need to hold whole models if only call facts are needed).
-
-New semantic surface (sketch):
-
-```rust
-// A function-definition target in a specific file of the closure.
-pub struct CrossFileFunction { pub path: PathBuf, pub binding: BindingId, pub name: Name, ... }
-
-impl EditorQuery<'_> {
-    // Outgoing edges that resolve into followed files, keyed by target file.
-    fn cross_file_outgoing(&self, item: &EditorCallHierarchyItem, closure: &FollowClosure) -> Vec<EditorOutgoingCall>;
-    // Incoming edges discoverable within the querying document's own closure.
-    fn cross_file_incoming(&self, item: &EditorCallHierarchyItem, closure: &FollowClosure) -> Vec<EditorIncomingCall>;
-}
+```
+WorkspaceCallIndex
+  files: Map<Path, FileCallFacts>            // one entry per indexed file
+  ...
+FileCallFacts
+  definitions: [{ name, binding, def_span, selection_span }]   // functions defined here
+  call_sites:  [{ callee_name, name_span, enclosing_function }] // calls made here
+  source_edges:[{ resolved_path, kind }]      // determinable sources this file has
 ```
 
-The existing `EditorCallHierarchyItem` gains a file identity (its resolved path)
-so items can address functions outside the active document; `EditorIncomingCall`
-/ `EditorOutgoingCall` already carry the call spans.
+Cross-file resolution layered on top:
 
-### Server layer: enable the closure and address by file
+- `resolve(call_site in B) -> Option<(A, definition)>`: search `B`'s own
+  definitions first, then walk `B`'s transitive `source_edges` (visited-set
+  bounded), returning the nearest definition of `callee_name`.
+- `outgoing(F in A)`: for each call site enclosed by `F`, `resolve` it; group by
+  target definition. (Targets may be in `A` or any followed file.)
+- `incoming(F in A)`: scan the index for call sites whose `resolve` lands on
+  `F` — i.e. files that transitively source `A` and call `F.name` without a
+  nearer shadow. Both directions are the same edge set traversed opposite ways.
 
-1. **Turn the closure on for call hierarchy.** The LSP analysis path currently
-   forces `resolve_source_closure: false`. Enable it for the call-hierarchy
-   requests (either always, or lazily when the document contains `follow-source`
-   hints, to avoid paying for closure resolution on documents that have none).
-   This is the one place 024's resolution feeds the server.
-2. **Read followed targets.** Followed files may not be open buffers. The server
-   resolves each `follow-source` path (reusing 024's `NativeSourceResolver` logic,
-   promoted to a shared crate so both `shuck check` and the server use one
-   resolver) and reads the file — preferring the open in-memory buffer when the
-   editor has it, falling back to disk. Transitive follows use a visited set, as
-   in the CLI.
-3. **Address items by their file.** `to_lsp_call_hierarchy_item` must stamp each
-   item with the *target file's* `Url`, not the active document's. Items for
-   followed files carry their resolved path's URI; the round-trip `data` payload
-   (currently a position in the current doc) becomes `{ uri, line, character }`.
-4. **Advertise nothing new.** `callHierarchyProvider` is already advertised by
-   spec 023's work; this spec only widens what the existing requests return.
+The index is what makes incoming complete: it holds every file's call sites and
+source edges, so the reverse lookup is a scan over known data rather than an
+impossible walk outward from the callee.
 
-### Phasing
+### Construction, laziness, and invalidation
 
-- **Phase 1 — outgoing cross-file.** Retain follow-closure call facts; answer
-  outgoing calls that descend into followed files; address items by file. This
-  alone makes "step into the helper's function" work and is the bulk of the
-  value.
-- **Phase 2 — closure-local incoming.** Answer incoming calls whose callers live
-  in files already in the querying document's follow closure. (Complete for the
-  common "main follows helpers" shape.)
-- **Phase 3 — workspace incoming (optional / later).** A workspace-wide reverse
-  index (which files follow/call which) to answer "who calls `F`" across files
-  that the current document does not itself follow. Larger; may reuse the
-  workspace-symbol indexing machinery. Explicitly out of scope for the first PR.
+- **Population.** Reuse the workspace-symbol discovery that already enumerates
+  shell files (spec 023's `workspace/symbol` path) to seed the file set. Each
+  file's `FileCallFacts` is a cheap projection of its parsed model — function
+  definition bindings, call sites, and resolved source edges (the last via 024's
+  resolver, promoted to a shared crate so `shuck check` and the server share one
+  implementation). No full semantic model is retained; only the projection.
+- **Laziness.** Build on first call-hierarchy request, not at startup, to stay
+  within spec 018's latency budget. Index build is parallel over files.
+- **Incremental invalidation.** On `didChange`/`didSave`/watched-file events,
+  reproject only the changed file and drop cached resolutions that touched it.
+  Open buffers shadow on-disk content, so unsaved edits are honored. A file's
+  entry lists its `source_edges`, giving the reverse dependency needed to know
+  which callers' results to invalidate.
 
-### Caching and invalidation
+### Server layer
 
-The document analysis cache must track the resolved follow-target paths as
-dependencies, so editing a followed file invalidates the caller's call-hierarchy
-results. This mirrors `imported_dependency_paths` already produced by the closure
-and the `dependency_paths` the CLI check path records.
+1. **Feed determinable edges from 024.** Each file's `source_edges` come from the
+   shared resolver; this is where 024's hint resolution reaches the server.
+2. **Read files by preference.** A file in the index may be an open buffer or
+   on disk; prefer the buffer, fall back to disk. The server thus reads workspace
+   shell files it did not open — see Security.
+3. **Address items by file.** `to_lsp_call_hierarchy_item` stamps each item with
+   its *own* file's `Url`; the round-trip `data` payload becomes
+   `{ uri, line, character }` so incoming/outgoing can re-resolve an item in any
+   file, not just the active document.
+4. **No new capability.** `callHierarchyProvider` is already advertised; this
+   spec only widens what the three existing requests return.
+
+### Build sequencing (all ships in one feature; this is internal order)
+
+1. Shared source resolver crate (extract 024's `NativeSourceResolver`).
+2. `FileCallFacts` projection in `shuck-semantic` + per-file unit coverage.
+3. `WorkspaceCallIndex` with cross-file `resolve`, `outgoing`, `incoming`.
+4. Server wiring: lazy build, buffer/disk reads, per-file item URIs,
+   invalidation on document/watched-file events.
+5. Black-box multi-file LSP tests for both directions, including an incoming
+   caller that the queried file does not itself source.
 
 ## Alternatives Considered
 
-### Merged multi-file model (approach A above)
+### Closure-scoped overlay (outgoing-complete, incoming-partial)
 
-Rejected for v1. A single arena spanning the closure gives the simplest query
-surface, but it is a deep change to model construction, span ownership, and every
-consumer that assumes one model = one file. The overlay (B) delivers the same
-navigation with an additive change; a merged model can come later if multiple
-features need it.
+Rejected — this was the earlier draft of this spec. Retaining only the querying
+document's follow closure answers outgoing correctly but incoming only for
+callers inside that closure, silently missing callers elsewhere in the
+workspace. Partial incoming in a navigation tool is a correctness bug, and the
+user requirement is explicit: both directions complete, or neither.
 
-### Feed `assume-source` into the hierarchy too
+### Follow-only edges (exclude `assume-source` from the graph)
 
-Rejected. It would blur the 024 distinction users just gained: `assume-source`
-means "I only want symbols resolved, don't pull this file in." Overriding that to
-also add call edges removes the cheap "just silence the noise" option.
+Considered. Preserves the 023-era "follow participates, assume does not"
+distinction crisply: cross-file hierarchy would require `follow-source`
+everywhere, and `assume-source` would mean "symbols only, never in the graph." It
+loses incoming completeness for projects that annotated callers with
+`assume-source`, which conflicts with the completeness requirement. Chosen model
+instead counts all determinable edges; the assume/follow distinction survives in
+per-document cost and CLI linting. Revisit if users want an explicit "resolve
+symbols but keep out of the call graph" mode.
 
-### Workspace-index-first (incoming before outgoing)
+### Merged multi-file semantic model
 
-Rejected as the starting point. Incoming across the workspace needs a reverse
-call index that does not exist yet, while outgoing is reachable today via the
-follow closure. Shipping outgoing first delivers most of the value at a fraction
-of the cost and defers the index to when incoming demands it.
+Rejected for this feature. A single arena spanning the workspace would give the
+richest query surface but is a deep change to model construction and every
+span→file assumption. The index holds a compact projection instead and leaves
+per-file models untouched; a merged model can come later if several features
+need it.
 
-### Always resolve the closure in the LSP path
+### Eager full-workspace index at startup
 
-Considered. Simpler than gating on the presence of `follow-source` hints, but it
-makes every hover/definition/symbol request pay closure-resolution cost even for
-documents with no hints. Prefer lazy enablement keyed on hint presence, measured
-against the latency budget from spec 018.
+Rejected. Indexing every shell file on server start burns latency for sessions
+that never use call hierarchy. Lazy first-use build plus incremental maintenance
+keeps the common path cheap.
 
 ## Security Considerations
 
-Enabling the closure in the server means the LSP server **reads files named by
-the document under edit** (the `follow-source` targets), transitively. This is the
-same trust posture as 024's CLI following and ShellCheck's `-x`, now in an
-always-on editor process:
+Completing incoming calls requires the server to **index shell files across the
+workspace**, and resolving edges means **reading files named by other files'
+source statements** (including computed paths a hint makes determinable). This
+widens the trust surface beyond spec 024's CLI following into an always-on editor
+process:
 
-- Resolution stays confined to the annotating file's directory plus configured
-  `source-paths`; targets outside those roots are not followed.
-- The server only reads and parses; it never executes sourced content.
-- Transitive following uses a visited set to bound fan-out and prevent cycles.
-- Reads prefer open buffers, so unsaved editor state is honored over stale disk
-  content and the server does not race the user's edits.
+- Indexing is confined to the server's workspace folders and to targets that
+  resolve within a file's directory plus configured `source-paths`; paths outside
+  those roots are not read.
+- The server only reads and parses; it never executes shell content.
+- Transitive resolution is visited-set bounded to prevent cycles and runaway
+  fan-out.
+- Open buffers are preferred over disk, so the server honors unsaved editor state
+  and does not act on stale content.
+- The index respects the same file-discovery exclusions as the rest of the
+  server (gitignore, excluded dirs), so vendored or ignored trees are not walked.
+
+## Performance Considerations
+
+- The index is the new cost center. Build is lazy (first call-hierarchy request),
+  parallel across files, and produces a compact projection rather than retained
+  models.
+- Incremental reprojection on edit touches one file; resolution caches are keyed
+  so only dependent callers are invalidated.
+- Measure against spec 018's latency budget: first-request index build on a
+  representative repo, and steady-state incoming/outgoing latency with a warm
+  index. Fall back to single-file results if index build exceeds a budget rather
+  than blocking the request.
 
 ## Verification
 
-- **Semantic** (`shuck-semantic`): given a caller model with a `follow-source`
-  edge to a helper defining `greet`, `cross_file_outgoing` for a function that
-  calls `greet` returns an edge whose target item carries the helper's path; and
-  a helper-local query surfaces the caller's call span via `cross_file_incoming`
-  when the caller is in the closure.
-- **Server** (`shuck-server`): a black-box LSP session over two files — `main.sh`
-  with `# shuck: follow-source=helper.sh` and `helper.sh` defining `greet` —
-  where `prepareCallHierarchy` on `main`'s call to `greet` plus `outgoingCalls`
-  returns an item with `helper.sh`'s URI, and `incomingCalls` on `greet` returns
-  `main`'s call site. Verify the followed file is read from disk when not open and
-  from the buffer when open.
-- **Invalidation**: editing `helper.sh` (buffer change) updates the caller's
-  outgoing/incoming results without a server restart.
-- **Scope guard**: an `assume-source` edge does *not* produce cross-file call
-  edges.
-- **Regression**: single-file call hierarchy (spec 023) and all 024 behaviors are
-  unchanged; `make test` and the black-box LSP suite stay green.
+- **Projection** (`shuck-semantic`): `FileCallFacts` for a file lists its
+  function definitions, call sites with enclosing function, and resolved source
+  edges (literal, `assume-source`, `follow-source`); `/dev/null` and unresolvable
+  dynamic sources contribute no edge.
+- **Index** (`shuck-semantic`): over a three-file graph `a.sh` (defines `greet`)
+  ← `b.sh` (`follow-source=a.sh`, calls `greet`) ← `c.sh` (`assume-source=a.sh`,
+  calls `greet`), `incoming(greet in a.sh)` returns both `b.sh` and `c.sh` call
+  sites; `outgoing` from `b.sh`'s caller lands on `a.sh`'s `greet`. A nearer
+  local `greet` in `b.sh` shadows the cross-file one.
+- **Server** (`shuck-server`, black-box LSP): `prepareCallHierarchy` on a call to
+  a followed function returns an item with the *target* file's URI;
+  `outgoingCalls` descends into followed files; `incomingCalls` on a function
+  returns callers **in files the queried file does not itself source**, proving
+  the reverse index rather than a closure walk. Verify buffer-preferred reads and
+  that editing a caller (buffer change) updates the callee's incoming results
+  without restart.
+- **Completeness guard**: a caller reachable only through an unresolvable dynamic
+  source is *absent* (documented limitation), while the same caller with an
+  `assume-source`/`follow-source` hint *appears* — demonstrating hints maximize
+  the resolvable graph.
+- **Regression**: single-file call hierarchy (023) and all 024 behaviors
+  unchanged; `make test` and the black-box LSP suite green.
 
-Clean-room: all directive names, types, and documentation are authored in-repo;
-no ShellCheck source or wiki text is referenced.
+Clean-room: all names, types, and documentation are authored in-repo; no
+ShellCheck source or wiki text is referenced.


### PR DESCRIPTION
**Part 3 of 3** — cross-file call hierarchy for the LSP, split per the review below:

1. #1162 — `feat(server)`: single-file LSP call hierarchy
2. #1163 — `feat(semantic,cli)`: `# shuck: source=` directive + opt-in target linting
3. **this PR** — `feat(server)`: cross-file call hierarchy over a workspace call-graph index

Each PR is stacked on the previous one; because all heads live on a fork, later PRs show cumulative diffs until their predecessors merge. To review just this PR's increment: `git diff feat/source-directives..feat/lsp-cross-file-call-hierarchy`. Draft until #1163 lands.

---

Makes LSP call hierarchy complete across files (issue #1144). Rewritten on top of the redesigned `# shuck: source=` directive per the review discussion below; this branch was force-pushed when the original PR was split into the stack above.

- **shuck-semantic**: `FileCallFacts` — a compact per-file projection of function definitions, call sites (tagged with enclosing function or top level), and resolved source-edge targets — and `WorkspaceCallIndex`, which answers `resolve` / `outgoing` / `incoming` as symmetric traversals of one call graph. Incoming is complete across the workspace rather than only a file's own closure. All determinable edges count: resolvable literals and `source=` directives with or without `lint=true`.
- **shuck-server**: session-scoped `incomingCalls`/`outgoingCalls` build the index over open buffers (preferred) plus discovered workspace shell files plus files reachable only through resolved source edges; the built index is cached on the session behind an epoch counter and invalidated on any document/workspace/configuration change. Edge resolution honors `[lint] source-paths` per project root, matching `shuck check`. Top-level MODULE nodes round-trip through `item.data` so they expand correctly. In-file call resolution stays binding-accurate (definition order and shadowing honored).
- **Hard `maxFiles` bound (review point 2).** `server.callHierarchy.maxFiles` (default 10k) is now a hard cap: one budget shared by all three population phases — open buffers consume it first, closed-file discovery gets what they leave over, and source-edge expansion re-checks before every insertion — with a warning when truncated. Covered by a bound test exercising all three phases.

Spec: `specs/025-cross-file-call-hierarchy.md`. Black-box multi-file LSP tests cover both directions, `source-paths`-only resolution, and MODULE expansion.
