### PR TITLE
fix(formatter): honor command substitution continuation style

### DIFF
--- a/crates/shuck-formatter/src/word/command_substitution.rs
+++ b/crates/shuck-formatter/src/word/command_substitution.rs
@@ -918,6 +918,8 @@ pub(super) fn push_command_substitution_inline_body(
     }
     if options.space_redirects() {
         target.push_str(body);
+    } else if options.binary_next_line() {
+        push_raw_shell_text_with_normalized_redirect_spacing_preserving_continuations(target, body);
     } else {
         push_raw_shell_text_with_normalized_redirect_spacing(target, body);
     }

--- a/crates/shuck-formatter/src/word/raw_rewrites.rs
+++ b/crates/shuck-formatter/src/word/raw_rewrites.rs
@@ -503,6 +503,13 @@ pub(super) fn push_raw_shell_text_with_normalized_redirect_spacing(
 ) {
     let normalized_pipeline = normalize_raw_pipeline_continuations(text);
     let text = normalized_pipeline.as_deref().unwrap_or(text);
+    push_raw_shell_text_with_normalized_redirect_spacing_preserving_continuations(target, text);
+}
+
+pub(super) fn push_raw_shell_text_with_normalized_redirect_spacing_preserving_continuations(
+    target: &mut String,
+    text: &str,
+) {
     let mut lines = text.split('\n');
     if let Some(first) = lines.next() {
         push_raw_shell_line_with_normalized_redirect_spacing(target, first);
@@ -1531,6 +1538,9 @@ pub(super) fn source_indent_plus_one_unit(
     indent: &str,
     options: &ResolvedShellFormatOptions,
 ) -> String {
+    if indent.is_empty() {
+        return options.indent_prefix(1);
+    }
     if indent.chars().all(|ch| ch == '\t') {
         let mut extended = indent.to_string();
         extended.push('\t');

--- a/crates/shuck-formatter/tests/format_cases.rs
+++ b/crates/shuck-formatter/tests/format_cases.rs
@@ -8,8 +8,8 @@ use shuck_linter::{AnalysisRequest, Diagnostic, LinterSettings};
 use shuck_parser::{ShellDialect as ParseShellDialect, parser::Parser};
 
 use shuck_formatter::{
-    FormatError, FormattedSource, ShellDialect, ShellFormatOptions, format_file_ast, format_source,
-    source_is_formatted,
+    FormatError, FormattedSource, IndentStyle, ShellDialect, ShellFormatOptions, format_file_ast,
+    format_source, source_is_formatted,
 };
 
 fn parse_for_ast_format(
@@ -2273,6 +2273,37 @@ unchanged_cases_with_options! {
     binary_next_line_does_not_force_single_line_pipelines_to_wrap:
         ShellFormatOptions::default().with_binary_next_line(true),
         "cat foo | cat bar\n";
+}
+
+#[test]
+fn space_indented_binary_next_line_command_substitution_keeps_continuations() {
+    let options = ShellFormatOptions::default()
+        .with_indent_style(IndentStyle::Space)
+        .with_indent_width(4)
+        .with_binary_next_line(true);
+    let source = r#"#!/bin/bash
+
+ls -al \
+    | grep "$USER" \
+    | grep -i "jul"
+
+foobar=$(ls -al \
+    | grep "$USER" \
+    | grep -i "jul")
+echo "$foobar"
+"#;
+
+    assert_unchanged_with_ast(source, Some(Path::new("sample.sh")), &options);
+    assert!(!format_to_string(source, Some(Path::new("sample.sh")), &options).contains('\t'));
+}
+
+format_cases_with_options! {
+    space_indented_command_substitution_normalizes_with_spaces:
+        ShellFormatOptions::default()
+            .with_indent_style(IndentStyle::Space)
+            .with_indent_width(4),
+        "foobar=$(ls -al \\\n    | grep \"$USER\" \\\n    | grep -i \"jul\")\n",
+        => "foobar=$(ls -al |\n    grep \"$USER\" |\n    grep -i \"jul\")\n";
 }
 
 format_cases_with_options! {


### PR DESCRIPTION
Closes #1176.

## Summary

- derive empty inline continuation indentation from the resolved formatter indent style
- preserve leading pipeline operators inside command substitutions when `binary-next-line = true`
- keep redirect-spacing normalization without rewriting the selected continuation layout
- add coverage for the exact reported space-indented reproduction and the default trailing-operator normalization path

## Root cause

Inline command-substitution continuations built indentation from an empty source prefix. The empty prefix was treated as tab-indented, so one literal tab was added even when `indent-style = "space"`. After the nested pipeline had already been formatted with leading operators, redirect-spacing cleanup also normalized it back to trailing operators, overriding `binary-next-line = true`.

## Validation

- `cargo test -p shuck-formatter --test format_cases space_indented_ -- --nocapture`
- `cargo test -p shuck-formatter`
- `cargo fmt --check`
- `cargo test --workspace`
- `cargo run -q -p shuck-cli -- format - --stdin-filename sample.sh --indent-style space --indent-width 4 --binary-next-line` with the issue reproduction on stdin; output was unchanged and contained no tab indentation
- `git diff --check`

Local note: `cargo clippy --all-targets -- -D warnings` currently stops on the existing untouched `clippy::collapsible_match` warning at `crates/shuck-ast/src/command_resolution.rs:397`.