### PR TITLE
fix(server): resolve sourced calls in call hierarchy preparation

### DIFF
--- a/crates/shuck-semantic/src/call_facts.rs
+++ b/crates/shuck-semantic/src/call_facts.rs
@@ -19,7 +19,15 @@ use shuck_ast::{Name, Span};
 use crate::editor::binding_definition_span;
 use crate::{ScopeId, SemanticModel};
 
-type SourceResolution = Option<(PathBuf, Span)>;
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct ResolvedDefinition {
+    path: PathBuf,
+    def_span: Span,
+}
+
+/// A definition exported through a source edge, paired with that edge's span
+/// in the referring file for source-order precedence.
+type SourceResolution = Option<(ResolvedDefinition, Span)>;
 
 /// Identity of a call-graph node within a file: a named function, or the file's
 /// top-level (module) body.
@@ -226,7 +234,39 @@ impl WorkspaceCallIndex {
             .find(|definition| &definition.name == callee)
             .map(|definition| definition.def_span);
         let sourced = self.resolve_through_edges_before(from_path, callee, None);
-        choose_resolved_target(from_path, local, sourced)
+        choose_resolved_target(from_path, local, sourced).map(|target| target.path)
+    }
+
+    /// Resolves the exact call token at `name_span` to its function node.
+    ///
+    /// Unlike [`Self::resolve`], this preserves the call site's execution
+    /// position: top-level calls only see source edges that ran before them,
+    /// while calls in deferred function bodies see the final sourced
+    /// environment. File-local definitions participate in the same ordering.
+    pub fn resolve_call_site(&self, from_path: &Path, name_span: Span) -> Option<CrossFileCall> {
+        let facts = self.files.get(from_path)?;
+        let site = facts
+            .call_sites
+            .iter()
+            .find(|site| site.name_span == name_span)?;
+        let cutoff = match site.enclosing {
+            CallNodeKind::TopLevel => Some(site.name_span.start.offset),
+            CallNodeKind::Function(_) => None,
+        };
+        let sourced = self.resolve_through_edges_before(from_path, &site.callee, cutoff);
+        let target = choose_resolved_target(from_path, site.local_definition_span, sourced)?;
+        let definition = self.files.get(&target.path).and_then(|facts| {
+            facts.definitions.iter().find(|definition| {
+                definition.name == site.callee && definition.def_span == target.def_span
+            })
+        });
+        Some(CrossFileCall {
+            path: target.path,
+            node: CallNodeKind::Function(site.callee.clone()),
+            def_span: Some(target.def_span),
+            selection_span: definition.map(|definition| definition.selection_span),
+            call_spans: vec![site.name_span],
+        })
     }
 
     /// Resolves through source edges that execute before `cutoff`. A `None`
@@ -251,7 +291,7 @@ impl WorkspaceCallIndex {
             })
             .find_map(|edge| {
                 self.resolve_exported(&edge.path, callee, &mut stack)
-                    .map(|path| (path, edge.span))
+                    .map(|target| (target, edge.span))
             })
     }
 
