### PR TITLE
perf(semantic): reuse recorded command info in flow analysis

### DIFF
--- a/crates/shuck-semantic/src/builder/traversal.rs
+++ b/crates/shuck-semantic/src/builder/traversal.rs
@@ -71,17 +71,39 @@ impl<'a, 'idx, 'observer> SemanticModelBuilder<'a, 'idx, 'observer> {
             self.observer
                 .recorded_statement_sequence_command(commands.span, stmt.span, command);
             recorded.push(command);
-            flow = self.flow_after_statement(stmt, flow);
+            flow = self.flow_after_recorded_statement(stmt, command, flow);
         }
     }
 
-    fn flow_after_statement(&self, stmt: &'a Stmt, flow: FlowState) -> FlowState {
-        self.flow_after_command(&stmt.command, flow)
+    fn flow_after_recorded_statement(
+        &self,
+        stmt: &'a Stmt,
+        recorded: CommandId,
+        flow: FlowState,
+    ) -> FlowState {
+        let info = self
+            .recorded_program
+            .command(recorded)
+            .command_info
+            .map(|info| self.recorded_program.command_info(info));
+        self.flow_after_command(&stmt.command, info, flow)
     }
 
-    fn flow_after_command(&self, command: &'a Command, flow: FlowState) -> FlowState {
+    fn flow_after_statement(&self, stmt: &'a Stmt, flow: FlowState) -> FlowState {
+        self.flow_after_command(&stmt.command, None, flow)
+    }
+
+    fn flow_after_command(
+        &self,
+        command: &'a Command,
+        info: Option<&RecordedCommandInfo>,
+        flow: FlowState,
+    ) -> FlowState {
         match command {
             Command::Simple(_) => {
+                if let Some(info) = info {
+                    return flow_after_zsh_effects(flow, &info.zsh_effects);
+                }
                 let info = recorded_command_info(
                     command,
                     self.source,


### PR DESCRIPTION
## Summary

- reuse the command information already recorded by `visit_stmt()` when updating statement-sequence flow
- avoid normalizing the same simple command twice on the primary traversal path
- retain the existing normalization fallback for recursively evaluated compound commands, avoiding an additional span lookup

## Impact

Profiling the `romkatv__powerlevel10k__internal__p10k.zsh` fixture reduced samples attributed to duplicate command normalization from 0.9% to 0.5% of the total profile. Semantic model construction fell from 6.6% to 6.1% of samples.

Targeted semantic benchmarks improved by approximately 1.3–2.8% on individual fixtures. The aggregate and whole-fixture wall-clock differences remained within run-to-run noise, so this should be treated as a small local optimization rather than a claimed end-to-end speedup.

## Validation

- `cargo test -p shuck-semantic -p shuck-linter --quiet`
- `cargo clippy -p shuck-semantic --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`
