### PR TITLE
feat(server): add LSP call hierarchy for functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ Shuck ships with a first-party Language Server Protocol (LSP) server in the main
 shuck server
 ```
 
-The server analyzes the editor's in-memory buffer, publishes diagnostics as you edit, and reuses the same parser, lint rules, formatter settings, configuration, and fix machinery as the CLI. It currently supports incremental document sync, real-time diagnostics, quick fixes, `source.fixAll.shuck`, disable-this-line actions, whole-document and range formatting, hover help for rule codes in `# shuck:` and `# shellcheck` directives, completion, go-to-definition, references, document highlights, document symbols, and workspace symbols.
+The server analyzes the editor's in-memory buffer, publishes diagnostics as you edit, and reuses the same parser, lint rules, formatter settings, configuration, and fix machinery as the CLI. It currently supports incremental document sync, real-time diagnostics, quick fixes, `source.fixAll.shuck`, disable-this-line actions, whole-document and range formatting, hover help for rule codes in `# shuck:` and `# shellcheck` directives, completion, go-to-definition, references, document highlights, call hierarchy (incoming and outgoing calls for functions), document symbols, and workspace symbols.
 
 Any editor that can launch a stdio LSP server can use Shuck by pointing shell buffers at `shuck server`. See the [editor integration guide](https://ewhauser.github.io/shuck/docs/editors/) for setup examples.
 

--- a/crates/shuck-semantic/src/editor.rs
+++ b/crates/shuck-semantic/src/editor.rs
@@ -113,6 +113,46 @@ pub struct EditorOccurrence {
     pub kind: EditorOccurrenceKind,
 }
 
+/// Identifies a call-hierarchy node: a named function or the script's top level.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum EditorCallHierarchyTarget {
+    /// A named function definition.
+    Function(BindingId),
+    /// The script's top-level (module) scope.
+    TopLevel,
+}
+
+/// A call-hierarchy node suitable for editor presentation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EditorCallHierarchyItem {
+    /// Function name; empty for the top-level node (the presenter supplies a label).
+    pub name: Name,
+    /// What the node refers to.
+    pub target: EditorCallHierarchyTarget,
+    /// Span covering the whole definition; `None` for the top-level node.
+    pub full_span: Option<Span>,
+    /// Span to select when navigating; `None` for the top-level node.
+    pub selection_span: Option<Span>,
+}
+
+/// One incoming-call group: a caller and the call-token spans where it calls the subject.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EditorIncomingCall {
+    /// The calling node.
+    pub from: EditorCallHierarchyItem,
+    /// Spans of the callee tokens inside `from` that call the subject.
+    pub call_spans: Vec<Span>,
+}
+
+/// One outgoing-call group: a callee and the call-token spans where the subject calls it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EditorOutgoingCall {
+    /// The called node.
+    pub to: EditorCallHierarchyItem,
+    /// Spans of the callee tokens inside the subject that call `to`.
+    pub call_spans: Vec<Span>,
+}
+
 /// Completion category for editor presentation.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum EditorCompletionKind {
@@ -398,6 +438,148 @@ impl<'model> EditorQuery<'model> {
                 .unwrap_or_default(),
             EditorSymbolTarget::RuntimeName(_) => Vec::new(),
         }
