### PR TITLE
fix(discover): analyze explicit shell inputs

### DIFF
--- a/crates/shuck-cli/tests/integration_test.rs
+++ b/crates/shuck-cli/tests/integration_test.rs
@@ -1950,6 +1950,92 @@ fn check_zsh_shebang_parses_with_inferred_zsh_dialect() {
 }
 
 #[test]
+fn check_analyzes_every_explicit_regular_file() {
+    #[cfg(unix)]
+    use std::os::unix::fs::PermissionsExt;
+
+    let tempdir = tempdir().unwrap();
+    #[cfg(unix)]
+    let executable = tempdir.path().join("tool");
+    for name in ["script", "PKGBUILD", ".bashrc", "notes.txt", "tool"] {
+        fs::write(tempdir.path().join(name), "{\n").unwrap();
+    }
+    #[cfg(unix)]
+    {
+        let mut permissions = fs::metadata(&executable).unwrap().permissions();
+        permissions.set_mode(0o755);
+        fs::set_permissions(&executable, permissions).unwrap();
+    }
+
+    for name in ["script", "PKGBUILD", ".bashrc", "notes.txt", "tool"] {
+        let mut cmd = Command::cargo_bin("shuck").unwrap();
+        configure_env_cache(&mut cmd, tempdir.path());
+        cmd.current_dir(tempdir.path())
+            .args(["check", "--no-cache", name]);
+        cmd.assert()
+            .code(1)
+            .stdout(predicate::str::contains(format!("--> {name}:1:1")));
+    }
+}
+
+#[test]
+fn check_per_file_shell_reaches_explicit_extensionless_file() {
+    let tempdir = tempdir().unwrap();
+    fs::write(tempdir.path().join("configured"), "{\n").unwrap();
+
+    let mut cmd = Command::cargo_bin("shuck").unwrap();
+    configure_env_cache(&mut cmd, tempdir.path());
+    cmd.current_dir(tempdir.path()).args([
+        "check",
+        "--no-cache",
+        "--per-file-shell",
+        "configured:bash",
+        "configured",
+    ]);
+    cmd.assert()
+        .code(1)
+        .stdout(predicate::str::contains("--> configured:1:1"));
+}
+
+#[test]
+fn check_directory_discovery_stays_limited_to_shell_candidates() {
+    #[cfg(unix)]
+    use std::os::unix::fs::PermissionsExt;
+
+    let tempdir = tempdir().unwrap();
+    fs::write(tempdir.path().join("script"), "#!/bin/sh\n{\n").unwrap();
+    fs::write(tempdir.path().join("PKGBUILD"), "{\n").unwrap();
+    fs::write(tempdir.path().join(".bashrc"), "{\n").unwrap();
+    fs::write(tempdir.path().join(".profile"), "{\n").unwrap();
+    fs::write(tempdir.path().join(".zshrc"), "{\n").unwrap();
+    fs::write(tempdir.path().join("unknown"), "{\n").unwrap();
+    fs::write(tempdir.path().join("notes.txt"), "{\n").unwrap();
+    let executable = tempdir.path().join("tool");
+    fs::write(&executable, "{\n").unwrap();
+    #[cfg(unix)]
+    {
+        let mut permissions = fs::metadata(&executable).unwrap().permissions();
+        permissions.set_mode(0o755);
+        fs::set_permissions(&executable, permissions).unwrap();
+    }
+
+    let mut cmd = Command::cargo_bin("shuck").unwrap();
+    configure_env_cache(&mut cmd, tempdir.path());
+    cmd.current_dir(tempdir.path())
+        .args(["check", "--no-cache"]);
+    cmd.assert()
+        .code(1)
+        .stdout(predicate::str::contains("--> script:2:1"))
+        .stdout(predicate::str::contains("--> PKGBUILD:1:1"))
+        .stdout(predicate::str::contains("--> .bashrc:1:1"))
+        .stdout(predicate::str::contains("--> .profile:1:1"))
+        .stdout(predicate::str::contains("--> .zshrc:1:1"))
+        .stdout(predicate::str::contains("--> unknown:").not())
+        .stdout(predicate::str::contains("--> notes.txt:").not())
+        .stdout(predicate::str::contains("--> tool:").not());
+}
+
+#[test]
 fn check_exclude_skips_walked_files_but_not_explicit_files_without_force_exclude() {
     let tempdir = tempdir().unwrap();
     fs::write(tempdir.path().join("ok.sh"), "#!/bin/bash\necho ok\n").unwrap();

--- a/crates/shuck-discover/src/lib.rs
+++ b/crates/shuck-discover/src/lib.rs
@@ -142,9 +142,8 @@ fn collect_input(
             return Ok(());
         }
         collect_directory(input, cwd, project_root, exclude_matcher, options, files)?;
-    } else if metadata.is_file()
-        && let Some(kind) = discovered_file_kind(input)?
-    {
+    } else if metadata.is_file() {
+        let kind = explicit_file_kind(input)?;
         if options.force_exclude {
             if exclude_matcher.matches(input, cwd) {
                 return Ok(());
@@ -629,6 +628,15 @@ fn discovered_file_kind(path: &Path) -> Result<Option<FileKind>> {
     Ok(None)
 }
 
+fn explicit_file_kind(path: &Path) -> Result<FileKind> {
+    // A directly named regular file is an authoritative request to process that
+    // file. Preserve embedded-host detection, but otherwise let the shell parser
+    // decide whether the contents are valid instead of silently dropping the
+    // input. Directory walks continue to use `discovered_file_kind` so unknown
+    // files are not parsed indiscriminately.
+    Ok(discovered_file_kind(path)?.unwrap_or(FileKind::Shell))
+}
+
 fn read_shebang_prefix(path: &Path) -> Result<Vec<u8>> {
     let file = fs::File::open(path).with_context(|| format!("open {}", path.display()))?;
     let mut reader = BufReader::new(file).take(SHEBANG_SNIFF_LIMIT_BYTES);
@@ -701,6 +709,8 @@ impl ExcludeMatcher {
 
 #[cfg(test)]
 mod tests {
+    #[cfg(unix)]
+    use std::os::unix::fs::PermissionsExt;
     use std::path::PathBuf;
 
     use tempfile::tempdir;
@@ -745,6 +755,16 @@ mod tests {
     }
 
     #[test]
+    fn detects_known_shell_filenames_without_shebangs() {
+        let tempdir = tempdir().unwrap();
+        for name in ["PKGBUILD", ".bashrc", ".profile"] {
+            let script = tempdir.path().join(name);
+            fs::write(&script, "echo ok\n").unwrap();
+            assert!(is_shell_script(&script).unwrap(), "{name}");
+        }
+    }
+
+    #[test]
     fn detects_extensionless_compdef_completion_file() {
         let tempdir = tempdir().unwrap();
         let script = tempdir.path().join("_zdot");
@@ -782,6 +802,74 @@ mod tests {
         fs::write(&file, vec![b'x'; (SHEBANG_SNIFF_LIMIT_BYTES as usize) * 2]).unwrap();
 
         assert!(!is_shell_script(&file).unwrap());
+    }
+
+    #[test]
+    fn explicit_regular_files_bypass_recursive_candidate_filtering() {
+        let tempdir = tempdir().unwrap();
+        let extensionless = tempdir.path().join("script");
+        let executable = tempdir.path().join("tool");
+        let non_shell = tempdir.path().join("notes.txt");
+        for path in [&extensionless, &executable, &non_shell] {
+            fs::write(path, "plain text without a shell marker\n").unwrap();
+        }
+        #[cfg(unix)]
+        {
+            let mut permissions = fs::metadata(&executable).unwrap().permissions();
+            permissions.set_mode(0o755);
+            fs::set_permissions(&executable, permissions).unwrap();
+        }
+
+        let files = discover_files(
+            &[extensionless, executable, non_shell],
+            tempdir.path(),
+            &DiscoveryOptions::default(),
+        )
+        .unwrap();
+
+        assert_eq!(files.len(), 3);
+        assert!(files.iter().all(|file| file.kind == FileKind::Shell));
+    }
+
+    #[test]
+    fn directory_walk_keeps_unknown_regular_files_filtered() {
+        let tempdir = tempdir().unwrap();
+        let executable = tempdir.path().join("tool");
+        fs::write(&executable, "plain text without a shell marker\n").unwrap();
+        #[cfg(unix)]
+        {
+            let mut permissions = fs::metadata(&executable).unwrap().permissions();
+            permissions.set_mode(0o755);
+            fs::set_permissions(&executable, permissions).unwrap();
+        }
+        fs::write(tempdir.path().join("notes.txt"), "not shell\n").unwrap();
+        fs::write(tempdir.path().join("script"), "#!/bin/sh\necho ok\n").unwrap();
+        fs::write(tempdir.path().join("PKGBUILD"), "echo package\n").unwrap();
+        fs::write(tempdir.path().join(".bashrc"), "echo bash\n").unwrap();
+        fs::write(tempdir.path().join(".profile"), "echo profile\n").unwrap();
+        fs::write(tempdir.path().join(".zshrc"), "print zsh\n").unwrap();
+
+        let files = discover_files(
+            &[tempdir.path().to_path_buf()],
+            tempdir.path(),
+            &DiscoveryOptions::default(),
+        )
+        .unwrap();
+        let display_paths = files
+            .iter()
+            .map(|file| file.display_path.clone())
+            .collect::<Vec<_>>();
+
+        assert_eq!(
+            display_paths,
+            vec![
+                PathBuf::from(".bashrc"),
+                PathBuf::from(".profile"),
+                PathBuf::from(".zshrc"),
+                PathBuf::from("PKGBUILD"),
+                PathBuf::from("script"),
+            ]
+        );
     }
 
     #[test]

--- a/crates/shuck-linter/src/shell.rs
+++ b/crates/shuck-linter/src/shell.rs
@@ -79,9 +79,7 @@ impl ShellDialect {
             _ => path
                 .file_name()
                 .and_then(|name| name.to_str())
-                .filter(|name| is_known_zsh_dotfile_name(name))
-                .map(|_| Self::Zsh)
-                .unwrap_or(Self::Unknown),
+                .map_or(Self::Unknown, infer_from_known_shell_filename),
         }
     }
 
@@ -555,20 +553,18 @@ fn is_shell_name_byte(byte: u8) -> bool {
     byte == b'_' || byte.is_ascii_alphanumeric()
 }
 
-fn is_known_zsh_dotfile_name(name: &str) -> bool {
-    matches!(
-        name.to_ascii_lowercase().as_str(),
-        ".zshrc"
-            | "zshrc"
-            | ".zshenv"
-            | "zshenv"
-            | ".zprofile"
-            | "zprofile"
-            | ".zlogin"
-            | "zlogin"
-            | ".zlogout"
-            | "zlogout"
-    )
+fn infer_from_known_shell_filename(name: &str) -> ShellDialect {
+    if name == "PKGBUILD" {
+        return ShellDialect::Bash;
+    }
+
+    match name.to_ascii_lowercase().as_str() {
+        ".bashrc" | "bashrc" => ShellDialect::Bash,
+        ".profile" | "profile" => ShellDialect::Sh,
+        ".zshrc" | "zshrc" | ".zshenv" | "zshenv" | ".zprofile" | "zprofile" | ".zlogin"
+        | "zlogin" | ".zlogout" | "zlogout" => ShellDialect::Zsh,
+        _ => ShellDialect::Unknown,
+    }
 }
 
 fn shell_words(line: &str) -> Vec<&str> {
@@ -606,6 +602,18 @@ mod tests {
             Some(Path::new("/tmp/.zshrc")),
         );
         assert_eq!(inferred, ShellDialect::Zsh);
+    }
+
+    #[test]
+    fn infers_known_shell_filenames_without_extensions() {
+        for (path, expected) in [
+            ("/tmp/PKGBUILD", ShellDialect::Bash),
+            ("/tmp/.bashrc", ShellDialect::Bash),
+            ("/tmp/.profile", ShellDialect::Sh),
+            ("/tmp/.zshrc", ShellDialect::Zsh),
+        ] {
+            assert_eq!(ShellDialect::infer_from_path(Path::new(path)), expected);
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- treat directly named regular files as authoritative inputs, preserving embedded-host detection while falling back to shell analysis instead of silently skipping them
- keep recursive discovery conservative, while recognizing PKGBUILD, .bashrc, and .profile through the central filename-to-dialect policy
- add regression coverage for extensionless shebangs, known shell filenames and dotfiles, executable inputs, per-file shell overrides, arbitrary explicit files, and truly non-shell recursive candidates

## Root cause

Explicit files and directory-walk candidates used the same recognition gate. When an explicit path had no known shell extension, supported shebang, known filename, or embedded-file handler, discovery returned no file at all. That happened before per-file settings or parsing, so the command reported success without checking the requested input.

## Behavior

Directly named regular files are now analyzed even when their name and contents provide no discovery signal. Directory walks still require a supported extension, shell shebang, known shell filename, zsh autoload marker, or embedded host format, so recursive checks do not parse arbitrary text or extensionless executables indiscriminately.

Closes #1177.

## Validation

- `cargo test -p shuck-discover`
- `cargo test -p shuck-linter infers_known_shell_filenames_without_extensions`
- `cargo test -p shuck-cli --test integration_test check_analyzes_every_explicit_regular_file -- --exact`
- `cargo test -p shuck-cli --test integration_test check_per_file_shell_reaches_explicit_extensionless_file -- --exact`
- `cargo test -p shuck-cli --test integration_test check_directory_discovery_stays_limited_to_shell_candidates -- --exact`
- `make test`
- `cargo fmt --check`
- `make check-scripts`
- `cargo clippy -p shuck-discover -p shuck-linter -p shuck-cli --all-targets --all-features --no-deps -- -D warnings -A clippy::unneeded-wildcard-pattern -A clippy::some-filter -A clippy::while-let-loop -A clippy::question-mark`

Local `make check` reaches clippy but Rust 1.97 reports unrelated pre-existing warnings in untouched workspace files; the local environment also lacks `nix` for the cargo-shear step.