### PR TITLE
fix(discover): skip explicit plain YAML files

### DIFF
--- a/crates/shuck-cli/tests/integration_test.rs
+++ b/crates/shuck-cli/tests/integration_test.rs
@@ -1979,6 +1979,55 @@ fn check_analyzes_every_explicit_regular_file() {
 }
 
 #[test]
+fn check_skips_explicit_plain_yaml_files() {
+    let tempdir = tempdir().unwrap();
+    for name in ["config.yml", "config.yaml"] {
+        fs::write(tempdir.path().join(name), "- foo: 'bar'\n  bar: [foo]\n").unwrap();
+    }
+
+    for extra_args in [Vec::new(), vec!["--config", "check.embedded=false"]] {
+        let mut cmd = Command::cargo_bin("shuck").unwrap();
+        configure_env_cache(&mut cmd, tempdir.path());
+        cmd.current_dir(tempdir.path())
+            .args(["check", "--no-cache"])
+            .args(extra_args)
+            .args(["config.yml", "config.yaml"]);
+        cmd.assert().success().stdout("");
+    }
+}
+
+#[test]
+fn check_extracts_explicit_workflow_yaml() {
+    let tempdir = tempdir().unwrap();
+    let workflows = tempdir.path().join(".github/workflows");
+    fs::create_dir_all(&workflows).unwrap();
+    fs::write(
+        workflows.join("ci.yml"),
+        r#"on: push
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          unused=1
+          echo ok
+"#,
+    )
+    .unwrap();
+
+    let mut cmd = Command::cargo_bin("shuck").unwrap();
+    configure_env_cache(&mut cmd, tempdir.path());
+    cmd.current_dir(tempdir.path())
+        .args(["check", "--no-cache", ".github/workflows/ci.yml"]);
+    cmd.assert()
+        .code(1)
+        .stdout(predicate::str::contains("jobs.test.steps[0].run"))
+        .stdout(predicate::str::contains(
+            "--> .github/workflows/ci.yml:7:11",
+        ));
+}
+
+#[test]
 fn check_per_file_shell_reaches_explicit_extensionless_file() {
     let tempdir = tempdir().unwrap();
     fs::write(tempdir.path().join("configured"), "{\n").unwrap();

--- a/crates/shuck-cli/tests/integration_test.rs
+++ b/crates/shuck-cli/tests/integration_test.rs
@@ -2022,9 +2022,10 @@ jobs:
     cmd.assert()
         .code(1)
         .stdout(predicate::str::contains("jobs.test.steps[0].run"))
-        .stdout(predicate::str::contains(
-            "--> .github/workflows/ci.yml:7:11",
-        ));
+        .stdout(predicate::str::contains(format!(
+            "--> {}:7:11",
+            platform_path(".github/workflows/ci.yml")
+        )));
 }
 
 #[test]

--- a/crates/shuck-discover/src/lib.rs
+++ b/crates/shuck-discover/src/lib.rs
@@ -10,7 +10,7 @@ use globset::{Glob, GlobSet, GlobSetBuilder};
 use ignore::gitignore::{Gitignore, GitignoreBuilder};
 use ignore::{DirEntry, ParallelVisitor, WalkBuilder, WalkState};
 use shuck_config::{resolve_project_root_for_file, resolve_project_root_for_input};
