### PR TITLE
fix(server): exit cleanly when LSP client disconnects

### DIFF
--- a/crates/shuck-cli/tests/integration_test.rs
+++ b/crates/shuck-cli/tests/integration_test.rs
@@ -44,6 +44,13 @@ fn stdout_string(output: &std::process::Output) -> String {
     String::from_utf8(output.stdout.clone()).unwrap()
 }
 
+#[test]
+fn server_exits_cleanly_when_stdin_reaches_eof() {
+    let mut cmd = Command::cargo_bin("shuck").unwrap();
+    cmd.arg("server").write_stdin("");
+    cmd.assert().success().stdout("").stderr("");
+}
+
 fn platform_path(path: &str) -> String {
     if std::path::MAIN_SEPARATOR == '/' {
         path.to_owned()

--- a/crates/shuck-cli/tests/integration_test.rs
+++ b/crates/shuck-cli/tests/integration_test.rs
@@ -1,5 +1,5 @@
 use std::fs;
-use std::io::{BufRead, BufReader};
+use std::io::{BufRead, BufReader, Write};
 use std::path::{Path, PathBuf};
 use std::process::{Command as ProcessCommand, Stdio};
 use std::sync::mpsc::{self, Receiver};
@@ -49,6 +49,27 @@ fn server_exits_cleanly_when_stdin_reaches_eof() {
     let mut cmd = Command::cargo_bin("shuck").unwrap();
     cmd.arg("server").write_stdin("");
     cmd.assert().success().stdout("").stderr("");
+}
+
+#[test]
+fn server_reports_invalid_initialization_without_waiting_for_stdin_eof() {
+    let mut child = ProcessCommand::new(assert_cmd::cargo::cargo_bin("shuck"))
+        .arg("server")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .unwrap();
+    let mut stdin = child.stdin.take().unwrap();
+    let body = r#"{"jsonrpc":"2.0","method":"initialize","params":null,"id":1}"#;
+    write!(stdin, "Content-Length: {}\r\n\r\n{body}", body.len()).unwrap();
+    stdin.flush().unwrap();
+
+    let Some(exit) = child.wait_timeout(Duration::from_secs(2)).unwrap() else {
+        stop_child(&mut child);
+        panic!("invalid initialization should exit while stdin remains open");
+    };
+    assert_eq!(exit.code(), Some(2));
 }
 
 fn platform_path(path: &str) -> String {

--- a/crates/shuck-server/src/lib.rs
+++ b/crates/shuck-server/src/lib.rs
@@ -53,7 +53,10 @@ pub fn run() -> Result<()> {
         .min(four);
 
     let (connection, io_threads) = server::ConnectionInitializer::stdio();
-    let server_result = run_server(worker_threads, connection);
+    let server_result = match start_server(worker_threads, connection)? {
+        Some(server) => server.run(),
+        None => Ok(()),
+    };
 
     let io_result = io_threads.join();
     match (server_result, io_result) {
@@ -71,19 +74,22 @@ pub fn run_connection(connection: lsp_server::Connection) -> Result<()> {
     let worker_threads = std::thread::available_parallelism()
         .unwrap_or(four)
         .min(four);
-    run_server(
+    match start_server(
         worker_threads,
         server::ConnectionInitializer::from_connection(connection),
-    )
+    )? {
+        Some(server) => server.run(),
+        None => Ok(()),
+    }
 }
 
-fn run_server(
+fn start_server(
     worker_threads: NonZeroUsize,
     connection: server::ConnectionInitializer,
-) -> Result<()> {
+) -> Result<Option<Server>> {
     match Server::new(worker_threads, connection) {
-        Ok(server) => server.run(),
-        Err(error) if is_disconnected(&error) => Ok(()),
+        Ok(server) => Ok(Some(server)),
+        Err(error) if is_disconnected(&error) => Ok(None),
         Err(error) => Err(error.context("Failed to start server")),
     }
 }

--- a/crates/shuck-server/src/lib.rs
+++ b/crates/shuck-server/src/lib.rs
@@ -53,9 +53,7 @@ pub fn run() -> Result<()> {
         .min(four);
 
     let (connection, io_threads) = server::ConnectionInitializer::stdio();
-    let server_result = Server::new(worker_threads, connection)
-        .map_err(|err| err.context("Failed to start server"))?
-        .run();
+    let server_result = run_server(worker_threads, connection);
 
     let io_result = io_threads.join();
     match (server_result, io_result) {
@@ -73,10 +71,25 @@ pub fn run_connection(connection: lsp_server::Connection) -> Result<()> {
     let worker_threads = std::thread::available_parallelism()
         .unwrap_or(four)
         .min(four);
-    Server::new(
+    run_server(
         worker_threads,
         server::ConnectionInitializer::from_connection(connection),
     )
-    .map_err(|err| err.context("Failed to start server"))?
-    .run()
+}
+
+fn run_server(
+    worker_threads: NonZeroUsize,
+    connection: server::ConnectionInitializer,
+) -> Result<()> {
+    match Server::new(worker_threads, connection) {
+        Ok(server) => server.run(),
+        Err(error) if is_disconnected(&error) => Ok(()),
+        Err(error) => Err(error.context("Failed to start server")),
+    }
+}
+
+fn is_disconnected(error: &anyhow::Error) -> bool {
+    error
+        .downcast_ref::<lsp_server::ProtocolError>()
+        .is_some_and(lsp_server::ProtocolError::channel_is_disconnected)
 }

--- a/crates/shuck-server/src/server/main_loop.rs
+++ b/crates/shuck-server/src/server/main_loop.rs
@@ -17,7 +17,7 @@ impl Server {
         let mut scheduler = schedule::Scheduler::new(self.worker_threads);
         while let Ok(next_event) = self.next_event() {
             let Some(next_event) = next_event else {
-                anyhow::bail!("client exited without proper shutdown sequence");
+                return Ok(());
             };
 
             match next_event {

--- a/crates/shuck-server/tests/disconnect.rs
+++ b/crates/shuck-server/tests/disconnect.rs
@@ -1,0 +1,48 @@
+use std::thread;
+use std::time::Duration;
+
+use lsp_server::{Connection, Message, Notification, Request, RequestId};
+
+#[test]
+fn disconnect_before_initialization_exits_cleanly() {
+    let (server_connection, client_connection) = Connection::memory();
+    drop(client_connection);
+
+    shuck_server::run_connection(server_connection)
+        .expect("disconnect before initialization should be a clean shutdown");
+}
+
+#[test]
+fn disconnect_after_initialization_exits_cleanly() {
+    let (server_connection, client_connection) = Connection::memory();
+    let server_thread = thread::spawn(move || shuck_server::run_connection(server_connection));
+
+    client_connection
+        .sender
+        .send(Message::Request(Request {
+            id: RequestId::from(1),
+            method: "initialize".to_owned(),
+            params: serde_json::json!({ "capabilities": {} }),
+        }))
+        .expect("initialize request should send");
+
+    let response = client_connection
+        .receiver
+        .recv_timeout(Duration::from_secs(2))
+        .expect("server should respond to initialization");
+    assert!(matches!(response, Message::Response(response) if response.error.is_none()));
+
+    client_connection
+        .sender
+        .send(Message::Notification(Notification::new(
+            "initialized".to_owned(),
+            serde_json::json!({}),
+        )))
+        .expect("initialized notification should send");
+    drop(client_connection);
+
+    server_thread
+        .join()
+        .expect("server thread should join")
+        .expect("disconnect after initialization should be a clean shutdown");
+}


### PR DESCRIPTION
## Summary

- treat LSP channel disconnects during initialization as a clean shutdown
- exit the server main loop successfully when stdin reaches EOF
- always join stdio transport threads after initialization attempts
- add server and CLI regression coverage for disconnects before and after initialization

## Validation

- `cargo test -p shuck-server`
- `cargo test -p shuck-cli --test integration_test server_exits_cleanly_when_stdin_reaches_eof`
- `cargo clippy -p shuck-server -p shuck-cli --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- verified `shuck server </dev/null` exits 0 with empty stderr

Closes #1130