### PR TITLE
feat(cli): support stdin in native check

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,9 @@ shuck check action.yml
 # Read from stdin
 echo 'echo $foo' | shuck check -
 
+# Read from stdin using a logical filename for dialect and project settings
+echo 'echo $foo' | shuck check --stdin-filename script.bash
+
 # Apply safe fixes automatically
 shuck check --fix .
 

--- a/crates/shuck-cli/src/args.rs
+++ b/crates/shuck-cli/src/args.rs
@@ -321,8 +321,11 @@ pub struct CheckCommand {
     /// Run in watch mode by re-running whenever files change.
     #[arg(short = 'w', long, conflicts_with = "add_ignore")]
     pub watch: bool,
-    /// Files or directories to check.
+    /// Files or directories to check, or `-` to read from stdin.
     pub paths: Vec<PathBuf>,
+    /// The name of the file when passing it through stdin.
+    #[arg(long, help_heading = "Miscellaneous")]
+    pub stdin_filename: Option<PathBuf>,
     /// Rule selection and suppression settings.
     #[command(flatten)]
     pub rule_selection: RuleSelectionArgs,

--- a/crates/shuck-cli/src/commands/check.rs
+++ b/crates/shuck-cli/src/commands/check.rs
@@ -15,6 +15,7 @@ mod display;
 mod embedded;
 mod run;
 mod settings;
+mod stdin;
 mod watch;
 #[cfg(test)]
 mod zsh_plugin_dependency_fixtures;
@@ -68,6 +69,9 @@ pub(crate) fn check(
     cache_dir: Option<&Path>,
 ) -> Result<ExitStatus> {
     let cwd = std::env::current_dir()?;
+    if stdin::is_stdin(&args)? {
+        return stdin::check_stdin(&args, config_arguments, &cwd);
+    }
     let cache_root = resolve_cache_root(&cwd, cache_dir)?;
     if args.watch {
         return watch_check(&args, config_arguments, &cwd, &cache_root);

--- a/crates/shuck-cli/src/commands/check/analyze.rs
+++ b/crates/shuck-cli/src/commands/check/analyze.rs
@@ -79,7 +79,6 @@ fn analyze_shell_file(
     let linter_settings = base_linter_settings.clone().with_shell(inferred_shell);
     let mut parse_result = Parser::with_dialect(&source, parse_dialect).parse();
     let mut analysis = collect_lint_diagnostics(
-        &pending,
         &source,
         &parse_result,
         &linter_settings,
@@ -102,7 +101,6 @@ fn analyze_shell_file(
             fs::write(&pending.file.absolute_path, &*source)?;
             parse_result = Parser::with_dialect(&source, parse_dialect).parse();
             analysis = collect_lint_diagnostics(
-                &pending,
                 &source,
                 &parse_result,
                 &linter_settings,
@@ -148,7 +146,6 @@ fn analyze_shell_file(
     })
 }
 pub(super) fn collect_lint_diagnostics(
-    _pending: &PendingProjectFile,
     source: &Arc<str>,
     parse_result: &ParseResult,
     linter_settings: &LinterSettings,
@@ -362,7 +359,6 @@ mod tests {
         let parse_result = Parser::with_dialect(&source, shuck_parser::ShellDialect::Bash).parse();
 
         let diagnostics = collect_lint_diagnostics(
-            &pending,
             &source,
             &parse_result,
             &LinterSettings::default(),

--- a/crates/shuck-cli/src/commands/check/display.rs
+++ b/crates/shuck-cli/src/commands/check/display.rs
@@ -12,6 +12,7 @@ use crate::commands::check_output::{
     DisplayedDiagnosticKind, DisplayedEdit, DisplayedFix, print_report_to,
 };
 use crate::commands::project_runner::PendingProjectFile;
+use crate::discover::DiscoveredFile;
 
 pub(super) fn print_report(
     report: &CheckReport,
@@ -39,14 +40,23 @@ pub(super) fn display_lint_diagnostics(
     diagnostics: &[shuck_linter::Diagnostic],
     include_source: bool,
 ) -> Vec<DisplayedDiagnostic> {
+    display_lint_diagnostics_for_file(&pending.file, source, diagnostics, include_source)
+}
+
+pub(super) fn display_lint_diagnostics_for_file(
+    file: &DiscoveredFile,
+    source: &Arc<str>,
+    diagnostics: &[shuck_linter::Diagnostic],
+    include_source: bool,
+) -> Vec<DisplayedDiagnostic> {
     let diagnostic_source = (!diagnostics.is_empty() && include_source).then(|| source.clone());
 
     diagnostics
         .iter()
         .map(|diagnostic| DisplayedDiagnostic {
-            path: pending.file.display_path.clone(),
-            relative_path: pending.file.relative_path.clone(),
-            absolute_path: pending.file.absolute_path.clone(),
+            path: file.display_path.clone(),
+            relative_path: file.relative_path.clone(),
+            absolute_path: file.absolute_path.clone(),
             span: DisplaySpan::new(
                 DisplayPosition::new(diagnostic.span.start.line, diagnostic.span.start.column),
                 DisplayPosition::new(diagnostic.span.end.line, diagnostic.span.end.column),

--- a/crates/shuck-cli/src/commands/check/embedded.rs
+++ b/crates/shuck-cli/src/commands/check/embedded.rs
@@ -65,7 +65,6 @@ pub(super) fn analyze_embedded_file(
                 pipefail: embedded.implicit_flags.pipefail,
             });
         let diagnostics = collect_lint_diagnostics(
-            &pending,
             &snippet_source,
             &parse_result,
             &linter_settings,

--- a/crates/shuck-cli/src/commands/check/run.rs
+++ b/crates/shuck-cli/src/commands/check/run.rs
@@ -158,6 +158,7 @@ pub(crate) fn benchmark_check_paths(
             output_format,
             watch: false,
             paths: paths.to_vec(),
+            stdin_filename: None,
             rule_selection: RuleSelectionArgs {
                 select: Some(vec![RuleSelector::All]),
                 ..RuleSelectionArgs::default()

--- a/crates/shuck-cli/src/commands/check/stdin.rs
+++ b/crates/shuck-cli/src/commands/check/stdin.rs
@@ -1,0 +1,230 @@
+use std::io::{self, BufWriter, Write};
+use std::path::Path;
+use std::sync::Arc;
+
+use anyhow::{Result, anyhow};
+use shuck_config::{
+    ConfigArguments, resolve_project_root_for_file, resolve_project_root_for_input,
+};
+use shuck_linter::{Applicability, LinterSettings, ShellCheckCodeMap, ShellDialect};
+use shuck_parser::{Error as ParseError, parser::Parser};
+
+use super::CheckReport;
+use super::analyze::collect_lint_diagnostics;
+use super::display::{display_lint_diagnostics_for_file, display_parse_error};
+use super::settings::resolve_project_check_settings;
+use crate::ExitStatus;
+use crate::args::{CheckCommand, CheckOutputFormatArg};
+use crate::commands::check_output::print_report_to;
+use crate::discover::{DiscoveredFile, FileKind, ProjectRoot, normalize_path};
+use crate::stdin::read_from_stdin;
+
+pub(super) fn is_stdin(args: &CheckCommand) -> Result<bool> {
+    if args.stdin_filename.is_some() {
+        if args.paths.len() > 1 {
+            return Err(anyhow!("cannot check multiple inputs together with stdin"));
+        }
+        if let Some(path) = args
+            .paths
+            .first()
+            .filter(|path| path.as_path() != Path::new("-"))
+        {
+            return Err(anyhow!(
+                "cannot check path `{}` together with --stdin-filename",
+                path.display()
+            ));
+        }
+        return Ok(true);
+    }
+
+    if args.paths.iter().any(|path| path == Path::new("-")) {
+        if args.paths.len() != 1 {
+            return Err(anyhow!("cannot check stdin together with filesystem paths"));
+        }
+        return Ok(true);
+    }
+
+    Ok(false)
+}
+
+pub(super) fn check_stdin(
+    args: &CheckCommand,
+    config_arguments: &ConfigArguments,
+    cwd: &Path,
+) -> Result<ExitStatus> {
+    if args.watch {
+        return Err(anyhow!("--watch cannot be used when checking stdin"));
+    }
+    if args.add_ignore.is_some() {
+        return Err(anyhow!("--add-ignore cannot be used when checking stdin"));
+    }
+
+    let source = Arc::<str>::from(read_from_stdin()?);
+    let file = stdin_file(args.stdin_filename.as_deref(), cwd, config_arguments)?;
+    let settings = resolve_project_check_settings(
+        &file.project_root,
+        config_arguments,
+        &args.rule_selection,
+        &args.zsh_plugin_resolution,
+    )?;
+    let shell = settings
+        .per_file_shell
+        .shell_for_path(&file.absolute_path)
+        .unwrap_or_else(|| ShellDialect::infer(&source, Some(&file.absolute_path)));
+    let linter_settings = settings
+        .linter_settings
+        .clone()
+        .with_analyzed_path_set(LinterSettings::analyzed_path_set([file
+            .absolute_path
+            .clone()]))
+        .with_shell(shell);
+    let shellcheck_map = ShellCheckCodeMap::default();
+    let applicability = requested_fix_applicability(args);
+    let include_source = matches!(args.output_format, CheckOutputFormatArg::Full);
+
+    let mut checked_source = source;
+    let mut parse_result = Parser::with_dialect(&checked_source, shell.parser_dialect()).parse();
+    let mut analysis = collect_lint_diagnostics(
+        &checked_source,
+        &parse_result,
+        &linter_settings,
+        Some(settings.zsh_plugins.as_ref()),
+        &shellcheck_map,
+        &file.absolute_path,
+    );
+    let mut fixes_applied = 0;
+
+    if let Some(applicability) = applicability {
+        let fixable = analysis
+            .diagnostics
+            .iter()
+            .filter(|diagnostic| settings.fixable_rules.contains(diagnostic.rule))
+            .cloned()
+            .collect::<Vec<_>>();
+        let applied = shuck_linter::apply_fixes(&checked_source, &fixable, applicability);
+        fixes_applied = applied.fixes_applied;
+        checked_source = Arc::<str>::from(applied.code);
+        parse_result = Parser::with_dialect(&checked_source, shell.parser_dialect()).parse();
+        analysis = collect_lint_diagnostics(
+            &checked_source,
+            &parse_result,
+            &linter_settings,
+            Some(settings.zsh_plugins.as_ref()),
+            &shellcheck_map,
+            &file.absolute_path,
+        );
+    }
+
+    let parse_failed = parse_result.is_err();
+    let diagnostics = if parse_failed && analysis.diagnostics.is_empty() {
+        let ParseError::Parse {
+            message,
+            line,
+            column,
+        } = parse_result.strict_error();
+        vec![display_parse_error(
+            &file.display_path,
+            &file.relative_path,
+            &file.absolute_path,
+            line,
+            column,
+            message,
+            include_source.then_some(checked_source.clone()),
+        )]
+    } else {
+        display_lint_diagnostics_for_file(
+            &file,
+            &checked_source,
+            &analysis.diagnostics,
+            include_source,
+        )
+    };
+    let report = CheckReport {
+        diagnostics,
+        fixes_applied,
+        parse_failed,
+        dependency_paths: analysis.semantic.imported_dependency_paths().to_vec(),
+        ..CheckReport::default()
+    };
+
+    if applicability.is_some() {
+        let mut stdout = BufWriter::new(io::stdout().lock());
+        stdout.write_all(checked_source.as_bytes())?;
+        stdout.flush()?;
+
+        let mut stderr = BufWriter::new(io::stderr().lock());
+        print_report_to(
+            &mut stderr,
+            &report.diagnostics,
+            args.output_format,
+            colored::control::SHOULD_COLORIZE.should_colorize(),
+        )?;
+        if fixes_applied > 0 {
+            writeln!(
+                stderr,
+                "Applied {fixes_applied} fix{}.",
+                if fixes_applied == 1 { "" } else { "es" }
+            )?;
+        }
+    } else {
+        let mut stdout = BufWriter::new(io::stdout().lock());
+        print_report_to(
+            &mut stdout,
+            &report.diagnostics,
+            args.output_format,
+            colored::control::SHOULD_COLORIZE.should_colorize(),
+        )?;
+    }
+
+    Ok(report.exit_status(args.exit_zero, args.exit_non_zero_on_fix))
+}
+
+fn requested_fix_applicability(args: &CheckCommand) -> Option<Applicability> {
+    if args.unsafe_fixes {
+        Some(Applicability::Unsafe)
+    } else if args.fix {
+        Some(Applicability::Safe)
+    } else {
+        None
+    }
+}
+
+fn stdin_file(
+    filename: Option<&Path>,
+    cwd: &Path,
+    config_arguments: &ConfigArguments,
+) -> Result<DiscoveredFile> {
+    let display_path = filename.unwrap_or_else(|| Path::new("-")).to_path_buf();
+    let absolute_path = filename
+        .map(|path| {
+            if path.is_absolute() {
+                path.to_path_buf()
+            } else {
+                cwd.join(path)
+            }
+        })
+        .unwrap_or_else(|| cwd.join("<stdin>"));
+    let absolute_path = normalize_path(&absolute_path);
+    let storage_root = match filename {
+        Some(_) => {
+            resolve_project_root_for_file(&absolute_path, cwd, config_arguments.use_config_roots())?
+        }
+        None => resolve_project_root_for_input(cwd, config_arguments.use_config_roots())?,
+    };
+    let canonical_root = std::fs::canonicalize(&storage_root)?;
+    let relative_path = absolute_path
+        .strip_prefix(&canonical_root)
+        .map(Path::to_path_buf)
+        .unwrap_or_else(|_| display_path.clone());
+
+    Ok(DiscoveredFile {
+        display_path,
+        absolute_path,
+        relative_path,
+        project_root: ProjectRoot {
+            storage_root,
+            canonical_root,
+        },
+        kind: FileKind::Shell,
+    })
+}

--- a/crates/shuck-cli/src/commands/check/stdin.rs
+++ b/crates/shuck-cli/src/commands/check/stdin.rs
@@ -159,7 +159,7 @@ pub(super) fn check_stdin(
             args.output_format,
             colored::control::SHOULD_COLORIZE.should_colorize(),
         )?;
-        if fixes_applied > 0 {
+        if fixes_applied > 0 && is_human_readable(args.output_format) {
             writeln!(
                 stderr,
                 "Applied {fixes_applied} fix{}.",
@@ -187,6 +187,13 @@ fn requested_fix_applicability(args: &CheckCommand) -> Option<Applicability> {
     } else {
         None
     }
+}
+
+fn is_human_readable(output_format: CheckOutputFormatArg) -> bool {
+    matches!(
+        output_format,
+        CheckOutputFormatArg::Concise | CheckOutputFormatArg::Full | CheckOutputFormatArg::Grouped
+    )
 }
 
 fn stdin_file(

--- a/crates/shuck-cli/src/commands/check/test_support.rs
+++ b/crates/shuck-cli/src/commands/check/test_support.rs
@@ -73,6 +73,7 @@ pub(super) fn check_args_with_format(
         output_format,
         watch: false,
         paths: Vec::new(),
+        stdin_filename: None,
         rule_selection: RuleSelectionArgs::default(),
         zsh_plugin_resolution: ZshPluginArgs::default(),
         file_selection: FileSelectionArgs::default(),

--- a/crates/shuck-cli/tests/integration_test.rs
+++ b/crates/shuck-cli/tests/integration_test.rs
@@ -355,6 +355,34 @@ fn check_fix_stdin_routes_remaining_diagnostics_to_stderr() {
 }
 
 #[test]
+fn check_fix_stdin_keeps_json_diagnostics_parseable() {
+    let tempdir = tempdir().unwrap();
+    let mut cmd = Command::cargo_bin("shuck").unwrap();
+    configure_env_cache(&mut cmd, tempdir.path());
+    cmd.current_dir(tempdir.path())
+        .args([
+            "check",
+            "--fix",
+            "--select",
+            "S074",
+            "--output-format",
+            "json",
+            "-",
+        ])
+        .write_stdin("#!/bin/bash\nprintf '%s\\n' x &;\n");
+    let output = cmd.output().unwrap();
+
+    assert!(output.status.success());
+    assert_eq!(
+        String::from_utf8(output.stdout).unwrap(),
+        "#!/bin/bash\nprintf '%s\\n' x &\n"
+    );
+    let stderr = String::from_utf8(output.stderr).unwrap();
+    assert_eq!(stderr, "[]\n");
+    serde_json::from_str::<serde_json::Value>(&stderr).unwrap();
+}
+
+#[test]
 fn check_stdin_rejects_mixed_paths_and_non_streaming_modes() {
     let tempdir = tempdir().unwrap();
     for args in [

--- a/crates/shuck-cli/tests/integration_test.rs
+++ b/crates/shuck-cli/tests/integration_test.rs
@@ -268,6 +268,109 @@ fn check_good_file_succeeds() {
 }
 
 #[test]
+fn check_dash_reads_from_stdin() {
+    let tempdir = tempdir().unwrap();
+    let mut cmd = Command::cargo_bin("shuck").unwrap();
+    configure_env_cache(&mut cmd, tempdir.path());
+    cmd.current_dir(tempdir.path())
+        .args(["check", "--output-format", "concise", "-"])
+        .write_stdin("#!/bin/bash\necho $foo\n");
+    cmd.assert()
+        .code(1)
+        .stdout("-:2:6: error[C006] variable `foo` is referenced before assignment\n")
+        .stderr("");
+    assert!(!cache_dir(tempdir.path()).exists());
+}
+
+#[test]
+fn check_stdin_filename_is_optional_and_controls_per_file_settings() {
+    let tempdir = tempdir().unwrap();
+    let mut cmd = Command::cargo_bin("shuck").unwrap();
+    configure_env_cache(&mut cmd, tempdir.path());
+    cmd.current_dir(tempdir.path())
+        .args([
+            "check",
+            "--stdin-filename",
+            "ignored.sh",
+            "--per-file-ignores",
+            "ignored.sh:C006",
+            "--output-format",
+            "concise",
+        ])
+        .write_stdin("#!/bin/bash\necho $foo\n");
+    cmd.assert().success().stdout("").stderr("");
+}
+
+#[test]
+fn check_stdin_loads_project_configuration() {
+    let tempdir = tempdir().unwrap();
+    fs::write(
+        tempdir.path().join(".shuck.toml"),
+        "[lint]\nignore = ['C006']\n",
+    )
+    .unwrap();
+
+    let mut cmd = Command::cargo_bin("shuck").unwrap();
+    configure_env_cache(&mut cmd, tempdir.path());
+    cmd.current_dir(tempdir.path())
+        .args(["check", "-"])
+        .write_stdin("#!/bin/bash\necho $foo\n");
+    cmd.assert().success().stdout("").stderr("");
+}
+
+#[test]
+fn check_fix_stdin_writes_fixed_source_to_stdout() {
+    let tempdir = tempdir().unwrap();
+    let mut cmd = Command::cargo_bin("shuck").unwrap();
+    configure_env_cache(&mut cmd, tempdir.path());
+    cmd.current_dir(tempdir.path())
+        .args(["check", "--fix", "--select", "S074", "-"])
+        .write_stdin("#!/bin/bash\nprintf '%s\\n' x &;\n");
+    cmd.assert()
+        .success()
+        .stdout("#!/bin/bash\nprintf '%s\\n' x &\n")
+        .stderr("Applied 1 fix.\n");
+}
+
+#[test]
+fn check_fix_stdin_routes_remaining_diagnostics_to_stderr() {
+    let tempdir = tempdir().unwrap();
+    let mut cmd = Command::cargo_bin("shuck").unwrap();
+    configure_env_cache(&mut cmd, tempdir.path());
+    cmd.current_dir(tempdir.path())
+        .args([
+            "check",
+            "--fix",
+            "--select",
+            "C006",
+            "--output-format",
+            "concise",
+            "-",
+        ])
+        .write_stdin("#!/bin/bash\necho $foo\n");
+    cmd.assert()
+        .code(1)
+        .stdout("#!/bin/bash\necho $foo\n")
+        .stderr("-:2:6: error[C006] variable `foo` is referenced before assignment\n");
+}
+
+#[test]
+fn check_stdin_rejects_mixed_paths_and_non_streaming_modes() {
+    let tempdir = tempdir().unwrap();
+    for args in [
+        vec!["check", "-", "script.sh"],
+        vec!["check", "--stdin-filename", "input.sh", "script.sh"],
+        vec!["check", "--watch", "-"],
+        vec!["check", "--add-ignore", "-"],
+    ] {
+        let mut cmd = Command::cargo_bin("shuck").unwrap();
+        configure_env_cache(&mut cmd, tempdir.path());
+        cmd.current_dir(tempdir.path()).args(args).write_stdin("");
+        cmd.assert().code(2);
+    }
+}
+
+#[test]
 fn check_fix_rewrites_safe_s074_and_bypasses_cache() {
     let tempdir = tempdir().unwrap();
     let script = tempdir.path().join("warn.sh");


### PR DESCRIPTION
## Summary

- make `shuck check -` lint shell source from stdin
- add `--stdin-filename` for logical path, dialect inference, and project/per-file settings
- stream fixed source to stdout while routing remaining diagnostics and fix summaries to stderr
- reject mixed filesystem/stdin inputs and non-streaming watch/add-ignore modes
- add integration coverage and document the filename form

## Validation

- `cargo fmt --check`
- `cargo clippy -p shuck-cli --all-targets -- -D warnings`
- `cargo test -p shuck-cli`
- `git diff --check`

Closes #1123