### PR TITLE
feat(wasm): distribute Shuck through npm

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -156,6 +156,28 @@ jobs:
           GITHUB_WORKSPACE: ${{ github.workspace }}
         run: ./scripts/ci/smoke-python-packaging.sh
 
+  wasm-package:
+    name: "wasm npm package"
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+      - name: "Install Rust toolchain"
+        run: rustup show
+      - name: "Install wasm-pack"
+        run: cargo install wasm-pack --locked --version 0.15.0
+      - name: "Smoke test generated JavaScript"
+        run: make test-wasm
+      - name: "Build npm artifact"
+        run: make build-wasm
+      - name: "Inspect npm package"
+        run: npm pack --dry-run ./target/npm/shuck-wasm
+
   cargo-test-other:
     strategy:
       matrix:

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,0 +1,55 @@
+name: Publish to npm
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: npm-publish-${{ github.event.release.tag_name }}
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    name: npm publish
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    environment: release
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+          ref: ${{ github.event.release.tag_name }}
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 24
+          package-manager-cache: false
+          registry-url: https://registry.npmjs.org
+
+      - name: Install Rust toolchain
+        run: rustup show
+
+      - name: Install wasm-pack
+        run: cargo install wasm-pack --locked --version 0.15.0
+
+      - name: Install npm with trusted publishing support
+        run: npm install --global npm@11.12.1
+
+      - name: Build package
+        run: make build-wasm
+
+      - name: Verify release version
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: |
+          package_version="$(node --print "require('./target/npm/shuck-wasm/package.json').version")"
+          test "v${package_version}" = "$RELEASE_TAG"
+
+      - name: Publish package
+        run: npm publish ./target/npm/shuck-wasm --access public

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1977,6 +1977,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "shuck-wasm"
+version = "0.0.43"
+dependencies = [
+ "js-sys",
+ "serde",
+ "serde_json",
+ "shuck-ast",
+ "shuck-formatter",
+ "shuck-indexer",
+ "shuck-linter",
+ "shuck-parser",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "similar"
 version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,6 +74,8 @@ similar = "2"
 toml = "0.8"
 quick-junit = "0.6.1"
 url = "2.5.0"
+js-sys = "0.3"
+wasm-bindgen = "0.2"
 
 # Testing
 tempfile = "3"

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,9 @@
-.PHONY: build test run check check-scripts setup-hooks setup-large-corpus ensure-cache test-large-corpus large-corpus-report large-corpus-report-from-log large-corpus-report-open test-oracle-shfmt test-oracle-shfmt-fixtures test-oracle-shfmt-benchmark test-oracle-shfmt-large-corpus update-oracle-shfmt-large-corpus-allowlist test-oracle-shellcheck-cli fuzz-setup fuzz-list fuzz-smoke fuzz-run fuzz-cli bench bench-save bench-compare bench-parser bench-arithmetic bench-lexer bench-semantic bench-linter bench-formatter bench-large-corpus-hotspots bench-macro bench-macro-single bench-macro-format bench-macro-format-summary bench-macro-format-single bench-macro-site-local bench-repo-corpus profile-parser profile-parser-view profile-arithmetic profile-arithmetic-view profile-formatter profile-formatter-view profile-linter profile-linter-view profile-cli profile-cli-view profile-large-corpus profile-large-corpus-view flame-parser flame-arithmetic flame-formatter flame-linter flame-cli harden-release check-release-security
+.PHONY: build test build-wasm test-wasm run check check-scripts setup-hooks setup-large-corpus ensure-cache test-large-corpus large-corpus-report large-corpus-report-from-log large-corpus-report-open test-oracle-shfmt test-oracle-shfmt-fixtures test-oracle-shfmt-benchmark test-oracle-shfmt-large-corpus update-oracle-shfmt-large-corpus-allowlist test-oracle-shellcheck-cli fuzz-setup fuzz-list fuzz-smoke fuzz-run fuzz-cli bench bench-save bench-compare bench-parser bench-arithmetic bench-lexer bench-semantic bench-linter bench-formatter bench-large-corpus-hotspots bench-macro bench-macro-single bench-macro-format bench-macro-format-summary bench-macro-format-single bench-macro-site-local bench-repo-corpus profile-parser profile-parser-view profile-arithmetic profile-arithmetic-view profile-formatter profile-formatter-view profile-linter profile-linter-view profile-cli profile-cli-view profile-large-corpus profile-large-corpus-view flame-parser flame-arithmetic flame-formatter flame-linter flame-cli harden-release check-release-security
 
 ARGS ?= --help
+WASM_PACK ?= wasm-pack
+WASM_NPM_DIR ?= target/npm/shuck-wasm
+WASM_TEST_DIR ?= target/wasm-test/shuck-wasm
 BENCH_FILE ?=
 NIX_DEVELOP ?= nix --extra-experimental-features 'nix-command flakes' develop --command
 UV_PYTHON ?= uv run python
@@ -39,6 +42,14 @@ build:
 
 test:
 	cargo test
+
+build-wasm:
+	$(WASM_PACK) build crates/shuck-wasm --target bundler --out-dir ../../$(WASM_NPM_DIR) --out-name shuck
+
+test-wasm:
+	cargo test -p shuck-wasm
+	$(WASM_PACK) build crates/shuck-wasm --target nodejs --out-dir ../../$(WASM_TEST_DIR) --out-name shuck
+	node scripts/ci/smoke-wasm-package.mjs $(WASM_TEST_DIR)
 
 setup-large-corpus:
 	./scripts/corpus-download.sh

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Shuck parses, analyzes, formats, and powers editor feedback for shell scripts. I
 - Automatic file discovery via extensions and shebang detection
 - Embedded shell extraction for GitHub Actions workflows and composite actions
 - First-party Language Server Protocol server for editor diagnostics, code actions, navigation, symbols, hover, completion, and formatting
+- WebAssembly npm package for bundled Node.js extensions and browser-hosted editors
 - ShellCheck suppression compatibility (`# shellcheck disable=SC2086`)
 
 ## Installation
@@ -32,6 +33,18 @@ pip install shuck-cli
 
 The PyPI package is named `shuck-cli`, but it still installs the `shuck`
 command.
+
+### npm / WebAssembly
+
+```sh
+npm install shuck-wasm
+```
+
+`shuck-wasm` exposes source linting and formatting to wasm-aware bundlers, so
+Node.js editor extensions and browser-hosted editors can use Shuck without a
+separately installed executable. See the
+[`shuck-wasm` package documentation](crates/shuck-wasm/README.md) for its
+TypeScript API and runtime boundaries.
 
 ### From source
 

--- a/crates/shuck-wasm/Cargo.toml
+++ b/crates/shuck-wasm/Cargo.toml
@@ -1,0 +1,32 @@
+[package]
+name = "shuck-wasm"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+authors.workspace = true
+repository.workspace = true
+homepage = "https://github.com/ewhauser/shuck"
+description = "WebAssembly bindings for the Shuck shell linter and formatter"
+keywords = ["shell", "bash", "linter", "webassembly", "wasm"]
+categories = ["development-tools", "web-programming"]
+readme = "README.md"
+publish = false
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+doctest = false
+
+[dependencies]
+js-sys = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+shuck-ast = { workspace = true }
+shuck-formatter = { workspace = true }
+shuck-indexer = { workspace = true }
+shuck-linter = { workspace = true }
+shuck-parser = { workspace = true }
+wasm-bindgen = { workspace = true }
+
+[package.metadata.wasm-pack.profile.release]
+wasm-opt = ["-Oz", "--enable-bulk-memory"]

--- a/crates/shuck-wasm/LICENSE
+++ b/crates/shuck-wasm/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Eric Hauser
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/crates/shuck-wasm/README.md
+++ b/crates/shuck-wasm/README.md
@@ -1,0 +1,42 @@
+# shuck-wasm
+
+WebAssembly bindings for the [Shuck](https://github.com/ewhauser/shuck) shell
+script linter and formatter.
+
+The npm package is built for wasm-aware bundlers such as webpack, Rollup, or
+esbuild. It can be bundled into Node.js editor extensions and browser-hosted
+editors without installing the native `shuck` executable.
+
+```sh
+npm install shuck-wasm
+```
+
+```ts
+import { format, lint, version } from "shuck-wasm";
+
+const diagnostics = lint("echo $name\n", {
+  filename: "script.bash",
+  select: ["ALL"],
+});
+
+for (const diagnostic of diagnostics) {
+  console.log(diagnostic.code, diagnostic.range, diagnostic.message);
+}
+
+const formatted = format("hello(){\necho hi\n}\n", {
+  shell: "bash",
+  indentStyle: "space",
+  indentWidth: 2,
+});
+
+console.log(`shuck ${version()}`);
+```
+
+Diagnostic and fix ranges use zero-based UTF-16 positions, matching VS Code and
+the Language Server Protocol default. Linting is source-only: `filename` is a
+logical path used for shell inference and policy context, and is never read from
+the filesystem.
+
+The package exposes source linting and formatting. Project discovery,
+configuration-file loading, embedded shell extraction, source-file resolution,
+and the stdio language server remain features of the native Shuck CLI.

--- a/crates/shuck-wasm/src/lib.rs
+++ b/crates/shuck-wasm/src/lib.rs
@@ -1,0 +1,462 @@
+#![warn(missing_docs)]
+#![cfg_attr(not(test), warn(clippy::unwrap_used))]
+
+//! WebAssembly bindings for source-only Shuck linting and formatting.
+
+use std::path::Path;
+use std::str::FromStr;
+
+use serde::de::DeserializeOwned;
+use serde::{Deserialize, Serialize};
+use shuck_ast::{TextRange, TextSize};
+use shuck_formatter::{
+    FormattedSource, IndentStyle, ShellDialect as FormatDialect, ShellFormatOptions,
+};
+use shuck_indexer::LineIndex;
+use shuck_linter::{
+    AnalysisRequest, Applicability, Diagnostic as ShuckDiagnostic, LinterSettings, RuleSelector,
+    ShellDialect as LintDialect,
+};
+use shuck_parser::parser::Parser;
+use wasm_bindgen::prelude::*;
+
+#[wasm_bindgen(typescript_custom_section)]
+const TYPESCRIPT_TYPES: &str = r#"
+export type Shell = "sh" | "bash" | "dash" | "ksh" | "mksh" | "zsh";
+export type DiagnosticSeverity = "hint" | "warning" | "error";
+export type FixApplicability = "safe" | "unsafe";
+
+export interface Position {
+  /** Zero-based source line. */
+  line: number;
+  /** Zero-based UTF-16 code-unit offset on the line. */
+  character: number;
+}
+
+export interface Range {
+  start: Position;
+  end: Position;
+}
+
+export interface TextEdit {
+  range: Range;
+  newText: string;
+}
+
+export interface DiagnosticFix {
+  title: string;
+  applicability: FixApplicability;
+  edits: TextEdit[];
+}
+
+export interface Diagnostic {
+  code: string;
+  message: string;
+  severity: DiagnosticSeverity;
+  range: Range;
+  fix?: DiagnosticFix;
+}
+
+export interface LintOptions {
+  /** Logical filename used for dialect inference; no file is read. */
+  filename?: string;
+  /** Explicit shell dialect. Omit to infer it from the source and filename. */
+  shell?: Shell;
+  /** Rule selectors to enable. Omit for Shuck's defaults; [] enables no rules. */
+  select?: string[];
+  /** Rule selectors to remove from the selected or default rules. */
+  ignore?: string[];
+}
+
+export interface FormatOptions {
+  /** Logical filename used for dialect inference; no file is read. */
+  filename?: string;
+  /** Explicit shell dialect. Omit to infer it from the source and filename. */
+  shell?: Shell;
+  indentStyle?: "tab" | "space";
+  indentWidth?: number;
+  binaryNextLine?: boolean;
+  switchCaseIndent?: boolean;
+  spaceRedirects?: boolean;
+  keepPadding?: boolean;
+  functionNextLine?: boolean;
+  neverSplit?: boolean;
+  simplify?: boolean;
+  minify?: boolean;
+}
+
+export function lint(source: string, options?: LintOptions): Diagnostic[];
+export function format(source: string, options?: FormatOptions): string;
+"#;
+
+/// Return the Shuck version embedded in this package.
+#[wasm_bindgen]
+pub fn version() -> String {
+    env!("CARGO_PKG_VERSION").to_owned()
+}
+
+/// Lint shell source and return structured editor diagnostics.
+#[wasm_bindgen(skip_typescript)]
+pub fn lint(source: &str, options: JsValue) -> Result<JsValue, JsValue> {
+    let options = decode_options(options)?;
+    let diagnostics = lint_source(source, &options).map_err(js_error)?;
+    encode_value(&diagnostics)
+}
+
+/// Format shell source and return the complete formatted text.
+#[wasm_bindgen(skip_typescript)]
+pub fn format(source: &str, options: JsValue) -> Result<String, JsValue> {
+    let options = decode_options(options)?;
+    format_source(source, &options).map_err(js_error)
+}
+
+#[derive(Debug, Clone, Copy, Deserialize)]
+#[serde(rename_all = "lowercase")]
+enum ShellName {
+    Sh,
+    Bash,
+    Dash,
+    Ksh,
+    Mksh,
+    Zsh,
+}
+
+impl ShellName {
+    const fn lint_dialect(self) -> LintDialect {
+        match self {
+            Self::Sh => LintDialect::Sh,
+            Self::Bash => LintDialect::Bash,
+            Self::Dash => LintDialect::Dash,
+            Self::Ksh => LintDialect::Ksh,
+            Self::Mksh => LintDialect::Mksh,
+            Self::Zsh => LintDialect::Zsh,
+        }
+    }
+
+    const fn format_dialect(self) -> FormatDialect {
+        match self {
+            Self::Sh | Self::Dash | Self::Ksh => FormatDialect::Posix,
+            Self::Bash => FormatDialect::Bash,
+            Self::Mksh => FormatDialect::Mksh,
+            Self::Zsh => FormatDialect::Zsh,
+        }
+    }
+}
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(default, deny_unknown_fields, rename_all = "camelCase")]
+struct LintOptions {
+    filename: Option<String>,
+    shell: Option<ShellName>,
+    select: Option<Vec<String>>,
+    ignore: Vec<String>,
+}
+
+#[derive(Debug, Clone, Copy, Deserialize)]
+#[serde(rename_all = "lowercase")]
+enum IndentStyleName {
+    Tab,
+    Space,
+}
+
+impl From<IndentStyleName> for IndentStyle {
+    fn from(value: IndentStyleName) -> Self {
+        match value {
+            IndentStyleName::Tab => Self::Tab,
+            IndentStyleName::Space => Self::Space,
+        }
+    }
+}
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(default, deny_unknown_fields, rename_all = "camelCase")]
+struct FormatOptions {
+    filename: Option<String>,
+    shell: Option<ShellName>,
+    indent_style: Option<IndentStyleName>,
+    indent_width: Option<u8>,
+    binary_next_line: Option<bool>,
+    switch_case_indent: Option<bool>,
+    space_redirects: Option<bool>,
+    keep_padding: Option<bool>,
+    function_next_line: Option<bool>,
+    never_split: Option<bool>,
+    simplify: Option<bool>,
+    minify: Option<bool>,
+}
+
+#[derive(Debug, Serialize)]
+struct Diagnostic {
+    code: String,
+    message: String,
+    severity: String,
+    range: Range,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    fix: Option<DiagnosticFix>,
+}
+
+#[derive(Debug, Serialize)]
+struct DiagnosticFix {
+    title: String,
+    applicability: String,
+    edits: Vec<TextEdit>,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct TextEdit {
+    range: Range,
+    new_text: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+struct Range {
+    start: Position,
+    end: Position,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+struct Position {
+    line: u32,
+    character: u32,
+}
+
+fn lint_source(source: &str, options: &LintOptions) -> Result<Vec<Diagnostic>, String> {
+    let path = options.filename.as_deref().map(Path::new);
+    let shell = options.shell.map_or_else(
+        || inferred_lint_dialect(source, path),
+        ShellName::lint_dialect,
+    );
+    let settings = linter_settings(options, shell)?;
+    let parsed = Parser::with_profile(source, shell.shell_profile()).parse();
+    let diagnostics = AnalysisRequest::from_parse_result(&parsed, source, &settings)
+        .with_optional_source_path(path)
+        .lint();
+    let lines = LineIndex::new(source);
+
+    Ok(diagnostics
+        .iter()
+        .map(|diagnostic| diagnostic_for_js(diagnostic, source, &lines))
+        .collect())
+}
+
+fn inferred_lint_dialect(source: &str, path: Option<&Path>) -> LintDialect {
+    match LintDialect::infer(source, path) {
+        LintDialect::Unknown => LintDialect::Bash,
+        shell => shell,
+    }
+}
+
+fn linter_settings(options: &LintOptions, shell: LintDialect) -> Result<LinterSettings, String> {
+    let mut settings = LinterSettings::default();
+    if let Some(select) = &options.select {
+        settings.rules = selectors(select)?
+            .iter()
+            .fold(shuck_linter::RuleSet::EMPTY, |rules, selector| {
+                rules.union(&selector.into_rule_set())
+            });
+    }
+    for selector in selectors(&options.ignore)? {
+        settings.rules = settings.rules.subtract(&selector.into_rule_set());
+    }
+    settings.shell = shell;
+    settings.resolve_source_closure = false;
+    Ok(settings)
+}
+
+fn selectors(values: &[String]) -> Result<Vec<RuleSelector>, String> {
+    values
+        .iter()
+        .map(|value| RuleSelector::from_str(value).map_err(|error| error.to_string()))
+        .collect()
+}
+
+fn diagnostic_for_js(diagnostic: &ShuckDiagnostic, source: &str, lines: &LineIndex) -> Diagnostic {
+    let fix = diagnostic.fix.as_ref().map(|fix| DiagnosticFix {
+        title: diagnostic
+            .fix_title
+            .clone()
+            .unwrap_or_else(|| diagnostic.message.clone()),
+        applicability: match fix.applicability() {
+            Applicability::Safe => "safe",
+            Applicability::Unsafe => "unsafe",
+        }
+        .to_owned(),
+        edits: fix
+            .edits()
+            .iter()
+            .map(|edit| TextEdit {
+                range: range_for_js(edit.range(), source, lines),
+                new_text: edit.content().to_owned(),
+            })
+            .collect(),
+    });
+
+    Diagnostic {
+        code: diagnostic.code().to_owned(),
+        message: diagnostic.message.clone(),
+        severity: diagnostic.severity.as_str().to_owned(),
+        range: range_for_js(diagnostic.span.to_range(), source, lines),
+        fix,
+    }
+}
+
+fn range_for_js(range: TextRange, source: &str, lines: &LineIndex) -> Range {
+    Range {
+        start: position_for_js(usize::from(range.start()), source, lines),
+        end: position_for_js(usize::from(range.end()), source, lines),
+    }
+}
+
+fn position_for_js(offset: usize, source: &str, lines: &LineIndex) -> Position {
+    let offset = clamp_to_char_boundary(source, offset);
+    let line = lines.line_number(TextSize::new(offset as u32));
+    let line_start = lines.line_start(line).map(usize::from).unwrap_or_default();
+    let character = source[line_start..offset].encode_utf16().count();
+
+    Position {
+        line: u32::try_from(line.saturating_sub(1)).unwrap_or(u32::MAX),
+        character: u32::try_from(character).unwrap_or(u32::MAX),
+    }
+}
+
+fn clamp_to_char_boundary(source: &str, offset: usize) -> usize {
+    let mut offset = offset.min(source.len());
+    while offset > 0 && !source.is_char_boundary(offset) {
+        offset -= 1;
+    }
+    offset
+}
+
+fn format_source(source: &str, options: &FormatOptions) -> Result<String, String> {
+    let path = options.filename.as_deref().map(Path::new);
+    let mut format_options = ShellFormatOptions::default();
+
+    if let Some(shell) = options.shell {
+        format_options = format_options.with_dialect(shell.format_dialect());
+    }
+    if let Some(indent_style) = options.indent_style {
+        format_options = format_options.with_indent_style(indent_style.into());
+    }
+    if let Some(indent_width) = options.indent_width {
+        format_options = format_options.with_indent_width(indent_width);
+    }
+    if let Some(value) = options.binary_next_line {
+        format_options = format_options.with_binary_next_line(value);
+    }
+    if let Some(value) = options.switch_case_indent {
+        format_options = format_options.with_switch_case_indent(value);
+    }
+    if let Some(value) = options.space_redirects {
+        format_options = format_options.with_space_redirects(value);
+    }
+    if let Some(value) = options.keep_padding {
+        format_options = format_options.with_keep_padding(value);
+    }
+    if let Some(value) = options.function_next_line {
+        format_options = format_options.with_function_next_line(value);
+    }
+    if let Some(value) = options.never_split {
+        format_options = format_options.with_never_split(value);
+    }
+    if let Some(value) = options.simplify {
+        format_options = format_options.with_simplify(value);
+    }
+    if let Some(value) = options.minify {
+        format_options = format_options.with_minify(value);
+    }
+
+    match shuck_formatter::format_source(source, path, &format_options)
+        .map_err(|error| error.to_string())?
+    {
+        FormattedSource::Unchanged => Ok(source.to_owned()),
+        FormattedSource::Formatted(formatted) => Ok(formatted),
+    }
+}
+
+fn decode_options<T>(value: JsValue) -> Result<T, JsValue>
+where
+    T: Default + DeserializeOwned,
+{
+    if value.is_null() || value.is_undefined() {
+        return Ok(T::default());
+    }
+
+    let serialized = js_sys::JSON::stringify(&value)?
+        .as_string()
+        .ok_or_else(|| js_error("options must be a JSON-compatible object"))?;
+    serde_json::from_str(&serialized).map_err(js_error)
+}
+
+fn encode_value<T: Serialize>(value: &T) -> Result<JsValue, JsValue> {
+    let serialized = serde_json::to_string(value).map_err(js_error)?;
+    js_sys::JSON::parse(&serialized)
+}
+
+fn js_error(error: impl std::fmt::Display) -> JsValue {
+    js_sys::Error::new(&error.to_string()).into()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn lint_returns_diagnostics_and_utf16_ranges() {
+        let source = "😀; echo $name\n";
+        let diagnostics = lint_source(
+            source,
+            &LintOptions {
+                shell: Some(ShellName::Bash),
+                select: Some(vec!["ALL".to_owned()]),
+                ..LintOptions::default()
+            },
+        )
+        .expect("lint request should succeed");
+
+        assert!(!diagnostics.is_empty());
+        assert!(
+            diagnostics
+                .iter()
+                .any(|diagnostic| diagnostic.code == "S001")
+        );
+        let name_offset = source.find("$name").expect("fixture contains expansion");
+        assert_eq!(
+            position_for_js(name_offset, source, &LineIndex::new(source)),
+            Position {
+                line: 0,
+                character: 9,
+            }
+        );
+    }
+
+    #[test]
+    fn lint_rejects_unknown_rule_selectors() {
+        let error = lint_source(
+            "echo ok\n",
+            &LintOptions {
+                select: Some(vec!["NOT-A-RULE".to_owned()]),
+                ..LintOptions::default()
+            },
+        )
+        .expect_err("unknown selector should fail");
+
+        assert!(error.contains("unknown rule selector"));
+    }
+
+    #[test]
+    fn formatter_uses_source_only_options() {
+        let formatted = format_source(
+            "hello(){\necho hi\n}\n",
+            &FormatOptions {
+                shell: Some(ShellName::Bash),
+                indent_style: Some(IndentStyleName::Space),
+                indent_width: Some(2),
+                ..FormatOptions::default()
+            },
+        )
+        .expect("format request should succeed");
+
+        assert_eq!(formatted, "hello() {\n  echo hi\n}\n");
+    }
+}

--- a/scripts/ci/smoke-wasm-package.mjs
+++ b/scripts/ci/smoke-wasm-package.mjs
@@ -1,0 +1,33 @@
+import assert from "node:assert/strict";
+import { createRequire } from "node:module";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const packageDirectory = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "../..",
+  process.argv[2] ?? "target/wasm-test/shuck-wasm",
+);
+const require = createRequire(import.meta.url);
+const shuck = require(packageDirectory);
+const packageJson = require(path.join(packageDirectory, "package.json"));
+
+const diagnostics = shuck.lint("echo $name\n", {
+  filename: "script.bash",
+  select: ["ALL"],
+});
+
+assert.ok(Array.isArray(diagnostics));
+assert.ok(diagnostics.some((diagnostic) => diagnostic.code === "S001"));
+assert.ok(Array.isArray(shuck.lint("echo ok\n")));
+assert.equal(shuck.version(), packageJson.version);
+assert.equal(
+  shuck.format("hello(){\necho hi\n}\n", {
+    shell: "bash",
+    indentStyle: "space",
+    indentWidth: 2,
+  }),
+  "hello() {\n  echo hi\n}\n",
+);
+
+console.log(`smoke-tested ${packageJson.name}@${packageJson.version}`);

--- a/specs/024-wasm-npm.md
+++ b/specs/024-wasm-npm.md
@@ -1,0 +1,140 @@
+# 024: WebAssembly npm Package
+
+## Status
+
+Implemented
+
+## Summary
+
+Shuck publishes a `shuck-wasm` npm package containing the parser, linter, and
+formatter compiled to WebAssembly. The package gives bundled Node.js extensions
+and browser-hosted editors the same in-process analysis primitives without
+requiring the native `shuck` executable.
+
+## Motivation
+
+The native CLI and stdio language server work well when an editor can launch a
+local process. They do not work in browser-only environments such as VS Code for
+the Web, and requiring a separately installed binary complicates otherwise
+self-contained Node.js editor extensions.
+
+The package must therefore:
+
+- run without filesystem, process, network, or thread access;
+- expose editor-ready UTF-16 ranges and rule fixes;
+- infer a shell from source text and a logical filename while allowing an
+  explicit override;
+- keep its version synchronized with the rest of the workspace; and
+- be built and published from a tagged Shuck release with provenance.
+
+## Design
+
+### Workspace crate and npm artifact
+
+`crates/shuck-wasm` is a non-crates.io workspace crate with `cdylib` and `rlib`
+outputs. It depends directly on the parser, linter, indexer, and formatter
+libraries rather than the CLI or language server, avoiding native-only file
+discovery, caching, process management, and stdio transport.
+
+`wasm-pack` builds the crate for `wasm32-unknown-unknown` using its `bundler`
+target. The resulting package is named `shuck-wasm`. Its generated JavaScript
+imports the `.wasm` module, which makes it suitable for extension toolchains
+that bundle npm dependencies for Node.js or the browser.
+
+The generated package is a release artifact and is not committed. The Cargo
+workspace version is its only version source.
+
+### JavaScript API
+
+The initial API is synchronous after the bundler loads the module:
+
+```ts
+export function version(): string;
+export function lint(source: string, options?: LintOptions): Diagnostic[];
+export function format(source: string, options?: FormatOptions): string;
+```
+
+`LintOptions` supports a logical `filename`, a shell override, and `select` and
+`ignore` rule selectors. An omitted `select` uses Shuck's default rule set; an
+explicit empty array selects no lint rules. Syntax diagnostics are still
+returned for malformed input.
+
+Each diagnostic contains its code, message, severity, range, and optional fix.
+Ranges use zero-based UTF-16 code-unit positions, matching the default Language
+Server Protocol and VS Code position encoding. Fixes contain replacement edits
+in the same coordinate system and retain Shuck's safe/unsafe applicability.
+
+`FormatOptions` exposes the source-only formatter controls that do not require
+project configuration or filesystem access. Formatting returns the original
+source when no change is necessary and throws a JavaScript `Error` for invalid
+options or malformed shell input.
+
+### Runtime boundaries
+
+WASM lint requests always disable source-closure resolution. A logical filename
+is used only for dialect inference, per-file policy context, and diagnostic
+behavior; the runtime never reads that path. Configuration-file discovery,
+embedded host-file extraction, multi-file analysis, and LSP transport remain
+native responsibilities.
+
+### Release automation
+
+CI builds a Node.js-targeted smoke package, executes linting and formatting
+through the generated JavaScript, and builds the exact bundler artifact intended
+for npm.
+
+When a GitHub release is published, a protected release job checks out the tag,
+rebuilds the bundler package, verifies that the tag and package versions match,
+and runs `npm publish`. npm trusted publishing supplies short-lived OIDC
+credentials and provenance; no long-lived npm token is stored in the repository.
+
+## Alternatives Considered
+
+### Package native binaries through npm
+
+Platform-specific binaries would work for desktop Node.js extensions but still
+could not run in browser-hosted editors. They would also duplicate the existing
+native release matrix and launcher selection logic.
+
+### Compile the CLI or stdio language server directly
+
+Those crates intentionally depend on filesystem discovery, caching, process
+execution, and native transport. Compiling the library pipeline instead keeps
+the WASM boundary small and gives editors direct access to structured results.
+
+### Publish separate browser and Node.js packages
+
+Separate packages would duplicate the WebAssembly payload and create two
+versioned public surfaces. The bundler target covers the extension use case in
+both environments; an unbundled Node.js entrypoint can be added later if a
+concrete consumer requires one.
+
+### Commit wasm-pack output
+
+Generated JavaScript and binary output are release artifacts. Rebuilding them in
+CI from the tagged source gives npm provenance a direct, auditable build path and
+avoids noisy binary changes in the repository.
+
+## Security Considerations
+
+The API accepts untrusted source and options, so it retains the parser's depth
+and fuel limits and performs no ambient I/O. Options are strictly deserialized;
+unknown fields and rule selectors fail with a JavaScript error. Publishing uses
+GitHub-hosted runners, minimal permissions, a protected `release` environment,
+and npm OIDC trusted publishing.
+
+## Verification
+
+Run:
+
+```sh
+cargo test -p shuck-wasm
+make test-wasm
+make build-wasm
+npm pack --dry-run ./target/npm/shuck-wasm
+```
+
+`make test-wasm` builds a Node.js-targeted package and executes the public API.
+CI additionally compiles and packs the bundler artifact. A release is complete
+when the workflow publishes `shuck-wasm` at the same version as its `vX.Y.Z`
+tag and npm records provenance for it.


### PR DESCRIPTION
## Summary

- add a `shuck-wasm` workspace crate with typed `lint`, `format`, and `version` WebAssembly APIs
- return editor-ready UTF-16 diagnostic ranges and rule fix edits without filesystem or process access
- add reproducible `wasm-pack` builds, Node.js smoke coverage, npm package inspection, and an OIDC trusted-publishing workflow
- document the package API, runtime boundaries, and design decisions

## Why

Editor extensions currently need the native Shuck binary and cannot run in browser-only environments such as VS Code for the Web. The new bundler-targeted npm package embeds Shuck's parser, linter, and formatter so extensions can analyze in-memory source without installing or launching a native executable.

Closes #1132.

## User and developer impact

Consumers can install `shuck-wasm` and bundle synchronous linting and formatting into Node.js or browser-hosted editor extensions. Native-only concerns such as project discovery, configuration-file loading, embedded host-file extraction, source closure resolution, and stdio LSP transport remain in the CLI.

Before the first automated release, the `shuck-wasm` package must be initialized on npm and configured to trust `.github/workflows/npm-publish.yml` in the `release` environment.

## Validation

- `make test-wasm build-wasm`
- generated Node.js package smoke test covering linting, formatting, optional arguments, and version parity
- `npm pack --dry-run ./target/npm/shuck-wasm`
- `make check`
- `python3 scripts/check-release-please-config.py`
- `python3 scripts/check-release-security.py check`
- workflow YAML parsing and `node --check scripts/ci/smoke-wasm-package.mjs`