### PR TITLE
chore(deps): update crates flagged by cargo audit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -94,9 +94,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "arraydeque"
@@ -467,9 +467,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -1431,9 +1431,9 @@ dependencies = [
 
 [[package]]
 name = "quick-junit"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3e64c58c4c88fc1045e8fe98a1b7cec3643187e3dd678f9bbcdd8f12a6933d6"
+checksum = "8216516c957e00535b3c91770524c219dd7df90dec439a182547f750dfe41591"
 dependencies = [
  "chrono",
  "indexmap",
@@ -1446,9 +1446,9 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.38.4"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b66c2058c55a409d601666cffe35f04333cf1013010882cec174a7467cd4e21c"
+checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,7 +72,7 @@ saphyr = "0.0.6"
 saphyr-parser = "0.0.6"
 similar = "2"
 toml = "0.8"
-quick-junit = "0.6.0"
+quick-junit = "0.6.1"
 url = "2.5.0"
 
 # Testing


### PR DESCRIPTION
Fixes the `cargo audit` CI job currently failing on every open PR.

- `crossbeam-epoch` 0.9.18 → 0.9.20 — RUSTSEC-2026-0204 (invalid pointer deref in `fmt::Pointer` impls)
- `quick-xml` 0.38.4 → 0.41.0 via `quick-junit` 0.6.0 → 0.6.1 — RUSTSEC-2026-0194 / RUSTSEC-2026-0195 (DoS in attribute checking and namespace resolution)
- `anyhow` 1.0.102 → 1.0.103 — RUSTSEC-2026-0190 (unsound `downcast_mut`)

`make build`, `make test`, and the JUnit output tests (which exercise quick-junit/quick-xml) pass locally. No source changes beyond the manifest floor bump for quick-junit.
