### PR TITLE
fix(parser): preserve unterminated quote locations

### DIFF
--- a/crates/shuck-cli/tests/integration_test.rs
+++ b/crates/shuck-cli/tests/integration_test.rs
@@ -781,11 +781,11 @@ fn check_unfixable_prevents_fixing_matching_rules() {
 }
 
 #[test]
-fn check_unterminated_quote_reports_parse_error() {
+fn check_unterminated_quote_reports_opening_quote_location() {
     let tempdir = tempdir().unwrap();
     fs::write(
         tempdir.path().join("broken.sh"),
-        "#!/bin/bash\necho \"unterminated\n",
+        "#!/bin/bash\nvalue=abc\"unterminated\n",
     )
     .unwrap();
 
@@ -795,8 +795,8 @@ fn check_unterminated_quote_reports_parse_error() {
     cmd.assert()
         .code(1)
         .stdout(predicate::str::contains("error[parse-error]:"))
-        .stdout(predicate::str::contains("--> broken.sh:2:6"))
-        .stdout(predicate::str::contains("2 | echo \"unterminated"))
+        .stdout(predicate::str::contains("--> broken.sh:2:10"))
+        .stdout(predicate::str::contains("2 | value=abc\"unterminated"))
         .stdout(predicate::str::contains("^"));
 }
 

--- a/crates/shuck-parser/src/parser/lexer/mod.rs
+++ b/crates/shuck-parser/src/parser/lexer/mod.rs
@@ -320,6 +320,18 @@ impl LexerErrorKind {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct LexerError {
+    kind: LexerErrorKind,
+    position: Position,
+}
+
+impl LexerError {
+    fn new(kind: LexerErrorKind, position: Position) -> Self {
+        Self { kind, position }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum TokenPayload<'a> {
     None,
@@ -416,17 +428,23 @@ impl<'a> LexedToken<'a> {
         }
     }
 
-    fn error(kind: LexerErrorKind) -> Self {
+    fn error(error: LexerError) -> Self {
         Self {
             kind: TokenKind::Error,
-            span: Span::new(),
+            span: Span::at(error.position),
             flags: TokenFlags::empty(),
-            payload: TokenPayload::Error(kind),
+            payload: TokenPayload::Error(error.kind),
         }
     }
 
     pub(crate) fn with_span(mut self, span: Span) -> Self {
-        self.span = span;
+        // The error constructor records the failing construct's start; the
+        // outer token wrapper supplies the end reached while lexing it.
+        self.span = if self.kind == TokenKind::Error {
+            Span::from_positions(self.span.start, span.end)
+        } else {
+            span
+        };
         self
     }
 

--- a/crates/shuck-parser/src/parser/lexer/quotes.rs
+++ b/crates/shuck-parser/src/parser/lexer/quotes.rs
@@ -4,11 +4,11 @@ impl<'a> Lexer<'a> {
     pub(in crate::parser) fn read_single_quoted_string(&mut self) -> Option<LexedToken<'a>> {
         let segment = match self.read_single_quoted_segment() {
             Ok(segment) => segment,
-            Err(kind) => return Some(LexedToken::error(kind)),
+            Err(error) => return Some(LexedToken::error(error)),
         };
         let mut word = LexedWord::from_segment(segment);
-        if let Err(kind) = self.append_segmented_continuation(&mut word) {
-            return Some(LexedToken::error(kind));
+        if let Err(error) = self.append_segmented_continuation(&mut word) {
+            return Some(LexedToken::error(error));
         }
 
         Some(LexedToken::with_word_payload(TokenKind::LiteralWord, word))
@@ -16,7 +16,7 @@ impl<'a> Lexer<'a> {
 
     pub(in crate::parser) fn read_single_quoted_segment(
         &mut self,
-    ) -> Result<LexedWordSegment<'a>, LexerErrorKind> {
+    ) -> Result<LexedWordSegment<'a>, LexerError> {
         debug_assert_eq!(self.peek_char(), Some('\''));
 
         let wrapper_start = self.current_position();
@@ -64,7 +64,7 @@ impl<'a> Lexer<'a> {
         }
 
         if !closed {
-            return Err(LexerErrorKind::SingleQuote);
+            return Err(LexerError::new(LexerErrorKind::SingleQuote, wrapper_start));
         }
 
         let wrapper_span = Some(Span::from_positions(wrapper_start, self.current_position()));
@@ -90,11 +90,11 @@ impl<'a> Lexer<'a> {
     pub(in crate::parser) fn read_dollar_single_quoted_string(&mut self) -> Option<LexedToken<'a>> {
         let segment = match self.read_dollar_single_quoted_segment() {
             Ok(segment) => segment,
-            Err(kind) => return Some(LexedToken::error(kind)),
+            Err(error) => return Some(LexedToken::error(error)),
         };
         let mut word = LexedWord::from_segment(segment);
-        if let Err(kind) = self.append_segmented_continuation(&mut word) {
-            return Some(LexedToken::error(kind));
+        if let Err(error) = self.append_segmented_continuation(&mut word) {
+            return Some(LexedToken::error(error));
         }
 
         let kind = if word.single_segment().is_some() {
@@ -108,7 +108,7 @@ impl<'a> Lexer<'a> {
 
     pub(in crate::parser) fn read_dollar_single_quoted_segment(
         &mut self,
-    ) -> Result<LexedWordSegment<'a>, LexerErrorKind> {
+    ) -> Result<LexedWordSegment<'a>, LexerError> {
         debug_assert_eq!(self.peek_char(), Some('$'));
         debug_assert_eq!(self.second_char(), Some('\''));
 
@@ -242,7 +242,7 @@ impl<'a> Lexer<'a> {
             self.advance();
         }
 
-        Err(LexerErrorKind::SingleQuote)
+        Err(LexerError::new(LexerErrorKind::SingleQuote, wrapper_start))
     }
     pub(in crate::parser) fn read_double_quoted_string(&mut self) -> Option<LexedToken<'a>> {
         self.read_double_quoted_word(false)
@@ -258,11 +258,11 @@ impl<'a> Lexer<'a> {
     ) -> Option<LexedToken<'a>> {
         let segment = match self.read_double_quoted_segment_with_dollar(dollar) {
             Ok(segment) => segment,
-            Err(kind) => return Some(LexedToken::error(kind)),
+            Err(error) => return Some(LexedToken::error(error)),
         };
         let mut word = LexedWord::from_segment(segment);
-        if let Err(kind) = self.append_segmented_continuation(&mut word) {
-            return Some(LexedToken::error(kind));
+        if let Err(error) = self.append_segmented_continuation(&mut word) {
+            return Some(LexedToken::error(error));
         }
 
         let kind = if word.single_segment().is_some() {
@@ -276,20 +276,20 @@ impl<'a> Lexer<'a> {
 
     pub(in crate::parser) fn read_double_quoted_segment(
         &mut self,
-    ) -> Result<LexedWordSegment<'a>, LexerErrorKind> {
+    ) -> Result<LexedWordSegment<'a>, LexerError> {
         self.read_double_quoted_segment_with_dollar(false)
     }
 
     pub(in crate::parser) fn read_dollar_double_quoted_segment(
         &mut self,
-    ) -> Result<LexedWordSegment<'a>, LexerErrorKind> {
+    ) -> Result<LexedWordSegment<'a>, LexerError> {
         self.read_double_quoted_segment_with_dollar(true)
     }
 
     pub(in crate::parser) fn read_double_quoted_segment_with_dollar(
         &mut self,
         dollar: bool,
-    ) -> Result<LexedWordSegment<'a>, LexerErrorKind> {
+    ) -> Result<LexedWordSegment<'a>, LexerError> {
         if dollar {
             debug_assert_eq!(self.peek_char(), Some('$'));
             debug_assert_eq!(self.second_char(), Some('"'));
@@ -321,7 +321,10 @@ impl<'a> Lexer<'a> {
                         }
                         None => {
                             self.consume_source_bytes(rest.len());
-                            return Err(LexerErrorKind::DoubleQuote);
+                            return Err(LexerError::new(
+                                LexerErrorKind::DoubleQuote,
+                                wrapper_start,
+                            ));
                         }
                         _ => {}
                     }
@@ -464,7 +467,7 @@ impl<'a> Lexer<'a> {
         }
 
         if !closed {
-            return Err(LexerErrorKind::DoubleQuote);
+            return Err(LexerError::new(LexerErrorKind::DoubleQuote, wrapper_start));
         }
 
         let wrapper_span = Some(Span::from_positions(wrapper_start, self.current_position()));

--- a/crates/shuck-parser/src/parser/lexer/tests/quotes.rs
+++ b/crates/shuck-parser/src/parser/lexer/tests/quotes.rs
@@ -20,6 +20,21 @@ fn test_double_quoted_string() {
 }
 
 #[test]
+fn test_unterminated_segmented_quote_error_span_starts_at_quote() {
+    let source = "prefix=ok\"first line\nsecond line";
+    let mut lexer = Lexer::new(source);
+
+    let token = lexer.next_lexed_token().unwrap();
+
+    assert_eq!(token.kind, TokenKind::Error);
+    assert_eq!(token.error_kind(), Some(LexerErrorKind::DoubleQuote));
+    assert_eq!(token.span.start.line, 1);
+    assert_eq!(token.span.start.column, 10);
+    assert_eq!(token.span.start.offset, 9);
+    assert_eq!(token.span.end.offset, source.len());
+}
+
+#[test]
 fn test_brace_expansion_token_ignores_quoted_closers() {
     let mut lexer = Lexer::new("echo {\"}\",a}\n");
 

--- a/crates/shuck-parser/src/parser/lexer/word.rs
+++ b/crates/shuck-parser/src/parser/lexer/word.rs
@@ -93,14 +93,14 @@ impl<'a> Lexer<'a> {
     ) -> Option<LexedToken<'a>> {
         let segment = match self.read_unquoted_segment(start) {
             Ok(segment) => segment,
-            Err(kind) => return Some(LexedToken::error(kind)),
+            Err(error) => return Some(LexedToken::error(error)),
         };
         if segment.as_str().is_empty() {
             return None;
         }
         let mut lexed_word = LexedWord::from_segment(segment);
-        if let Err(kind) = self.append_segmented_continuation(&mut lexed_word) {
-            return Some(LexedToken::error(kind));
+        if let Err(error) = self.append_segmented_continuation(&mut lexed_word) {
+            return Some(LexedToken::error(error));
         }
         Some(LexedToken::with_word_payload(TokenKind::Word, lexed_word))
     }
@@ -177,8 +177,8 @@ impl<'a> Lexer<'a> {
         &mut self,
         mut lexed_word: LexedWord<'a>,
     ) -> Option<LexedToken<'a>> {
-        if let Err(kind) = self.append_segmented_continuation(&mut lexed_word) {
-            return Some(LexedToken::error(kind));
+        if let Err(error) = self.append_segmented_continuation(&mut lexed_word) {
+            return Some(LexedToken::error(error));
         }
 
         Some(LexedToken::with_word_payload(TokenKind::Word, lexed_word))
@@ -198,7 +198,7 @@ impl<'a> Lexer<'a> {
 
         let segment = match self.read_unquoted_segment(start) {
             Ok(segment) => segment,
-            Err(kind) => return Some(LexedToken::error(kind)),
+            Err(error) => return Some(LexedToken::error(error)),
         };
 
         if segment.as_str().is_empty() {
@@ -211,12 +211,13 @@ impl<'a> Lexer<'a> {
     pub(in crate::parser) fn read_unquoted_segment(
         &mut self,
         start: Position,
-    ) -> Result<LexedWordSegment<'a>, LexerErrorKind> {
+    ) -> Result<LexedWordSegment<'a>, LexerError> {
         let mut word = (!self.reinject_buf.is_empty()).then(|| String::with_capacity(16));
         while let Some(ch) = self.peek_char() {
             if ch == '"' || ch == '\'' {
                 break;
             } else if ch == '$' {
+                let expansion_start = self.current_position();
                 if matches!(self.second_char(), Some('\'') | Some('"'))
                     && (self.current_position().offset > start.offset
                         || word.as_ref().is_some_and(|word| !word.is_empty()))
@@ -234,18 +235,27 @@ impl<'a> Lexer<'a> {
                     Self::push_capture_char(&mut word, '[');
                     self.advance();
                     if !self.read_legacy_arithmetic_into(&mut word, start) {
-                        return Err(LexerErrorKind::CommandSubstitution);
+                        return Err(LexerError::new(
+                            LexerErrorKind::CommandSubstitution,
+                            expansion_start,
+                        ));
                     }
                 } else if self.peek_char() == Some('(') {
                     if self.second_char() == Some('(') {
                         if !self.read_arithmetic_expansion_into(&mut word) {
-                            return Err(LexerErrorKind::CommandSubstitution);
+                            return Err(LexerError::new(
+                                LexerErrorKind::CommandSubstitution,
+                                expansion_start,
+                            ));
                         }
                     } else {
                         Self::push_capture_char(&mut word, '(');
                         self.advance();
                         if !self.read_command_subst_into(&mut word) {
-                            return Err(LexerErrorKind::CommandSubstitution);
+                            return Err(LexerError::new(
+                                LexerErrorKind::CommandSubstitution,
+                                expansion_start,
+                            ));
                         }
                     }
                 } else if self.peek_char() == Some('{') {
@@ -311,7 +321,10 @@ impl<'a> Lexer<'a> {
                     }
                 }
                 if !closed {
-                    return Err(LexerErrorKind::BacktickSubstitution);
+                    return Err(LexerError::new(
+                        LexerErrorKind::BacktickSubstitution,
+                        capture_end,
+                    ));
                 }
             } else if ch == '\\' {
                 let capture_end = self.current_position();
@@ -536,7 +549,7 @@ impl<'a> Lexer<'a> {
     pub(in crate::parser) fn append_segmented_continuation(
         &mut self,
         word: &mut LexedWord<'a>,
-    ) -> Result<(), LexerErrorKind> {
+    ) -> Result<(), LexerError> {
         loop {
             match self.peek_char() {
                 Some('\\') if self.second_char() == Some('\n') => {

--- a/crates/shuck-parser/src/parser/tests/words/integration.rs
+++ b/crates/shuck-parser/src/parser/tests/words/integration.rs
@@ -19,6 +19,37 @@ fn test_unterminated_double_quote_rejected() {
 }
 
 #[test]
+fn test_unterminated_double_quote_reports_segment_start() {
+    let source = r#"_FFS_TX="${_FFS_TX:-$(cat "${_donation_tx_file"} || { echo BAD; exit 1;}"#;
+    let input = format!("{}{source}", "\n".repeat(26));
+    let parsed = Parser::new(&input).parse();
+    let diagnostic = parsed.diagnostics.first().unwrap();
+
+    assert_eq!(diagnostic.span.start.line, 27);
+    assert_eq!(diagnostic.span.start.column, 9);
+    assert_eq!(diagnostic.span.start.offset, input.find('"').unwrap());
+
+    let Error::Parse { line, column, .. } = parsed.strict_error();
+    assert_eq!((line, column), (27, 9));
+}
+
+#[test]
+fn test_unterminated_multiline_quotes_report_their_opening_tokens() {
+    let cases = [
+        ("prefix=ok\"first line\nsecond line", 10),
+        ("prefix=ok'first line\nsecond line", 10),
+    ];
+
+    for (input, expected_column) in cases {
+        let parsed = Parser::new(input).parse();
+        let diagnostic = parsed.diagnostics.first().unwrap();
+
+        assert_eq!(diagnostic.span.start.line, 1, "{input:?}");
+        assert_eq!(diagnostic.span.start.column, expected_column, "{input:?}");
+    }
+}
+
+#[test]
 fn test_parse_long_suffix_trim_operator_inside_double_quotes() {
     let input = "echo \"${1%%.*}\" \"${package_url%%#*}\"\n";
     let script = Parser::new(input).parse().unwrap().file;


### PR DESCRIPTION
Closes #1178

## Summary

- retain the source position where a lexer failure begins instead of replacing it with the start of the surrounding word
- point unterminated single- and double-quote diagnostics at the opening quote, including segmented and multiline words
- cover the reported nested parameter-expansion/command-substitution case at parser level and the rendered CLI location end to end

## Root cause

Quoted-segment readers returned only a lexer error kind. When the outer word became an error token, its full token span started at the assignment name, so parser recovery propagated column 1. Lexer errors now carry the cursor position of the failing construct, and the final error span combines that retained start with the consumed token end without rescanning or allocating.

Shuck uses one-based columns, so the reported fixture's opening double quote is column 9; column 10 is the following `$`.

## Validation

Passed:

- `cargo fmt --all -- --check`
- `cargo test -p shuck-parser unterminated`
- `cargo test -p shuck-parser`
- `cargo test -p shuck-cli --test integration_test check_unterminated_quote_reports_opening_quote_location -- --exact`
- `cargo clippy -p shuck-parser --all-targets --no-deps -- -D warnings -A clippy::while_let_loop`
- `cargo test`

Also attempted `cargo clippy --all-targets -- -D warnings`; the current toolchain reports pre-existing warnings in untouched AST, parser arithmetic, formatter, and semantic files. The documented `cargo test --features http_client` command is no longer runnable because no workspace package defines that feature, so the full plain workspace test suite was used instead.