### PR TITLE
fix(formatter): preserve heredocs in array substitutions

### DIFF
--- a/crates/shuck-formatter/src/command.rs
+++ b/crates/shuck-formatter/src/command.rs
@@ -4,7 +4,8 @@ use crate::facts::classify_stmt_contains_heredoc;
 use crate::raw_syntax::{
     RawShellText, common_nonempty_shell_indent, leading_shell_indent,
     matching_raw_command_substitution_close, normalize_raw_pipeline_continuations,
-    refine_common_indent, shell_comment_can_start, skip_escaped_or_quoted,
+    refine_common_indent, rendered_heredoc_tail_start, shell_comment_can_start,
+    skip_escaped_or_quoted,
 };
 use crate::source::SourceView;
 use crate::word::{render_arithmetic_expr_to_buf, render_word_syntax_to_buf};

--- a/crates/shuck-formatter/src/command/compound_assignments.rs
+++ b/crates/shuck-formatter/src/command/compound_assignments.rs
@@ -67,13 +67,33 @@ pub(crate) fn multiline_compound_assignment_layout(
     for line in &mut lines {
         *line = RawShellText::new(line).trim_command_substitution_open_padding();
     }
-    let lines = normalize_multiline_compound_assignment_command_substitutions(lines);
+    let mut lines = normalize_multiline_compound_assignment_command_substitutions(lines);
+    restore_multiline_compound_assignment_heredoc_tails(&mut lines, &raw_lines);
 
     (!lines.is_empty()).then_some(MultilineCompoundAssignmentLayout {
         lines,
         open_inline: !open_line.trim().is_empty(),
         close_inline: !close_line.trim().is_empty(),
     })
+}
+
+fn restore_multiline_compound_assignment_heredoc_tails(
+    lines: &mut [String],
+    source_lines: &[&str],
+) {
+    let mut active_heredoc: Option<crate::raw_syntax::RenderedHeredocTail> = None;
+    for (line, source_line) in lines.iter_mut().zip(source_lines) {
+        if let Some(heredoc) = active_heredoc.as_ref() {
+            if !heredoc.strip_tabs {
+                *line = (*source_line).to_string();
+            }
+            if heredoc.closes_source_line(source_line) {
+                active_heredoc = None;
+            }
+        } else {
+            active_heredoc = rendered_heredoc_tail_start(line);
+        }
+    }
 }
 
 fn normalize_multiline_compound_assignment_command_substitutions(

--- a/crates/shuck-formatter/src/raw_syntax.rs
+++ b/crates/shuck-formatter/src/raw_syntax.rs
@@ -409,6 +409,14 @@ impl RenderedHeredocTail {
             line == self.delimiter
         }
     }
+
+    pub(crate) fn closes_source_line(&self, line: &str) -> bool {
+        if self.strip_tabs {
+            line.trim_start_matches('\t') == self.delimiter
+        } else {
+            line == self.delimiter
+        }
+    }
 }
 
 pub(crate) fn rendered_shell_text_has_heredoc_tail(text: &str) -> bool {

--- a/crates/shuck-formatter/src/streaming/statements.rs
+++ b/crates/shuck-formatter/src/streaming/statements.rs
@@ -735,8 +735,18 @@ where
                     && !multiline_compound_assignment_command_substitution_body_prefix(line)
                         .is_empty()
             });
+        let mut active_heredoc: Option<RenderedHeredocTail> = None;
         for (index, line) in layout.lines[body_start..].iter().enumerate() {
             self.newline();
+            if let Some(heredoc) = active_heredoc.as_ref()
+                && !heredoc.strip_tabs
+            {
+                self.write_verbatim(line);
+                if heredoc.closes_source_line(line) {
+                    active_heredoc = None;
+                }
+                continue;
+            }
             let closes_inline_assignment =
                 layout.close_inline && body_start + index + 1 == layout.lines.len();
             let extra_indent = if inline_command_substitution_open {
@@ -754,6 +764,13 @@ where
                         formatter.write_text(line);
                     });
                 }
