### PR TITLE
docs(server): document sourced call hierarchy preparation

### DIFF
--- a/website/content/editors/index.mdx
+++ b/website/content/editors/index.mdx
@@ -25,7 +25,7 @@ files.
 | Workspace symbols | `workspace/symbol` | Fuzzy search over open buffers and discovered shell files in workspace folders, subject to a configurable file limit. |
 | Rename | `textDocument/prepareRename`, `textDocument/rename` | Conservative, semantically resolved edits within the active document. Cross-file rename is not supported. |
 | Formatting | `textDocument/formatting`, `textDocument/rangeFormatting` | Whole-document formatting or the smallest complete statement containing the selected range. Incomplete syntactic fragments are left unchanged. |
-| Call hierarchy | `textDocument/prepareCallHierarchy`, `callHierarchy/incomingCalls`, `callHierarchy/outgoingCalls` | Incoming and outgoing calls across the statically resolvable source graph. Literal sources and valid `# shuck: source=` hints participate; runtime-only dispatch and unresolved dynamic sources do not. Multiple same-named function definitions in one file currently collapse onto the first indexed node. |
+| Call hierarchy | `textDocument/prepareCallHierarchy`, `callHierarchy/incomingCalls`, `callHierarchy/outgoingCalls` | Preparation, incoming calls, and outgoing calls work across the statically resolvable source graph. Preparing on a sourced function call returns the target definition. Literal sources and valid `# shuck: source=` hints participate; runtime-only dispatch and unresolved dynamic sources do not. Multiple same-named function definitions in one file currently collapse onto the first indexed node. |
 
 Editor formatting uses the same parser-backed formatter as [`shuck format`](/docs/formatting). Once `shuck server` is attached, use your editor's normal LSP format command or format-on-save integration.
 
@@ -33,10 +33,6 @@ Editor formatting uses the same parser-backed formatter as [`shuck format`](/doc
 
 - Cross-file rename is intentionally disabled until Shuck can prove safe edits
   for every affected open or closed file.
-- Preparing call hierarchy directly on a call to a function in a sourced file
-  is intended to resolve to the target definition. This currently has a known
-  implementation gap tracked in
-  [issue #1194](https://github.com/ewhauser/shuck/issues/1194).
 - Cross-file go-to-definition and references need a broader workspace-navigation
   design. They are not covered by the current call-hierarchy index.
 - Language-server support for embedded shell regions, such as scripts inside


### PR DESCRIPTION
## Summary

- remove the outdated #1194 caveat from the LSP support contract
- document that preparing call hierarchy on a sourced function call returns the target definition

## Why

PR #1198 implemented cross-file `prepareCallHierarchy` resolution, so the deferred-capability note no longer reflects the server's behavior.

## User impact

The editor documentation now accurately describes preparation, incoming calls, and outgoing calls as working across the statically resolvable source graph.

## Validation

- `pnpm --dir website build`
- `git diff --check`

Follow-up to #1198.