### PR TITLE
perf(linter): index statement spans for pipeline fact lookups

### DIFF
--- a/crates/shuck-linter/src/facts/commands.rs
+++ b/crates/shuck-linter/src/facts/commands.rs
@@ -1460,10 +1460,25 @@ pub(crate) fn command_fact<'facts, 'a>(
         .unwrap_or_else(|| panic!("command id {} must exist", id.index()))
 }
 
+/// Command positions keyed by their statement span, in source order.
+pub(crate) type StmtSpanIndex = FxHashMap<FactSpan, SmallVec<[u32; 2]>>;
+
+pub(crate) fn build_stmt_span_index(commands: &[CommandFact<'_>]) -> StmtSpanIndex {
+    let mut index = StmtSpanIndex::default();
+    for (position, command) in commands.iter().enumerate() {
+        index
+            .entry(FactSpan::new(command.stmt().span))
+            .or_default()
+            .push(position as u32);
+    }
+    index
+}
+
 pub(crate) fn command_fact_for_semantic_span_matching<'facts, 'a>(
     commands: &'facts [CommandFact<'a>],
     indices_by_id: &[Option<usize>],
     command_ids_by_span: &CommandLookupIndex,
+    stmt_span_index: &StmtSpanIndex,
     span: Span,
     predicate: impl Fn(&CommandFact<'a>) -> bool,
 ) -> Option<&'facts CommandFact<'a>> {
@@ -1476,9 +1491,14 @@ pub(crate) fn command_fact_for_semantic_span_matching<'facts, 'a>(
                 .find(|command| predicate(command))
         })
         .or_else(|| {
-            commands.iter().find(|command| {
-                predicate(command) && FactSpan::new(command.stmt().span) == FactSpan::new(span)
-            })
+            stmt_span_index
+                .get(&FactSpan::new(span))
+                .and_then(|positions| {
+                    positions
+                        .iter()
+                        .map(|position| &commands[*position as usize])
+                        .find(|command| predicate(command))
+                })
         })
         .or_else(|| {
             commands

--- a/crates/shuck-linter/src/facts/pipelines.rs
+++ b/crates/shuck-linter/src/facts/pipelines.rs
@@ -105,6 +105,7 @@ pub(crate) fn build_pipeline_facts<'a>(
         command_ids_by_span,
         command_child_index,
     );
+    let stmt_span_index = build_stmt_span_index(commands);
 
     semantic
         .pipeline_commands()
@@ -114,6 +115,7 @@ pub(crate) fn build_pipeline_facts<'a>(
                 commands,
                 command_fact_indices_by_id,
                 command_ids_by_span,
+                &stmt_span_index,
                 pipeline.span,
                 |command| matches!(command.command(), Command::Binary(_)),
             )?;
@@ -130,7 +132,11 @@ pub(crate) fn build_pipeline_facts<'a>(
                     .segments
                     .iter()
                     .map(|segment| {
-                        build_pipeline_segment_fact(segment.command_span, command_relationships)
+                        build_pipeline_segment_fact(
+                            segment.command_span,
+                            command_relationships,
+                            &stmt_span_index,
+                        )
                     })
                     .collect::<Vec<_>>()
                     .into_boxed_slice(),
@@ -158,11 +164,13 @@ pub(crate) fn build_pipeline_facts<'a>(
 pub(crate) fn build_pipeline_segment_fact<'a>(
     command_span: Span,
     command_relationships: CommandRelationshipContext<'_, 'a>,
+    stmt_span_index: &StmtSpanIndex,
 ) -> PipelineSegmentFact<'a> {
     let Some(fact) = command_fact_for_semantic_span_matching(
         command_relationships.commands,
         command_relationships.command_fact_indices_by_id,
         command_relationships.command_ids_by_span,
+        stmt_span_index,
         command_span,
         |command| {
             !matches!(


### PR DESCRIPTION
## Summary

Hotspot #9 from the large-corpus profile: `facts::pipelines::build_pipeline_facts` (~1.3% of lint wall time).

Pipeline fact construction resolves each semantic pipeline span and every segment span to a command fact via `command_fact_for_semantic_span_matching`. Segment spans are **statement** spans, which are not keyed in the command lookup index, so the fallback scanned every command fact per segment — effectively segments × commands.

A statement-span index (built once per file) now answers that fallback with a hash lookup. Entries are stored in source order, preserving the original first-match semantics; the final containment fallback is unchanged.

## Measured impact (xwmx/nb fixture)

| Metric | Before | After | Delta |
|---|---|---|---|
| `build_pipeline_facts` samples | ~1.3% | ~1.02% | **−22%** |

Diagnostics unchanged.

## Testing

- `cargo test` (full workspace) passes
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean (pinned 1.94.1 toolchain)
- `make test-large-corpus SHUCK_LARGE_CORPUS_SAMPLE_PERCENT=10` conformance passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)