+            }
+            if let Some(heredoc) = active_heredoc.as_ref() {
+                if heredoc.closes(line) {
+                    active_heredoc = None;
+                }
+            } else {
+                active_heredoc = rendered_heredoc_tail_start(line);
             }
             if inline_command_substitution_open
                 && line.trim_start_matches([' ', '\t']).starts_with(')')

--- a/crates/shuck-formatter/tests/format_cases.rs
+++ b/crates/shuck-formatter/tests/format_cases.rs
@@ -1194,12 +1194,30 @@ default_format_cases! {
 }
 
 default_format_ast_cases! {
+    compound_assignment_command_substitution_heredoc_keeps_body_unindented:
+        "values=(\"$(\n    cat <<EOF\nHello World\nTime is $(date)\nEOF\n)\")\n"
+        => "values=(\"$(\n\tcat <<EOF\nHello World\nTime is $(date)\nEOF\n)\")\n";
+    compound_assignment_heredoc_does_not_close_on_indented_delimiter_text:
+        "values=(\"$(\n    cat <<EOF\n\tEOF\nstill body\nEOF\n)\")\n"
+        => "values=(\"$(\n\tcat <<EOF\n\tEOF\nstill body\nEOF\n)\")\n";
+    compound_assignment_tab_stripped_heredoc_keeps_valid_tab_indentation:
+        "values=(\"$(\n    cat <<-EOF\n\tbody\n\tEOF\n)\")\n"
+        => "values=(\"$(\n\tcat <<-EOF\n\tbody\n\tEOF\n)\")\n";
+    compound_assignment_quoted_heredoc_keeps_body_unindented:
+        "values=(\"$(\n    cat << 'EOF'\nbody\nEOF\n)\")\n"
+        => "values=(\"$(\n\tcat << 'EOF'\nbody\nEOF\n)\")\n";
     preserves_inline_multiline_compound_assignment_delimiters:
         "options=(path frozen without\n  ssl_verify_mode system_bindir user_agent)\n"
         => "options=(path frozen without\n\tssl_verify_mode system_bindir user_agent)\n";
     aligns_compound_assignment_command_substitution_close_suffixes:
         "f() {\n  case \"$prev\" in\n  -a)\n    COMPREPLY=($(compgen -W \"$(\n      salt-key -l un --no-color\n      salt-key -l rej --no-color\n    )\" -- \"${cur}\"))\n    ;;\n  esac\n}\n"
         => "f() {\n\tcase \"$prev\" in\n\t-a)\n\t\tCOMPREPLY=($(compgen -W \"$(\n\t\t\tsalt-key -l un --no-color\n\t\t\tsalt-key -l rej --no-color\n\t\t)\" -- \"${cur}\"))\n\t\t;;\n\tesac\n}\n";
+}
+
+default_idempotent_cases! {
+    compound_assignment_command_substitution_heredoc_is_idempotent:
+        "values=(\"$(\n\tcat <<EOF\nHello World\nTime is $(date)\nEOF\n)\")\n",
+        "compound-heredoc.bash";
 }
 
 bash_format_ast_cases! {


### PR DESCRIPTION
## Summary

- preserve ordinary heredoc bodies while formatting compound array assignments
- distinguish source-valid heredoc closers from indented delimiter-like payload lines
- retain the existing tab-stripping behavior for `<<-`
- add regression coverage for ordinary, quoted, and tab-stripped delimiters plus idempotency

## Root cause

The multiline compound-assignment formatter normalized every command-substitution body line as an array row. That inserted tabs into ordinary heredoc bodies and closing markers, changing the script's runtime behavior. The initial marker tracking also needed to distinguish a true source closer from indented payload text matching the delimiter.

## Impact

Formatting an array element containing a heredoc-backed command substitution no longer changes the heredoc contents or prevents the delimiter from closing the document.

Closes #1165.

## Validation

- `cargo fmt --check`
- `cargo test -p shuck-formatter` (589 passed; 2 opt-in oracle tests ignored)