### PR TITLE
perf(ast): inline the hot span-slice path

### DIFF
--- a/crates/shuck-ast/src/span.rs
+++ b/crates/shuck-ast/src/span.rs
@@ -136,6 +136,7 @@ impl Span {
     }
 
     /// Slice the source text covered by this span.
+    #[inline]
     pub fn slice<'a>(&self, source: &'a str) -> &'a str {
         slice_with_byte_offsets(source, self.start.offset, self.end.offset)
     }
@@ -240,6 +241,7 @@ impl TextRange {
     }
 
     /// Slice the source text covered by this range.
+    #[inline]
     pub fn slice<'a>(&self, source: &'a str) -> &'a str {
         slice_with_byte_offsets(source, usize::from(self.start), usize::from(self.end))
     }
@@ -253,15 +255,19 @@ impl TextRange {
     }
 }
 
+#[inline]
 fn slice_with_byte_offsets(source: &str, start: usize, end: usize) -> &str {
-    if start > end || end > source.len() {
-        return "";
-    }
-
     if let Some(slice) = source.get(start..end) {
         return slice;
     }
+    slice_with_clamped_byte_offsets(source, start, end)
+}
 
+#[cold]
+fn slice_with_clamped_byte_offsets(source: &str, start: usize, end: usize) -> &str {
+    if start > end || end > source.len() {
+        return "";
+    }
     let start = floor_char_boundary(source, start);
     let end = ceil_char_boundary(source, end);
     source.get(start..end).unwrap_or("")


### PR DESCRIPTION
## Summary

Hotspot #7 from the large-corpus profile: `shuck_ast::span::slice_with_byte_offsets` (~1.5% of lint wall time). `Span::slice` is called for nearly every fact and rule decision, but the slicer was a cross-crate out-of-line call in non-LTO builds and pre-checked bounds that `str::get` checks anyway.

- Hot path is now a single inlinable `str::get`
- The clamped/char-boundary fallback moves to a `#[cold]` helper
- `Span::slice` / `TextRange::slice` are `#[inline]`

Behavior is identical (the removed pre-check produced the same "" result through the fallback).

## Measured impact (xwmx/nb fixture)

| Metric | Before | After |
|---|---|---|
| `slice_with_byte_offsets` samples | ~1.5% | 0% (inlined) |

Diagnostics unchanged.

## Testing

- `cargo test` (full workspace) passes
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean (pinned 1.94.1 toolchain)
- `make test-large-corpus SHUCK_LARGE_CORPUS_SAMPLE_PERCENT=10` conformance passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)