### PR TITLE
fix(server): preserve call hierarchy definition identity

### DIFF
--- a/crates/shuck-semantic/src/call_facts.rs
+++ b/crates/shuck-semantic/src/call_facts.rs
@@ -29,12 +29,39 @@ struct ResolvedDefinition {
 /// in the referring file for source-order precedence.
 type SourceResolution = Option<(ResolvedDefinition, Span)>;
 
-/// Identity of a call-graph node within a file: a named function, or the file's
-/// top-level (module) body.
+/// Stable identity of one function node within its file.
+///
+/// Function names alone are insufficient because shell permits later
+/// definitions to replace earlier same-named definitions. The definition byte
+/// range distinguishes those bindings while remaining serializable through an
+/// LSP call-hierarchy item's opaque data payload.
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct CallFunctionId {
+    /// Function name.
+    pub name: Name,
+    /// Inclusive byte offset where the full definition starts.
+    pub definition_start: usize,
+    /// Exclusive byte offset where the full definition ends.
+    pub definition_end: usize,
+}
+
+impl CallFunctionId {
+    /// Creates an identity from a function name and its full definition span.
+    pub fn new(name: Name, definition_span: Span) -> Self {
+        Self {
+            name,
+            definition_start: definition_span.start.offset,
+            definition_end: definition_span.end.offset,
+        }
+    }
+}
+
+/// Identity of a call-graph node within a file: an exact function definition,
+/// or the file's top-level (module) body.
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub enum CallNodeKind {
-    /// A named function defined in the file.
-    Function(Name),
+    /// One named function definition in the file.
+    Function(CallFunctionId),
     /// The file's top-level statements.
     TopLevel,
 }
@@ -48,6 +75,13 @@ pub struct CallFactDefinition {
     pub def_span: Span,
     /// Span to select when navigating to the definition (the name token).
     pub selection_span: Span,
+}
+
+impl CallFactDefinition {
+    /// Returns this definition's exact call-graph identity.
+    pub fn identity(&self) -> CallFunctionId {
+        CallFunctionId::new(self.name.clone(), self.def_span)
+    }
 }
 
 /// A call site discovered in a file.
@@ -112,32 +146,43 @@ impl FileCallFacts {
         let analysis = model.analysis();
         source_edges.sort_by_key(|edge| edge.span.start.offset);
 
-        let mut function_names_by_scope: FxHashMap<ScopeId, Vec<Name>> = FxHashMap::default();
+        let mut functions_by_scope: FxHashMap<ScopeId, Vec<(CallFunctionId, Span)>> =
+            FxHashMap::default();
         let mut definitions = Vec::new();
         for binding in model.function_definition_bindings() {
-            definitions.push(CallFactDefinition {
+            let definition = CallFactDefinition {
                 name: binding.name.clone(),
                 def_span: binding_definition_span(binding),
                 selection_span: binding.span,
-            });
+            };
             if let Some(scope) = analysis.function_scope_for_binding(binding.id) {
-                function_names_by_scope
+                functions_by_scope
                     .entry(scope)
                     .or_default()
-                    .push(binding.name.clone());
+                    .push((definition.identity(), definition.def_span));
             }
+            definitions.push(definition);
         }
 
         let mut call_sites = Vec::new();
         for site in model.all_call_sites() {
             let enclosing_functions = model
                 .ancestor_scopes(site.scope)
-                .find_map(|scope| function_names_by_scope.get(&scope));
+                .find_map(|scope| functions_by_scope.get(&scope));
             let local_definition_span = analysis
                 .visible_function_binding_at_call(&site.callee, site.name_span)
-                .map(|binding_id| binding_definition_span(model.binding(binding_id)));
+                .map(|binding_id| binding_definition_span(model.binding(binding_id)))
+                .or_else(|| {
+                    enclosing_functions.and_then(|functions| {
+                        functions
+                            .iter()
+                            .rev()
+                            .find(|(function, _)| function.name == site.callee)
+                            .map(|(_, definition_span)| *definition_span)
+                    })
+                });
             if let Some(enclosing_functions) = enclosing_functions {
-                for enclosing in enclosing_functions {
+                for (enclosing, _) in enclosing_functions {
                     call_sites.push(CallFactSite {
                         callee: site.callee.clone(),
                         name_span: site.name_span,
@@ -162,9 +207,13 @@ impl FileCallFacts {
         }
     }
 
-    /// Returns the definition of `name` in this file, if any (first wins).
-    pub fn definition(&self, name: &Name) -> Option<&CallFactDefinition> {
-        self.definitions.iter().find(|def| &def.name == name)
+    /// Returns the exact function definition identified by `function`.
+    pub fn definition(&self, function: &CallFunctionId) -> Option<&CallFactDefinition> {
+        self.definitions.iter().find(|definition| {
+            definition.name == function.name
+                && definition.def_span.start.offset == function.definition_start
+                && definition.def_span.end.offset == function.definition_end
+        })
     }
 }
 
@@ -262,7 +311,7 @@ impl WorkspaceCallIndex {
         });
         Some(CrossFileCall {
             path: target.path,
-            node: CallNodeKind::Function(site.callee.clone()),
+            node: CallNodeKind::Function(CallFunctionId::new(site.callee.clone(), target.def_span)),
             def_span: Some(target.def_span),
             selection_span: definition.map(|definition| definition.selection_span),
             call_spans: vec![site.name_span],
@@ -354,8 +403,8 @@ impl WorkspaceCallIndex {
             return Vec::new();
         };
 
-        let mut order: Vec<(PathBuf, Name)> = Vec::new();
-        let mut spans: FxHashMap<(PathBuf, Name), Vec<Span>> = FxHashMap::default();
+        let mut order: Vec<(PathBuf, CallFunctionId)> = Vec::new();
+        let mut spans: FxHashMap<(PathBuf, CallFunctionId), Vec<Span>> = FxHashMap::default();
         // Resolution is per-callee, not per-site: memoize it so repeated calls
         // to the same helper do not re-run the source-edge search.
         let mut resolved: FxHashMap<(Name, Option<usize>), SourceResolution> = FxHashMap::default();
@@ -378,7 +427,8 @@ impl WorkspaceCallIndex {
                 continue;
             };
             let target_path = target.path;
-            let key = (target_path, site.callee.clone());
+            let function = CallFunctionId::new(site.callee.clone(), target.def_span);
+            let key = (target_path, function);
             spans
                 .entry(key.clone())
                 .or_insert_with(|| {
@@ -390,29 +440,34 @@ impl WorkspaceCallIndex {
 
         order
             .into_iter()
-            .map(|(target_path, name)| {
+            .map(|(target_path, function)| {
                 let definition = self
                     .files
                     .get(&target_path)
-                    .and_then(|facts| facts.definition(&name));
+                    .and_then(|facts| facts.definition(&function));
                 let call_spans = spans
-                    .remove(&(target_path.clone(), name.clone()))
+                    .remove(&(target_path.clone(), function.clone()))
                     .unwrap_or_default();
                 CrossFileCall {
                     path: target_path,
                     def_span: definition.map(|def| def.def_span),
                     selection_span: definition.map(|def| def.selection_span),
-                    node: CallNodeKind::Function(name),
+                    node: CallNodeKind::Function(function),
                     call_spans,
                 }
             })
             .collect()
     }
 
-    /// Returns the callers of the function `name` defined in `target_path`,
-    /// grouped by caller node. A caller is any file that transitively sources
-    /// `target_path` and calls `name` without a nearer shadowing definition.
-    pub fn incoming(&self, target_path: &Path, name: &Name) -> Vec<CrossFileCall> {
+    /// Returns callers of the exact function node in `target_path`, grouped by
+    /// caller node. A caller is any file that transitively sources
+    /// `target_path` and calls that binding without a nearer shadowing
+    /// definition. Top-level nodes have no callers.
+    pub fn incoming(&self, target_path: &Path, target_node: &CallNodeKind) -> Vec<CrossFileCall> {
+        let CallNodeKind::Function(target_function) = target_node else {
+            return Vec::new();
+        };
+        let name = &target_function.name;
         let mut order: Vec<(PathBuf, CallNodeKind)> = Vec::new();
         let mut spans: FxHashMap<(PathBuf, CallNodeKind), Vec<Span>> = FxHashMap::default();
 
@@ -438,7 +493,11 @@ impl WorkspaceCallIndex {
                     .clone();
                 let resolves =
                     choose_resolved_target(caller_path, site.local_definition_span, sourced)
-                        .is_some_and(|target| target.path.as_path() == target_path);
+                        .is_some_and(|target| {
+                            target.path.as_path() == target_path
+                                && target.def_span.start.offset == target_function.definition_start
+                                && target.def_span.end.offset == target_function.definition_end
+                        });
                 if !resolves {
                     continue;
                 }
@@ -518,6 +577,32 @@ mod tests {
         Name::from(text)
     }
 
+    fn function_node(
+        index: &WorkspaceCallIndex,
+        path: &str,
+        function_name: &str,
+        occurrence: usize,
+    ) -> CallNodeKind {
+        let facts = index
+            .files()
+            .find_map(|(candidate, facts)| (candidate == Path::new(path)).then_some(facts))
+            .expect("file should be indexed");
+        let definition = facts
+            .definitions
+            .iter()
+            .filter(|definition| definition.name == name(function_name))
+            .nth(occurrence)
+            .expect("function definition should be indexed");
+        CallNodeKind::Function(definition.identity())
+    }
+
+    fn function_name(node: &CallNodeKind) -> Option<&str> {
+        match node {
+            CallNodeKind::Function(function) => Some(function.name.as_str()),
+            CallNodeKind::TopLevel => None,
+        }
+    }
+
     #[test]
     fn projects_definitions_call_sites_and_enclosing() {
         let facts = facts(
@@ -539,8 +624,12 @@ mod tests {
             .iter()
             .map(|site| (site.callee.to_string(), site.enclosing.clone()))
             .collect();
-        assert!(enclosings.contains(&("inner".to_owned(), CallNodeKind::Function(name("outer")))));
-        assert!(enclosings.contains(&("inner".to_owned(), CallNodeKind::Function(name("nested")))));
+        assert!(enclosings.iter().any(|(callee, enclosing)| {
+            callee == "inner" && function_name(enclosing) == Some("outer")
+        }));
+        assert!(enclosings.iter().any(|(callee, enclosing)| {
+            callee == "inner" && function_name(enclosing) == Some("nested")
+        }));
         assert!(enclosings.contains(&("outer".to_owned(), CallNodeKind::TopLevel)));
     }
 
@@ -574,29 +663,34 @@ mod tests {
     #[test]
     fn incoming_collects_callers_across_files_including_assume_and_top_level() {
         let index = three_file_index();
-        let incoming = index.incoming(Path::new("/w/a.sh"), &name("greet"));
+        let greet = function_node(&index, "/w/a.sh", "greet", 0);
+        let incoming = index.incoming(Path::new("/w/a.sh"), &greet);
         let mut callers: Vec<String> = incoming
             .iter()
-            .map(|call| format!("{}:{:?}", call.path.to_string_lossy(), call.node))
+            .map(|call| {
+                format!(
+                    "{}:{}",
+                    call.path.to_string_lossy(),
+                    function_name(&call.node).unwrap_or("top-level")
+                )
+            })
             .collect();
         callers.sort();
         // b.sh's `run` (follow edge) and c.sh's top level (assume edge).
         assert_eq!(
             callers,
-            vec![
-                format!("/w/b.sh:{:?}", CallNodeKind::Function(name("run"))),
-                format!("/w/c.sh:{:?}", CallNodeKind::TopLevel),
-            ]
+            vec!["/w/b.sh:run".to_owned(), "/w/c.sh:top-level".to_owned(),]
         );
     }
 
     #[test]
     fn outgoing_descends_into_followed_file() {
         let index = three_file_index();
-        let outgoing = index.outgoing(Path::new("/w/b.sh"), &CallNodeKind::Function(name("run")));
+        let run = function_node(&index, "/w/b.sh", "run", 0);
+        let outgoing = index.outgoing(Path::new("/w/b.sh"), &run);
         assert_eq!(outgoing.len(), 1);
         assert_eq!(outgoing[0].path, PathBuf::from("/w/a.sh"));
-        assert_eq!(outgoing[0].node, CallNodeKind::Function(name("greet")));
+        assert_eq!(function_name(&outgoing[0].node), Some("greet"));
         assert_eq!(outgoing[0].call_spans.len(), 1);
         assert!(outgoing[0].def_span.is_some());
     }
@@ -629,11 +723,109 @@ mod tests {
             Some(caller_path)
         );
         // a.sh's greet therefore has no incoming call from b.sh.
+        let sourced_greet = function_node(&index, "/w/a.sh", "greet", 0);
         assert!(
             index
-                .incoming(Path::new("/w/a.sh"), &name("greet"))
+                .incoming(Path::new("/w/a.sh"), &sourced_greet)
                 .is_empty()
         );
+    }
+
+    #[test]
+    fn same_named_definitions_keep_distinct_recursive_edges() {
+        let source = "left() { :; }\nright() { :; }\nworker() { left; worker; }\nworker\nworker() { right; worker; }\nworker\n";
+        let path = PathBuf::from("/w/script.sh");
+        let mut index = WorkspaceCallIndex::new();
+        index.insert(path.clone(), facts(source, &[]));
+
+        let first_worker = function_node(&index, "/w/script.sh", "worker", 0);
+        let second_worker = function_node(&index, "/w/script.sh", "worker", 1);
+
+        let first_outgoing = index.outgoing(&path, &first_worker);
+        assert_eq!(
+            first_outgoing
+                .iter()
+                .filter_map(|call| function_name(&call.node))
+                .collect::<Vec<_>>(),
+            ["left", "worker"]
+        );
+        assert!(first_outgoing.iter().any(|call| call.node == first_worker));
+        assert!(!first_outgoing.iter().any(|call| call.node == second_worker));
+
+        let second_outgoing = index.outgoing(&path, &second_worker);
+        assert_eq!(
+            second_outgoing
+                .iter()
+                .filter_map(|call| function_name(&call.node))
+                .collect::<Vec<_>>(),
+            ["right", "worker"]
+        );
+        assert!(
+            second_outgoing
+                .iter()
+                .any(|call| call.node == second_worker)
+        );
+        assert!(!second_outgoing.iter().any(|call| call.node == first_worker));
+
+        let first_incoming = index.incoming(&path, &first_worker);
+        assert_eq!(first_incoming.len(), 2, "recursive and top-level callers");
+        assert_eq!(
+            first_incoming
+                .iter()
+                .map(|call| call.call_spans.len())
+                .sum::<usize>(),
+            2
+        );
+        let second_incoming = index.incoming(&path, &second_worker);
+        assert_eq!(second_incoming.len(), 2, "recursive and top-level callers");
+        assert_eq!(
+            second_incoming
+                .iter()
+                .map(|call| call.call_spans.len())
+                .sum::<usize>(),
+            2
+        );
+    }
+
+    #[test]
+    fn sourced_redefinitions_report_incoming_calls_only_for_final_binding() {
+        let target_path = PathBuf::from("/w/lib.sh");
+        let caller_path = PathBuf::from("/w/main.sh");
+        let mut index = WorkspaceCallIndex::new();
+        index.insert(
+            target_path.clone(),
+            facts("greet() { echo first; }\ngreet() { echo final; }\n", &[]),
+        );
+        index.insert(caller_path, facts("greet\n", &["/w/lib.sh"]));
+
+        let first = function_node(&index, "/w/lib.sh", "greet", 0);
+        let final_binding = function_node(&index, "/w/lib.sh", "greet", 1);
+        assert!(index.incoming(&target_path, &first).is_empty());
+        let incoming = index.incoming(&target_path, &final_binding);
+        assert_eq!(incoming.len(), 1);
+        assert_eq!(incoming[0].call_spans.len(), 1);
+    }
+
+    #[test]
+    fn replaced_file_does_not_resolve_a_stale_function_identity_by_name() {
+        let path = PathBuf::from("/w/script.sh");
+        let mut index = WorkspaceCallIndex::new();
+        index.insert(
+            path.clone(),
+            facts("worker() { helper; }\nhelper() { :; }\nworker\n", &[]),
+        );
+        let stale_worker = function_node(&index, "/w/script.sh", "worker", 0);
+
+        index.insert(
+            path.clone(),
+            facts(
+                "# moved\nworker() { helper; }\nhelper() { :; }\nworker\n",
+                &[],
+            ),
+        );
+
+        assert!(index.outgoing(&path, &stale_worker).is_empty());
+        assert!(index.incoming(&path, &stale_worker).is_empty());
     }
 
     #[test]
@@ -651,11 +843,8 @@ mod tests {
         index.insert(caller_path.clone(), caller_facts);
         assert_eq!(index.resolve(&caller_path, &name("greet")), None);
         assert!(index.resolve_call_site(&caller_path, call_span).is_none());
-        assert!(
-            index
-                .incoming(Path::new("/w/a.sh"), &name("greet"))
-                .is_empty()
-        );
+        let greet = function_node(&index, "/w/a.sh", "greet", 0);
+        assert!(index.incoming(Path::new("/w/a.sh"), &greet).is_empty());
     }
 
     #[test]
@@ -723,10 +912,12 @@ mod tests {
             Some(c_path.clone())
         );
 
-        let incoming_a = index.incoming(&a_path, &name("greet"));
+        let greet_a = function_node(&index, "/w/a.sh", "greet", 0);
+        let incoming_a = index.incoming(&a_path, &greet_a);
         assert_eq!(incoming_a.len(), 1);
         assert_eq!(incoming_a[0].call_spans.len(), 1);
-        let incoming_c = index.incoming(&c_path, &name("greet"));
+        let greet_c = function_node(&index, "/w/c.sh", "greet", 0);
+        let incoming_c = index.incoming(&c_path, &greet_c);
         assert_eq!(incoming_c.len(), 1);
         assert_eq!(incoming_c[0].call_spans.len(), 1);
     }
@@ -832,22 +1023,18 @@ mod tests {
         let mut index = WorkspaceCallIndex::new();
         index.insert(path.clone(), FileCallFacts::project(&model, Vec::new()));
 
-        let outgoing = index.outgoing(&path, &CallNodeKind::Function(name("itunes")));
+        let itunes = function_node(&index, "/w/script.zsh", "itunes", 0);
+        let outgoing = index.outgoing(&path, &itunes);
         assert_eq!(outgoing.len(), 1);
-        assert_eq!(outgoing[0].node, CallNodeKind::Function(name("helper")));
+        assert_eq!(function_name(&outgoing[0].node), Some("helper"));
 
+        let helper = function_node(&index, "/w/script.zsh", "helper", 0);
         let mut callers = index
-            .incoming(&path, &name("helper"))
+            .incoming(&path, &helper)
             .into_iter()
-            .map(|call| call.node)
+            .filter_map(|call| function_name(&call.node).map(str::to_owned))
             .collect::<Vec<_>>();
-        callers.sort_by_key(|node| format!("{node:?}"));
-        assert_eq!(
-            callers,
-            [
-                CallNodeKind::Function(name("itunes")),
-                CallNodeKind::Function(name("music")),
-            ]
-        );
+        callers.sort();
+        assert_eq!(callers, ["itunes", "music"]);
     }
 }

--- a/crates/shuck-semantic/src/lib.rs
+++ b/crates/shuck-semantic/src/lib.rs
@@ -43,8 +43,8 @@ pub use binding::{
 /// Call-graph structures derived from the analyzed script.
 /// Workspace call-graph index types for cross-file call hierarchy.
 pub use call_facts::{
-    CallFactDefinition, CallFactSite, CallFactSourceEdge, CallNodeKind, CrossFileCall,
-    FileCallFacts, WorkspaceCallIndex,
+    CallFactDefinition, CallFactSite, CallFactSourceEdge, CallFunctionId, CallNodeKind,
+    CrossFileCall, FileCallFacts, WorkspaceCallIndex,
 };
 pub use call_graph::{
     CallGraph, CallSite, OverwrittenFunction, UnreachedFunction, UnreachedFunctionReason,

--- a/crates/shuck-semantic/src/tests.rs
+++ b/crates/shuck-semantic/src/tests.rs
@@ -32,6 +32,32 @@ fn model_with_profile(source: &str, profile: ShellProfile) -> SemanticModel {
     )
 }
 
+fn indexed_function(
+    index: &WorkspaceCallIndex,
+    path: &Path,
+    name: &str,
+    occurrence: usize,
+) -> CallNodeKind {
+    let facts = index
+        .files()
+        .find_map(|(candidate, facts)| (candidate == path).then_some(facts))
+        .expect("file should be indexed");
+    let definition = facts
+        .definitions
+        .iter()
+        .filter(|definition| definition.name.as_str() == name)
+        .nth(occurrence)
+        .expect("function definition should be indexed");
+    CallNodeKind::Function(definition.identity())
+}
+
+fn call_node_name(node: &CallNodeKind) -> Option<&str> {
+    match node {
+        CallNodeKind::Function(function) => Some(function.name.as_str()),
+        CallNodeKind::TopLevel => None,
+    }
+}
+
 #[test]
 fn editor_document_symbols_include_top_level_assignments_and_declarations() {
     let source = "\
@@ -346,33 +372,34 @@ outer
     let path = std::path::PathBuf::from("/ws/script.sh");
     let mut index = WorkspaceCallIndex::new();
     index.insert(path.clone(), FileCallFacts::project(&model, Vec::new()));
+    let outer = indexed_function(&index, &path, "outer", 0);
+    let inner = indexed_function(&index, &path, "inner", 0);
 
     // `outer` calls `inner` directly once; the `inner` inside `nested` belongs
     // to `nested`, not to `outer`.
     let outgoing = index
-        .outgoing(&path, &CallNodeKind::Function(Name::from("outer")))
+        .outgoing(&path, &outer)
         .into_iter()
-        .map(|call| (call.node.clone(), call.call_spans.len()))
+        .map(|call| {
+            (
+                call_node_name(&call.node).map(str::to_owned),
+                call.call_spans.len(),
+            )
+        })
         .collect::<Vec<_>>();
-    assert_eq!(outgoing, [(CallNodeKind::Function(Name::from("inner")), 1)]);
+    assert_eq!(outgoing, [(Some("inner".to_owned()), 1)]);
 
     // `inner` is called from both `outer` and the nested `nested` function.
     let mut callers = index
-        .incoming(&path, &Name::from("inner"))
+        .incoming(&path, &inner)
         .into_iter()
-        .map(|call| call.node)
+        .filter_map(|call| call_node_name(&call.node).map(str::to_owned))
         .collect::<Vec<_>>();
-    callers.sort_by_key(|node| format!("{node:?}"));
-    assert_eq!(
-        callers,
-        [
-            CallNodeKind::Function(Name::from("nested")),
-            CallNodeKind::Function(Name::from("outer")),
-        ]
-    );
+    callers.sort();
+    assert_eq!(callers, ["nested", "outer"]);
 
     // `outer` itself is called once, from the script top level.
-    let incoming_outer = index.incoming(&path, &Name::from("outer"));
+    let incoming_outer = index.incoming(&path, &outer);
     assert_eq!(incoming_outer.len(), 1);
     assert_eq!(incoming_outer[0].node, CallNodeKind::TopLevel);
     assert_eq!(incoming_outer[0].call_spans.len(), 1);
@@ -542,6 +569,9 @@ main() {
         FileCallFacts::project(&caller, vec![lib_path.clone()]),
     );
     index.insert(lib_path.clone(), FileCallFacts::project(&lib, Vec::new()));
+    let grep = indexed_function(&index, &caller_path, "grep", 0);
+    let main = indexed_function(&index, &caller_path, "main", 0);
+    let helper = indexed_function(&index, &lib_path, "helper", 0);
 
     // The top level's `grep` call precedes the definition, so it resolves to
     // the external command: no edge from the top level.
@@ -551,26 +581,25 @@ main() {
         "expected no top-level edges, got {top_level_outgoing:?}"
     );
     // Symmetrically, the local `grep` function has no callers.
-    assert!(index.incoming(&caller_path, &Name::from("grep")).is_empty());
+    assert!(index.incoming(&caller_path, &grep).is_empty());
 
     // `main` resolves `helper` through the source edge.
     let outgoing = index
-        .outgoing(&caller_path, &CallNodeKind::Function(Name::from("main")))
+        .outgoing(&caller_path, &main)
         .into_iter()
-        .map(|call| (call.path.clone(), call.node.clone()))
+        .map(|call| {
+            (
+                call.path.clone(),
+                call_node_name(&call.node).map(str::to_owned),
+            )
+        })
         .collect::<Vec<_>>();
-    assert_eq!(
-        outgoing,
-        [(
-            lib_path.clone(),
-            CallNodeKind::Function(Name::from("helper"))
-        )]
-    );
+    assert_eq!(outgoing, [(lib_path.clone(), Some("helper".to_owned()))]);
     // And `helper`'s caller is `main` in the sourcing file.
-    let incoming = index.incoming(&lib_path, &Name::from("helper"));
+    let incoming = index.incoming(&lib_path, &helper);
     assert_eq!(incoming.len(), 1);
     assert_eq!(incoming[0].path, caller_path);
-    assert_eq!(incoming[0].node, CallNodeKind::Function(Name::from("main")));
+    assert_eq!(call_node_name(&incoming[0].node), Some("main"));
 }
 
 #[test]

--- a/crates/shuck-server/src/call_hierarchy.rs
+++ b/crates/shuck-server/src/call_hierarchy.rs
@@ -7,8 +7,8 @@
 //! traversals of the resulting call graph. `prepareCallHierarchy` first uses
 //! document-local identity and then consults the same index when the cursor is
 //! on a call resolved through a source edge. The returned item contains its
-//! name, file URI, and a [`CallHierarchyData`] payload distinguishing top-level
-//! nodes, which is enough for later index queries to locate it.
+//! name, file URI, and a [`CallHierarchyData`] payload carrying the exact
+//! definition byte range, which is enough for later index queries to locate it.
 //!
 //! The built index is cached on the session and invalidated whenever a
 //! document, workspace folder, or configuration changes, so expanding a call
@@ -16,9 +16,8 @@
 //!
 //! Call sites combine binding-accurate in-file definitions with positioned
 //! source edges, so later sourced and local definitions override earlier ones
-//! in shell execution order. Known limitation:
-//! nodes are keyed by function *name* within a file, so two same-named
-//! definitions in one file collapse onto the first.
+//! in shell execution order. Nodes retain their definition ranges, keeping
+//! same-named definitions distinct throughout preparation and expansion.
 
 use std::collections::{BTreeMap, HashMap};
 use std::path::{Path, PathBuf};
@@ -31,8 +30,8 @@ use shuck_config::{ConfigArguments, load_project_config, resolve_project_root_fo
 use shuck_indexer::LineIndex;
 use shuck_linter::ShellDialect;
 use shuck_semantic::{
-    CallFactSourceEdge, CallNodeKind, CrossFileCall, EditorSymbolTarget, FileCallFacts,
-    WorkspaceCallIndex, resolve_source_ref_targets,
+    CallFactSourceEdge, CallFunctionId, CallNodeKind, CrossFileCall, EditorSymbolTarget,
+    FileCallFacts, WorkspaceCallIndex, resolve_source_ref_targets,
 };
 
 use crate::PositionEncoding;
@@ -214,14 +213,14 @@ pub(crate) fn incoming_calls(
     let Some((path, node)) = item_identity(&params.item) else {
         return Ok(None);
     };
-    let CallNodeKind::Function(name) = node else {
+    let CallNodeKind::Function(_) = node else {
         // Nothing "calls" a script's top level in this model.
         return Ok(Some(Vec::new()));
     };
     let built = cached_index(&context);
     let calls = built
         .index
-        .incoming(&path, &name)
+        .incoming(&path, &node)
         .into_iter()
         .filter_map(|call| {
             let from = built.item_for(&call)?;
@@ -258,12 +257,13 @@ pub(crate) fn outgoing_calls(
     Ok(Some(calls))
 }
 
-/// The queried node's identity: its file path plus which node in that file.
+/// The queried node's identity: its file path plus which exact node in that file.
 ///
 /// The `data` payload stamped by `prepare` (and by [`BuiltIndex::item_for`])
-/// distinguishes a script top-level MODULE node from a function; without it a
-/// top-level item would be misread as a function named after the file's label.
-/// Items from clients that drop `data` fall back to the LSP `kind`.
+/// distinguishes a script top-level MODULE node from a function and preserves
+/// the function definition's byte range. Function items whose clients drop
+/// `data` cannot be expanded safely because a name may identify more than one
+/// definition, so they are rejected instead of guessed.
 fn item_identity(item: &types::CallHierarchyItem) -> Option<(PathBuf, CallNodeKind)> {
     let path = canonical(&item.uri.to_file_path().ok()?);
     let data = item
@@ -272,11 +272,16 @@ fn item_identity(item: &types::CallHierarchyItem) -> Option<(PathBuf, CallNodeKi
         .and_then(|value| serde_json::from_value::<CallHierarchyData>(value).ok());
     let node = match data {
         Some(CallHierarchyData::TopLevel) => CallNodeKind::TopLevel,
-        Some(CallHierarchyData::Function { .. }) => {
-            CallNodeKind::Function(Name::from(item.name.as_str()))
-        }
+        Some(CallHierarchyData::Function {
+            definition_start,
+            definition_end,
+        }) => CallNodeKind::Function(CallFunctionId {
+            name: Name::from(item.name.as_str()),
+            definition_start,
+            definition_end,
+        }),
         None if item.kind == types::SymbolKind::MODULE => CallNodeKind::TopLevel,
-        None => CallNodeKind::Function(Name::from(item.name.as_str())),
+        None => return None,
     };
     Some((path, node))
 }
@@ -379,15 +384,16 @@ impl BuiltIndex {
     fn item_for(&self, call: &CrossFileCall) -> Option<types::CallHierarchyItem> {
         let uri = types::Url::from_file_path(&call.path).ok()?;
         match &call.node {
-            CallNodeKind::Function(name) => {
+            CallNodeKind::Function(function) => {
                 let range = self.range_of(&call.path, call.def_span?)?;
                 let selection_range = call
                     .selection_span
                     .and_then(|span| self.range_of(&call.path, span))
                     .unwrap_or(range);
                 Some(crate::editor_features::call_hierarchy_function_item(
-                    name.to_string(),
+                    function.name.to_string(),
                     uri,
+                    call.def_span?,
                     range,
                     selection_range,
                 ))

--- a/crates/shuck-server/src/editor_features.rs
+++ b/crates/shuck-server/src/editor_features.rs
@@ -27,7 +27,10 @@ pub(crate) type CallHierarchyPrepareResponse = Option<Vec<types::CallHierarchyIt
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase", tag = "kind")]
 pub(crate) enum CallHierarchyData {
-    Function { line: u32, character: u32 },
+    Function {
+        definition_start: usize,
+        definition_end: usize,
+    },
     TopLevel,
 }
 
@@ -221,17 +224,13 @@ fn to_lsp_call_hierarchy_item(
     let uri = snapshot.query().file_url().clone();
     match item.target {
         EditorCallHierarchyTarget::Function(_) => {
-            let full_range = item
-                .full_span
-                .map(|span| {
-                    crate::edit::to_lsp_range(
-                        span.to_range(),
-                        source,
-                        line_index,
-                        snapshot.encoding(),
-                    )
-                })
-                .unwrap_or_default();
+            let full_span = item.full_span.unwrap_or_default();
+            let full_range = crate::edit::to_lsp_range(
+                full_span.to_range(),
+                source,
+                line_index,
+                snapshot.encoding(),
+            );
             let selection_range = item
                 .selection_span
                 .map(|span| {
@@ -243,7 +242,13 @@ fn to_lsp_call_hierarchy_item(
                     )
                 })
                 .unwrap_or(full_range);
-            call_hierarchy_function_item(item.name.to_string(), uri, full_range, selection_range)
+            call_hierarchy_function_item(
+                item.name.to_string(),
+                uri,
+                full_span,
+                full_range,
+                selection_range,
+            )
         }
         EditorCallHierarchyTarget::TopLevel => call_hierarchy_top_level_item(uri),
     }
@@ -255,6 +260,7 @@ fn to_lsp_call_hierarchy_item(
 pub(crate) fn call_hierarchy_function_item(
     name: String,
     uri: types::Url,
+    definition_span: shuck_ast::Span,
     range: types::Range,
     selection_range: types::Range,
 ) -> types::CallHierarchyItem {
@@ -267,8 +273,8 @@ pub(crate) fn call_hierarchy_function_item(
         range,
         selection_range,
         data: serde_json::to_value(CallHierarchyData::Function {
-            line: selection_range.start.line,
-            character: selection_range.start.character,
+            definition_start: definition_span.start.offset,
+            definition_end: definition_span.end.offset,
         })
         .ok(),
     }

--- a/crates/shuck-server/tests/manual.rs
+++ b/crates/shuck-server/tests/manual.rs
@@ -694,3 +694,99 @@ fn cross_file_call_hierarchy_honors_configured_source_paths() {
         .expect("server thread should join")
         .expect("server should exit cleanly");
 }
+
+#[test]
+fn call_hierarchy_round_trips_same_named_definition_identity() {
+    let (server_connection, client_connection) = Connection::memory();
+    let server_thread = thread::spawn(move || shuck_server::run_connection(server_connection));
+
+    let workspace = tempfile::tempdir().expect("tempdir should be created");
+    let script_path = workspace.path().join("script.sh");
+    std::fs::write(&script_path, "stale() { :; }\n").unwrap();
+    let script_uri = Url::from_file_path(&script_path).unwrap();
+    let source = "first() { :; }\nsecond() { :; }\nworker() {\n  first\n}\nworker\nworker() {\n  second\n}\nworker\n";
+
+    send_request(
+        &client_connection,
+        1,
+        "initialize",
+        serde_json::json!({
+            "capabilities": replay_capabilities(),
+            "rootUri": Url::from_file_path(workspace.path()).unwrap(),
+        }),
+    );
+    let _ = recv_response(&client_connection, 1);
+    client_connection
+        .sender
+        .send(Message::Notification(Notification::new(
+            "initialized".to_owned(),
+            serde_json::json!({}),
+        )))
+        .expect("initialized should send");
+    open_document(&client_connection, &script_uri, source);
+
+    let mut prepared = Vec::new();
+    for (request_id, line) in [(2, 2), (3, 6)] {
+        send_request(
+            &client_connection,
+            request_id,
+            "textDocument/prepareCallHierarchy",
+            serde_json::json!({
+                "textDocument": { "uri": script_uri },
+                "position": { "line": line, "character": 0 },
+            }),
+        );
+        let response = recv_response(&client_connection, request_id);
+        prepared.push(response.as_array().unwrap()[0].clone());
+    }
+
+    assert_eq!(prepared[0]["range"]["start"]["line"], 2);
+    assert_eq!(prepared[1]["range"]["start"]["line"], 6);
+    assert_ne!(prepared[0]["data"], prepared[1]["data"]);
+
+    for (request_id, item, expected_callee) in
+        [(4, &prepared[0], "first"), (5, &prepared[1], "second")]
+    {
+        send_request(
+            &client_connection,
+            request_id,
+            "callHierarchy/outgoingCalls",
+            serde_json::json!({ "item": item }),
+        );
+        let response = recv_response(&client_connection, request_id);
+        let outgoing = response.as_array().unwrap();
+        assert_eq!(outgoing.len(), 1);
+        assert_eq!(outgoing[0]["to"]["name"], expected_callee);
+    }
+
+    for (request_id, item, expected_call_line) in [(6, &prepared[0], 5), (7, &prepared[1], 9)] {
+        send_request(
+            &client_connection,
+            request_id,
+            "callHierarchy/incomingCalls",
+            serde_json::json!({ "item": item }),
+        );
+        let response = recv_response(&client_connection, request_id);
+        let incoming = response.as_array().unwrap();
+        assert_eq!(incoming.len(), 1);
+        assert_eq!(incoming[0]["fromRanges"].as_array().unwrap().len(), 1);
+        assert_eq!(
+            incoming[0]["fromRanges"][0]["start"]["line"],
+            expected_call_line
+        );
+    }
+
+    send_request(&client_connection, 99, "shutdown", serde_json::json!(null));
+    let _ = recv_response(&client_connection, 99);
+    client_connection
+        .sender
+        .send(Message::Notification(Notification::new(
+            "exit".to_owned(),
+            serde_json::json!({}),
+        )))
+        .expect("exit notification should send");
+    server_thread
+        .join()
+        .expect("server thread should join")
+        .expect("server should exit cleanly");
+}

--- a/specs/025-cross-file-call-hierarchy.md
+++ b/specs/025-cross-file-call-hierarchy.md
@@ -15,8 +15,10 @@ change, so expanding a call tree reuses one build. Call sites the semantic
 model binds in-file stay binding-accurate (definition order and shadowing are
 honored), while source edges retain their positions so later sourced and local
 definitions override earlier ones; only sites without an effective local
-binding are matched by name across source edges. Top-level MODULE nodes
-round-trip through `CallHierarchyItem.data`, so
+binding are matched by name across source edges. Function nodes carry their
+exact definition byte range through `CallHierarchyItem.data`, keeping
+same-named redefinitions distinct across preparation, incoming calls, and
+outgoing calls. Top-level MODULE nodes also round-trip through that payload, so
 their outgoing calls expand. Edges come from all determinable sources
 (literal-resolvable paths and `source=` directives with and without
 `lint=true`), resolved against the annotating file's own directory and the
@@ -28,10 +30,6 @@ expansion — and every insertion checks it, so a runaway workspace degrades to 
 partial graph (with a warning) rather than an unbounded scan. Covered by
 semantic unit tests, an index-size bound test, and black-box multi-file LSP
 tests (including one that resolves only via `source-paths`).
-
-Known limitation (noted follow-up, not blocking): nodes are keyed by function
-name within a file, so two same-named definitions in one file collapse onto the
-first.
 
 ## Summary
 

--- a/website/content/editors/index.mdx
+++ b/website/content/editors/index.mdx
@@ -25,7 +25,7 @@ files.
 | Workspace symbols | `workspace/symbol` | Fuzzy search over open buffers and discovered shell files in workspace folders, subject to a configurable file limit. |
 | Rename | `textDocument/prepareRename`, `textDocument/rename` | Conservative, semantically resolved edits within the active document. Cross-file rename is not supported. |
 | Formatting | `textDocument/formatting`, `textDocument/rangeFormatting` | Whole-document formatting or the smallest complete statement containing the selected range. Incomplete syntactic fragments are left unchanged. |
-| Call hierarchy | `textDocument/prepareCallHierarchy`, `callHierarchy/incomingCalls`, `callHierarchy/outgoingCalls` | Preparation, incoming calls, and outgoing calls work across the statically resolvable source graph. Preparing on a sourced function call returns the target definition. Literal sources and valid `# shuck: source=` hints participate; runtime-only dispatch and unresolved dynamic sources do not. Multiple same-named function definitions in one file currently collapse onto the first indexed node. |
+| Call hierarchy | `textDocument/prepareCallHierarchy`, `callHierarchy/incomingCalls`, `callHierarchy/outgoingCalls` | Preparation, incoming calls, and outgoing calls work across the statically resolvable source graph. Preparing on a sourced function call returns the exact target definition, including when a file redefines the same function name. Literal sources and valid `# shuck: source=` hints participate; runtime-only dispatch and unresolved dynamic sources do not. |
 
 Editor formatting uses the same parser-backed formatter as [`shuck format`](/docs/formatting). Once `shuck server` is attached, use your editor's normal LSP format command or format-on-save integration.
 


### PR DESCRIPTION
## Summary

- preserve exact function-definition identities throughout the semantic workspace call graph
- round-trip definition byte ranges through LSP call-hierarchy items
- keep local redefinitions, recursion, sourced definitions, stale identities, and unsaved open buffers binding-accurate
- update the call-hierarchy specification and editor documentation to remove the same-name limitation

## Why

The call hierarchy previously keyed function nodes by name within a file. When a shell file redefined a function, prepare, incoming, and outgoing requests could collapse both definitions onto the first indexed node. This change keys nodes by the function name plus its full definition range, so the selected binding and its edges remain distinct.

## User impact

Editors now show callers and callees for the exact selected definition, even when another function in the same file has the same name. Stale item identities fail safely after edits instead of silently resolving to a different binding.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -q -p shuck-semantic -p shuck-server` (670 passed, 1 intentionally ignored)
- `cargo clippy -p shuck-semantic -p shuck-server --all-targets --no-deps -- -D warnings -A clippy::question_mark`
- `pnpm --dir website build`

Repository-wide Clippy remains blocked by pre-existing warnings outside this change; the edited crates pass with the existing `question_mark` lint allowed.

Closes #1208