### PR TITLE
feat(formatter): support config-based file exclusions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1833,6 +1833,7 @@ dependencies = [
  "anyhow",
  "clap",
  "etcetera",
+ "globset",
  "serde",
  "shuck-formatter",
  "shuck-run",

--- a/README.md
+++ b/README.md
@@ -383,6 +383,7 @@ extend-per-file-shell = { "tools/**/*.zsh" = "zsh" }
 
 [format]
 # Configure `shuck format` and editor formatting.
+exclude = ["generated/**"] # project-relative globs that should never be formatted
 indent-style = "tab"       # tab | space
 indent-width = 4           # used when indent-style = "space"
 binary-next-line = false   # put binary operators on continuation lines
@@ -392,6 +393,11 @@ keep-padding = false       # preserve safe horizontal padding
 function-next-line = false # put function opening braces on their own line
 never-split = false        # prefer compact layouts
 ```
+
+`format.exclude` applies to directory discovery, explicitly named files, and
+whole-document or range formatting requested through the language server. This
+makes it suitable for generated files that must remain untouched even when an
+editor has format-on-save enabled.
 
 Formatter dialect is inferred from the file name or shebang. For stdin or one-off formatting runs, use `shuck format --dialect bash|posix|mksh|zsh`.
 

--- a/crates/shuck-cli/src/commands/format.rs
+++ b/crates/shuck-cli/src/commands/format.rs
@@ -183,7 +183,9 @@ fn run_format_with_cwd(
     let mut report = FormatReport::default();
 
     for mut run in runs {
-        run.files.retain(|file| file.kind == FileKind::Shell);
+        run.files.retain(|file| {
+            file.kind == FileKind::Shell && !run.settings.is_file_excluded(&file.absolute_path)
+        });
         let settings = run.settings.to_shell_format_options();
         let pending = run.take_pending_files(|file, cached| {
             report.cache_hits += 1;

--- a/crates/shuck-cli/src/format_settings.rs
+++ b/crates/shuck-cli/src/format_settings.rs
@@ -2,7 +2,7 @@ use std::path::Path;
 
 use anyhow::{Result, anyhow};
 use shuck_cache::{CacheKey, CacheKeyHasher};
-use shuck_config::{ConfigArguments, FormatSettingsPatch, load_project_config};
+use shuck_config::{ConfigArguments, FormatExclusions, FormatSettingsPatch, load_project_config};
 use shuck_formatter::{IndentStyle, ShellDialect, ShellFormatOptions};
 
 const CLI_INDENT_WIDTH_ERROR: &str = "`--indent-width` must be at least 1";
@@ -11,6 +11,7 @@ const CONFIG_INDENT_WIDTH_ERROR: &str = "`[format].indent-width` must be at leas
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub(crate) struct ResolvedFormatSettings {
     options: ShellFormatOptions,
+    exclusions: FormatExclusions,
 }
 
 impl CacheKey for ResolvedFormatSettings {
@@ -27,12 +28,17 @@ impl CacheKey for ResolvedFormatSettings {
         state.write_bool(self.options.never_split());
         state.write_bool(self.options.simplify());
         state.write_bool(self.options.minify());
+        self.exclusions.patterns().cache_key(state);
     }
 }
 
 impl ResolvedFormatSettings {
     pub(crate) fn to_shell_format_options(&self) -> ShellFormatOptions {
         self.options.clone()
+    }
+
+    pub(crate) fn is_file_excluded(&self, path: &Path) -> bool {
+        self.exclusions.is_excluded(path)
     }
 
     fn apply_patch(&mut self, patch: FormatSettingsPatch, indent_width_error: &str) -> Result<()> {
@@ -87,8 +93,12 @@ pub(crate) fn resolve_project_format_settings(
 ) -> Result<ResolvedFormatSettings> {
     let config = load_project_config(project_root, config_arguments)?;
     let config_patch = config.format.to_patch()?;
+    let exclusions = config.format.compile_exclusions(project_root)?;
 
-    let mut settings = ResolvedFormatSettings::default();
+    let mut settings = ResolvedFormatSettings {
+        exclusions,
+        ..ResolvedFormatSettings::default()
+    };
     settings.apply_patch(config_patch, CONFIG_INDENT_WIDTH_ERROR)?;
     settings.apply_patch(cli_patch, CLI_INDENT_WIDTH_ERROR)?;
     Ok(settings)

--- a/crates/shuck-cli/tests/integration_test.rs
+++ b/crates/shuck-cli/tests/integration_test.rs
@@ -2236,6 +2236,49 @@ fn format_exclude_skips_walked_files_but_not_explicit_files_without_force_exclud
 }
 
 #[test]
+fn format_config_exclude_skips_walked_and_explicit_files_per_project() {
+    let tempdir = tempdir().unwrap();
+    let nested = tempdir.path().join("nested");
+    fs::create_dir_all(&nested).unwrap();
+    fs::write(tempdir.path().join("shuck.toml"), "[format]\n").unwrap();
+    fs::write(
+        nested.join("shuck.toml"),
+        "[format]\nexclude = ['**/*p10k.zsh']\n",
+    )
+    .unwrap();
+
+    let regular = nested.join("regular.zsh");
+    let generated = nested.join(".p10k.zsh");
+    let unformatted_regular = "if true; then\nprint ok\nfi\n";
+    let formatted_regular = "if true; then\n\tprint ok\nfi\n";
+    let unformatted_generated = "if true\n";
+    fs::write(&regular, unformatted_regular).unwrap();
+    fs::write(&generated, unformatted_generated).unwrap();
+
+    let mut walked = Command::cargo_bin("shuck").unwrap();
+    configure_env_cache(&mut walked, tempdir.path());
+    walked.current_dir(tempdir.path()).arg("format");
+    walked.assert().success().stdout("");
+
+    assert_eq!(fs::read_to_string(&regular).unwrap(), formatted_regular);
+    assert_eq!(
+        fs::read_to_string(&generated).unwrap(),
+        unformatted_generated
+    );
+
+    let mut explicit = Command::cargo_bin("shuck").unwrap();
+    configure_env_cache(&mut explicit, tempdir.path());
+    explicit
+        .current_dir(tempdir.path())
+        .args(["format", "nested/.p10k.zsh"]);
+    explicit.assert().success().stdout("");
+    assert_eq!(
+        fs::read_to_string(&generated).unwrap(),
+        unformatted_generated
+    );
+}
+
+#[test]
 fn format_gitignore_and_force_exclude_flags_control_explicit_files() {
     let tempdir = tempdir().unwrap();
     fs::write(tempdir.path().join(".gitignore"), "ignored.sh\n").unwrap();

--- a/crates/shuck-config/Cargo.toml
+++ b/crates/shuck-config/Cargo.toml
@@ -12,6 +12,7 @@ description = "Configuration loading and project-root discovery for shuck"
 anyhow = { workspace = true }
 clap = { workspace = true }
 etcetera = { workspace = true }
+globset = { workspace = true }
 serde = { workspace = true }
 shuck-formatter = { workspace = true }
 shuck-run = { workspace = true }

--- a/crates/shuck-config/src/lib.rs
+++ b/crates/shuck-config/src/lib.rs
@@ -17,6 +17,7 @@ use std::str::FromStr;
 use anyhow::{Context, Result, anyhow};
 use clap::builder::{TypedValueParser, ValueParserFactory};
 use clap::error::{ContextKind, ContextValue, ErrorKind};
+use globset::{Glob, GlobSet, GlobSetBuilder};
 use serde::Deserialize;
 use shuck_formatter::{IndentStyle, ShellDialect};
 use shuck_run::RunConfig;
@@ -32,6 +33,7 @@ const CONFIG_OVERRIDE_ROOT_KEYS: &[&str] = &["check", "format", "lint", "run"];
 const CONFIG_OVERRIDE_CHECK_KEYS: &[&str] = &["embedded"];
 const CONFIG_OVERRIDE_FORMAT_KEYS: &[&str] = &[
     "dialect",
+    "exclude",
     "indent-style",
     "indent-width",
     "binary-next-line",
@@ -133,6 +135,8 @@ pub struct CheckConfig {
 pub struct FormatConfig {
     /// Deprecated formatter dialect value retained only to reject config-file use clearly.
     pub dialect: Option<toml::Value>,
+    /// Project-relative glob patterns for files that should not be formatted.
+    pub exclude: Option<Vec<String>>,
     /// Requested indentation style, such as `tab` or `space`.
     pub indent_style: Option<String>,
     /// Requested indentation width.
@@ -149,6 +153,96 @@ pub struct FormatConfig {
     pub function_next_line: Option<bool>,
     /// Whether the formatter should avoid splitting lines.
     pub never_split: Option<bool>,
+}
+
+/// Compiled formatter exclusions resolved relative to one project root.
+#[derive(Debug, Clone)]
+pub struct FormatExclusions {
+    project_root: PathBuf,
+    canonical_project_root: Option<PathBuf>,
+    patterns: Vec<String>,
+    matcher: Option<GlobSet>,
+}
+
+impl PartialEq for FormatExclusions {
+    fn eq(&self, other: &Self) -> bool {
+        self.project_root == other.project_root
+            && self.canonical_project_root == other.canonical_project_root
+            && self.patterns == other.patterns
+    }
+}
+
+impl Eq for FormatExclusions {}
+
+impl FormatExclusions {
+    fn compile(project_root: &Path, patterns: &[String]) -> Result<Self> {
+        let project_root = normalize_path(project_root);
+        let canonical_project_root = fs::canonicalize(&project_root)
+            .ok()
+            .map(|path| normalize_path(&path))
+            .filter(|path| path != &project_root);
+
+        if patterns.is_empty() {
+            return Ok(Self {
+                project_root,
+                canonical_project_root,
+                patterns: Vec::new(),
+                matcher: None,
+            });
+        }
+
+        let mut builder = GlobSetBuilder::new();
+        for pattern in patterns {
+            builder.add(
+                Glob::new(pattern)
+                    .with_context(|| format!("invalid `[format].exclude` pattern `{pattern}`"))?,
+            );
+        }
+
+        Ok(Self {
+            project_root,
+            canonical_project_root,
+            patterns: patterns.to_vec(),
+            matcher: Some(builder.build()?),
+        })
+    }
+
+    /// Return the configured glob patterns in declaration order.
+    pub fn patterns(&self) -> &[String] {
+        &self.patterns
+    }
+
+    /// Return whether a path is excluded from formatting.
+    pub fn is_excluded(&self, path: &Path) -> bool {
+        let Some(matcher) = &self.matcher else {
+            return false;
+        };
+
+        let path = normalize_path(path);
+        let relative_path = path.strip_prefix(&self.project_root).ok().or_else(|| {
+            self.canonical_project_root
+                .as_deref()
+                .and_then(|root| path.strip_prefix(root).ok())
+        });
+
+        relative_path.is_some_and(|path| matcher.is_match(path))
+            || matcher.is_match(&path)
+            || relative_path
+                .unwrap_or(&path)
+                .file_name()
+                .is_some_and(|file_name| matcher.is_match(Path::new(file_name)))
+    }
+}
+
+impl Default for FormatExclusions {
+    fn default() -> Self {
+        Self {
+            project_root: PathBuf::from("."),
+            canonical_project_root: None,
+            patterns: Vec::new(),
+            matcher: None,
+        }
+    }
 }
 
 /// Configuration for lint rule selection and analysis behavior.
@@ -806,7 +900,7 @@ const CONFIGURATION_METADATA: [ConfigSectionMetadata; 4] = [
     },
     ConfigSectionMetadata {
         key: "format",
-        docs: "Formatter style options for `shuck format`.",
+        docs: "Formatter file-selection and style options for `shuck format` and editor formatting.",
         fields: &[
             ConfigFieldMetadata {
                 key: "binary-next-line",
@@ -814,6 +908,13 @@ const CONFIGURATION_METADATA: [ConfigSectionMetadata; 4] = [
                 default: "false",
                 value_type: "bool",
                 example: "binary-next-line = true",
+            },
+            ConfigFieldMetadata {
+                key: "exclude",
+                docs: "Do not format files matching these project-relative glob patterns.",
+                default: "[]",
+                value_type: "list[str]",
+                example: r#"exclude = ["generated/**"]"#,
             },
             ConfigFieldMetadata {
                 key: "function-next-line",
@@ -1668,6 +1769,11 @@ impl FormatConfig {
             minify: None,
         })
     }
+
+    /// Compile formatter exclusions relative to the given project root.
+    pub fn compile_exclusions(&self, project_root: &Path) -> Result<FormatExclusions> {
+        FormatExclusions::compile(project_root, self.exclude.as_deref().unwrap_or_default())
+    }
 }
 
 impl ShuckConfig {
@@ -1691,6 +1797,9 @@ impl FormatConfig {
     fn apply_overrides(&mut self, overrides: FormatConfig) {
         if overrides.dialect.is_some() {
             self.dialect = overrides.dialect;
+        }
+        if overrides.exclude.is_some() {
+            self.exclude = overrides.exclude;
         }
         if overrides.indent_style.is_some() {
             self.indent_style = overrides.indent_style;
@@ -2486,6 +2595,42 @@ mod tests {
     fn inline_config_overrides_validate_supported_keys() {
         let config = parse_config_override("format.indent-width = 2").unwrap();
         assert_eq!(config.format.indent_width, Some(2));
+    }
+
+    #[test]
+    fn inline_config_overrides_accept_format_exclusions() {
+        let config = parse_config_override("format.exclude = ['generated/**']").unwrap();
+        assert_eq!(config.format.exclude, Some(vec!["generated/**".to_owned()]));
+    }
+
+    #[test]
+    fn format_exclusions_match_project_relative_paths_and_basenames() {
+        let project_root = Path::new("/workspace/project");
+        let config = FormatConfig {
+            exclude: Some(vec!["generated/**".to_owned(), "*.generated.sh".to_owned()]),
+            ..FormatConfig::default()
+        };
+        let exclusions = config.compile_exclusions(project_root).unwrap();
+
+        assert!(exclusions.is_excluded(Path::new("/workspace/project/generated/script.sh")));
+        assert!(exclusions.is_excluded(Path::new("/workspace/project/scripts/tool.generated.sh")));
+        assert!(!exclusions.is_excluded(Path::new("/workspace/project/scripts/tool.sh")));
+        assert!(!exclusions.is_excluded(Path::new("/workspace/other/generated/script.sh")));
+    }
+
+    #[test]
+    fn format_exclusions_reject_invalid_globs() {
+        let config = FormatConfig {
+            exclude: Some(vec!["[".to_owned()]),
+            ..FormatConfig::default()
+        };
+
+        let error = config.compile_exclusions(Path::new(".")).unwrap_err();
+        assert!(
+            error
+                .to_string()
+                .contains("invalid `[format].exclude` pattern `[`")
+        );
     }
 
     #[test]

--- a/crates/shuck-server/src/format.rs
+++ b/crates/shuck-server/src/format.rs
@@ -14,10 +14,17 @@ pub(crate) fn format_document(
     _params: types::DocumentFormattingParams,
 ) -> crate::server::Result<FormatResponse> {
     let query = snapshot.query();
+    let file_path = query.file_path();
+    if snapshot
+        .shuck_settings()
+        .is_format_excluded(file_path.as_deref())
+    {
+        return Ok(None);
+    }
     let source = query.document().contents();
     let formatted = shuck_formatter::format_source(
         source,
-        query.file_path().as_deref(),
+        file_path.as_deref(),
         snapshot.shuck_settings().formatter(),
     )
     .map_err(Error::new)?;
@@ -40,6 +47,13 @@ pub(crate) fn format_range(
     _client: &Client,
     params: types::DocumentRangeFormattingParams,
 ) -> crate::server::Result<FormatResponse> {
+    let file_path = snapshot.query().file_path();
+    if snapshot
+        .shuck_settings()
+        .is_format_excluded(file_path.as_deref())
+    {
+        return Ok(None);
+    }
     let Some(analysis) = snapshot.analysis() else {
         return Ok(None);
     };
@@ -57,7 +71,7 @@ pub(crate) fn format_range(
         &source[usize::from(statement_range.start())..usize::from(statement_range.end())];
     let formatted = shuck_formatter::format_source(
         statement_source,
-        snapshot.query().file_path().as_deref(),
+        file_path.as_deref(),
         snapshot.shuck_settings().formatter(),
     )
     .map_err(Error::new)?;
@@ -245,6 +259,69 @@ mod tests {
         assert_eq!(edits[0].range.start, types::Position::new(1, 0));
         assert_eq!(edits[0].range.end, types::Position::new(1, 0));
         assert_eq!(edits[0].new_text, "\t");
+    }
+
+    #[test]
+    fn formatting_returns_none_for_config_excluded_document() {
+        let tempdir = tempfile::tempdir().expect("workspace should be created");
+        std::fs::write(
+            tempdir.path().join("shuck.toml"),
+            "[format]\nexclude = ['**/*p10k.zsh']\n",
+        )
+        .expect("config should be written");
+
+        let (main_loop_sender, _main_loop_receiver) = channel::unbounded();
+        let (client_sender, _client_receiver) = channel::unbounded();
+        let client = Client::new(main_loop_sender, client_sender);
+        let workspace_uri =
+            Url::from_file_path(tempdir.path()).expect("workspace path should convert to a URL");
+        let workspaces = Workspaces::new(vec![Workspace::default(workspace_uri)]);
+        let global = GlobalOptions::default().into_settings(client.clone());
+        let mut session = Session::new(
+            &ClientCapabilities::default(),
+            PositionEncoding::UTF16,
+            global,
+            &workspaces,
+            &client,
+        )
+        .expect("test session should initialize");
+
+        let uri = Url::from_file_path(tempdir.path().join(".p10k.zsh"))
+            .expect("script path should convert to a URL");
+        session.open_text_document(
+            uri.clone(),
+            TextDocument::new("if true; then\nprint ok\nfi\n".to_owned(), 1)
+                .with_language_id("shellscript"),
+        );
+
+        let document_response = format_document(
+            session
+                .take_snapshot(uri.clone())
+                .expect("test document should produce a snapshot"),
+            &client,
+            types::DocumentFormattingParams {
+                text_document: types::TextDocumentIdentifier { uri: uri.clone() },
+                options: types::FormattingOptions::default(),
+                work_done_progress_params: types::WorkDoneProgressParams::default(),
+            },
+        )
+        .expect("document formatting should succeed");
+        assert!(document_response.is_none());
+
+        let range_response = format_range(
+            session
+                .take_snapshot(uri.clone())
+                .expect("test document should produce a snapshot"),
+            &client,
+            types::DocumentRangeFormattingParams {
+                text_document: types::TextDocumentIdentifier { uri },
+                range: types::Range::new(types::Position::new(0, 0), types::Position::new(2, 2)),
+                options: types::FormattingOptions::default(),
+                work_done_progress_params: types::WorkDoneProgressParams::default(),
+            },
+        )
+        .expect("range formatting should succeed");
+        assert!(range_response.is_none());
     }
 
     #[test]

--- a/crates/shuck-server/src/session/settings.rs
+++ b/crates/shuck-server/src/session/settings.rs
@@ -5,8 +5,8 @@ use std::sync::Arc;
 
 use globset::{Glob, GlobMatcher};
 use shuck_config::{
-    ConfigArguments, FormatSettingsPatch, LintConfig, ShuckConfig, apply_config_overrides,
-    load_project_config, resolve_project_root_for_file,
+    ConfigArguments, FormatExclusions, FormatSettingsPatch, LintConfig, ShuckConfig,
+    apply_config_overrides, load_project_config, resolve_project_root_for_file,
 };
 use shuck_formatter::{ShellDialect as FormatDialect, ShellFormatOptions};
 use shuck_linter::{
@@ -31,6 +31,7 @@ pub(crate) struct ClientSettings {
 pub struct ShuckSettings {
     linter: LinterSettings,
     formatter: ShellFormatOptions,
+    format_exclusions: FormatExclusions,
     fixable_rules: RuleSet,
     project_root: Option<PathBuf>,
 }
@@ -45,6 +46,7 @@ pub(crate) struct SettingsResolveContext {
 pub(crate) struct ResolvedProjectSettings {
     linter: ResolvedLinterSettings,
     formatter: ShellFormatOptions,
+    format_exclusions: FormatExclusions,
     fixable_rules: RuleSet,
     project_root: Option<PathBuf>,
 }
@@ -137,6 +139,10 @@ impl ShuckSettings {
         &self.formatter
     }
 
+    pub(crate) fn is_format_excluded(&self, path: Option<&Path>) -> bool {
+        path.is_some_and(|path| self.format_exclusions.is_excluded(path))
+    }
+
     pub(crate) fn fixable_rules(&self) -> RuleSet {
         self.fixable_rules
     }
@@ -151,6 +157,7 @@ impl Default for ShuckSettings {
         Self {
             linter: LinterSettings::default(),
             formatter: ShellFormatOptions::default(),
+            format_exclusions: FormatExclusions::default(),
             fixable_rules: RuleSet::all(),
             project_root: None,
         }
@@ -206,6 +213,13 @@ impl ResolvedProjectSettings {
                 )
             })
             .unwrap_or_default();
+        let format_config = format_config_for_layers(&project_config, option_layers);
+        let format_exclusions = format_config
+            .compile_exclusions(context.config_root())
+            .unwrap_or_else(|error| {
+                tracing::warn!("Failed to compile formatter exclusions: {error}");
+                FormatExclusions::default()
+            });
 
         Self {
             linter: resolved_linter_settings_for_layers(
@@ -213,7 +227,8 @@ impl ResolvedProjectSettings {
                 &project_config,
                 option_layers,
             ),
-            formatter: formatter_settings_for_layers(&project_config, option_layers),
+            formatter: formatter_settings_for_config(&format_config),
+            format_exclusions,
             fixable_rules: fixable_rules_for_layers(&project_config, option_layers),
             project_root: context.project_root.clone(),
         }
@@ -223,6 +238,7 @@ impl ResolvedProjectSettings {
         ShuckSettings {
             linter: self.linter.for_file(file_path),
             formatter: self.formatter.clone(),
+            format_exclusions: self.format_exclusions.clone(),
             fixable_rules: self.fixable_rules,
             project_root: self.project_root.clone(),
         }
@@ -371,10 +387,10 @@ fn resolved_linter_settings_for_layers(
     }
 }
 
-fn formatter_settings_for_layers(
+fn format_config_for_layers(
     project_config: &ShuckConfig,
     option_layers: &[&ClientOptions],
-) -> ShellFormatOptions {
+) -> shuck_config::FormatConfig {
     let mut config = ShuckConfig {
         format: project_config.format.clone(),
         ..ShuckConfig::default()
@@ -383,11 +399,11 @@ fn formatter_settings_for_layers(
         apply_config_overrides(&mut config, options.to_config_overrides());
     }
 
-    formatter_settings_for_config(&config)
+    config.format
 }
 
-fn formatter_settings_for_config(config: &ShuckConfig) -> ShellFormatOptions {
-    let patch = config.format.to_patch().unwrap_or(FormatSettingsPatch {
+fn formatter_settings_for_config(config: &shuck_config::FormatConfig) -> ShellFormatOptions {
+    let patch = config.to_patch().unwrap_or(FormatSettingsPatch {
         ..FormatSettingsPatch::default()
     });
     let mut options = ShellFormatOptions::default();


### PR DESCRIPTION
## Summary

- add project-relative `[format].exclude` glob configuration
- honor formatter exclusions for discovered and explicitly named CLI files, including nested project configs
- skip whole-document and range LSP formatting for excluded files
- document the behavior and cover invalid globs, generated-file parse failures, CLI formatting, and editor formatting

## Why

Generated files could be excluded from lint diagnostics, but there was no project configuration that prevented `shuck format` or format-on-save from rewriting them. Formatter exclusions are now resolved per project and checked before cache lookup or LSP analysis.

Closes #1192.

## Validation

- `make test`
- `cargo fmt --all -- --check`
- `cargo test -p shuck-config`
- `cargo test -p shuck-cli --test integration_test format_`
- `cargo test -p shuck-server`
- `cargo clippy -p shuck-config -p shuck-cli -p shuck-server --all-targets --no-deps -- -D warnings`

The repository-wide clippy command currently stops on a pre-existing `collapsible_match` warning in `crates/shuck-ast/src/command_resolution.rs`; the changed packages pass with warnings denied.