-use shuck_extract::is_extractable;
+use shuck_extract::{is_embedded_host, is_extractable};
 use shuck_linter::ShellDialect;
 
 pub const DEFAULT_IGNORED_DIR_NAMES: &[&str] = &[
@@ -143,7 +143,9 @@ fn collect_input(
         }
         collect_directory(input, cwd, project_root, exclude_matcher, options, files)?;
     } else if metadata.is_file() {
-        let kind = explicit_file_kind(input)?;
+        let Some(kind) = explicit_file_kind(input)? else {
+            return Ok(());
+        };
         if options.force_exclude {
             if exclude_matcher.matches(input, cwd) {
                 return Ok(());
@@ -628,13 +630,20 @@ fn discovered_file_kind(path: &Path) -> Result<Option<FileKind>> {
     Ok(None)
 }
 
-fn explicit_file_kind(path: &Path) -> Result<FileKind> {
+fn explicit_file_kind(path: &Path) -> Result<Option<FileKind>> {
     // A directly named regular file is an authoritative request to process that
-    // file. Preserve embedded-host detection, but otherwise let the shell parser
-    // decide whether the contents are valid instead of silently dropping the
-    // input. Directory walks continue to use `discovered_file_kind` so unknown
-    // files are not parsed indiscriminately.
-    Ok(discovered_file_kind(path)?.unwrap_or(FileKind::Shell))
+    // file. Preserve embedded-host detection and skip other files in a format
+    // owned by an embedded extractor; otherwise let the shell parser decide
+    // whether the contents are valid instead of silently dropping the input.
+    // Directory walks continue to use `discovered_file_kind` so unknown files
+    // are not parsed indiscriminately.
+    if let Some(kind) = discovered_file_kind(path)? {
+        return Ok(Some(kind));
+    }
+    if is_embedded_host(path) {
+        return Ok(None);
+    }
+    Ok(Some(FileKind::Shell))
 }
 
 fn read_shebang_prefix(path: &Path) -> Result<Vec<u8>> {
@@ -829,6 +838,35 @@ mod tests {
 
         assert_eq!(files.len(), 3);
         assert!(files.iter().all(|file| file.kind == FileKind::Shell));
+    }
+
+    #[test]
+    fn explicit_plain_yaml_is_not_treated_as_shell() {
+        let tempdir = tempdir().unwrap();
+        let plain_yaml = tempdir.path().join("config.yaml");
+        let workflows = tempdir.path().join(".github/workflows");
+        let workflow = workflows.join("ci.yml");
+        fs::create_dir_all(&workflows).unwrap();
+        fs::write(&plain_yaml, "key: value\n").unwrap();
+        fs::write(
+            &workflow,
+            "on: push\njobs:\n  test:\n    runs-on: ubuntu-latest\n    steps: []\n",
+        )
+        .unwrap();
+
+        let files = discover_files(
+            &[plain_yaml, workflow],
+            tempdir.path(),
+            &DiscoveryOptions::default(),
+        )
+        .unwrap();
+
+        assert_eq!(files.len(), 1);
+        assert_eq!(
+            files[0].display_path,
+            PathBuf::from(".github/workflows/ci.yml")
+        );
+        assert_eq!(files[0].kind, FileKind::Embedded);
     }
 
     #[test]

--- a/crates/shuck-extract/src/lib.rs
+++ b/crates/shuck-extract/src/lib.rs
@@ -128,6 +128,12 @@ pub struct ImplicitShellFlags {
 
 /// Extracts embedded shell snippets from a host file.
 pub trait Extractor {
+    /// Returns true when the path has a host-file format owned by this extractor,
+    /// even if its location is not one the extractor should inspect.
+    fn matches_host_format(&self, path: &Path) -> bool {
+        self.matches(path)
+    }
+
     /// Returns true when this extractor should inspect the given path.
     fn matches(&self, path: &Path) -> bool;
 
@@ -141,6 +147,13 @@ pub trait Extractor {
 /// Returns true when any registered extractor can handle the path.
 pub fn is_extractable(path: &Path) -> bool {
     extractors().iter().any(|extractor| extractor.matches(path))
+}
+
+/// Returns true when the path has a host-file format owned by a registered extractor.
+pub fn is_embedded_host(path: &Path) -> bool {
+    extractors()
+        .iter()
+        .any(|extractor| extractor.matches_host_format(path))
 }
 
 /// Runs all matching extractors for a host path and source.
@@ -162,6 +175,10 @@ fn extractors() -> [GitHubActionsExtractor; 1] {
 struct GitHubActionsExtractor;
 
 impl Extractor for GitHubActionsExtractor {
+    fn matches_host_format(&self, path: &Path) -> bool {
+        is_yaml_path(path)
+    }
+
     fn matches(&self, path: &Path) -> bool {
         gha_path_matches(path)
     }
@@ -324,10 +341,7 @@ fn yaml_mapping_get_scalar<'a>(
 }
 
 fn gha_path_matches(path: &Path) -> bool {
-    let Some(extension) = path.extension().and_then(|value| value.to_str()) else {
-        return false;
-    };
-    if !matches!(extension.to_ascii_lowercase().as_str(), "yml" | "yaml") {
+    if !is_yaml_path(path) {
         return false;
     }
 
@@ -351,6 +365,12 @@ fn gha_path_matches(path: &Path) -> bool {
     parts
         .windows(2)
         .any(|window| matches!(window, [".github", "workflows"]))
+}
+
+fn is_yaml_path(path: &Path) -> bool {
+    path.extension()
+        .and_then(|value| value.to_str())
+        .is_some_and(|extension| matches!(extension.to_ascii_lowercase().as_str(), "yml" | "yaml"))
 }
 
 fn is_github_actions_mapping(root: &YamlMapping<'_>) -> bool {
@@ -1859,6 +1879,10 @@ mod tests {
         assert!(is_extractable(Path::new("action.yaml")));
         assert!(!is_extractable(Path::new("ci.yml")));
         assert!(!is_extractable(Path::new("script.sh")));
+
+        assert!(is_embedded_host(Path::new("ci.yml")));
+        assert!(is_embedded_host(Path::new("CONFIG.YAML")));
+        assert!(!is_embedded_host(Path::new("script.sh")));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- distinguish registered embedded host formats from paths eligible for extraction
- skip explicitly named plain `.yml` and `.yaml` files instead of parsing them as shell
- preserve embedded `run:` extraction for explicitly named GitHub workflows and actions

## Root cause

The explicit-file fallback added in #1181 classified every directly named regular file not otherwise recognized as shell. Plain YAML outside GitHub Actions paths was not considered extractable, so it fell through to whole-file shell analysis and produced false positives in pre-commit hooks.

## Impact

Repositories can pass mixed shell and YAML file lists to `shuck check` without ordinary YAML producing shell diagnostics. GitHub workflow and composite-action YAML continues to use embedded-script extraction.

## Validation

- `cargo test -p shuck-extract -p shuck-discover -p shuck-cli`
- `cargo clippy -p shuck-extract -p shuck-discover -p shuck-cli --all-targets --no-deps -- -D warnings`

Fixes #1197