### PR TITLE
perf(semantic): slim the unused-assignment dataflow

### DIFF
--- a/crates/shuck-semantic/src/dataflow/dense.rs
+++ b/crates/shuck-semantic/src/dataflow/dense.rs
@@ -127,18 +127,20 @@ pub(super) fn build_name_table(
     bindings: &[Binding],
     references: &[Reference],
     synthetic_reads: &[SyntheticRead],
-) -> NameTable {
+) -> (NameTable, Vec<NameId>, Vec<NameId>) {
     let mut names = NameTable::default();
     for binding in bindings {
         names.intern(&binding.name);
     }
-    for reference in references {
-        names.intern(&reference.name);
-    }
-    for synthetic_read in synthetic_reads {
-        names.intern(&synthetic_read.name);
-    }
-    names
+    let reference_name_ids = references
+        .iter()
+        .map(|reference| names.intern(&reference.name))
+        .collect();
+    let synthetic_read_name_ids = synthetic_reads
+        .iter()
+        .map(|synthetic_read| names.intern(&synthetic_read.name))
+        .collect();
+    (names, reference_name_ids, synthetic_read_name_ids)
 }
 
 pub(super) fn build_dense_binding_data(

--- a/crates/shuck-semantic/src/dataflow/exact.rs
+++ b/crates/shuck-semantic/src/dataflow/exact.rs
@@ -18,6 +18,8 @@ use super::*;
 #[derive(Debug)]
 pub(crate) struct ExactVariableDataflow {
     pub(super) names: NameTable,
+    pub(super) reference_name_ids: Vec<NameId>,
+    pub(super) synthetic_read_name_ids: Vec<NameId>,
     pub(super) binding_data: DenseBindingData,
     pub(super) binding_blocks: Vec<Option<BlockId>>,
     pub(super) reference_blocks: Vec<Option<BlockId>>,

--- a/crates/shuck-semantic/src/dataflow/mod.rs
+++ b/crates/shuck-semantic/src/dataflow/mod.rs
@@ -151,9 +151,9 @@ pub(crate) use dense::materialize_reaching_definitions;
 use dense::*;
 pub(crate) use exact::ExactVariableDataflow;
 use scope_reads::{
-    ScopeReadPlan, binding_has_future_reads_before_local_shadow, build_scope_read_plans,
-    compute_compatibility_read_sets, compute_transitive_read_sets, is_function_escape_candidate,
-    next_shadowing_local_declarations, reachable_blocks_dense,
+    BoundNameSpace, ScopeReadPlan, binding_has_future_reads_before_local_shadow,
+    build_scope_read_plans, compute_compatibility_read_sets, compute_transitive_read_sets,
+    is_function_escape_candidate, next_shadowing_local_declarations, reachable_blocks_dense,
 };
 pub(crate) use scope_reads::{
     binding_initializes_name, function_binding_certainty, summarize_scope_provided_bindings,
@@ -195,7 +195,7 @@ pub(crate) fn analyze_unused_assignments_with_options(
 pub(crate) fn build_exact_variable_dataflow(
     context: &DataflowContext<'_>,
 ) -> ExactVariableDataflow {
-    let names = build_name_table(
+    let (names, reference_name_ids, synthetic_read_name_ids) = build_name_table(
         context.bindings,
         context.references,
         context.synthetic_reads,
@@ -207,6 +207,8 @@ pub(crate) fn build_exact_variable_dataflow(
 
     ExactVariableDataflow {
         names,
+        reference_name_ids,
+        synthetic_read_name_ids,
         binding_data,
         binding_blocks,
         reference_blocks,

--- a/crates/shuck-semantic/src/dataflow/scope_reads.rs
+++ b/crates/shuck-semantic/src/dataflow/scope_reads.rs
@@ -44,6 +44,41 @@ pub(super) struct ScopeReadPlan {
     pub(super) is_function: bool,
 }
 
+/// Compact id space covering only names that have bindings.
+///
+/// Scope-read bitsets are only ever queried for binding names, so the
+/// matrices stay narrow by dropping every other referenced name.
+pub(super) struct BoundNameSpace {
+    compact_by_name: Vec<Option<u32>>,
+    len: usize,
+}
+
+impl BoundNameSpace {
+    pub(super) fn new(binding_name_ids: &[NameId], name_count: usize) -> Self {
+        let mut compact_by_name = vec![None; name_count];
+        let mut len = 0u32;
+        for name in binding_name_ids {
+            let compact = &mut compact_by_name[name.index()];
+            if compact.is_none() {
+                *compact = Some(len);
+                len += 1;
+            }
+        }
+        Self {
+            compact_by_name,
+            len: len as usize,
+        }
+    }
+
+    pub(super) fn len(&self) -> usize {
+        self.len
+    }
+
+    pub(super) fn get(&self, name: NameId) -> Option<usize> {
+        self.compact_by_name[name.index()].map(|compact| compact as usize)
+    }
+}
+
 impl ScopeReadPlan {
     pub(super) fn new(name_count: usize, is_function: bool) -> Self {
         Self {
@@ -280,7 +315,7 @@ pub(super) fn build_scope_read_plans(
     call_sites: &FxHashMap<Name, SmallVec<[CallSite; 2]>>,
     visible_function_call_bindings: &FxHashMap<SpanKey, BindingId>,
     function_body_scopes: &FxHashMap<BindingId, ScopeId>,
-    name_count: usize,
+    bound_names: &BoundNameSpace,
 ) -> (Vec<ScopeReadPlan>, Vec<Vec<CallerReadSite>>) {
     let calls_by_scope = resolved_calls_by_scope(
         call_sites,
@@ -289,14 +324,21 @@ pub(super) fn build_scope_read_plans(
     );
     let mut plans = scopes
         .iter()
-        .map(|scope| ScopeReadPlan::new(name_count, matches!(scope.kind, ScopeKind::Function(_))))
+        .map(|scope| {
+            ScopeReadPlan::new(
+                bound_names.len(),
+                matches!(scope.kind, ScopeKind::Function(_)),
+            )
+        })
         .collect::<Vec<_>>();
     let mut callers_by_callee = vec![Vec::new(); scopes.len()];
 
     for (reference_index, reference) in references.iter().enumerate() {
         let plan = &mut plans[reference.scope.index()];
         let name_id = reference_name_ids[reference_index];
-        plan.direct_reads.insert(name_id.index());
+        if let Some(compact) = bound_names.get(name_id) {
+            plan.direct_reads.insert(compact);
+        }
         plan.events.push(ScopeReadEvent {
             offset: reference.span.start.offset,
             block: reference_blocks[reference_index],
@@ -307,7 +349,9 @@ pub(super) fn build_scope_read_plans(
     for (read_index, synthetic_read) in synthetic_reads.iter().enumerate() {
         let plan = &mut plans[synthetic_read.scope.index()];
         let name_id = synthetic_read_name_ids[read_index];
-        plan.direct_reads.insert(name_id.index());
+        if let Some(compact) = bound_names.get(name_id) {
+            plan.direct_reads.insert(compact);
+        }
         plan.events.push(ScopeReadEvent {
             offset: synthetic_read.span.start.offset,
             block: command_block_for_span(cfg, synthetic_read.span),
@@ -372,11 +416,11 @@ pub(super) fn compute_compatibility_read_sets(
     read_plans: &[ScopeReadPlan],
     callers_by_callee: &[Vec<CallerReadSite>],
     transitive_reads: &DenseBitMatrix,
-    name_count: usize,
+    bound_names: &BoundNameSpace,
 ) -> CompatibilityReadSets {
-    let future_reads = build_future_read_summaries(read_plans, transitive_reads, name_count);
-    let mut escape_reads = DenseBitMatrix::zeros(read_plans.len(), name_count);
-    let mut reads = DenseBitSet::new(name_count);
+    let future_reads = build_future_read_summaries(read_plans, transitive_reads, bound_names);
+    let mut escape_reads = DenseBitMatrix::zeros(read_plans.len(), bound_names.len());
+    let mut reads = DenseBitSet::new(bound_names.len());
     loop {
         let mut changed = false;
         for (scope_index, plan) in read_plans.iter().enumerate() {
@@ -427,17 +471,19 @@ fn nested_non_function_child_scopes(scopes: &[Scope]) -> Vec<Vec<ScopeId>> {
 fn build_future_read_summaries(
     read_plans: &[ScopeReadPlan],
     transitive_reads: &DenseBitMatrix,
-    name_count: usize,
+    bound_names: &BoundNameSpace,
 ) -> Vec<ScopeFutureReads> {
     read_plans
         .iter()
         .map(|plan| {
-            let mut suffix_reads = DenseBitMatrix::zeros(plan.events.len() + 1, name_count);
+            let mut suffix_reads = DenseBitMatrix::zeros(plan.events.len() + 1, bound_names.len());
             for event_index in (0..plan.events.len()).rev() {
                 suffix_reads.copy_row_from_row(event_index, event_index + 1);
                 match plan.events[event_index].kind {
                     ScopeReadEventKind::Direct(name_id) => {
-                        suffix_reads.insert(event_index, name_id.index());
+                        if let Some(compact) = bound_names.get(name_id) {
+                            suffix_reads.insert(event_index, compact);
+                        }
                     }
                     ScopeReadEventKind::Call(callee_scope) => {
                         suffix_reads.union_row_with_words(
@@ -471,7 +517,7 @@ fn future_reads_union_after(
 fn future_reads_contain_after(
     scope: ScopeId,
     offset: usize,
-    name_id: NameId,
+    compact_name: usize,
     read_plans: &[ScopeReadPlan],
     future_reads: &[ScopeFutureReads],
     escape_reads: &DenseBitMatrix,
@@ -480,14 +526,15 @@ fn future_reads_contain_after(
     let index = plan.events.partition_point(|event| event.offset <= offset);
     future_reads[scope.index()]
         .suffix_reads
-        .contains(index, name_id.index())
-        || (plan.is_function && escape_reads.contains(scope.index(), name_id.index()))
+        .contains(index, compact_name)
+        || (plan.is_function && escape_reads.contains(scope.index(), compact_name))
 }
 
 #[allow(clippy::too_many_arguments)]
 pub(super) fn binding_has_future_reads_before_local_shadow(
     binding: &Binding,
     name_id: NameId,
+    bound_names: &BoundNameSpace,
     bindings: &[Binding],
     next_local_shadows: &[Option<BindingId>],
     cfg: &ControlFlowGraph,
@@ -497,9 +544,12 @@ pub(super) fn binding_has_future_reads_before_local_shadow(
     future_reads: &[ScopeFutureReads],
     escape_reads: &DenseBitMatrix,
 ) -> bool {
+    let Some(compact_name) = bound_names.get(name_id) else {
+        return false;
+    };
     let shadow = next_local_shadows[binding.id.index()].map(|shadow| &bindings[shadow.index()]);
     let escape_reads_visible = read_plans[binding.scope.index()].is_function
-        && escape_reads.contains(binding.scope.index(), name_id.index());
+        && escape_reads.contains(binding.scope.index(), compact_name);
 
     if let Some(shadow) = shadow {
         if let (Some(binding_block), Some(shadow_block)) = (
@@ -514,6 +564,7 @@ pub(super) fn binding_has_future_reads_before_local_shadow(
                     binding_block,
                     shadow_block,
                     name_id,
+                    compact_name,
                     read_plans,
                     transitive_reads,
                     cfg,
@@ -525,6 +576,7 @@ pub(super) fn binding_has_future_reads_before_local_shadow(
                     binding.span.start.offset,
                     shadow.span.start.offset,
                     name_id,
+                    compact_name,
                     read_plans,
                     transitive_reads,
                 )
@@ -533,7 +585,7 @@ pub(super) fn binding_has_future_reads_before_local_shadow(
         future_reads_contain_after(
             binding.scope,
             binding.span.start.offset,
-            name_id,
+            compact_name,
             read_plans,
             future_reads,
             escape_reads,
@@ -541,12 +593,15 @@ pub(super) fn binding_has_future_reads_before_local_shadow(
     }
 }
 
-pub(super) fn next_shadowing_local_declarations(bindings: &[Binding]) -> Vec<Option<BindingId>> {
+pub(super) fn next_shadowing_local_declarations(
+    bindings: &[Binding],
+    binding_name_ids: &[NameId],
+) -> Vec<Option<BindingId>> {
     let mut next_shadows = vec![None; bindings.len()];
-    let mut next_by_scope_and_name: FxHashMap<(ScopeId, Name), BindingId> = FxHashMap::default();
+    let mut next_by_scope_and_name: FxHashMap<(ScopeId, NameId), BindingId> = FxHashMap::default();
 
     for binding in bindings.iter().rev() {
-        let key = (binding.scope, binding.name.clone());
+        let key = (binding.scope, binding_name_ids[binding.id.index()]);
         next_shadows[binding.id.index()] = next_by_scope_and_name.get(&key).copied();
 
         if matches!(binding.kind, BindingKind::Declaration(_))
@@ -564,6 +619,7 @@ pub(super) fn future_reads_contain_after_until(
     after_offset: usize,
     before_offset: usize,
     name_id: NameId,
+    compact_name: usize,
     read_plans: &[ScopeReadPlan],
     transitive_reads: &DenseBitMatrix,
 ) -> bool {
@@ -584,7 +640,7 @@ pub(super) fn future_reads_contain_after_until(
         .any(|event| match event.kind {
             ScopeReadEventKind::Direct(candidate) => candidate == name_id,
             ScopeReadEventKind::Call(callee_scope) => {
-                transitive_reads.contains(callee_scope.index(), name_id.index())
+                transitive_reads.contains(callee_scope.index(), compact_name)
             }
         })
 }
@@ -597,6 +653,7 @@ fn future_reads_contain_after_without_shadow(
     binding_block: BlockId,
     shadow_block: BlockId,
     name_id: NameId,
+    compact_name: usize,
     read_plans: &[ScopeReadPlan],
     transitive_reads: &DenseBitMatrix,
     cfg: &ControlFlowGraph,
@@ -610,7 +667,7 @@ fn future_reads_contain_after_without_shadow(
         let uses_name = match event.kind {
             ScopeReadEventKind::Direct(candidate) => candidate == name_id,
             ScopeReadEventKind::Call(callee_scope) => {
-                transitive_reads.contains(callee_scope.index(), name_id.index())
+                transitive_reads.contains(callee_scope.index(), compact_name)
             }
         };
         if !uses_name {

--- a/crates/shuck-semantic/src/dataflow/tests.rs
+++ b/crates/shuck-semantic/src/dataflow/tests.rs
@@ -112,6 +112,7 @@ fn future_reads_contain_after_until_ignores_backwards_intervals() {
         10,
         5,
         NameId(0),
+        0,
         &[plan],
         &transitive_reads,
     ));

--- a/crates/shuck-semantic/src/dataflow/unused.rs
+++ b/crates/shuck-semantic/src/dataflow/unused.rs
@@ -36,44 +36,31 @@ pub(super) fn analyze_unused_assignments_exact(
     exact: &ExactVariableDataflow,
     options: UnusedAssignmentAnalysisOptions,
 ) -> UnusedAssignmentsResult {
-    let reference_name_ids = context
-        .references
-        .iter()
-        .map(|reference| {
-            let Some(name_id) = exact.names.get(&reference.name) else {
-                unreachable!("reference name interned");
-            };
-            name_id
-        })
-        .collect::<Vec<_>>();
-    let synthetic_read_name_ids = context
-        .synthetic_reads
-        .iter()
-        .map(|read| {
-            let Some(name_id) = exact.names.get(&read.name) else {
-                unreachable!("synthetic read name interned");
-            };
-            name_id
-        })
-        .collect::<Vec<_>>();
+    let reference_name_ids = exact.reference_name_ids.as_slice();
+    let synthetic_read_name_ids = exact.synthetic_read_name_ids.as_slice();
+    let bound_names = BoundNameSpace::new(&exact.binding_data.binding_name_ids, exact.names.len());
     let (read_plans, callers_by_callee) = build_scope_read_plans(
         context.cfg,
         context.scopes,
         context.references,
         context.synthetic_reads,
         &exact.reference_blocks,
-        &reference_name_ids,
-        &synthetic_read_name_ids,
+        reference_name_ids,
+        synthetic_read_name_ids,
         context.call_sites,
         context.visible_function_call_bindings,
         context.function_body_scopes,
-        exact.names.len(),
+        &bound_names,
     );
     let transitive_reads =
-        compute_transitive_read_sets(&read_plans, context.scopes, exact.names.len());
+        compute_transitive_read_sets(&read_plans, context.scopes, bound_names.len());
 
     let mut used_bindings = DenseBitSet::new(context.bindings.len());
+    let mut always_used_bindings = DenseBitSet::new(context.bindings.len());
     for binding in context.bindings {
+        if context.runtime.is_always_used_binding(&binding.name) {
+            always_used_bindings.insert(binding.id.index());
+        }
         if !binding.references.is_empty()
             || binding
                 .attributes
@@ -81,7 +68,7 @@ pub(super) fn analyze_unused_assignments_exact(
             || binding
                 .attributes
                 .contains(BindingAttributes::EXTERNALLY_CONSUMED)
-            || context.runtime.is_always_used_binding(&binding.name)
+            || always_used_bindings.contains(binding.id.index())
         {
             used_bindings.insert(binding.id.index());
         }
@@ -91,10 +78,11 @@ pub(super) fn analyze_unused_assignments_exact(
         context,
         exact,
         options,
-        &reference_name_ids,
-        &synthetic_read_name_ids,
+        reference_name_ids,
+        synthetic_read_name_ids,
         &read_plans,
         &transitive_reads,
+        &bound_names,
         &mut used_bindings,
     );
 
@@ -106,14 +94,18 @@ pub(super) fn analyze_unused_assignments_exact(
             &read_plans,
             &callers_by_callee,
             &transitive_reads,
-            exact.names.len(),
+            &bound_names,
         );
-        let next_local_shadows = next_shadowing_local_declarations(context.bindings);
+        let next_local_shadows = next_shadowing_local_declarations(
+            context.bindings,
+            &exact.binding_data.binding_name_ids,
+        );
         for binding in context.bindings {
             if is_function_escape_candidate(binding, context.scopes)
                 && binding_has_future_reads_before_local_shadow(
                     binding,
                     exact.binding_data.binding_name_ids[binding.id.index()],
+                    &bound_names,
                     context.bindings,
                     &next_local_shadows,
                     context.cfg,
@@ -130,6 +122,7 @@ pub(super) fn analyze_unused_assignments_exact(
                 && binding_has_future_reads_before_local_shadow(
                     binding,
                     exact.binding_data.binding_name_ids[binding.id.index()],
+                    &bound_names,
                     context.bindings,
                     &next_local_shadows,
                     context.cfg,
@@ -153,7 +146,7 @@ pub(super) fn analyze_unused_assignments_exact(
         if matches!(
             binding.kind,
             BindingKind::FunctionDefinition | BindingKind::Imported
-        ) || context.runtime.is_always_used_binding(&binding.name)
+        ) || always_used_bindings.contains(binding.id.index())
             || (exact.unreachable_blocks.contains(block_id.index())
                 && !options.report_unreachable_assignments)
             || used_bindings.contains(binding.id.index())
@@ -472,15 +465,40 @@ impl SlotId {
 
 #[derive(Debug, Clone)]
 struct UnusedAssignmentSlots {
-    binding_slots: Vec<SlotId>,
-    slots_for_name: Vec<SlotId>,
+    binding_slots: Vec<Option<SlotId>>,
+    slots_for_name: Vec<Option<SlotId>>,
+    slot_count: usize,
 }
 
 impl UnusedAssignmentSlots {
-    fn new(binding_name_ids: &[NameId], name_count: usize) -> Self {
-        let slots_for_name = (0..name_count)
-            .map(|index| SlotId(index as u32))
-            .collect::<Vec<_>>();
+    fn new(
+        binding_name_ids: &[NameId],
+        name_count: usize,
+        bindings: &[Binding],
+        used_bindings: &DenseBitSet,
+    ) -> Self {
+        // Liveness bits are only ever read back when a binding's unused-ness
+        // is still undetermined, so only names with at least one such binding
+        // get a slot; inserts for every other name become no-ops. This keeps
+        // the dataflow bitsets narrow.
+        let mut slots_for_name = vec![None; name_count];
+        let mut slot_count = 0u32;
+        for binding in bindings {
+            if used_bindings.contains(binding.id.index())
+                || matches!(
+                    binding.kind,
+                    BindingKind::FunctionDefinition | BindingKind::Imported
+                )
+            {
+                continue;
+            }
+            let name = binding_name_ids[binding.id.index()];
+            let slot = &mut slots_for_name[name.index()];
+            if slot.is_none() {
+                *slot = Some(SlotId(slot_count));
+                slot_count += 1;
+            }
+        }
         let binding_slots = binding_name_ids
             .iter()
             .map(|name| slots_for_name[name.index()])
@@ -489,18 +507,19 @@ impl UnusedAssignmentSlots {
         Self {
             binding_slots,
             slots_for_name,
+            slot_count: slot_count as usize,
         }
     }
 
     fn len(&self) -> usize {
-        self.slots_for_name.len()
+        self.slot_count
     }
 
-    fn slot_for_name(&self, name: NameId) -> SlotId {
+    fn slot_for_name(&self, name: NameId) -> Option<SlotId> {
         self.slots_for_name[name.index()]
     }
 
-    fn slot_for_binding(&self, binding: BindingId) -> SlotId {
+    fn slot_for_binding(&self, binding: BindingId) -> Option<SlotId> {
         self.binding_slots[binding.index()]
     }
 }
@@ -656,43 +675,71 @@ fn mark_used_bindings_with_backward_liveness(
     synthetic_read_name_ids: &[NameId],
     read_plans: &[ScopeReadPlan],
     transitive_reads: &DenseBitMatrix,
+    bound_names: &BoundNameSpace,
     used_bindings: &mut DenseBitSet,
 ) {
-    let slots = UnusedAssignmentSlots::new(&exact.binding_data.binding_name_ids, exact.names.len());
+    let slots = UnusedAssignmentSlots::new(
+        &exact.binding_data.binding_name_ids,
+        exact.names.len(),
+        context.bindings,
+        used_bindings,
+    );
     let events = build_unused_assignment_events(context, exact, read_plans);
+    // Project each scope's transitive reads into slot space once so call
+    // events union whole words instead of iterating name bits per visit.
+    let mut slot_for_compact = vec![None; bound_names.len()];
+    for name in &exact.binding_data.binding_name_ids {
+        if let (Some(compact), Some(slot)) = (bound_names.get(*name), slots.slot_for_name(*name)) {
+            slot_for_compact[compact] = Some(slot);
+        }
+    }
+    let mut call_read_slot_masks = DenseBitMatrix::zeros(read_plans.len(), slots.len());
+    for scope_index in 0..read_plans.len() {
+        for compact_index in DenseBitSetIter::over_words(transitive_reads.row(scope_index)) {
+            if let Some(slot) = slot_for_compact[compact_index] {
+                call_read_slot_masks.insert(scope_index, slot.index());
+            }
+        }
+    }
     let block_count = context.cfg.blocks().len();
     let mut live_in = SlotLiveMatrix::new(block_count, slots.len());
-    let mut live_out = SlotLiveMatrix::new(block_count, slots.len());
     let mut outgoing = SlotLiveSet::new(slots.len());
     let mut incoming = SlotLiveSet::new(slots.len());
     let backward_order = exact.backward_block_order(context.cfg);
 
     run_backward_dataflow_worklist(context.cfg, backward_order, |block_id| {
         let block_index = block_id.index();
-        outgoing.clear();
-        for (successor, _) in context.cfg.successors(block_id) {
-            outgoing.union_with_slice(live_in.set(successor.index()));
-        }
-
-        incoming.copy_from_slice(outgoing.as_slice());
-        if !exact.unreachable_blocks.contains(block_index) || options.report_unreachable_assignments
-        {
-            for event in events[block_index].iter().rev() {
-                apply_unused_assignment_event(
-                    context,
-                    options,
-                    reference_name_ids,
-                    synthetic_read_name_ids,
-                    transitive_reads,
-                    &slots,
-                    &mut incoming,
-                    used_bindings,
-                    event.kind,
-                );
+        let successors = context.cfg.successors(block_id);
+        if let [(only, _)] = successors {
+            outgoing.copy_from_slice(live_in.set(only.index()));
+        } else {
+            outgoing.clear();
+            for (successor, _) in successors {
+                outgoing.union_with_slice(live_in.set(successor.index()));
             }
         }
 
-        live_out.replace_if_changed(block_index, &outgoing);
+        let apply_events = (!exact.unreachable_blocks.contains(block_index)
+            || options.report_unreachable_assignments)
+            && !events[block_index].is_empty();
+        if !apply_events {
+            return live_in.replace_if_changed(block_index, &outgoing);
+        }
+
+        incoming.copy_from_slice(outgoing.as_slice());
+        for event in events[block_index].iter().rev() {
+            apply_unused_assignment_event(
+                context,
+                options,
+                reference_name_ids,
+                synthetic_read_name_ids,
+                &call_read_slot_masks,
+                &slots,
+                &mut incoming,
+                used_bindings,
+                event.kind,
+            );
+        }
         live_in.replace_if_changed(block_index, &incoming)
     });
 }
@@ -789,7 +836,7 @@ fn apply_unused_assignment_event(
     options: UnusedAssignmentAnalysisOptions,
     reference_name_ids: &[NameId],
     synthetic_read_name_ids: &[NameId],
-    transitive_reads: &DenseBitMatrix,
+    call_read_slot_masks: &DenseBitMatrix,
     slots: &UnusedAssignmentSlots,
     live: &mut SlotLiveSet,
     used_bindings: &mut DenseBitSet,
@@ -799,7 +846,9 @@ fn apply_unused_assignment_event(
         UnusedAssignmentEventKind::Reference(reference_id) => {
             let reference = &context.references[reference_id.index()];
             let name = reference_name_ids[reference_id.index()];
-            live.insert(slots.slot_for_name(name).index());
+            if let Some(slot) = slots.slot_for_name(name) {
+                live.insert(slot.index());
+            }
 
             if (options.treat_indirect_expansion_targets_as_used
                 || context
@@ -808,21 +857,21 @@ fn apply_unused_assignment_event(
                 && let Some(candidates) = context.indirect_targets_by_reference.get(&reference.id)
             {
                 for candidate in candidates {
-                    live.insert(slots.slot_for_binding(*candidate).index());
+                    if let Some(slot) = slots.slot_for_binding(*candidate) {
+                        live.insert(slot.index());
+                    }
                 }
             }
         }
         UnusedAssignmentEventKind::SyntheticRead(read_index) => {
             let name = synthetic_read_name_ids[read_index];
-            live.insert(slots.slot_for_name(name).index());
+            if let Some(slot) = slots.slot_for_name(name) {
+                live.insert(slot.index());
+            }
         }
         UnusedAssignmentEventKind::Call(callee_scope)
         | UnusedAssignmentEventKind::FunctionDefinition(callee_scope) => {
-            union_name_reads_into_live_slots(
-                live,
-                transitive_reads.row(callee_scope.index()),
-                slots,
-            );
+            live.union_with_slice(call_read_slot_masks.row(callee_scope.index()));
         }
         UnusedAssignmentEventKind::Binding(binding_id) => {
             apply_unused_assignment_binding_event(context, slots, live, used_bindings, binding_id);
@@ -842,7 +891,9 @@ fn apply_unused_assignment_binding_event(
         return;
     }
 
-    let slot = slots.slot_for_binding(binding_id);
+    let Some(slot) = slots.slot_for_binding(binding_id) else {
+        return;
+    };
     if resolved_binding_shadows_name_without_initializing(Some(binding)) {
         if live.contains(slot.index()) {
             used_bindings.insert(binding_id.index());
@@ -873,15 +924,4 @@ fn binding_writes_unused_assignment_slot(binding: &Binding) -> bool {
         binding.kind,
         BindingKind::FunctionDefinition | BindingKind::Imported
     ) && binding_initializes_name(binding).is_some()
-}
-
-fn union_name_reads_into_live_slots(
-    live: &mut SlotLiveSet,
-    read_words: &[usize],
-    slots: &UnusedAssignmentSlots,
-) {
-    let reads = DenseBitSetIter::over_words(read_words);
-    for name_index in reads {
-        live.insert(slots.slot_for_name(NameId(name_index as u32)).index());
-    }
 }


### PR DESCRIPTION
## Summary

Hotspot #10 from the large-corpus profile: `dataflow::unused::analyze_unused_assignments_exact`.

- Drop the write-only `live_out` matrix; skip the incoming copy for blocks without events; single-successor blocks copy instead of clear+union
- Restrict liveness slots to names whose bindings are still undetermined after the reference pre-pass
- Run the scope-read matrices (direct/transitive/suffix/escape) in a compact bound-name space instead of the full interned-name space
- Project per-scope transitive reads into slot masks once, so call events union whole words instead of iterating name bits per worklist visit
- Intern reference/synthetic-read name ids once while building the name table instead of re-hashing every reference name per analysis
- Key the local-shadow index by interned name ids (no `Name` clone per binding) and cache always-used checks across the pre-pass and reporting loops

## Measured impact (xwmx/nb fixture, interleaved A/B against the pre-optimization commit)

| Metric | Before | After | Delta |
|---|---|---|---|
| Analysis inclusive share | 2.55% | 2.25% | |
| Absolute per lint | ~4.99 ms | ~3.93 ms | **−21%** |

Diagnostics unchanged.

## Testing

- `cargo test` (full workspace) passes
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean (pinned 1.94.1 toolchain)
- `make test-large-corpus SHUCK_LARGE_CORPUS_RULES=C001` (full corpus, the rule this dataflow feeds) passes
- `make test-large-corpus SHUCK_LARGE_CORPUS_SAMPLE_PERCENT=10` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)