+    }
+
+    /// Resolves the call-hierarchy node under `offset`, if it is a function.
+    ///
+    /// The cursor may sit on a function definition name or on a call to a
+    /// function that resolves to a definition; both yield the same node.
+    pub fn prepare_call_hierarchy(&self, offset: usize) -> Option<EditorCallHierarchyItem> {
+        let binding_id = self.function_binding_at_offset(offset)?;
+        Some(function_call_hierarchy_item(self.model, binding_id))
+    }
+
+    /// Returns the top-level (module) call-hierarchy node for this document.
+    pub fn top_level_call_hierarchy_item(&self) -> EditorCallHierarchyItem {
+        EditorCallHierarchyItem {
+            name: Name::from(""),
+            target: EditorCallHierarchyTarget::TopLevel,
+            full_span: None,
+            selection_span: None,
+        }
+    }
+
+    /// Returns callers of `item`, grouped by calling node.
+    ///
+    /// A caller is either the enclosing named function of each call site or the
+    /// script's top level. The top-level node itself has no callers.
+    pub fn incoming_calls(&self, item: &EditorCallHierarchyItem) -> Vec<EditorIncomingCall> {
+        let EditorCallHierarchyTarget::Function(binding_id) = item.target else {
+            return Vec::new();
+        };
+        let name = self.model.binding(binding_id).name.clone();
+        let function_by_body_scope = self.function_by_body_scope();
+        let analysis = self.model.analysis();
+
+        let mut order: Vec<EditorCallHierarchyTarget> = Vec::new();
+        let mut spans_by_caller: FxHashMap<EditorCallHierarchyTarget, Vec<Span>> =
+            FxHashMap::default();
+        for (site, resolved) in analysis.resolved_function_call_sites(&name) {
+            if resolved != binding_id {
+                continue;
+            }
+            let caller = enclosing_function_target(self.model, &function_by_body_scope, site.scope);
+            spans_by_caller
+                .entry(caller)
+                .or_insert_with(|| {
+                    order.push(caller);
+                    Vec::new()
+                })
+                .push(site.name_span);
+        }
+
+        order
+            .into_iter()
+            .map(|caller| {
+                let mut spans = spans_by_caller.remove(&caller).unwrap_or_default();
+                sort_dedup_spans(&mut spans);
+                EditorIncomingCall {
+                    from: self.item_for_target(caller),
+                    call_spans: spans,
+                }
+            })
+            .collect()
+    }
+
+    /// Returns the functions that `item` calls, grouped by callee.
+    ///
+    /// Only calls whose innermost enclosing function is `item` are attributed to
+    /// it, so calls made by nested function definitions belong to those nested
+    /// functions rather than their enclosing one. Callees that do not resolve to
+    /// a function definition (builtins, external commands) are omitted.
+    pub fn outgoing_calls(&self, item: &EditorCallHierarchyItem) -> Vec<EditorOutgoingCall> {
+        let function_by_body_scope = self.function_by_body_scope();
+        let analysis = self.model.analysis();
+
+        let mut order: Vec<BindingId> = Vec::new();
+        let mut spans_by_callee: FxHashMap<BindingId, Vec<Span>> = FxHashMap::default();
+        for site in self.model.all_call_sites() {
+            let enclosing =
+                enclosing_function_target(self.model, &function_by_body_scope, site.scope);
+            if enclosing != item.target {
+                continue;
+            }
+            let Some(callee) =
+                analysis.visible_function_binding_at_call(&site.callee, site.name_span)
+            else {
+                continue;
+            };
+            spans_by_callee
+                .entry(callee)
+                .or_insert_with(|| {
+                    order.push(callee);
+                    Vec::new()
+                })
+                .push(site.name_span);
+        }
+
+        order
+            .into_iter()
+            .map(|callee| {
+                let mut spans = spans_by_callee.remove(&callee).unwrap_or_default();
+                sort_dedup_spans(&mut spans);
+                EditorOutgoingCall {
+                    to: function_call_hierarchy_item(self.model, callee),
+                    call_spans: spans,
+                }
+            })
+            .collect()
+    }
+
+    fn item_for_target(&self, target: EditorCallHierarchyTarget) -> EditorCallHierarchyItem {
+        match target {
+            EditorCallHierarchyTarget::Function(binding_id) => {
+                function_call_hierarchy_item(self.model, binding_id)
+            }
+            EditorCallHierarchyTarget::TopLevel => self.top_level_call_hierarchy_item(),
+        }
+    }
+
+    fn function_binding_at_offset(&self, offset: usize) -> Option<BindingId> {
+        match self.target_at_offset(offset)? {
+            EditorSymbolTarget::FunctionCall(call) => call.binding,
+            EditorSymbolTarget::Binding(binding_id) => matches!(
+                self.model.binding(binding_id).kind,
+                BindingKind::FunctionDefinition
+            )
+            .then_some(binding_id),
+            EditorSymbolTarget::Reference(reference_id) => {
+                let binding = self.model.resolved_binding(reference_id)?;
+                matches!(binding.kind, BindingKind::FunctionDefinition).then_some(binding.id)
+            }
+            EditorSymbolTarget::RuntimeName(_) => None,
+        }
+    }
+
+    fn function_by_body_scope(&self) -> FxHashMap<ScopeId, BindingId> {
+        let analysis = self.model.analysis();
+        let mut map = FxHashMap::default();
+        for binding in self.model.function_definition_bindings() {
+            if let Some(scope) = analysis.function_scope_for_binding(binding.id) {
+                map.entry(scope).or_insert(binding.id);
+            }
+        }
+        map
     }
 
     /// Returns syntax-aware completion candidates at `offset`.
@@ -1315,6 +1497,33 @@ fn function_child_binding_is_document_symbol(binding: &Binding) -> bool {
         binding.kind,
         BindingKind::Declaration(_) | BindingKind::LoopVariable | BindingKind::Nameref
     )
