### PR TITLE
fix(ci): make cargo audit installation reproducible

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -103,16 +103,15 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
-      checks: write
       contents: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
+      - name: "Install cargo-audit"
+        run: cargo install cargo-audit --locked --version 0.22.2
       - name: "Run cargo audit"
-        uses: rustsec/audit-check@69366f33c96575abad1ee0dba8212993eecbe998 # v2.0.0
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+        run: cargo audit
 
   cargo-test-linux:
     name: "cargo test (linux)"


### PR DESCRIPTION
## Summary

- replace the Node-based `rustsec/audit-check` action with direct `cargo-audit` CLI invocation
- pin `cargo-audit` to 0.22.2 and install it with `--locked`
- remove the no-longer-needed `checks: write` permission

## Root cause

The action installed the latest `cargo-audit` without using its published lockfile. Dependency resolution selected `kstring` 2.0.3, which requires Rust 1.96.0, while CI intentionally uses Rust 1.94.1. The action also used the deprecated Node 20 runtime.

Using the locked cargo-audit dependency graph selects `kstring` 2.0.2, which compiles with the pinned CI toolchain. Invoking the CLI directly also removes the Node runtime dependency.

## Validation

- installed `cargo-audit` 0.22.2 with `--locked` using Rust 1.94.1
- confirmed the installation selects `kstring` 2.0.2 and completes successfully
- parsed `.github/workflows/ci.yaml`
- ran `git diff --check`
- ran zizmor; no low, medium, or high findings