@@ -263,7 +303,7 @@ impl WorkspaceCallIndex {
         path: &Path,
         callee: &Name,
         stack: &mut FxHashSet<PathBuf>,
-    ) -> Option<PathBuf> {
+    ) -> Option<ResolvedDefinition> {
         if !stack.insert(path.to_path_buf()) {
             return None;
         }
@@ -273,13 +313,16 @@ impl WorkspaceCallIndex {
         };
 
         enum Event<'a> {
-            Definition,
+            Definition(&'a CallFactDefinition),
             Source(&'a CallFactSourceEdge),
         }
 
         let mut events = Vec::new();
         for definition in facts.definitions.iter().filter(|def| &def.name == callee) {
-            events.push((definition.def_span.start.offset, Event::Definition));
+            events.push((
+                definition.def_span.start.offset,
+                Event::Definition(definition),
+            ));
         }
         for edge in &facts.source_edges {
             events.push((edge.span.start.offset, Event::Source(edge)));
@@ -288,7 +331,10 @@ impl WorkspaceCallIndex {
 
         for (_, event) in events.into_iter().rev() {
             let resolved = match event {
-                Event::Definition => Some(path.to_path_buf()),
+                Event::Definition(definition) => Some(ResolvedDefinition {
+                    path: path.to_path_buf(),
+                    def_span: definition.def_span,
+                }),
                 Event::Source(edge) => self.resolve_exported(&edge.path, callee, stack),
             };
             if resolved.is_some() {
@@ -328,9 +374,10 @@ impl WorkspaceCallIndex {
                 })
                 .clone();
             let target = choose_resolved_target(from_path, site.local_definition_span, sourced);
-            let Some(target_path) = target else {
+            let Some(target) = target else {
                 continue;
             };
+            let target_path = target.path;
             let key = (target_path, site.callee.clone());
             spans
                 .entry(key.clone())
@@ -391,8 +438,7 @@ impl WorkspaceCallIndex {
                     .clone();
                 let resolves =
                     choose_resolved_target(caller_path, site.local_definition_span, sourced)
-                        .as_deref()
-                        == Some(target_path);
+                        .is_some_and(|target| target.path.as_path() == target_path);
                 if !resolves {
                     continue;
                 }
@@ -436,15 +482,18 @@ fn choose_resolved_target(
     from_path: &Path,
     local_definition: Option<Span>,
     sourced: SourceResolution,
-) -> Option<PathBuf> {
+) -> Option<ResolvedDefinition> {
     match (local_definition, sourced) {
-        (Some(definition), Some((path, source_span)))
+        (Some(definition), Some((target, source_span)))
             if source_span != Span::new() && source_span.start.offset > definition.start.offset =>
         {
-            Some(path)
+            Some(target)
         }
-        (Some(_), _) => Some(from_path.to_path_buf()),
-        (None, Some((path, _))) => Some(path),
+        (Some(def_span), _) => Some(ResolvedDefinition {
+            path: from_path.to_path_buf(),
+            def_span,
+        }),
+        (None, Some((target, _))) => Some(target),
         (None, None) => None,
     }
 }
@@ -560,13 +609,24 @@ mod tests {
             facts("greet() { echo a; }\n", &[]),
         );
         // b defines its own greet, so its call resolves locally, not to a.sh.
-        index.insert(
-            PathBuf::from("/w/b.sh"),
-            facts("greet() { echo b; }\ngreet\n", &["/w/a.sh"]),
+        let caller_path = PathBuf::from("/w/b.sh");
+        let caller_facts = facts("greet() { echo b; }\ngreet\n", &["/w/a.sh"]);
+        let call_span = caller_facts
+            .call_sites
+            .iter()
+            .find(|site| site.callee == name("greet"))
+            .expect("greet call should be projected")
+            .name_span;
+        index.insert(caller_path.clone(), caller_facts);
+        assert_eq!(
+            index.resolve(&caller_path, &name("greet")),
+            Some(caller_path.clone())
         );
         assert_eq!(
-            index.resolve(Path::new("/w/b.sh"), &name("greet")),
-            Some(PathBuf::from("/w/b.sh"))
+            index
+                .resolve_call_site(&caller_path, call_span)
+                .map(|call| call.path),
+            Some(caller_path)
         );
         // a.sh's greet therefore has no incoming call from b.sh.
         assert!(
@@ -585,8 +645,12 @@ mod tests {
             PathBuf::from("/w/a.sh"),
             facts("greet() { echo hi; }\n", &[]),
         );
-        index.insert(PathBuf::from("/w/b.sh"), facts("greet\n", &[]));
-        assert_eq!(index.resolve(Path::new("/w/b.sh"), &name("greet")), None);
+        let caller_path = PathBuf::from("/w/b.sh");
+        let caller_facts = facts("greet\n", &[]);
+        let call_span = caller_facts.call_sites[0].name_span;
+        index.insert(caller_path.clone(), caller_facts);
+        assert_eq!(index.resolve(&caller_path, &name("greet")), None);
+        assert!(index.resolve_call_site(&caller_path, call_span).is_none());
         assert!(
             index
                 .incoming(Path::new("/w/a.sh"), &name("greet"))
@@ -616,10 +680,14 @@ mod tests {
         let a_path = PathBuf::from("/w/a.sh");
         let c_path = PathBuf::from("/w/c.sh");
         let mut index = WorkspaceCallIndex::new();
-        index.insert(
-            caller_path.clone(),
-            FileCallFacts::project_with_source_edges(&caller, edges),
-        );
+        let caller_facts = FileCallFacts::project_with_source_edges(&caller, edges);
+        let call_spans = caller_facts
+            .call_sites
+            .iter()
+            .filter(|site| site.callee == name("greet"))
+            .map(|site| site.name_span)
+            .collect::<Vec<_>>();
+        index.insert(caller_path.clone(), caller_facts);
         index.insert(a_path.clone(), facts("greet() { echo a; }\n", &[]));
         index.insert(c_path.clone(), facts("greet() { echo c; }\n", &[]));
 
@@ -635,6 +703,24 @@ mod tests {
             index.resolve(&caller_path, &name("greet")),
             Some(c_path.clone()),
             "the later sourced definition is the final visible binding"
+        );
+        assert_eq!(call_spans.len(), 3);
+        assert!(
+            index
+                .resolve_call_site(&caller_path, call_spans[0])
+                .is_none()
+        );
+        assert_eq!(
+            index
+                .resolve_call_site(&caller_path, call_spans[1])
+                .map(|call| call.path),
+            Some(a_path.clone())
+        );
+        assert_eq!(
+            index
+                .resolve_call_site(&caller_path, call_spans[2])
+                .map(|call| call.path),
+            Some(c_path.clone())
         );
 
         let incoming_a = index.incoming(&a_path, &name("greet"));
@@ -662,10 +748,21 @@ mod tests {
         let caller_path = PathBuf::from("/w/main.sh");
         let a_path = PathBuf::from("/w/a.sh");
         let mut index = WorkspaceCallIndex::new();
-        index.insert(
-            caller_path.clone(),
-            FileCallFacts::project_with_source_edges(&caller, vec![edge]),
-        );
+        let caller_facts = FileCallFacts::project_with_source_edges(&caller, vec![edge]);
+        let call_spans = caller_facts
+            .call_sites
+            .iter()
+            .filter(|site| site.callee == name("greet"))
+            .map(|site| site.name_span)
+            .collect::<Vec<_>>();
+        let final_definition_span = caller_facts
+            .definitions
+            .iter()
+            .filter(|definition| definition.name == name("greet"))
+            .max_by_key(|definition| definition.def_span.start.offset)
+            .expect("final greet definition should be projected")
+            .def_span;
+        index.insert(caller_path.clone(), caller_facts);
         index.insert(a_path.clone(), facts("greet() { echo sourced; }\n", &[]));
 
         let outgoing = index.outgoing(&caller_path, &CallNodeKind::TopLevel);
@@ -680,6 +777,47 @@ mod tests {
             "the final local definition overrides the earlier source"
         );
         assert_eq!(outgoing[1].call_spans.len(), 1);
+        assert_eq!(call_spans.len(), 2);
+        assert_eq!(
+            index
+                .resolve_call_site(&caller_path, call_spans[0])
+                .map(|call| call.path),
+            Some(a_path)
+        );
+        let final_call = index
+            .resolve_call_site(&caller_path, call_spans[1])
+            .expect("final call should resolve locally");
+        assert_eq!(final_call.path, caller_path);
+        assert_eq!(final_call.def_span, Some(final_definition_span));
+    }
+
+    #[test]
+    fn call_site_resolution_preserves_latest_sourced_definition_span() {
+        let caller_path = PathBuf::from("/w/main.sh");
+        let target_path = PathBuf::from("/w/a.sh");
+        let caller_facts = facts("greet\n", &["/w/a.sh"]);
+        let call_span = caller_facts.call_sites[0].name_span;
+        let target_facts = facts("greet() { echo first; }\ngreet() { echo final; }\n", &[]);
+        let final_definition = target_facts
+            .definitions
+            .iter()
+            .max_by_key(|definition| definition.def_span.start.offset)
+            .expect("final sourced definition should be projected")
+            .clone();
+
+        let mut index = WorkspaceCallIndex::new();
+        index.insert(caller_path.clone(), caller_facts);
+        index.insert(target_path.clone(), target_facts);
+
+        let resolved = index
+            .resolve_call_site(&caller_path, call_span)
+            .expect("sourced call should resolve");
+        assert_eq!(resolved.path, target_path);
+        assert_eq!(resolved.def_span, Some(final_definition.def_span));
+        assert_eq!(
+            resolved.selection_span,
+            Some(final_definition.selection_span)
+        );
     }
 
     #[test]

--- a/crates/shuck-server/src/call_hierarchy.rs
+++ b/crates/shuck-server/src/call_hierarchy.rs
@@ -4,10 +4,11 @@
 //! building a [`WorkspaceCallIndex`]: every workspace shell file (open buffer
 //! preferred over disk) is parsed and projected into call facts, its
 //! determinable source edges resolved, and the two directions answered as
-//! traversals of the resulting call graph. `prepareCallHierarchy` stays a
-//! single-file identity step; the item it returns (name + file URI + a
-//! [`CallHierarchyData`] payload distinguishing top-level nodes) is enough for
-//! the index queries to locate the node.
+//! traversals of the resulting call graph. `prepareCallHierarchy` first uses
+//! document-local identity and then consults the same index when the cursor is
+//! on a call resolved through a source edge. The returned item contains its
+//! name, file URI, and a [`CallHierarchyData`] payload distinguishing top-level
+//! nodes, which is enough for later index queries to locate it.
 //!
 //! The built index is cached on the session and invalidated whenever a
 //! document, workspace folder, or configuration changes, so expanding a call
@@ -30,13 +31,15 @@ use shuck_config::{ConfigArguments, load_project_config, resolve_project_root_fo
 use shuck_indexer::LineIndex;
 use shuck_linter::ShellDialect;
 use shuck_semantic::{
-    CallFactSourceEdge, CallNodeKind, CrossFileCall, FileCallFacts, WorkspaceCallIndex,
-    resolve_source_ref_targets,
+    CallFactSourceEdge, CallNodeKind, CrossFileCall, EditorSymbolTarget, FileCallFacts,
+    WorkspaceCallIndex, resolve_source_ref_targets,
 };
 
 use crate::PositionEncoding;
+use crate::edit::RangeExt;
 use crate::editor::analyze_editor_document;
-use crate::editor_features::CallHierarchyData;
+use crate::editor_features::{self, CallHierarchyData, CallHierarchyPrepareResponse};
+use crate::session::{Client, DocumentSnapshot};
 use crate::symbols::WorkspaceOpenDocument;
 
 /// Resolves and memoizes `[lint] source-paths` per project root, so cross-file
@@ -74,6 +77,54 @@ impl SourcePathsCache {
 
 pub(crate) type IncomingResponse = Option<Vec<types::CallHierarchyIncomingCall>>;
 pub(crate) type OutgoingResponse = Option<Vec<types::CallHierarchyOutgoingCall>>;
+
+/// Prepares the function under the cursor, including functions resolved from a
+/// statically sourced file.
+pub(crate) fn prepare_call_hierarchy(
+    context: CallHierarchyContext,
+    snapshot: DocumentSnapshot,
+    client: &Client,
+    params: types::CallHierarchyPrepareParams,
+) -> crate::server::Result<CallHierarchyPrepareResponse> {
+    let Some(analysis) = snapshot.analysis() else {
+        return Ok(None);
+    };
+    let source = analysis.source();
+    let position = params.text_document_position_params.position;
+    let offset = usize::from(
+        types::Range {
+            start: position,
+            end: position,
+        }
+        .to_text_range(source, analysis.line_index(), snapshot.encoding())
+        .start(),
+    );
+    let target = analysis.semantic().editor_query().target_at_offset(offset);
+    let Some(EditorSymbolTarget::FunctionCall(call)) = target else {
+        return editor_features::prepare_call_hierarchy(snapshot, client, params);
+    };
+    let Some(path) = snapshot
+        .query()
+        .file_url()
+        .to_file_path()
+        .ok()
+        .map(|path| canonical(&path))
+    else {
+        return editor_features::prepare_call_hierarchy(snapshot, client, params);
+    };
+    let built = cached_index(&context);
+    if let Some(target) = built.index.resolve_call_site(&path, call.name_span) {
+        return Ok(built.item_for(&target).map(|item| vec![item]));
+    }
+
+    // An indexed active document should resolve every proven local function
+    // call. Retain the document-local answer if a configured file limit made
+    // the workspace index partial before it reached this buffer.
+    if call.binding.is_some() {
+        return editor_features::prepare_call_hierarchy(snapshot, client, params);
+    }
+    Ok(None)
+}
 
 /// Workspace state needed to build the call index for one request.
 pub(crate) struct CallHierarchyContext {

--- a/crates/shuck-server/src/server/api.rs
+++ b/crates/shuck-server/src/server/api.rs
@@ -37,7 +37,10 @@ pub(super) fn request(req: server::Request) -> Task {
 
     match req.method.as_str() {
         request::CallHierarchyPrepare::METHOD => {
-            background_request_task::<request::CallHierarchyPrepare>(req, BackgroundSchedule::Worker)
+            background_session_request_task::<request::CallHierarchyPrepare>(
+                req,
+                BackgroundSchedule::Worker,
+            )
         }
         request::CallHierarchyIncomingCalls::METHOD => background_session_request_task::<
             request::CallHierarchyIncomingCalls,

--- a/crates/shuck-server/src/server/api/requests/call_hierarchy_prepare.rs
+++ b/crates/shuck-server/src/server/api/requests/call_hierarchy_prepare.rs
@@ -1,33 +1,46 @@
 use lsp_types::{self as types, request as req};
 
-use crate::editor_features;
-use crate::session::{Client, DocumentSnapshot};
+use crate::call_hierarchy::{self, CallHierarchyContext};
+use crate::editor_features::CallHierarchyPrepareResponse;
+use crate::session::{Client, DocumentSnapshot, Session};
 
 pub(crate) struct CallHierarchyPrepare;
+
+pub(crate) struct CallHierarchyPrepareSnapshot {
+    document: Option<DocumentSnapshot>,
+    context: CallHierarchyContext,
+}
 
 impl super::RequestHandler for CallHierarchyPrepare {
     type RequestType = req::CallHierarchyPrepare;
 }
 
-impl super::BackgroundDocumentRequestHandler for CallHierarchyPrepare {
-    fn document_url(
-        params: &types::CallHierarchyPrepareParams,
-    ) -> std::borrow::Cow<'_, types::Url> {
-        std::borrow::Cow::Borrowed(&params.text_document_position_params.text_document.uri)
-    }
+impl super::super::traits::BackgroundRequestHandler for CallHierarchyPrepare {
+    type Snapshot = CallHierarchyPrepareSnapshot;
 
-    fn run_without_snapshot(
-        _client: &Client,
-        _params: types::CallHierarchyPrepareParams,
-    ) -> crate::server::Result<editor_features::CallHierarchyPrepareResponse> {
-        Ok(None)
+    fn snapshot(
+        session: &Session,
+        params: &types::CallHierarchyPrepareParams,
+    ) -> crate::server::Result<Self::Snapshot> {
+        let uri = params
+            .text_document_position_params
+            .text_document
+            .uri
+            .clone();
+        Ok(CallHierarchyPrepareSnapshot {
+            document: session.take_snapshot(uri),
+            context: session.call_hierarchy_context(),
+        })
     }
 
     fn run_with_snapshot(
-        snapshot: DocumentSnapshot,
+        snapshot: Self::Snapshot,
         client: &Client,
         params: types::CallHierarchyPrepareParams,
-    ) -> crate::server::Result<editor_features::CallHierarchyPrepareResponse> {
-        editor_features::prepare_call_hierarchy(snapshot, client, params)
+    ) -> crate::server::Result<CallHierarchyPrepareResponse> {
+        let Some(document) = snapshot.document else {
+            return Ok(None);
+        };
+        call_hierarchy::prepare_call_hierarchy(snapshot.context, document, client, params)
     }
 }

--- a/crates/shuck-server/tests/manual.rs
+++ b/crates/shuck-server/tests/manual.rs
@@ -289,6 +289,192 @@ fn open_document(connection: &Connection, uri: &Url, text: &str) {
 }
 
 #[test]
+fn prepare_call_hierarchy_resolves_sourced_cross_file_call() {
+    let (server_connection, client_connection) = Connection::memory();
+    let server_thread = thread::spawn(move || shuck_server::run_connection(server_connection));
+
+    let workspace = tempfile::tempdir().expect("tempdir should be created");
+    std::fs::write(workspace.path().join("a.sh"), "greet() {\n  echo hi\n}\n").unwrap();
+    let caller = "greet() {\n  echo local\n}\n# shuck: source=a.sh\nsource \"$DIR/a.sh\"\ngreet\ngreet() {\n  echo final\n}\ngreet\nhandler=greet\n\"$handler\"\n";
+    std::fs::write(workspace.path().join("b.sh"), caller).unwrap();
+    let a_uri = Url::from_file_path(
+        std::fs::canonicalize(workspace.path().join("a.sh"))
+            .expect("definition path should canonicalize"),
+    )
+    .unwrap();
+    let b_uri = Url::from_file_path(workspace.path().join("b.sh")).unwrap();
+    let canonical_b_uri = Url::from_file_path(
+        std::fs::canonicalize(workspace.path().join("b.sh"))
+            .expect("caller path should canonicalize"),
+    )
+    .unwrap();
+
+    send_request(
+        &client_connection,
+        1,
+        "initialize",
+        serde_json::json!({
+            "capabilities": replay_capabilities(),
+            "rootUri": Url::from_file_path(workspace.path()).unwrap(),
+        }),
+    );
+    let _ = recv_response(&client_connection, 1);
+    client_connection
+        .sender
+        .send(Message::Notification(Notification::new(
+            "initialized".to_owned(),
+            serde_json::json!({}),
+        )))
+        .expect("initialized should send");
+    open_document(&client_connection, &b_uri, caller);
+
+    send_request(
+        &client_connection,
+        2,
+        "textDocument/prepareCallHierarchy",
+        serde_json::json!({
+            "textDocument": { "uri": b_uri },
+            "position": { "line": 5, "character": 0 },
+        }),
+    );
+    let prepared = recv_response(&client_connection, 2);
+    let item = &prepared.as_array().expect("prepare should return items")[0];
+    assert_eq!(item["name"], serde_json::json!("greet"));
+    assert_eq!(item["uri"], serde_json::json!(a_uri));
+    assert_eq!(
+        item["range"],
+        serde_json::json!({
+            "start": { "line": 0, "character": 0 },
+            "end": { "line": 3, "character": 0 },
+        })
+    );
+    assert_eq!(
+        item["selectionRange"],
+        serde_json::json!({
+            "start": { "line": 0, "character": 0 },
+            "end": { "line": 0, "character": 5 },
+        })
+    );
+
+    // A later local redefinition takes precedence over the sourced function,
+    // and prepare must retain that exact definition rather than the first
+    // same-named definition in the file.
+    send_request(
+        &client_connection,
+        3,
+        "textDocument/prepareCallHierarchy",
+        serde_json::json!({
+            "textDocument": { "uri": b_uri },
+            "position": { "line": 9, "character": 0 },
+        }),
+    );
+    let local_prepared = recv_response(&client_connection, 3);
+    let local_item = &local_prepared
+        .as_array()
+        .expect("local prepare should return items")[0];
+    assert_eq!(local_item["name"], serde_json::json!("greet"));
+    assert_eq!(local_item["uri"], serde_json::json!(canonical_b_uri));
+    assert_eq!(
+        local_item["range"],
+        serde_json::json!({
+            "start": { "line": 6, "character": 0 },
+            "end": { "line": 9, "character": 0 },
+        })
+    );
+    assert_eq!(
+        local_item["selectionRange"],
+        serde_json::json!({
+            "start": { "line": 6, "character": 0 },
+            "end": { "line": 6, "character": 5 },
+        })
+    );
+
+    // Runtime-only dispatch cannot be tied to a concrete function definition,
+    // even though its eventual value happens to spell the sourced function.
+    send_request(
+        &client_connection,
+        4,
+        "textDocument/prepareCallHierarchy",
+        serde_json::json!({
+            "textDocument": { "uri": b_uri },
+            "position": { "line": 11, "character": 2 },
+        }),
+    );
+    assert!(recv_response(&client_connection, 4).is_null());
+
+    send_request(&client_connection, 99, "shutdown", serde_json::json!(null));
+    let _ = recv_response(&client_connection, 99);
+    client_connection
+        .sender
+        .send(Message::Notification(Notification::new(
+            "exit".to_owned(),
+            serde_json::json!({}),
+        )))
+        .expect("exit notification should send");
+    server_thread
+        .join()
+        .expect("server thread should join")
+        .expect("server should exit cleanly");
+}
+
+#[test]
+fn prepare_call_hierarchy_keeps_local_calls_for_non_file_uri() {
+    let (server_connection, client_connection) = Connection::memory();
+    let server_thread = thread::spawn(move || shuck_server::run_connection(server_connection));
+
+    let workspace = tempfile::tempdir().expect("tempdir should be created");
+    let uri = Url::parse("untitled:script.sh").expect("untitled URI should parse");
+    let source = "greet() {\n  echo hi\n}\ngreet\n";
+
+    send_request(
+        &client_connection,
+        1,
+        "initialize",
+        serde_json::json!({
+            "capabilities": replay_capabilities(),
+            "rootUri": Url::from_file_path(workspace.path()).unwrap(),
+        }),
+    );
+    let _ = recv_response(&client_connection, 1);
+    client_connection
+        .sender
+        .send(Message::Notification(Notification::new(
+            "initialized".to_owned(),
+            serde_json::json!({}),
+        )))
+        .expect("initialized should send");
+    open_document(&client_connection, &uri, source);
+
+    send_request(
+        &client_connection,
+        2,
+        "textDocument/prepareCallHierarchy",
+        serde_json::json!({
+            "textDocument": { "uri": uri },
+            "position": { "line": 3, "character": 0 },
+        }),
+    );
+    let prepared = recv_response(&client_connection, 2);
+    let item = &prepared.as_array().expect("prepare should return items")[0];
+    assert_eq!(item["name"], serde_json::json!("greet"));
+    assert_eq!(item["uri"], serde_json::json!(uri));
+
+    send_request(&client_connection, 99, "shutdown", serde_json::json!(null));
+    let _ = recv_response(&client_connection, 99);
+    client_connection
+        .sender
+        .send(Message::Notification(Notification::new(
+            "exit".to_owned(),
+            serde_json::json!({}),
+        )))
+        .expect("exit notification should send");
+    server_thread
+        .join()
+        .expect("server thread should join")
+        .expect("server should exit cleanly");
+}
+
+#[test]
 fn cross_file_call_hierarchy_spans_source_edges() {
     let (server_connection, client_connection) = Connection::memory();
     let server_thread = thread::spawn(move || shuck_server::run_connection(server_connection));


### PR DESCRIPTION
## Summary

- resolve `textDocument/prepareCallHierarchy` call sites through the cached workspace call index
- preserve source-order and local-shadowing semantics, including the exact selected definition span
- retain document-local preparation for non-file URIs and reject runtime-only dispatch
- add semantic and black-box LSP regression coverage

## Root cause

The prepare handler only consulted the active document's semantic model. Incoming and outgoing hierarchy requests used the workspace index, so a call to a function defined by a statically sourced file could participate in later hierarchy traversal but could not produce the initial target item.

## Impact

Editors can now start call hierarchy from an imported call site and receive the resolved definition file, range, and selection range without changing existing single-file behavior.

## Validation

- `cargo test -p shuck-semantic -p shuck-server`
- `cargo fmt --all -- --check`
- `git diff --check origin/main...HEAD`
- `cargo clippy -p shuck-semantic -p shuck-server --all-targets --no-deps -- -D warnings -A clippy::question_mark`

Closes #1194