### PR TITLE
perf: stop rebuilding substring searchers in hot scans

### DIFF
--- a/crates/shuck-linter/src/ambient_contracts/signals.rs
+++ b/crates/shuck-linter/src/ambient_contracts/signals.rs
@@ -70,6 +70,7 @@ impl<'a> SourceSignals<'a> {
         let mut has_source_command = false;
         let mut loads_zsh_colors = false;
 
+        let source_mentions_zmodload = source.contains("zmodload");
         for line in source.lines() {
             let code = code_before_shell_comment(line);
             let trimmed = code.trim();
@@ -78,7 +79,7 @@ impl<'a> SourceSignals<'a> {
             has_probable_function_definition |= probable_function_definition(trimmed);
             has_source_command |= source_command_line(trimmed);
             loads_zsh_colors |= line_autoloads_zsh_colors(trim_start);
-            if code.contains("zmodload") {
+            if source_mentions_zmodload && code.contains("zmodload") {
                 zmodload_lines.push(code);
             }
         }
@@ -258,7 +259,13 @@ fn probable_function_definition(trimmed: &str) -> bool {
         return rest.contains('{');
     }
 
-    trimmed.contains("() {") || trimmed.contains("(){")
+    for (position, _) in trimmed.match_indices('(') {
+        let rest = &trimmed[position + 1..];
+        if rest.starts_with(") {") || rest.starts_with("){") {
+            return true;
+        }
+    }
+    false
 }
 
 fn source_command_line(trimmed: &str) -> bool {
@@ -269,6 +276,14 @@ fn source_command_line(trimmed: &str) -> bool {
 }
 
 fn line_autoloads_zsh_colors(code: &str) -> bool {
+    // The command must be the first word of the first segment, so a cheap
+    // first-token check avoids the separator searches on ordinary lines.
+    if !matches!(
+        code.split_whitespace().next(),
+        Some("autoload" | "builtin" | "command")
+    ) {
+        return false;
+    }
     let code = first_shell_command_segment(code);
     let mut words = code.split_whitespace();
     let mut command = words.next();

--- a/crates/shuck-parser/src/parser/words/expansion.rs
+++ b/crates/shuck-parser/src/parser/words/expansion.rs
@@ -21,25 +21,40 @@ impl<'a> Parser<'a> {
         inner_text: &str,
         approximate_dollar_start: Position,
     ) -> Option<(Position, Position)> {
-        let needle = format!("$({inner_text})");
-        let search_start = floor_char_boundary(
-            self.input,
-            approximate_dollar_start.offset.saturating_sub(512),
-        );
-        let search_end = ceil_char_boundary(
-            self.input,
-            (approximate_dollar_start.offset + needle.len() + 4096).min(self.input.len()),
-        );
-        let haystack = self.input.get(search_start..search_end)?;
-        let (relative_start, _) =
-            haystack
-                .match_indices(&needle)
-                .min_by_key(|(relative_start, _)| {
-                    (search_start + relative_start).abs_diff(approximate_dollar_start.offset)
-                })?;
-        let subst_start = search_start + relative_start;
+        let needle_len = "$(".len() + inner_text.len() + ")".len();
+        // The approximate start is usually exact, so try it before scanning.
+        let subst_start =
+            if substitution_matches_at(self.input, approximate_dollar_start.offset, inner_text) {
+                approximate_dollar_start.offset
+            } else {
+                let search_start = floor_char_boundary(
+                    self.input,
+                    approximate_dollar_start.offset.saturating_sub(512),
+                );
+                let search_end = ceil_char_boundary(
+                    self.input,
+                    (approximate_dollar_start.offset + needle_len + 4096).min(self.input.len()),
+                );
+                let haystack = self.input.get(search_start..search_end)?;
+                // Occurrences arrive in ascending order, so the distance to the
+                // approximate start is V-shaped and the scan can stop as soon as
+                // it grows again.
+                let mut best: Option<(usize, usize)> = None;
+                for (relative_start, _) in haystack.match_indices("$(") {
+                    if !substitution_matches_at(haystack, relative_start, inner_text) {
+                        continue;
+                    }
+                    let distance =
+                        (search_start + relative_start).abs_diff(approximate_dollar_start.offset);
+                    match best {
+                        Some((_, best_distance)) if distance >= best_distance => break,
+                        _ => best = Some((relative_start, distance)),
+                    }
+                }
+                search_start + best?.0
+            };
         let body_start_offset = subst_start + "$(".len();
-        let body_end_offset = subst_start + needle.len() - ")".len();
+        let body_end_offset = subst_start + needle_len - ")".len();
 
         Some((
             self.lexer.position_at_offset(body_start_offset),
@@ -1058,4 +1073,16 @@ impl<'a> Parser<'a> {
 
         false
     }
+}
+
+/// Returns whether `haystack[offset..]` starts a `$(<inner_text>)` command
+/// substitution.
+fn substitution_matches_at(haystack: &str, offset: usize, inner_text: &str) -> bool {
+    let Some(rest) = haystack.get(offset..) else {
+        return false;
+    };
+    let bytes = rest.as_bytes();
+    bytes.starts_with(b"$(")
+        && bytes[2..].starts_with(inner_text.as_bytes())
+        && bytes.get(2 + inner_text.len()) == Some(&b')')
 }


### PR DESCRIPTION
## Summary

Hotspot #5 from the large-corpus profile: substring searching (`TwoWaySearcher`/`StrSearcher`), 3.0% of lint wall time. Caller attribution showed 80% of it came from two sites:

**Parser dollar-paren body recovery** (`source_dollar_paren_body_span`) built a `$(<body>)` needle `String` per command substitution and scanned its whole ±4.5 KB window for **all** occurrences before picking the closest. It now:
- checks the approximate start position directly (which almost always matches) — zero allocation, zero scan
- otherwise scans for `$(` and compares the body in place, stopping as soon as the distance to the approximate start starts growing again

**Ambient signal collection** ran several multi-byte substring searches per source line:
- function-definition probes (`contains("() {")` + `contains("(){")`) → single char-anchored scan
- `zmodload` line collection → gated behind a one-time whole-source pre-check
- `autoload colors` detection ran four separator searches per line → first-token filter short-circuits ordinary lines

## Measured impact (xwmx/nb fixture)

| Metric | Before | After | Delta |
|---|---|---|---|
| Substring-search samples | 3.00% | 0.67% | **−78%** |

Diagnostics unchanged.

## Testing

- `cargo test` (full workspace) passes
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean (pinned 1.94.1 toolchain)
- `make test-large-corpus SHUCK_LARGE_CORPUS_SAMPLE_PERCENT=10` conformance passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)