+}
+
+fn function_call_hierarchy_item(
+    model: &SemanticModel,
+    binding_id: BindingId,
+) -> EditorCallHierarchyItem {
+    let binding = model.binding(binding_id);
+    EditorCallHierarchyItem {
+        name: binding.name.clone(),
+        target: EditorCallHierarchyTarget::Function(binding_id),
+        full_span: Some(binding_definition_span(binding)),
+        selection_span: Some(binding.span),
+    }
+}
+
+/// Maps a call site's scope to the target that owns it: the innermost enclosing
+/// named function, or the top level when no function encloses the site.
+fn enclosing_function_target(
+    model: &SemanticModel,
+    function_by_body_scope: &FxHashMap<ScopeId, BindingId>,
+    scope: ScopeId,
+) -> EditorCallHierarchyTarget {
+    model
+        .ancestor_scopes(scope)
+        .find_map(|ancestor| function_by_body_scope.get(&ancestor).copied())
+        .map(EditorCallHierarchyTarget::Function)
+        .unwrap_or(EditorCallHierarchyTarget::TopLevel)
 }
 
 fn document_symbol_for_function(binding: &Binding) -> Option<EditorDocumentSymbol> {

--- a/crates/shuck-semantic/src/editor.rs
+++ b/crates/shuck-semantic/src/editor.rs
@@ -468,7 +468,7 @@ impl<'model> EditorQuery<'model> {
             return Vec::new();
         };
         let name = self.model.binding(binding_id).name.clone();
-        let function_by_body_scope = self.function_by_body_scope();
+        let functions_by_body_scope = self.functions_by_body_scope();
         let analysis = self.model.analysis();
 
         let mut order: Vec<EditorCallHierarchyTarget> = Vec::new();
@@ -478,14 +478,29 @@ impl<'model> EditorQuery<'model> {
             if resolved != binding_id {
                 continue;
             }
-            let caller = enclosing_function_target(self.model, &function_by_body_scope, site.scope);
-            spans_by_caller
-                .entry(caller)
-                .or_insert_with(|| {
-                    order.push(caller);
-                    Vec::new()
-                })
-                .push(site.name_span);
+            let callers =
+                enclosing_function_bindings(self.model, &functions_by_body_scope, site.scope);
+            if let Some(callers) = callers {
+                for &caller in callers {
+                    let caller = EditorCallHierarchyTarget::Function(caller);
+                    spans_by_caller
+                        .entry(caller)
+                        .or_insert_with(|| {
+                            order.push(caller);
+                            Vec::new()
+                        })
+                        .push(site.name_span);
+                }
+            } else {
+                let caller = EditorCallHierarchyTarget::TopLevel;
+                spans_by_caller
+                    .entry(caller)
+                    .or_insert_with(|| {
+                        order.push(caller);
+                        Vec::new()
+                    })
+                    .push(site.name_span);
+            }
         }
 
         order
@@ -508,15 +523,21 @@ impl<'model> EditorQuery<'model> {
     /// functions rather than their enclosing one. Callees that do not resolve to
     /// a function definition (builtins, external commands) are omitted.
     pub fn outgoing_calls(&self, item: &EditorCallHierarchyItem) -> Vec<EditorOutgoingCall> {
-        let function_by_body_scope = self.function_by_body_scope();
+        let functions_by_body_scope = self.functions_by_body_scope();
         let analysis = self.model.analysis();
 
         let mut order: Vec<BindingId> = Vec::new();
         let mut spans_by_callee: FxHashMap<BindingId, Vec<Span>> = FxHashMap::default();
         for site in self.model.all_call_sites() {
             let enclosing =
-                enclosing_function_target(self.model, &function_by_body_scope, site.scope);
-            if enclosing != item.target {
+                enclosing_function_bindings(self.model, &functions_by_body_scope, site.scope);
+            let belongs_to_item = match item.target {
+                EditorCallHierarchyTarget::Function(binding_id) => {
+                    enclosing.is_some_and(|bindings| bindings.contains(&binding_id))
+                }
+                EditorCallHierarchyTarget::TopLevel => enclosing.is_none(),
+            };
+            if !belongs_to_item {
                 continue;
             }
             let Some(callee) =
@@ -571,12 +592,12 @@ impl<'model> EditorQuery<'model> {
         }
     }
 
-    fn function_by_body_scope(&self) -> FxHashMap<ScopeId, BindingId> {
+    fn functions_by_body_scope(&self) -> FxHashMap<ScopeId, Vec<BindingId>> {
         let analysis = self.model.analysis();
         let mut map = FxHashMap::default();
         for binding in self.model.function_definition_bindings() {
             if let Some(scope) = analysis.function_scope_for_binding(binding.id) {
-                map.entry(scope).or_insert(binding.id);
+                map.entry(scope).or_insert_with(Vec::new).push(binding.id);
             }
         }
         map
@@ -1512,18 +1533,18 @@ fn function_call_hierarchy_item(
     }
 }
 
-/// Maps a call site's scope to the target that owns it: the innermost enclosing
-/// named function, or the top level when no function encloses the site.
-fn enclosing_function_target(
+/// Returns every name bound to the innermost named function body enclosing a call site.
+///
+/// Zsh permits one definition to bind multiple names to the same body, so a body scope can own
+/// more than one call-hierarchy node.
+fn enclosing_function_bindings<'a>(
     model: &SemanticModel,
-    function_by_body_scope: &FxHashMap<ScopeId, BindingId>,
+    functions_by_body_scope: &'a FxHashMap<ScopeId, Vec<BindingId>>,
     scope: ScopeId,
-) -> EditorCallHierarchyTarget {
+) -> Option<&'a [BindingId]> {
     model
         .ancestor_scopes(scope)
-        .find_map(|ancestor| function_by_body_scope.get(&ancestor).copied())
-        .map(EditorCallHierarchyTarget::Function)
-        .unwrap_or(EditorCallHierarchyTarget::TopLevel)
+        .find_map(|ancestor| functions_by_body_scope.get(&ancestor).map(Vec::as_slice))
 }
 
 fn document_symbol_for_function(binding: &Binding) -> Option<EditorDocumentSymbol> {

--- a/crates/shuck-semantic/src/lib.rs
+++ b/crates/shuck-semantic/src/lib.rs
@@ -69,10 +69,11 @@ pub use dataflow::{
 pub use declaration::{Declaration, DeclarationBuiltin, DeclarationOperand};
 /// Editor-facing semantic query types.
 pub use editor::{
-    EditorCompletion, EditorCompletionKind, EditorCompletionOptions, EditorCompletions,
-    EditorDocumentSymbol, EditorFunctionCallTarget, EditorHover, EditorOccurrence,
-    EditorOccurrenceKind, EditorQuery, EditorRuntimeNameTarget, EditorSymbol, EditorSymbolKind,
-    EditorSymbolTarget, RenameSet, RenameUnavailable,
+    EditorCallHierarchyItem, EditorCallHierarchyTarget, EditorCompletion, EditorCompletionKind,
+    EditorCompletionOptions, EditorCompletions, EditorDocumentSymbol, EditorFunctionCallTarget,
+    EditorHover, EditorIncomingCall, EditorOccurrence, EditorOccurrenceKind, EditorOutgoingCall,
+    EditorQuery, EditorRuntimeNameTarget, EditorSymbol, EditorSymbolKind, EditorSymbolTarget,
+    RenameSet, RenameUnavailable,
 };
 /// Direct function-call reachability query types.
 pub use function_call_reachability::{
@@ -2187,6 +2188,11 @@ impl SemanticModel {
             .get(name)
             .map(SmallVec::as_slice)
             .unwrap_or(&[])
+    }
+
+    /// Iterates every recorded call site across all callee names.
+    pub fn all_call_sites(&self) -> impl Iterator<Item = &CallSite> + '_ {
+        self.call_sites.values().flat_map(|sites| sites.iter())
     }
 
     /// Returns the current call-graph summary for the model.

--- a/crates/shuck-semantic/src/tests.rs
+++ b/crates/shuck-semantic/src/tests.rs
@@ -385,6 +385,33 @@ outer
 }
 
 #[test]
+fn editor_call_hierarchy_preserves_zsh_multi_name_function_bodies() {
+    let source = "function music itunes() { helper; }\nhelper() { :; }\nitunes\n";
+    let model = model_with_dialect(source, ShellDialect::Zsh);
+    let query = model.editor_query();
+
+    let itunes_def = span_for_nth(source, "itunes", 0);
+    let itunes = query
+        .prepare_call_hierarchy(itunes_def.start.offset)
+        .expect("itunes should resolve to a function node");
+    let outgoing = query.outgoing_calls(&itunes);
+    assert_eq!(outgoing.len(), 1);
+    assert_eq!(outgoing[0].to.name.as_str(), "helper");
+
+    let helper_def = span_for_nth(source, "helper", 1);
+    let helper = query
+        .prepare_call_hierarchy(helper_def.start.offset)
+        .expect("helper should resolve to a function node");
+    let mut callers = query
+        .incoming_calls(&helper)
+        .into_iter()
+        .map(|call| call.from.name.to_string())
+        .collect::<Vec<_>>();
+    callers.sort();
+    assert_eq!(callers, ["itunes", "music"]);
+}
+
+#[test]
 fn editor_completion_is_context_aware() {
     let source = "\
 build() {

--- a/crates/shuck-semantic/src/tests.rs
+++ b/crates/shuck-semantic/src/tests.rs
@@ -333,6 +333,58 @@ build
 }
 
 #[test]
+fn editor_call_hierarchy_attributes_calls_by_enclosing_function() {
+    let source = "\
+inner() { :; }
+outer() {
+  inner
+  nested() { inner; }
+}
+outer
+";
+    let model = model(source);
+    let query = model.editor_query();
+
+    // Prepare on the `outer` definition name.
+    let outer_def = span_for_nth(source, "outer", 0);
+    let outer = query
+        .prepare_call_hierarchy(outer_def.start.offset)
+        .expect("outer should resolve to a function node");
+    assert_eq!(outer.name.as_str(), "outer");
+
+    // `outer` calls `inner` directly once; the `inner` inside `nested` belongs
+    // to `nested`, not to `outer`.
+    let outgoing = query
+        .outgoing_calls(&outer)
+        .into_iter()
+        .map(|call| (call.to.name.to_string(), call.call_spans.len()))
+        .collect::<Vec<_>>();
+    assert_eq!(outgoing, [("inner".to_owned(), 1)]);
+
+    // `inner` is called from both `outer` and the nested `nested` function.
+    let inner_def = span_for_nth(source, "inner", 0);
+    let inner = query
+        .prepare_call_hierarchy(inner_def.start.offset)
+        .expect("inner should resolve to a function node");
+    let mut callers = query
+        .incoming_calls(&inner)
+        .into_iter()
+        .map(|call| call.from.name.to_string())
+        .collect::<Vec<_>>();
+    callers.sort();
+    assert_eq!(callers, ["nested", "outer"]);
+
+    // `outer` itself is called once, from the script top level.
+    let incoming_outer = query.incoming_calls(&outer);
+    assert_eq!(incoming_outer.len(), 1);
+    assert!(matches!(
+        incoming_outer[0].from.target,
+        EditorCallHierarchyTarget::TopLevel
+    ));
+    assert_eq!(incoming_outer[0].call_spans.len(), 1);
+}
+
+#[test]
 fn editor_completion_is_context_aware() {
     let source = "\
 build() {

--- a/crates/shuck-server/src/editor_features.rs
+++ b/crates/shuck-server/src/editor_features.rs
@@ -400,11 +400,20 @@ fn spans_to_ranges(
 }
 
 fn top_level_label(uri: &types::Url) -> String {
-    uri.path_segments()
-        .and_then(|mut segments| segments.next_back())
-        .filter(|segment| !segment.is_empty())
-        .unwrap_or("script")
-        .to_owned()
+    uri.to_file_path()
+        .ok()
+        .and_then(|path| {
+            path.file_name()
+                .map(|name| name.to_string_lossy().into_owned())
+        })
+        .filter(|name| !name.is_empty())
+        .or_else(|| {
+            uri.path_segments()
+                .and_then(|mut segments| segments.next_back())
+                .filter(|segment| !segment.is_empty())
+                .map(str::to_owned)
+        })
+        .unwrap_or_else(|| "script".to_owned())
 }
 
 pub(crate) fn document_highlight(
@@ -1044,5 +1053,11 @@ mod tests {
         )
         .expect("prepare should succeed");
         assert!(response.is_none());
+    }
+
+    #[test]
+    fn call_hierarchy_top_level_label_decodes_file_name() {
+        let uri = Url::parse("file:///tmp/my%20script.sh").expect("file URI should parse");
+        assert_eq!(top_level_label(&uri), "my script.sh");
     }
 }

--- a/crates/shuck-server/src/editor_features.rs
+++ b/crates/shuck-server/src/editor_features.rs
@@ -5,8 +5,8 @@ use lsp_server::ErrorCode;
 use lsp_types as types;
 use serde::{Deserialize, Serialize};
 use shuck_semantic::{
-    EditorCompletionKind, EditorCompletionOptions, EditorOccurrenceKind, EditorSymbolKind,
-    RenameSet,
+    EditorCallHierarchyItem, EditorCallHierarchyTarget, EditorCompletionKind,
+    EditorCompletionOptions, EditorOccurrenceKind, EditorSymbolKind, RenameSet,
 };
 
 use crate::edit::RangeExt;
@@ -19,6 +19,18 @@ pub(crate) type ReferencesResponse = Option<Vec<types::Location>>;
 pub(crate) type DocumentHighlightResponse = Option<Vec<types::DocumentHighlight>>;
 pub(crate) type PrepareRenameResponse = Option<types::PrepareRenameResponse>;
 pub(crate) type RenameResponse = Option<types::WorkspaceEdit>;
+pub(crate) type CallHierarchyPrepareResponse = Option<Vec<types::CallHierarchyItem>>;
+pub(crate) type CallHierarchyIncomingResponse = Option<Vec<types::CallHierarchyIncomingCall>>;
+pub(crate) type CallHierarchyOutgoingResponse = Option<Vec<types::CallHierarchyOutgoingCall>>;
+
+/// Round-trip payload stored in `CallHierarchyItem.data` so the incoming/outgoing
+/// requests can re-resolve the node on a freshly analyzed document.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", tag = "kind")]
+enum CallHierarchyData {
+    Function { line: u32, character: u32 },
+    TopLevel,
+}
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase", tag = "kind")]
@@ -173,6 +185,226 @@ pub(crate) fn references(
         })
         .collect::<Vec<_>>();
     Ok((!locations.is_empty()).then_some(locations))
+}
+
+pub(crate) fn prepare_call_hierarchy(
+    snapshot: DocumentSnapshot,
+    _client: &Client,
+    params: types::CallHierarchyPrepareParams,
+) -> crate::server::Result<CallHierarchyPrepareResponse> {
+    let Some(analysis) = snapshot.analysis() else {
+        return Ok(None);
+    };
+    let source = analysis.source();
+    let position = params.text_document_position_params.position;
+    let offset = offset_for_position(&snapshot, source, analysis.line_index(), position);
+    let Some(item) = analysis
+        .semantic()
+        .editor_query()
+        .prepare_call_hierarchy(offset)
+    else {
+        return Ok(None);
+    };
+    Ok(Some(vec![to_lsp_call_hierarchy_item(
+        &snapshot,
+        source,
+        analysis.line_index(),
+        item,
+    )]))
+}
+
+pub(crate) fn call_hierarchy_incoming_calls(
+    snapshot: DocumentSnapshot,
+    _client: &Client,
+    params: types::CallHierarchyIncomingCallsParams,
+) -> crate::server::Result<CallHierarchyIncomingResponse> {
+    let Some(analysis) = snapshot.analysis() else {
+        return Ok(None);
+    };
+    let source = analysis.source();
+    let query = analysis.semantic().editor_query();
+    let Some(item) = resolve_call_hierarchy_item(
+        &snapshot,
+        source,
+        analysis.line_index(),
+        &query,
+        &params.item,
+    ) else {
+        return Ok(None);
+    };
+    let calls = query
+        .incoming_calls(&item)
+        .into_iter()
+        .map(|incoming| types::CallHierarchyIncomingCall {
+            from: to_lsp_call_hierarchy_item(
+                &snapshot,
+                source,
+                analysis.line_index(),
+                incoming.from,
+            ),
+            from_ranges: spans_to_ranges(
+                &snapshot,
+                source,
+                analysis.line_index(),
+                &incoming.call_spans,
+            ),
+        })
+        .collect();
+    Ok(Some(calls))
+}
+
+pub(crate) fn call_hierarchy_outgoing_calls(
+    snapshot: DocumentSnapshot,
+    _client: &Client,
+    params: types::CallHierarchyOutgoingCallsParams,
+) -> crate::server::Result<CallHierarchyOutgoingResponse> {
+    let Some(analysis) = snapshot.analysis() else {
+        return Ok(None);
+    };
+    let source = analysis.source();
+    let query = analysis.semantic().editor_query();
+    let Some(item) = resolve_call_hierarchy_item(
+        &snapshot,
+        source,
+        analysis.line_index(),
+        &query,
+        &params.item,
+    ) else {
+        return Ok(None);
+    };
+    let calls = query
+        .outgoing_calls(&item)
+        .into_iter()
+        .map(|outgoing| types::CallHierarchyOutgoingCall {
+            to: to_lsp_call_hierarchy_item(&snapshot, source, analysis.line_index(), outgoing.to),
+            from_ranges: spans_to_ranges(
+                &snapshot,
+                source,
+                analysis.line_index(),
+                &outgoing.call_spans,
+            ),
+        })
+        .collect();
+    Ok(Some(calls))
+}
+
+/// Re-resolves the semantic node identified by an incoming LSP `CallHierarchyItem`.
+///
+/// Prefers the `data` payload we attached during `prepare`; falls back to the
+/// item's selection-range position when a client does not round-trip it.
+fn resolve_call_hierarchy_item(
+    snapshot: &DocumentSnapshot,
+    source: &str,
+    line_index: &shuck_indexer::LineIndex,
+    query: &shuck_semantic::EditorQuery<'_>,
+    item: &types::CallHierarchyItem,
+) -> Option<EditorCallHierarchyItem> {
+    let data = item
+        .data
+        .clone()
+        .and_then(|value| serde_json::from_value::<CallHierarchyData>(value).ok());
+    match data {
+        Some(CallHierarchyData::TopLevel) => Some(query.top_level_call_hierarchy_item()),
+        Some(CallHierarchyData::Function { line, character }) => {
+            let offset = offset_for_position(
+                snapshot,
+                source,
+                line_index,
+                types::Position { line, character },
+            );
+            query.prepare_call_hierarchy(offset)
+        }
+        None => {
+            let offset =
+                offset_for_position(snapshot, source, line_index, item.selection_range.start);
+            query.prepare_call_hierarchy(offset)
+        }
+    }
+}
+
+fn to_lsp_call_hierarchy_item(
+    snapshot: &DocumentSnapshot,
+    source: &str,
+    line_index: &shuck_indexer::LineIndex,
+    item: EditorCallHierarchyItem,
+) -> types::CallHierarchyItem {
+    let uri = snapshot.query().file_url().clone();
+    match item.target {
+        EditorCallHierarchyTarget::Function(_) => {
+            let full_range = item
+                .full_span
+                .map(|span| {
+                    crate::edit::to_lsp_range(
+                        span.to_range(),
+                        source,
+                        line_index,
+                        snapshot.encoding(),
+                    )
+                })
+                .unwrap_or_default();
+            let selection_range = item
+                .selection_span
+                .map(|span| {
+                    crate::edit::to_lsp_range(
+                        span.to_range(),
+                        source,
+                        line_index,
+                        snapshot.encoding(),
+                    )
+                })
+                .unwrap_or(full_range);
+            types::CallHierarchyItem {
+                name: item.name.to_string(),
+                kind: types::SymbolKind::FUNCTION,
+                tags: None,
+                detail: None,
+                uri,
+                range: full_range,
+                selection_range,
+                data: serde_json::to_value(CallHierarchyData::Function {
+                    line: selection_range.start.line,
+                    character: selection_range.start.character,
+                })
+                .ok(),
+            }
+        }
+        EditorCallHierarchyTarget::TopLevel => {
+            let start = types::Position::new(0, 0);
+            let range = types::Range { start, end: start };
+            types::CallHierarchyItem {
+                name: top_level_label(&uri),
+                kind: types::SymbolKind::MODULE,
+                tags: None,
+                detail: Some("script top level".to_owned()),
+                uri,
+                range,
+                selection_range: range,
+                data: serde_json::to_value(CallHierarchyData::TopLevel).ok(),
+            }
+        }
+    }
+}
+
+fn spans_to_ranges(
+    snapshot: &DocumentSnapshot,
+    source: &str,
+    line_index: &shuck_indexer::LineIndex,
+    spans: &[shuck_ast::Span],
+) -> Vec<types::Range> {
+    spans
+        .iter()
+        .map(|span| {
+            crate::edit::to_lsp_range(span.to_range(), source, line_index, snapshot.encoding())
+        })
+        .collect()
+}
+
+fn top_level_label(uri: &types::Url) -> String {
+    uri.path_segments()
+        .and_then(|mut segments| segments.next_back())
+        .filter(|segment| !segment.is_empty())
+        .unwrap_or("script")
+        .to_owned()
 }
 
 pub(crate) fn document_highlight(
@@ -701,5 +933,116 @@ mod tests {
         .expect_err("assignment-like function names should be rejected");
 
         assert_eq!(error.code as i32, ErrorCode::InvalidParams as i32);
+    }
+
+    fn prepare_item(
+        snapshot: &DocumentSnapshot,
+        client: &Client,
+        uri: &Url,
+        position: Position,
+    ) -> types::CallHierarchyItem {
+        let mut items = prepare_call_hierarchy(
+            snapshot.clone(),
+            client,
+            types::CallHierarchyPrepareParams {
+                text_document_position_params: text_position(uri.clone(), position),
+                work_done_progress_params: WorkDoneProgressParams::default(),
+            },
+        )
+        .expect("prepare should succeed")
+        .expect("prepare should return an item");
+        assert_eq!(items.len(), 1);
+        items.remove(0)
+    }
+
+    #[test]
+    fn call_hierarchy_prepare_incoming_and_outgoing() {
+        let source = "helper() {\n  echo hi\n}\n\nmain() {\n  helper\n  helper\n}\n\nmain\n";
+        let (snapshot, client, uri) = make_snapshot(source);
+
+        // Prepare on the `main` definition name.
+        let main_item = prepare_item(
+            &snapshot,
+            &client,
+            &uri,
+            position_for_nth(source, "main", 0),
+        );
+        assert_eq!(main_item.name, "main");
+        assert_eq!(main_item.kind, types::SymbolKind::FUNCTION);
+
+        // main() calls helper twice.
+        let outgoing = call_hierarchy_outgoing_calls(
+            snapshot.clone(),
+            &client,
+            types::CallHierarchyOutgoingCallsParams {
+                item: main_item.clone(),
+                work_done_progress_params: WorkDoneProgressParams::default(),
+                partial_result_params: PartialResultParams::default(),
+            },
+        )
+        .expect("outgoing should succeed")
+        .expect("outgoing should return calls");
+        assert_eq!(outgoing.len(), 1);
+        assert_eq!(outgoing[0].to.name, "helper");
+        assert_eq!(outgoing[0].from_ranges.len(), 2);
+
+        // main() is called once, from the script top level.
+        let incoming_main = call_hierarchy_incoming_calls(
+            snapshot.clone(),
+            &client,
+            types::CallHierarchyIncomingCallsParams {
+                item: main_item,
+                work_done_progress_params: WorkDoneProgressParams::default(),
+                partial_result_params: PartialResultParams::default(),
+            },
+        )
+        .expect("incoming should succeed")
+        .expect("incoming should return calls");
+        assert_eq!(incoming_main.len(), 1);
+        assert_eq!(incoming_main[0].from.kind, types::SymbolKind::MODULE);
+        assert_eq!(incoming_main[0].from_ranges.len(), 1);
+
+        // Prepare on `helper`; its callers are the enclosing function `main`.
+        let helper_item = prepare_item(
+            &snapshot,
+            &client,
+            &uri,
+            position_for_nth(source, "helper", 0),
+        );
+        assert_eq!(helper_item.name, "helper");
+        let incoming_helper = call_hierarchy_incoming_calls(
+            snapshot,
+            &client,
+            types::CallHierarchyIncomingCallsParams {
+                item: helper_item,
+                work_done_progress_params: WorkDoneProgressParams::default(),
+                partial_result_params: PartialResultParams::default(),
+            },
+        )
+        .expect("incoming should succeed")
+        .expect("incoming should return calls");
+        assert_eq!(incoming_helper.len(), 1);
+        assert_eq!(incoming_helper[0].from.name, "main");
+        assert_eq!(incoming_helper[0].from.kind, types::SymbolKind::FUNCTION);
+        assert_eq!(incoming_helper[0].from_ranges.len(), 2);
+    }
+
+    #[test]
+    fn call_hierarchy_prepare_returns_none_off_a_function() {
+        let source = "name=1\necho \"$name\"\n";
+        let (snapshot, client, uri) = make_snapshot(source);
+        let response = prepare_call_hierarchy(
+            snapshot,
+            &client,
+            types::CallHierarchyPrepareParams {
+                text_document_position_params: text_position(
+                    uri,
+                    position_for_nth(source, "name", 0),
+                ),
+                work_done_progress_params: WorkDoneProgressParams::default(),
+            },
+        )
+        .expect("prepare should succeed");
+        assert!(response.is_none());
     }
 }

--- a/crates/shuck-server/src/editor_features.rs
+++ b/crates/shuck-server/src/editor_features.rs
@@ -1057,7 +1057,8 @@ mod tests {
 
     #[test]
     fn call_hierarchy_top_level_label_decodes_file_name() {
-        let uri = Url::parse("file:///tmp/my%20script.sh").expect("file URI should parse");
+        let path = std::env::temp_dir().join("my script.sh");
+        let uri = Url::from_file_path(path).expect("temporary file path should convert to a URI");
         assert_eq!(top_level_label(&uri), "my script.sh");
     }
 }

--- a/crates/shuck-server/src/server.rs
+++ b/crates/shuck-server/src/server.rs
@@ -152,6 +152,7 @@ impl Server {
                 ..types::CompletionOptions::default()
             }),
             definition_provider: Some(OneOf::Left(true)),
+            call_hierarchy_provider: Some(types::CallHierarchyServerCapability::Simple(true)),
             references_provider: Some(OneOf::Left(true)),
             document_highlight_provider: Some(OneOf::Left(true)),
             document_formatting_provider: Some(OneOf::Left(true)),

--- a/crates/shuck-server/src/server/api.rs
+++ b/crates/shuck-server/src/server/api.rs
@@ -36,6 +36,15 @@ pub(super) fn request(req: server::Request) -> Task {
     let id = req.id.clone();
 
     match req.method.as_str() {
+        request::CallHierarchyPrepare::METHOD => {
+            background_request_task::<request::CallHierarchyPrepare>(req, BackgroundSchedule::Worker)
+        }
+        request::CallHierarchyIncomingCalls::METHOD => background_request_task::<
+            request::CallHierarchyIncomingCalls,
+        >(req, BackgroundSchedule::Worker),
+        request::CallHierarchyOutgoingCalls::METHOD => background_request_task::<
+            request::CallHierarchyOutgoingCalls,
+        >(req, BackgroundSchedule::Worker),
         request::CodeActions::METHOD => {
             background_request_task::<request::CodeActions>(req, BackgroundSchedule::Worker)
         }

--- a/crates/shuck-server/src/server/api/requests.rs
+++ b/crates/shuck-server/src/server/api/requests.rs
@@ -1,3 +1,6 @@
+mod call_hierarchy_incoming;
+mod call_hierarchy_outgoing;
+mod call_hierarchy_prepare;
 mod code_action;
 mod code_action_resolve;
 mod completion;
@@ -21,6 +24,9 @@ use super::{
     traits::{BackgroundDocumentRequestHandler, RequestHandler, SyncRequestHandler},
 };
 
+pub(super) use call_hierarchy_incoming::CallHierarchyIncomingCalls;
+pub(super) use call_hierarchy_outgoing::CallHierarchyOutgoingCalls;
+pub(super) use call_hierarchy_prepare::CallHierarchyPrepare;
 pub(super) use code_action::CodeActions;
 pub(super) use code_action_resolve::CodeActionResolve;
 pub(super) use completion::Completion;

--- a/crates/shuck-server/src/server/api/requests/call_hierarchy_incoming.rs
+++ b/crates/shuck-server/src/server/api/requests/call_hierarchy_incoming.rs
@@ -1,0 +1,33 @@
+use lsp_types::{self as types, request as req};
+
+use crate::editor_features;
+use crate::session::{Client, DocumentSnapshot};
+
+pub(crate) struct CallHierarchyIncomingCalls;
+
+impl super::RequestHandler for CallHierarchyIncomingCalls {
+    type RequestType = req::CallHierarchyIncomingCalls;
+}
+
+impl super::BackgroundDocumentRequestHandler for CallHierarchyIncomingCalls {
+    fn document_url(
+        params: &types::CallHierarchyIncomingCallsParams,
+    ) -> std::borrow::Cow<'_, types::Url> {
+        std::borrow::Cow::Borrowed(&params.item.uri)
+    }
+
+    fn run_without_snapshot(
+        _client: &Client,
+        _params: types::CallHierarchyIncomingCallsParams,
+    ) -> crate::server::Result<editor_features::CallHierarchyIncomingResponse> {
+        Ok(None)
+    }
+
+    fn run_with_snapshot(
+        snapshot: DocumentSnapshot,
+        client: &Client,
+        params: types::CallHierarchyIncomingCallsParams,
+    ) -> crate::server::Result<editor_features::CallHierarchyIncomingResponse> {
+        editor_features::call_hierarchy_incoming_calls(snapshot, client, params)
+    }
+}

--- a/crates/shuck-server/src/server/api/requests/call_hierarchy_outgoing.rs
+++ b/crates/shuck-server/src/server/api/requests/call_hierarchy_outgoing.rs
@@ -1,0 +1,33 @@
+use lsp_types::{self as types, request as req};
+
+use crate::editor_features;
+use crate::session::{Client, DocumentSnapshot};
+
+pub(crate) struct CallHierarchyOutgoingCalls;
+
+impl super::RequestHandler for CallHierarchyOutgoingCalls {
+    type RequestType = req::CallHierarchyOutgoingCalls;
+}
+
+impl super::BackgroundDocumentRequestHandler for CallHierarchyOutgoingCalls {
+    fn document_url(
+        params: &types::CallHierarchyOutgoingCallsParams,
+    ) -> std::borrow::Cow<'_, types::Url> {
+        std::borrow::Cow::Borrowed(&params.item.uri)
+    }
+
+    fn run_without_snapshot(
+        _client: &Client,
+        _params: types::CallHierarchyOutgoingCallsParams,
+    ) -> crate::server::Result<editor_features::CallHierarchyOutgoingResponse> {
+        Ok(None)
+    }
+
+    fn run_with_snapshot(
+        snapshot: DocumentSnapshot,
+        client: &Client,
+        params: types::CallHierarchyOutgoingCallsParams,
+    ) -> crate::server::Result<editor_features::CallHierarchyOutgoingResponse> {
+        editor_features::call_hierarchy_outgoing_calls(snapshot, client, params)
+    }
+}

--- a/crates/shuck-server/src/server/api/requests/call_hierarchy_prepare.rs
+++ b/crates/shuck-server/src/server/api/requests/call_hierarchy_prepare.rs
@@ -1,0 +1,33 @@
+use lsp_types::{self as types, request as req};
+
+use crate::editor_features;
+use crate::session::{Client, DocumentSnapshot};
+
+pub(crate) struct CallHierarchyPrepare;
+
+impl super::RequestHandler for CallHierarchyPrepare {
+    type RequestType = req::CallHierarchyPrepare;
+}
+
+impl super::BackgroundDocumentRequestHandler for CallHierarchyPrepare {
+    fn document_url(
+        params: &types::CallHierarchyPrepareParams,
+    ) -> std::borrow::Cow<'_, types::Url> {
+        std::borrow::Cow::Borrowed(&params.text_document_position_params.text_document.uri)
+    }
+
+    fn run_without_snapshot(
+        _client: &Client,
+        _params: types::CallHierarchyPrepareParams,
+    ) -> crate::server::Result<editor_features::CallHierarchyPrepareResponse> {
+        Ok(None)
+    }
+
+    fn run_with_snapshot(
+        snapshot: DocumentSnapshot,
+        client: &Client,
+        params: types::CallHierarchyPrepareParams,
+    ) -> crate::server::Result<editor_features::CallHierarchyPrepareResponse> {
+        editor_features::prepare_call_hierarchy(snapshot, client, params)
+    }
+}


### PR DESCRIPTION
**Part 1 of 3** — cross-file call hierarchy for the LSP, split per the review on #1147:

1. **this PR** — `feat(server)`: single-file LSP call hierarchy
2. #1163 — `feat(semantic,cli)`: `# shuck: source=` directive + opt-in target linting
3. #1147 — `feat(server)`: cross-file call hierarchy over a workspace call-graph index

Each PR is stacked on the previous one; because all heads live on a fork, later PRs show cumulative diffs until their predecessors merge. This PR's diff is exactly its own increment (`main..feat/lsp-call-hierarchy`). Drafts are un-drafted as their bases land.

---

Implement `textDocument/prepareCallHierarchy` plus `callHierarchy/incomingCalls` and `outgoingCalls` so editors can navigate "who calls this function" and "what does this function call".

- **shuck-semantic**: `EditorQuery` gains `prepare_call_hierarchy` / `incoming_calls` / `outgoing_calls` over the existing call-site resolution. Calls are attributed to their innermost enclosing function; top-level calls are grouped under a module node so callers of a `main` invoked from the script body still show.
- **shuck-server**: advertises `callHierarchyProvider`, three request handlers, and `editor_features` mappings from the semantic shapes to LSP. Items round-trip through `CallHierarchyItem.data` (top-level vs function re-resolved by position), matching the single-file scope of the existing navigation features.

Scope: function-to-function within one file. Part 2 adds the computed-source directive the cross-file graph needs; #1147 (part 3) makes both hierarchy directions answer across the workspace.
