### PR TITLE
refactor(server): extract shared workspace function index

### DIFF
--- a/crates/shuck-server/src/call_hierarchy.rs
+++ b/crates/shuck-server/src/call_hierarchy.rs
@@ -1,78 +1,22 @@
 //! Cross-file call hierarchy (spec 025).
 //!
-//! `incomingCalls` / `outgoingCalls` answer across the whole workspace by
-//! building a [`WorkspaceCallIndex`]: every workspace shell file (open buffer
-//! preferred over disk) is parsed and projected into call facts, its
-//! determinable source edges resolved, and the two directions answered as
-//! traversals of the resulting call graph. `prepareCallHierarchy` first uses
-//! document-local identity and then consults the same index when the cursor is
-//! on a call resolved through a source edge. The returned item contains its
-//! name, file URI, and a [`CallHierarchyData`] payload carrying the exact
-//! definition byte range, which is enough for later index queries to locate it.
-//!
-//! The built index is cached on the session and invalidated whenever a
-//! document, workspace folder, or configuration changes, so expanding a call
-//! tree re-uses one build instead of re-analyzing the workspace per request.
-//!
-//! Call sites combine binding-accurate in-file definitions with positioned
-//! source edges, so later sourced and local definitions override earlier ones
-//! in shell execution order. Nodes retain their definition ranges, keeping
-//! same-named definitions distinct throughout preparation and expansion.
+//! Call hierarchy is the first consumer of the shared workspace function index.
+//! Every workspace shell file contributes compact definitions, call sites, and
+//! determinable source edges. Open buffers shadow disk, and exact definition
+//! byte ranges keep same-named redefinitions distinct.
 
-use std::collections::{BTreeMap, HashMap};
-use std::path::{Path, PathBuf};
-use std::sync::atomic::{AtomicU64, Ordering};
-use std::sync::{Arc, Mutex};
+use std::path::PathBuf;
 
 use lsp_types as types;
-use shuck_ast::{Name, Span};
-use shuck_config::{ConfigArguments, load_project_config, resolve_project_root_for_file};
-use shuck_indexer::LineIndex;
-use shuck_linter::ShellDialect;
-use shuck_semantic::{
-    CallFactSourceEdge, CallFunctionId, CallNodeKind, CrossFileCall, EditorSymbolTarget,
-    FileCallFacts, WorkspaceCallIndex, resolve_source_ref_targets,
-};
+use shuck_ast::Name;
+use shuck_semantic::{CallFunctionId, CallNodeKind, CrossFileCall, EditorSymbolTarget};
 
-use crate::PositionEncoding;
 use crate::edit::RangeExt;
-use crate::editor::analyze_editor_document;
 use crate::editor_features::{self, CallHierarchyData, CallHierarchyPrepareResponse};
 use crate::session::{Client, DocumentSnapshot};
-use crate::symbols::WorkspaceOpenDocument;
-
-/// Resolves and memoizes `[lint] source-paths` per project root, so cross-file
-/// hint resolution honors configured search roots the same way `shuck check`
-/// does. Relative roots are resolved against the project root.
-#[derive(Default)]
-struct SourcePathsCache {
-    by_project_root: HashMap<PathBuf, Vec<String>>,
-}
-
-impl SourcePathsCache {
-    /// Returns the configured source-path roots for `path` and the project root
-    /// that relative roots are resolved against.
-    fn resolve(&mut self, path: &Path, workspace_roots: &[PathBuf]) -> (Vec<String>, PathBuf) {
-        let fallback = workspace_roots
-            .iter()
-            .filter(|root| path.starts_with(root))
-            .max_by_key(|root| root.components().count())
-            .cloned()
-            .or_else(|| path.parent().map(Path::to_path_buf))
-            .unwrap_or_else(|| PathBuf::from("."));
-        let project_root = resolve_project_root_for_file(path, &fallback, true).unwrap_or(fallback);
-        let roots = self
-            .by_project_root
-            .entry(project_root.clone())
-            .or_insert_with(|| {
-                load_project_config(&project_root, &ConfigArguments::default())
-                    .map(|config| config.lint.source_paths.unwrap_or_default())
-                    .unwrap_or_default()
-            })
-            .clone();
-        (roots, project_root)
-    }
-}
+use crate::workspace_functions::{
+    WorkspaceFunctionContext, WorkspaceFunctionIndex, canonical_path, workspace_function_index,
+};
 
 pub(crate) type IncomingResponse = Option<Vec<types::CallHierarchyIncomingCall>>;
 pub(crate) type OutgoingResponse = Option<Vec<types::CallHierarchyOutgoingCall>>;
@@ -80,7 +24,7 @@ pub(crate) type OutgoingResponse = Option<Vec<types::CallHierarchyOutgoingCall>>
 /// Prepares the function under the cursor, including functions resolved from a
 /// statically sourced file.
 pub(crate) fn prepare_call_hierarchy(
-    context: CallHierarchyContext,
+    context: WorkspaceFunctionContext,
     snapshot: DocumentSnapshot,
     client: &Client,
     params: types::CallHierarchyPrepareParams,
@@ -107,13 +51,15 @@ pub(crate) fn prepare_call_hierarchy(
         .file_url()
         .to_file_path()
         .ok()
-        .map(|path| canonical(&path))
+        .map(|path| canonical_path(&path))
     else {
         return editor_features::prepare_call_hierarchy(snapshot, client, params);
     };
-    let built = cached_index(&context);
-    if let Some(target) = built.index.resolve_call_site(&path, call.name_span) {
-        return Ok(built.item_for(&target).map(|item| vec![item]));
+    let Some(built) = workspace_function_index(&context) else {
+        return Ok(None);
+    };
+    if let Some(target) = built.resolve_call_site(&path, call.name_span) {
+        return Ok(item_for(&built, &target).map(|item| vec![item]));
     }
 
     // An indexed active document should resolve every proven local function
@@ -125,105 +71,24 @@ pub(crate) fn prepare_call_hierarchy(
     Ok(None)
 }
 
-/// Workspace state needed to build the call index for one request.
-pub(crate) struct CallHierarchyContext {
-    pub(crate) workspace_roots: Vec<PathBuf>,
-    pub(crate) open_documents: Vec<WorkspaceOpenDocument>,
-    pub(crate) encoding: PositionEncoding,
-    /// Upper bound on indexed files (`server.callHierarchy.maxFiles`): a
-    /// runaway workspace degrades to a partial graph, not an unbounded scan.
-    pub(crate) max_files: usize,
-    pub(crate) cache: Arc<CallIndexCache>,
-    pub(crate) epoch: u64,
-}
-
-/// Session-lifetime cache of the built workspace call index.
-///
-/// Every document, workspace, or configuration change bumps the epoch and
-/// drops the cached build. Requests capture the epoch when they snapshot the
-/// session; a build finished after a concurrent change carries a stale epoch
-/// and is never served to later requests.
-#[derive(Default)]
-pub(crate) struct CallIndexCache {
-    epoch: AtomicU64,
-    built: Mutex<Option<(u64, Arc<BuiltIndex>)>>,
-}
-
-impl CallIndexCache {
-    /// Drops any cached index and marks in-flight builds stale.
-    pub(crate) fn invalidate(&self) {
-        self.epoch.fetch_add(1, Ordering::SeqCst);
-        if let Ok(mut slot) = self.built.lock() {
-            *slot = None;
-        }
-    }
-
-    pub(crate) fn current_epoch(&self) -> u64 {
-        self.epoch.load(Ordering::SeqCst)
-    }
-
-    fn get(&self, epoch: u64) -> Option<Arc<BuiltIndex>> {
-        let slot = self.built.lock().ok()?;
-        slot.as_ref()
-            .filter(|(built_epoch, _)| *built_epoch == epoch)
-            .map(|(_, built)| built.clone())
-    }
-
-    fn store(&self, epoch: u64, built: Arc<BuiltIndex>) {
-        // A build raced by an invalidation is tagged with a stale epoch; skip
-        // storing it so it cannot displace a fresher build. (If it slips past
-        // this check, `get`'s epoch comparison still refuses to serve it.)
-        if epoch != self.current_epoch() {
-            return;
-        }
-        if let Ok(mut slot) = self.built.lock() {
-            *slot = Some((epoch, built));
-        }
-    }
-}
-
-/// Returns the cached index for this context's epoch, building it on a miss.
-fn cached_index(context: &CallHierarchyContext) -> Arc<BuiltIndex> {
-    if let Some(built) = context.cache.get(context.epoch) {
-        return built;
-    }
-    let built = Arc::new(BuiltIndex::build(context));
-    context.cache.store(context.epoch, built.clone());
-    built
-}
-
-/// Source text and line index for one indexed file, retained for span→range
-/// mapping of cross-file results.
-struct FileText {
-    source: String,
-    line_index: LineIndex,
-}
-
-/// The per-request index plus the text needed to render results.
-struct BuiltIndex {
-    index: WorkspaceCallIndex,
-    texts: BTreeMap<PathBuf, FileText>,
-    encoding: PositionEncoding,
-}
-
 pub(crate) fn incoming_calls(
-    context: CallHierarchyContext,
+    context: WorkspaceFunctionContext,
     params: types::CallHierarchyIncomingCallsParams,
 ) -> crate::server::Result<IncomingResponse> {
     let Some((path, node)) = item_identity(&params.item) else {
         return Ok(None);
     };
     let CallNodeKind::Function(_) = node else {
-        // Nothing "calls" a script's top level in this model.
         return Ok(Some(Vec::new()));
     };
-    let built = cached_index(&context);
+    let Some(built) = workspace_function_index(&context) else {
+        return Ok(None);
+    };
     let calls = built
-        .index
         .incoming(&path, &node)
         .into_iter()
         .filter_map(|call| {
-            let from = built.item_for(&call)?;
+            let from = item_for(&built, &call)?;
             Some(types::CallHierarchyIncomingCall {
                 from_ranges: built.ranges_in(&call.path, &call.call_spans),
                 from,
@@ -234,20 +99,20 @@ pub(crate) fn incoming_calls(
 }
 
 pub(crate) fn outgoing_calls(
-    context: CallHierarchyContext,
+    context: WorkspaceFunctionContext,
     params: types::CallHierarchyOutgoingCallsParams,
 ) -> crate::server::Result<OutgoingResponse> {
     let Some((path, node)) = item_identity(&params.item) else {
         return Ok(None);
     };
-    let built = cached_index(&context);
-    // Outgoing call-token spans live in the queried file.
+    let Some(built) = workspace_function_index(&context) else {
+        return Ok(None);
+    };
     let calls = built
-        .index
         .outgoing(&path, &node)
         .into_iter()
         .filter_map(|call| {
-            let to = built.item_for(&call)?;
+            let to = item_for(&built, &call)?;
             Some(types::CallHierarchyOutgoingCall {
                 from_ranges: built.ranges_in(&path, &call.call_spans),
                 to,
@@ -258,14 +123,8 @@ pub(crate) fn outgoing_calls(
 }
 
 /// The queried node's identity: its file path plus which exact node in that file.
-///
-/// The `data` payload stamped by `prepare` (and by [`BuiltIndex::item_for`])
-/// distinguishes a script top-level MODULE node from a function and preserves
-/// the function definition's byte range. Function items whose clients drop
-/// `data` cannot be expanded safely because a name may identify more than one
-/// definition, so they are rejected instead of guessed.
 fn item_identity(item: &types::CallHierarchyItem) -> Option<(PathBuf, CallNodeKind)> {
-    let path = canonical(&item.uri.to_file_path().ok()?);
+    let path = canonical_path(&item.uri.to_file_path().ok()?);
     let data = item
         .data
         .clone()
@@ -286,323 +145,27 @@ fn item_identity(item: &types::CallHierarchyItem) -> Option<(PathBuf, CallNodeKi
     Some((path, node))
 }
 
-impl BuiltIndex {
-    fn build(context: &CallHierarchyContext) -> Self {
-        let mut index = WorkspaceCallIndex::new();
-        let mut texts: BTreeMap<PathBuf, FileText> = BTreeMap::new();
-
-        // `max_files` is a hard bound on the total index size. One budget is
-        // shared by all three population phases — open buffers, closed-file
-        // discovery, and source-edge expansion — and every insertion checks it.
-        let max_files = context.max_files;
-        let mut source_paths = SourcePathsCache::default();
-        // Resolve every open path up front (even ones over budget) so
-        // discovery below never re-reads an open buffer's stale on-disk
-        // contents.
-        let open_docs: Vec<(PathBuf, &WorkspaceOpenDocument)> = context
-            .open_documents
-            .iter()
-            .filter_map(|open| {
-                let path = canonical(&open.uri.to_file_path().ok()?);
-                Some((path, open))
-            })
-            .collect();
-        let open_paths: Vec<PathBuf> = open_docs.iter().map(|(path, _)| path.clone()).collect();
-        for (path, open) in &open_docs {
-            if index.file_count() >= max_files {
-                tracing::warn!(
-                    "call hierarchy: open documents exceed the {max_files}-file limit; \
-                     indexing only the first {max_files}"
-                );
-                break;
-            }
-            let (roots, base) = source_paths.resolve(path, &context.workspace_roots);
-            insert_file(
-                &mut index,
-                &mut texts,
-                path,
-                open.document.contents(),
-                &roots,
-                &base,
-            );
+fn item_for(
+    index: &WorkspaceFunctionIndex,
+    call: &CrossFileCall,
+) -> Option<types::CallHierarchyItem> {
+    let uri = index.file(&call.path)?.uri().clone();
+    match &call.node {
+        CallNodeKind::Function(function) => {
+            let definition_span = call.def_span?;
+            let range = index.range_of(&call.path, definition_span)?;
+            let selection_range = call
+                .selection_span
+                .and_then(|span| index.range_of(&call.path, span))
+                .unwrap_or(range);
+            Some(crate::editor_features::call_hierarchy_function_item(
+                function.name.to_string(),
+                uri,
+                definition_span,
+                range,
+                selection_range,
+            ))
         }
-
-        // Discovery is capped to the budget the open buffers left over.
-        let remaining = max_files.saturating_sub(index.file_count());
-        for file in discover_closed_shell_files(&context.workspace_roots, &open_paths, remaining) {
-            let Ok(source) = std::fs::read_to_string(&file) else {
-                continue;
-            };
-            let (roots, base) = source_paths.resolve(&file, &context.workspace_roots);
-            insert_file(&mut index, &mut texts, &file, &source, &roots, &base);
-        }
-
-        // Resolved source edges may point outside discovery (gitignored
-        // vendored files, targets outside the workspace roots). Index those
-        // files too — otherwise their definitions are invisible to the graph —
-        // following edges of newly added files to a fixpoint, re-checking the
-        // budget before every insertion.
-        'expand: loop {
-            let missing: Vec<PathBuf> = index
-                .files()
-                .flat_map(|(_, facts)| facts.source_edges.iter().map(|edge| edge.path.clone()))
-                .filter(|target| !index.contains(target))
-                .collect::<std::collections::BTreeSet<_>>()
-                .into_iter()
-                .collect();
-            if missing.is_empty() {
-                break;
-            }
-            for target in missing {
-                if index.file_count() >= max_files {
-                    tracing::warn!(
-                        "call hierarchy: source-edge targets exceed the {max_files}-file \
-                         limit; the call graph may be missing edges"
-                    );
-                    break 'expand;
-                }
-                let Ok(source) = std::fs::read_to_string(&target) else {
-                    // Unreadable target: record an empty entry so the loop
-                    // terminates instead of retrying it forever.
-                    index.insert(target.clone(), FileCallFacts::default());
-                    continue;
-                };
-                let (roots, base) = source_paths.resolve(&target, &context.workspace_roots);
-                insert_file(&mut index, &mut texts, &target, &source, &roots, &base);
-            }
-        }
-
-        Self {
-            index,
-            texts,
-            encoding: context.encoding,
-        }
-    }
-
-    /// Builds an LSP item for one end of a cross-file edge. Functions carry their
-    /// file URI and definition ranges; a top-level caller becomes a MODULE node.
-    fn item_for(&self, call: &CrossFileCall) -> Option<types::CallHierarchyItem> {
-        let uri = types::Url::from_file_path(&call.path).ok()?;
-        match &call.node {
-            CallNodeKind::Function(function) => {
-                let range = self.range_of(&call.path, call.def_span?)?;
-                let selection_range = call
-                    .selection_span
-                    .and_then(|span| self.range_of(&call.path, span))
-                    .unwrap_or(range);
-                Some(crate::editor_features::call_hierarchy_function_item(
-                    function.name.to_string(),
-                    uri,
-                    call.def_span?,
-                    range,
-                    selection_range,
-                ))
-            }
-            CallNodeKind::TopLevel => {
-                Some(crate::editor_features::call_hierarchy_top_level_item(uri))
-            }
-        }
-    }
-
-    fn ranges_in(&self, path: &Path, spans: &[Span]) -> Vec<types::Range> {
-        spans
-            .iter()
-            .filter_map(|span| self.range_of(path, *span))
-            .collect()
-    }
-
-    fn range_of(&self, path: &Path, span: Span) -> Option<types::Range> {
-        let text = self.texts.get(path)?;
-        Some(crate::edit::to_lsp_range(
-            span.to_range(),
-            &text.source,
-            &text.line_index,
-            self.encoding,
-        ))
-    }
-}
-
-fn insert_file(
-    index: &mut WorkspaceCallIndex,
-    texts: &mut BTreeMap<PathBuf, FileText>,
-    path: &Path,
-    source: &str,
-    source_path_roots: &[String],
-    source_path_base: &Path,
-) {
-    let key = canonical(path);
-    let shell = ShellDialect::infer(source, Some(path));
-    let model = analyze_editor_document(source, Some(path), shell);
-    // Resolve each determinable source edge against the file's own directory
-    // first, then the configured `[lint] source-paths` roots.
-    let edges = model
-        .source_refs()
-        .iter()
-        .filter_map(|source_ref| {
-            resolve_source_ref_targets(path, source_ref, source_path_roots, source_path_base).map(
-                |target| CallFactSourceEdge {
-                    path: canonical(&target),
-                    span: source_ref.span,
-                },
-            )
-        })
-        .collect::<Vec<_>>();
-    index.insert(
-        key.clone(),
-        FileCallFacts::project_with_source_edges(&model, edges),
-    );
-    texts.insert(
-        key,
-        FileText {
-            source: source.to_owned(),
-            line_index: LineIndex::new(source),
-        },
-    );
-}
-
-fn discover_closed_shell_files(
-    roots: &[PathBuf],
-    open_paths: &[PathBuf],
-    max_files: usize,
-) -> Vec<PathBuf> {
-    use shuck_discover::{DiscoveryOptions, FileKind, discover_files};
-
-    let mut files: BTreeMap<PathBuf, ()> = BTreeMap::new();
-    for root in roots {
-        let discovered = match discover_files(
-            std::slice::from_ref(root),
-            root,
-            &DiscoveryOptions {
-                respect_gitignore: true,
-                parallel: true,
-                use_config_roots: true,
-                ..DiscoveryOptions::default()
-            },
-        ) {
-            Ok(files) => files,
-            Err(error) => {
-                tracing::warn!(
-                    "call hierarchy: failed to discover files in {}: {error}",
-                    root.display()
-                );
-                continue;
-            }
-        };
-        for file in discovered {
-            if file.kind != FileKind::Shell {
-                continue;
-            }
-            let path = canonical(&file.absolute_path);
-            if open_paths.contains(&path) {
-                continue;
-            }
-            files.entry(path).or_default();
-        }
-    }
-    if files.len() > max_files {
-        tracing::warn!(
-            "call hierarchy: workspace has {} shell files; indexing only {max_files}",
-            files.len()
-        );
-    }
-    files.into_keys().take(max_files).collect()
-}
-
-fn canonical(path: &Path) -> PathBuf {
-    std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf())
-}
-
-#[cfg(test)]
-mod tests {
-    use std::sync::Arc;
-
-    use crate::edit::TextDocument;
-
-    use super::*;
-
-    /// Builds a workspace exercising all three index-population phases: open
-    /// buffers, closed-file discovery, and source-edge expansion to a target
-    /// outside the discovered set.
-    fn context_for(workspace: &Path, max_files: usize) -> CallHierarchyContext {
-        let open_path = workspace.join("open_a.sh");
-        let open_doc = WorkspaceOpenDocument {
-            uri: types::Url::from_file_path(&open_path).unwrap(),
-            document: Arc::new(
-                TextDocument::new(
-                    "# shuck: source=vendored/edge.sh\nsource \"$DIR/edge.sh\"\nedge_fn\n"
-                        .to_owned(),
-                    1,
-                )
-                .with_language_id("shellscript"),
-            ),
-        };
-        let open_b = WorkspaceOpenDocument {
-            uri: types::Url::from_file_path(workspace.join("open_b.sh")).unwrap(),
-            document: Arc::new(
-                TextDocument::new("b() { :; }\n".to_owned(), 1).with_language_id("shellscript"),
-            ),
-        };
-        CallHierarchyContext {
-            workspace_roots: vec![workspace.to_path_buf()],
-            open_documents: vec![open_doc, open_b],
-            encoding: PositionEncoding::UTF16,
-            max_files,
-            cache: Arc::new(CallIndexCache::default()),
-            epoch: 0,
-        }
-    }
-
-    fn populate_workspace(workspace: &Path) {
-        // Open buffers (also present on disk with different content).
-        std::fs::write(workspace.join("open_a.sh"), "stale() { :; }\n").unwrap();
-        std::fs::write(workspace.join("open_b.sh"), "stale() { :; }\n").unwrap();
-        // Closed files picked up by discovery.
-        for index in 0..4 {
-            std::fs::write(
-                workspace.join(format!("closed_{index}.sh")),
-                "closed() { :; }\n",
-            )
-            .unwrap();
-        }
-        // Edge target hidden from discovery by gitignore, reachable only
-        // through open_a.sh's source directive.
-        std::fs::create_dir_all(workspace.join("vendored")).unwrap();
-        std::fs::write(workspace.join(".gitignore"), "vendored/\n").unwrap();
-        std::fs::write(workspace.join("vendored/edge.sh"), "edge_fn() { :; }\n").unwrap();
-    }
-
-    #[test]
-    fn max_files_is_a_hard_bound_across_all_population_phases() {
-        let tempdir = tempfile::tempdir().unwrap();
-        let workspace = std::fs::canonicalize(tempdir.path()).unwrap();
-        populate_workspace(&workspace);
-
-        // 2 open + 4 discovered + 1 edge target = 7 candidates; the limit
-        // must cap the total, not any single phase.
-        for max_files in [1, 3, 5] {
-            let built = BuiltIndex::build(&context_for(&workspace, max_files));
-            assert!(
-                built.index.file_count() <= max_files,
-                "index size {} exceeds max_files {max_files}",
-                built.index.file_count()
-            );
-        }
-    }
-
-    #[test]
-    fn generous_max_files_indexes_open_discovered_and_edge_targets() {
-        let tempdir = tempfile::tempdir().unwrap();
-        let workspace = std::fs::canonicalize(tempdir.path()).unwrap();
-        populate_workspace(&workspace);
-
-        let built = BuiltIndex::build(&context_for(&workspace, 100));
-        assert_eq!(
-            built.index.file_count(),
-            7,
-            "2 open buffers + 4 discovered + 1 edge target"
-        );
-        // The edge target joined the graph through the source directive, so
-        // the open buffer's call resolves into it.
-        assert!(built.index.contains(&workspace.join("vendored/edge.sh")));
+        CallNodeKind::TopLevel => Some(crate::editor_features::call_hierarchy_top_level_item(uri)),
     }
 }

--- a/crates/shuck-server/src/lib.rs
+++ b/crates/shuck-server/src/lib.rs
@@ -33,6 +33,7 @@ mod server;
 mod session;
 mod symbols;
 mod workspace;
+mod workspace_functions;
 
 pub(crate) const SERVER_NAME: &str = "shuck";
 pub(crate) const DIAGNOSTIC_NAME: &str = "shuck";

--- a/crates/shuck-server/src/server/api.rs
+++ b/crates/shuck-server/src/server/api.rs
@@ -187,7 +187,7 @@ where
             .incoming()
             .cancellation_token(&id)
             .expect("request should be registered before scheduling");
-        let snapshot = R::snapshot(session, &params);
+        let snapshot = R::snapshot(session, &params, cancellation_token.clone());
         Box::new(move |client| {
             if cancellation_token.is_cancelled() {
                 return;

--- a/crates/shuck-server/src/server/api/requests/call_hierarchy_incoming.rs
+++ b/crates/shuck-server/src/server/api/requests/call_hierarchy_incoming.rs
@@ -1,8 +1,9 @@
 use lsp_types::{self as types, request as req};
 
-use crate::call_hierarchy::{self, CallHierarchyContext};
+use crate::call_hierarchy;
 use crate::server::Result;
-use crate::session::{Client, Session};
+use crate::session::{Client, RequestCancellationToken, Session};
+use crate::workspace_functions::WorkspaceFunctionContext;
 
 pub(crate) struct CallHierarchyIncomingCalls;
 
@@ -11,13 +12,14 @@ impl super::RequestHandler for CallHierarchyIncomingCalls {
 }
 
 impl super::super::traits::BackgroundRequestHandler for CallHierarchyIncomingCalls {
-    type Snapshot = CallHierarchyContext;
+    type Snapshot = WorkspaceFunctionContext;
 
     fn snapshot(
         session: &Session,
         _params: &types::CallHierarchyIncomingCallsParams,
+        cancellation: RequestCancellationToken,
     ) -> Result<Self::Snapshot> {
-        Ok(session.call_hierarchy_context())
+        Ok(session.workspace_function_context(cancellation))
     }
 
     fn run_with_snapshot(

--- a/crates/shuck-server/src/server/api/requests/call_hierarchy_outgoing.rs
+++ b/crates/shuck-server/src/server/api/requests/call_hierarchy_outgoing.rs
@@ -1,8 +1,9 @@
 use lsp_types::{self as types, request as req};
 
-use crate::call_hierarchy::{self, CallHierarchyContext};
+use crate::call_hierarchy;
 use crate::server::Result;
-use crate::session::{Client, Session};
+use crate::session::{Client, RequestCancellationToken, Session};
+use crate::workspace_functions::WorkspaceFunctionContext;
 
 pub(crate) struct CallHierarchyOutgoingCalls;
 
@@ -11,13 +12,14 @@ impl super::RequestHandler for CallHierarchyOutgoingCalls {
 }
 
 impl super::super::traits::BackgroundRequestHandler for CallHierarchyOutgoingCalls {
-    type Snapshot = CallHierarchyContext;
+    type Snapshot = WorkspaceFunctionContext;
 
     fn snapshot(
         session: &Session,
         _params: &types::CallHierarchyOutgoingCallsParams,
+        cancellation: RequestCancellationToken,
     ) -> Result<Self::Snapshot> {
-        Ok(session.call_hierarchy_context())
+        Ok(session.workspace_function_context(cancellation))
     }
 
     fn run_with_snapshot(

--- a/crates/shuck-server/src/server/api/requests/call_hierarchy_prepare.rs
+++ b/crates/shuck-server/src/server/api/requests/call_hierarchy_prepare.rs
@@ -1,14 +1,15 @@
 use lsp_types::{self as types, request as req};
 
-use crate::call_hierarchy::{self, CallHierarchyContext};
+use crate::call_hierarchy;
 use crate::editor_features::CallHierarchyPrepareResponse;
-use crate::session::{Client, DocumentSnapshot, Session};
+use crate::session::{Client, DocumentSnapshot, RequestCancellationToken, Session};
+use crate::workspace_functions::WorkspaceFunctionContext;
 
 pub(crate) struct CallHierarchyPrepare;
 
 pub(crate) struct CallHierarchyPrepareSnapshot {
     document: Option<DocumentSnapshot>,
-    context: CallHierarchyContext,
+    context: WorkspaceFunctionContext,
 }
 
 impl super::RequestHandler for CallHierarchyPrepare {
@@ -21,6 +22,7 @@ impl super::super::traits::BackgroundRequestHandler for CallHierarchyPrepare {
     fn snapshot(
         session: &Session,
         params: &types::CallHierarchyPrepareParams,
+        cancellation: RequestCancellationToken,
     ) -> crate::server::Result<Self::Snapshot> {
         let uri = params
             .text_document_position_params
@@ -29,7 +31,7 @@ impl super::super::traits::BackgroundRequestHandler for CallHierarchyPrepare {
             .clone();
         Ok(CallHierarchyPrepareSnapshot {
             document: session.take_snapshot(uri),
-            context: session.call_hierarchy_context(),
+            context: session.workspace_function_context(cancellation),
         })
     }
 

--- a/crates/shuck-server/src/server/api/requests/workspace_symbol.rs
+++ b/crates/shuck-server/src/server/api/requests/workspace_symbol.rs
@@ -1,7 +1,7 @@
 use lsp_types::{self as types, request as req};
 
 use crate::server::Result;
-use crate::session::{Client, Session};
+use crate::session::{Client, RequestCancellationToken, Session};
 use crate::symbols;
 
 pub(crate) struct WorkspaceSymbols;
@@ -16,6 +16,7 @@ impl super::super::traits::BackgroundRequestHandler for WorkspaceSymbols {
     fn snapshot(
         session: &Session,
         _params: &types::WorkspaceSymbolParams,
+        _cancellation: RequestCancellationToken,
     ) -> Result<Self::Snapshot> {
         Ok(session.workspace_symbol_context())
     }

--- a/crates/shuck-server/src/server/api/traits.rs
+++ b/crates/shuck-server/src/server/api/traits.rs
@@ -4,7 +4,7 @@ use lsp_types::notification::Notification as LspNotification;
 use lsp_types::request::Request;
 
 use crate::server::Result;
-use crate::session::{Client, DocumentSnapshot, Session};
+use crate::session::{Client, DocumentSnapshot, RequestCancellationToken, Session};
 
 pub(super) trait RequestHandler {
     type RequestType: Request;
@@ -47,6 +47,7 @@ pub(super) trait BackgroundRequestHandler: RequestHandler {
     fn snapshot(
         session: &Session,
         params: &<<Self as RequestHandler>::RequestType as Request>::Params,
+        cancellation: RequestCancellationToken,
     ) -> Result<Self::Snapshot>;
 
     fn run_with_snapshot(

--- a/crates/shuck-server/src/session.rs
+++ b/crates/shuck-server/src/session.rs
@@ -20,6 +20,7 @@ pub use self::options::{
     ClientOptions, CompletionFeatureOptions, GlobalOptions, RenameFeatureOptions,
     WorkspaceSymbolFeatureOptions,
 };
+pub(crate) use self::request_queue::RequestCancellationToken;
 pub(crate) use self::settings::ShuckSettings;
 pub use client::Client;
 
@@ -38,7 +39,7 @@ pub struct Session {
     resolved_client_capabilities: Arc<ResolvedClientCapabilities>,
     workspace_symbols: Arc<crate::symbols::WorkspaceSymbolIndex>,
     analysis_cache: Arc<DocumentAnalysisCache>,
-    call_index_cache: Arc<crate::call_hierarchy::CallIndexCache>,
+    workspace_function_index: Arc<crate::workspace_functions::WorkspaceFunctionIndexCache>,
     request_queue: RequestQueue,
     shutdown_requested: bool,
 }
@@ -72,7 +73,9 @@ impl Session {
             )),
             workspace_symbols: Arc::new(crate::symbols::WorkspaceSymbolIndex::default()),
             analysis_cache: Arc::new(DocumentAnalysisCache::new()),
-            call_index_cache: Arc::new(crate::call_hierarchy::CallIndexCache::default()),
+            workspace_function_index: Arc::new(
+                crate::workspace_functions::WorkspaceFunctionIndexCache::default(),
+            ),
             request_queue: RequestQueue::new(),
             shutdown_requested: false,
         })
@@ -126,7 +129,7 @@ impl Session {
                 .update_text_document(key, content_changes, new_version, self.encoding());
         if result.is_ok() {
             self.analysis_cache.invalidate_uri(&key.clone().into_url());
-            self.call_index_cache.invalidate();
+            self.workspace_function_index.invalidate();
         }
         result
     }
@@ -134,14 +137,14 @@ impl Session {
     /// Open or replace an in-memory text document.
     pub fn open_text_document(&mut self, url: Url, document: TextDocument) {
         self.analysis_cache.invalidate_uri(&url);
-        self.call_index_cache.invalidate();
+        self.workspace_function_index.invalidate();
         self.index.open_text_document(url, document);
     }
 
     pub(crate) fn close_document(&mut self, key: &DocumentKey) -> crate::Result<()> {
         self.index.close_document(key)?;
         self.analysis_cache.invalidate_uri(&key.clone().into_url());
-        self.call_index_cache.invalidate();
+        self.workspace_function_index.invalidate();
         self.workspace_symbols
             .invalidate_uri(&key.clone().into_url());
         Ok(())
@@ -150,7 +153,7 @@ impl Session {
     pub(crate) fn reload_settings(&mut self, changes: &[FileEvent], client: &Client) {
         self.index.reload_settings(changes, client);
         self.analysis_cache.clear();
-        self.call_index_cache.invalidate();
+        self.workspace_function_index.invalidate();
         self.workspace_symbols.invalidate_file_events(changes);
     }
 
@@ -158,7 +161,7 @@ impl Session {
         self.index
             .open_workspace_folder(url, &self.global_settings, client)?;
         self.analysis_cache.clear();
-        self.call_index_cache.invalidate();
+        self.workspace_function_index.invalidate();
         self.workspace_symbols.invalidate_all();
         Ok(())
     }
@@ -166,7 +169,7 @@ impl Session {
     pub(crate) fn close_workspace_folder(&mut self, url: &Url) -> crate::Result<()> {
         self.index.close_workspace_folder(url)?;
         self.analysis_cache.clear();
-        self.call_index_cache.invalidate();
+        self.workspace_function_index.invalidate();
         self.workspace_symbols.invalidate_all();
         Ok(())
     }
@@ -189,7 +192,7 @@ impl Session {
 
     pub(crate) fn update_client_options(&mut self, options: ClientOptions) {
         self.analysis_cache.clear();
-        self.call_index_cache.invalidate();
+        self.workspace_function_index.invalidate();
         self.workspace_symbols.invalidate_all();
         self.global_settings.update_options(options);
         self.index.clear_project_settings_cache();
@@ -201,7 +204,7 @@ impl Session {
         workspace_options: Option<WorkspaceOptionsMap>,
     ) {
         self.analysis_cache.clear();
-        self.call_index_cache.invalidate();
+        self.workspace_function_index.invalidate();
         self.workspace_symbols.invalidate_all();
         self.global_settings.update_options(options);
         if let Some(workspace_options) = workspace_options {
@@ -247,12 +250,27 @@ impl Session {
         }
     }
 
-    /// Build the workspace context used to answer cross-file call-hierarchy
-    /// requests: the workspace roots, a snapshot of open documents, and the
-    /// negotiated position encoding.
-    pub(crate) fn call_hierarchy_context(&self) -> crate::call_hierarchy::CallHierarchyContext {
-        crate::call_hierarchy::CallHierarchyContext {
-            workspace_roots: self.index.workspace_roots().to_vec(),
+    /// Build the immutable context used by cross-file function features.
+    pub(crate) fn workspace_function_context(
+        &self,
+        cancellation: RequestCancellationToken,
+    ) -> crate::workspace_functions::WorkspaceFunctionContext {
+        let workspace_settings = self.index.workspace_settings_snapshot();
+        let workspace_roots = self.index.workspace_roots().to_vec();
+        let mut settings_workspace_roots = workspace_roots.clone();
+        for workspace in &workspace_settings {
+            let Some(canonical_root) = &workspace.canonical_root else {
+                continue;
+            };
+            if !settings_workspace_roots.contains(canonical_root) {
+                settings_workspace_roots.push(canonical_root.clone());
+            }
+        }
+        crate::workspace_functions::WorkspaceFunctionContext {
+            workspace_roots,
+            settings_workspace_roots,
+            workspace_settings,
+            global_options: self.global_settings.options().clone(),
             open_documents: self.index.open_documents_snapshot(),
             encoding: self.position_encoding,
             max_files: self
@@ -261,8 +279,9 @@ impl Session {
                 .server
                 .call_hierarchy
                 .max_files,
-            epoch: self.call_index_cache.current_epoch(),
-            cache: self.call_index_cache.clone(),
+            epoch: self.workspace_function_index.current_epoch(),
+            cache: self.workspace_function_index.clone(),
+            cancellation,
         }
     }
 }
@@ -399,9 +418,11 @@ mod tests {
     }
 
     #[test]
-    fn call_index_cache_invalidates_after_closed_file_event() {
+    fn workspace_function_index_invalidates_after_closed_file_event() {
         let (workspace, mut session, _uri) = make_test_session();
-        let before = session.call_hierarchy_context().epoch;
+        let before = session
+            .workspace_function_context(RequestCancellationToken::default())
+            .epoch;
         let (main_loop_sender, _main_loop_receiver) = channel::unbounded();
         let (client_sender, _client_receiver) = channel::unbounded();
         let client = Client::new(main_loop_sender, client_sender);
@@ -416,7 +437,12 @@ mod tests {
             &client,
         );
 
-        assert!(session.call_hierarchy_context().epoch > before);
+        assert!(
+            session
+                .workspace_function_context(RequestCancellationToken::default())
+                .epoch
+                > before
+        );
     }
 
     #[test]

--- a/crates/shuck-server/src/session/request_queue.rs
+++ b/crates/shuck-server/src/session/request_queue.rs
@@ -63,11 +63,12 @@ impl Incoming {
         request_id: &RequestId,
     ) -> Option<RequestCancellationToken> {
         let pending = self.pending.get(request_id)?;
-        Some(RequestCancellationToken::clone(
+        Some(
             pending
                 .cancellation_token
-                .get_or_init(RequestCancellationToken::default),
-        ))
+                .get_or_init(RequestCancellationToken::default)
+                .clone(),
+        )
     }
 
     pub(crate) fn complete(&mut self, request_id: &RequestId) -> Option<(Instant, String)> {
@@ -94,7 +95,7 @@ impl PendingRequest {
     }
 }
 
-#[derive(Debug, Default)]
+#[derive(Clone, Debug, Default)]
 pub(crate) struct RequestCancellationToken(Arc<AtomicBool>);
 
 impl RequestCancellationToken {
@@ -102,12 +103,8 @@ impl RequestCancellationToken {
         self.0.load(std::sync::atomic::Ordering::Relaxed)
     }
 
-    fn cancel(&self) {
+    pub(crate) fn cancel(&self) {
         self.0.store(true, std::sync::atomic::Ordering::Relaxed);
-    }
-
-    fn clone(this: &Self) -> Self {
-        Self(this.0.clone())
     }
 }
 

--- a/crates/shuck-server/src/workspace_functions.rs
+++ b/crates/shuck-server/src/workspace_functions.rs
@@ -1,0 +1,1017 @@
+//! Shared workspace index for cross-file function editor features.
+//!
+//! The index projects each shell file into compact semantic function facts,
+//! resolves determinable `source` edges, and retains just enough source metadata
+//! to turn byte spans back into LSP ranges. Open buffers shadow disk content.
+//! The session caches one build and invalidates it whenever documents,
+//! workspaces, watched files, or configuration change.
+
+use std::collections::{BTreeMap, BTreeSet, HashMap};
+use std::path::{Component, Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Mutex};
+
+use lsp_types as types;
+use sha2::{Digest, Sha256};
+use shuck_ast::Span;
+use shuck_config::{
+    ConfigArguments, apply_config_overrides, load_project_config, resolve_project_root_for_file,
+};
+use shuck_indexer::LineIndex;
+use shuck_linter::ShellDialect;
+use shuck_semantic::{
+    CallFactSourceEdge, CallNodeKind, CrossFileCall, FileCallFacts, WorkspaceCallIndex,
+    source_ref_candidate_paths,
+};
+
+use crate::PositionEncoding;
+use crate::edit::DocumentVersion;
+use crate::editor::analyze_editor_document;
+use crate::session::{ClientOptions, RequestCancellationToken, WorkspaceSettingsSnapshot};
+use crate::symbols::WorkspaceOpenDocument;
+
+/// Immutable session state needed to build or query the workspace function index.
+pub(crate) struct WorkspaceFunctionContext {
+    pub(crate) workspace_roots: Vec<PathBuf>,
+    pub(crate) settings_workspace_roots: Vec<PathBuf>,
+    pub(crate) workspace_settings: Vec<WorkspaceSettingsSnapshot>,
+    pub(crate) global_options: ClientOptions,
+    pub(crate) open_documents: Vec<WorkspaceOpenDocument>,
+    pub(crate) encoding: PositionEncoding,
+    /// Hard bound on indexed files. A build that reaches this limit is marked
+    /// incomplete so mutation features can fail closed.
+    pub(crate) max_files: usize,
+    pub(crate) cache: Arc<WorkspaceFunctionIndexCache>,
+    pub(crate) epoch: u64,
+    pub(crate) cancellation: RequestCancellationToken,
+}
+
+/// Session-lifetime cache of the built workspace function index.
+#[derive(Default)]
+pub(crate) struct WorkspaceFunctionIndexCache {
+    epoch: AtomicU64,
+    built: Mutex<Option<(u64, Arc<WorkspaceFunctionIndex>)>>,
+}
+
+impl WorkspaceFunctionIndexCache {
+    /// Drops any cached index and marks in-flight builds stale.
+    pub(crate) fn invalidate(&self) {
+        self.epoch.fetch_add(1, Ordering::SeqCst);
+        if let Ok(mut slot) = self.built.lock() {
+            *slot = None;
+        }
+    }
+
+    pub(crate) fn current_epoch(&self) -> u64 {
+        self.epoch.load(Ordering::SeqCst)
+    }
+
+    fn get(&self, epoch: u64) -> Option<Arc<WorkspaceFunctionIndex>> {
+        let slot = self.built.lock().ok()?;
+        slot.as_ref()
+            .filter(|(built_epoch, _)| *built_epoch == epoch)
+            .map(|(_, built)| built.clone())
+    }
+
+    fn store(&self, epoch: u64, built: Arc<WorkspaceFunctionIndex>) {
+        if epoch != self.current_epoch() {
+            return;
+        }
+        if let Ok(mut slot) = self.built.lock() {
+            *slot = Some((epoch, built));
+        }
+    }
+}
+
+/// Returns the cached index for this context, building it on a miss.
+///
+/// Cancellation is checked between index-population steps. An aborted miss does
+/// not populate the cache, and the request wrapper suppresses its response.
+pub(crate) fn workspace_function_index(
+    context: &WorkspaceFunctionContext,
+) -> Option<Arc<WorkspaceFunctionIndex>> {
+    if context.cancellation.is_cancelled() {
+        return None;
+    }
+    if let Some(built) = context.cache.get(context.epoch) {
+        return Some(built);
+    }
+    let built = Arc::new(WorkspaceFunctionIndex::build(context)?);
+    context.cache.store(context.epoch, built.clone());
+    Some(built)
+}
+
+/// Source snapshot retained for one indexed file.
+pub(crate) struct IndexedWorkspaceFile {
+    uri: types::Url,
+    source: String,
+    line_index: LineIndex,
+    #[allow(dead_code)] // Used by the upcoming cross-file rename safety check.
+    version: Option<DocumentVersion>,
+    #[allow(dead_code)] // Used by the upcoming cross-file rename safety check.
+    content_hash: [u8; 32],
+}
+
+impl IndexedWorkspaceFile {
+    pub(crate) fn uri(&self) -> &types::Url {
+        &self.uri
+    }
+
+    pub(crate) fn source(&self) -> &str {
+        &self.source
+    }
+
+    pub(crate) fn line_index(&self) -> &LineIndex {
+        &self.line_index
+    }
+
+    /// Open-document version captured by the request, or `None` for disk input.
+    #[allow(dead_code)]
+    pub(crate) fn version(&self) -> Option<DocumentVersion> {
+        self.version
+    }
+
+    /// SHA-256 of the exact content used to build semantic facts and ranges.
+    #[allow(dead_code)]
+    pub(crate) fn content_hash(&self) -> [u8; 32] {
+        self.content_hash
+    }
+}
+
+/// Shared index queried by call hierarchy and future cross-file editor features.
+pub(crate) struct WorkspaceFunctionIndex {
+    graph: WorkspaceCallIndex,
+    files: BTreeMap<PathBuf, IndexedWorkspaceFile>,
+    encoding: PositionEncoding,
+    #[allow(dead_code)] // Mutation features must reject partial workspace indexes.
+    complete: bool,
+}
+
+impl WorkspaceFunctionIndex {
+    fn build(context: &WorkspaceFunctionContext) -> Option<Self> {
+        let mut graph = WorkspaceCallIndex::new();
+        let mut files = BTreeMap::new();
+        let mut complete = true;
+        let max_files = context.max_files;
+        let mut source_paths = SourcePathsCache::default();
+
+        let mut open_docs = context
+            .open_documents
+            .iter()
+            .filter_map(|open| {
+                let path = canonical_path(&open.uri.to_file_path().ok()?);
+                Some((path, open))
+            })
+            .collect::<Vec<_>>();
+        open_docs.sort_by(|(left, _), (right, _)| left.cmp(right));
+        let open_paths = open_docs
+            .iter()
+            .map(|(path, _)| path.clone())
+            .collect::<BTreeSet<_>>();
+
+        for (path, open) in &open_docs {
+            if context.cancellation.is_cancelled() {
+                return None;
+            }
+            if graph.file_count() >= max_files {
+                complete = false;
+                tracing::warn!(
+                    "workspace functions: open documents exceed the {max_files}-file limit; \
+                     indexing only the first {max_files}"
+                );
+                break;
+            }
+            let resolution = source_paths.resolve(path, context);
+            complete &= resolution.complete;
+            insert_file(
+                &mut graph,
+                &mut files,
+                WorkspaceFileInput {
+                    path,
+                    uri: open.uri.clone(),
+                    source: open.document.contents(),
+                    version: Some(open.document.version()),
+                },
+                &resolution,
+                &open_paths,
+            );
+        }
+
+        if context.cancellation.is_cancelled() {
+            return None;
+        }
+        let remaining = max_files.saturating_sub(graph.file_count());
+        let discovery = discover_closed_shell_files(
+            &context.workspace_roots,
+            &open_paths,
+            remaining,
+            &context.cancellation,
+        )?;
+        complete &= discovery.complete;
+        for file in discovery.files {
+            if context.cancellation.is_cancelled() {
+                return None;
+            }
+            let Ok(source) = std::fs::read_to_string(&file) else {
+                complete = false;
+                continue;
+            };
+            let Ok(uri) = types::Url::from_file_path(&file) else {
+                complete = false;
+                continue;
+            };
+            let resolution = source_paths.resolve(&file, context);
+            complete &= resolution.complete;
+            insert_file(
+                &mut graph,
+                &mut files,
+                WorkspaceFileInput {
+                    path: &file,
+                    uri,
+                    source: &source,
+                    version: None,
+                },
+                &resolution,
+                &open_paths,
+            );
+        }
+
+        'expand: loop {
+            if context.cancellation.is_cancelled() {
+                return None;
+            }
+            let missing = graph
+                .files()
+                .flat_map(|(_, facts)| facts.source_edges.iter().map(|edge| edge.path.clone()))
+                .filter(|target| !graph.contains(target))
+                .collect::<BTreeSet<_>>()
+                .into_iter()
+                .collect::<Vec<_>>();
+            if missing.is_empty() {
+                break;
+            }
+            for target in missing {
+                if context.cancellation.is_cancelled() {
+                    return None;
+                }
+                if graph.file_count() >= max_files {
+                    complete = false;
+                    tracing::warn!(
+                        "workspace functions: source-edge targets exceed the {max_files}-file \
+                         limit; cross-file results may be incomplete"
+                    );
+                    break 'expand;
+                }
+                let Some(open) = open_docs
+                    .iter()
+                    .find_map(|(path, open)| (path == &target).then_some(*open))
+                else {
+                    let Ok(source) = std::fs::read_to_string(&target) else {
+                        complete = false;
+                        graph.insert(target.clone(), FileCallFacts::default());
+                        continue;
+                    };
+                    let Ok(uri) = types::Url::from_file_path(&target) else {
+                        complete = false;
+                        graph.insert(target.clone(), FileCallFacts::default());
+                        continue;
+                    };
+                    let resolution = source_paths.resolve(&target, context);
+                    complete &= resolution.complete;
+                    insert_file(
+                        &mut graph,
+                        &mut files,
+                        WorkspaceFileInput {
+                            path: &target,
+                            uri,
+                            source: &source,
+                            version: None,
+                        },
+                        &resolution,
+                        &open_paths,
+                    );
+                    continue;
+                };
+                let resolution = source_paths.resolve(&target, context);
+                complete &= resolution.complete;
+                insert_file(
+                    &mut graph,
+                    &mut files,
+                    WorkspaceFileInput {
+                        path: &target,
+                        uri: open.uri.clone(),
+                        source: open.document.contents(),
+                        version: Some(open.document.version()),
+                    },
+                    &resolution,
+                    &open_paths,
+                );
+            }
+        }
+
+        Some(Self {
+            graph,
+            files,
+            encoding: context.encoding,
+            complete,
+        })
+    }
+
+    pub(crate) fn resolve_call_site(
+        &self,
+        from_path: &Path,
+        name_span: Span,
+    ) -> Option<CrossFileCall> {
+        self.graph.resolve_call_site(from_path, name_span)
+    }
+
+    pub(crate) fn incoming(
+        &self,
+        target_path: &Path,
+        target_node: &CallNodeKind,
+    ) -> Vec<CrossFileCall> {
+        self.graph.incoming(target_path, target_node)
+    }
+
+    pub(crate) fn outgoing(
+        &self,
+        from_path: &Path,
+        from_node: &CallNodeKind,
+    ) -> Vec<CrossFileCall> {
+        self.graph.outgoing(from_path, from_node)
+    }
+
+    pub(crate) fn file(&self, path: &Path) -> Option<&IndexedWorkspaceFile> {
+        self.files.get(path)
+    }
+
+    pub(crate) fn range_of(&self, path: &Path, span: Span) -> Option<types::Range> {
+        let file = self.file(path)?;
+        Some(crate::edit::to_lsp_range(
+            span.to_range(),
+            file.source(),
+            file.line_index(),
+            self.encoding,
+        ))
+    }
+
+    pub(crate) fn ranges_in(&self, path: &Path, spans: &[Span]) -> Vec<types::Range> {
+        spans
+            .iter()
+            .filter_map(|span| self.range_of(path, *span))
+            .collect()
+    }
+
+    /// Whether discovery and source-edge expansion completed within the file
+    /// budget and without unreadable inputs.
+    #[allow(dead_code)]
+    pub(crate) fn is_complete(&self) -> bool {
+        self.complete
+    }
+
+    /// Returns whether a closed file still matches the content used to build
+    /// this index. Open documents are versioned by the LSP session instead.
+    #[allow(dead_code)]
+    pub(crate) fn closed_file_is_current(&self, path: &Path) -> bool {
+        let Some(file) = self.file(path) else {
+            return false;
+        };
+        if file.version().is_some() {
+            return true;
+        }
+        std::fs::read(path)
+            .map(|contents| content_hash(&contents) == file.content_hash())
+            .unwrap_or(false)
+    }
+
+    #[cfg(test)]
+    fn file_count(&self) -> usize {
+        self.graph.file_count()
+    }
+
+    #[cfg(test)]
+    fn contains(&self, path: &Path) -> bool {
+        self.graph.contains(path)
+    }
+}
+
+#[derive(Clone)]
+struct SourcePathResolution {
+    roots: Vec<String>,
+    project_root: PathBuf,
+    complete: bool,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+struct SourcePathsCacheKey {
+    project_root: PathBuf,
+    workspace_root: Option<PathBuf>,
+}
+
+#[derive(Default)]
+struct SourcePathsCache {
+    by_project: HashMap<SourcePathsCacheKey, SourcePathResolution>,
+}
+
+impl SourcePathsCache {
+    fn resolve(&mut self, path: &Path, context: &WorkspaceFunctionContext) -> SourcePathResolution {
+        let workspace = workspace_settings_for_path(context, path);
+        let fallback = context
+            .settings_workspace_roots
+            .iter()
+            .filter(|root| path.starts_with(root))
+            .max_by_key(|root| root.components().count())
+            .cloned()
+            .or_else(|| path.parent().map(Path::to_path_buf))
+            .unwrap_or_else(|| PathBuf::from("."));
+        let (project_root, root_complete) =
+            match resolve_project_root_for_file(path, &fallback, true) {
+                Ok(project_root) => (project_root, true),
+                Err(error) => {
+                    tracing::warn!(
+                        "workspace functions: failed to resolve the project root for {}: {error}",
+                        path.display()
+                    );
+                    (fallback, false)
+                }
+            };
+        let key = SourcePathsCacheKey {
+            project_root: project_root.clone(),
+            workspace_root: workspace.map(|workspace| workspace.root.clone()),
+        };
+        let mut resolution = self
+            .by_project
+            .entry(key)
+            .or_insert_with(|| {
+                let (mut config, config_complete) =
+                    match load_project_config(&project_root, &ConfigArguments::default()) {
+                        Ok(config) => (config, true),
+                        Err(error) => {
+                            tracing::warn!(
+                                "workspace functions: failed to load config from {}: {error}",
+                                project_root.display()
+                            );
+                            (Default::default(), false)
+                        }
+                    };
+                apply_config_overrides(&mut config, context.global_options.to_config_overrides());
+                if let Some(options) = workspace.and_then(|workspace| workspace.options.as_ref()) {
+                    apply_config_overrides(&mut config, options.to_config_overrides());
+                }
+                SourcePathResolution {
+                    roots: config.lint.source_paths.unwrap_or_default(),
+                    project_root: project_root.clone(),
+                    complete: root_complete && config_complete,
+                }
+            })
+            .clone();
+        resolution.complete &= root_complete;
+        resolution
+    }
+}
+
+fn workspace_settings_for_path<'a>(
+    context: &'a WorkspaceFunctionContext,
+    path: &Path,
+) -> Option<&'a WorkspaceSettingsSnapshot> {
+    context
+        .workspace_settings
+        .iter()
+        .filter_map(|workspace| {
+            [Some(&workspace.root), workspace.canonical_root.as_ref()]
+                .into_iter()
+                .flatten()
+                .filter(|root| path.starts_with(root))
+                .map(|root| root.components().count())
+                .max()
+                .map(|length| (workspace, length))
+        })
+        .max_by_key(|(_, length)| *length)
+        .map(|(workspace, _)| workspace)
+}
+
+struct WorkspaceFileInput<'a> {
+    path: &'a Path,
+    uri: types::Url,
+    source: &'a str,
+    version: Option<DocumentVersion>,
+}
+
+fn insert_file(
+    graph: &mut WorkspaceCallIndex,
+    files: &mut BTreeMap<PathBuf, IndexedWorkspaceFile>,
+    input: WorkspaceFileInput<'_>,
+    source_paths: &SourcePathResolution,
+    open_paths: &BTreeSet<PathBuf>,
+) {
+    let key = canonical_path(input.path);
+    let uri = std::fs::canonicalize(input.path)
+        .ok()
+        .and_then(|path| types::Url::from_file_path(path).ok())
+        .unwrap_or(input.uri);
+    let shell = ShellDialect::infer(input.source, Some(input.path));
+    let model = analyze_editor_document(input.source, Some(input.path), shell);
+    let edges = model
+        .source_refs()
+        .iter()
+        .filter_map(|source_ref| {
+            source_ref_candidate_paths(
+                input.path,
+                source_ref,
+                &source_paths.roots,
+                &source_paths.project_root,
+            )
+            .into_iter()
+            .map(|candidate| canonical_path(&candidate))
+            .find(|candidate| open_paths.contains(candidate) || candidate.is_file())
+            .map(|target| CallFactSourceEdge {
+                path: target,
+                span: source_ref.span,
+            })
+        })
+        .collect::<Vec<_>>();
+    graph.insert(
+        key.clone(),
+        FileCallFacts::project_with_source_edges(&model, edges),
+    );
+    files.insert(
+        key,
+        IndexedWorkspaceFile {
+            uri,
+            source: input.source.to_owned(),
+            line_index: LineIndex::new(input.source),
+            version: input.version,
+            content_hash: content_hash(input.source.as_bytes()),
+        },
+    );
+}
+
+struct ClosedFileDiscovery {
+    files: Vec<PathBuf>,
+    complete: bool,
+}
+
+fn discover_closed_shell_files(
+    roots: &[PathBuf],
+    open_paths: &BTreeSet<PathBuf>,
+    max_files: usize,
+    cancellation: &RequestCancellationToken,
+) -> Option<ClosedFileDiscovery> {
+    use shuck_discover::{DiscoveryOptions, FileKind, discover_files};
+
+    let mut files = BTreeSet::new();
+    let mut complete = true;
+    for root in roots {
+        if cancellation.is_cancelled() {
+            return None;
+        }
+        let discovered = match discover_files(
+            std::slice::from_ref(root),
+            root,
+            &DiscoveryOptions {
+                respect_gitignore: true,
+                parallel: true,
+                use_config_roots: true,
+                ..DiscoveryOptions::default()
+            },
+        ) {
+            Ok(files) => files,
+            Err(error) => {
+                complete = false;
+                tracing::warn!(
+                    "workspace functions: failed to discover files in {}: {error}",
+                    root.display()
+                );
+                continue;
+            }
+        };
+        for file in discovered {
+            if cancellation.is_cancelled() {
+                return None;
+            }
+            if file.kind != FileKind::Shell {
+                continue;
+            }
+            let path = canonical_path(&file.absolute_path);
+            if open_paths.contains(&path) {
+                continue;
+            }
+            files.insert(path);
+        }
+    }
+    if files.len() > max_files {
+        complete = false;
+        tracing::warn!(
+            "workspace functions: workspace has {} closed shell files; indexing only {max_files}",
+            files.len()
+        );
+    }
+    Some(ClosedFileDiscovery {
+        files: files.into_iter().take(max_files).collect(),
+        complete,
+    })
+}
+
+pub(crate) fn canonical_path(path: &Path) -> PathBuf {
+    if let Ok(canonical) = std::fs::canonicalize(path) {
+        return canonical;
+    }
+
+    let normalized = normalize_path(path);
+    let mut ancestor = normalized.as_path();
+    let mut suffix = Vec::new();
+    while let Some(name) = ancestor.file_name() {
+        suffix.push(name.to_owned());
+        let Some(parent) = ancestor.parent() else {
+            break;
+        };
+        if let Ok(mut canonical) = std::fs::canonicalize(parent) {
+            for component in suffix.iter().rev() {
+                canonical.push(component);
+            }
+            return canonical;
+        }
+        ancestor = parent;
+    }
+    normalized
+}
+
+fn normalize_path(path: &Path) -> PathBuf {
+    let mut normalized = PathBuf::new();
+    for component in path.components() {
+        match component {
+            Component::CurDir => {}
+            Component::ParentDir => {
+                if !normalized.pop() {
+                    normalized.push(component.as_os_str());
+                }
+            }
+            _ => normalized.push(component.as_os_str()),
+        }
+    }
+    normalized
+}
+
+fn content_hash(contents: &[u8]) -> [u8; 32] {
+    Sha256::digest(contents).into()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::TextDocument;
+    use shuck_config::LintConfig;
+
+    fn context_for(workspace: &Path, max_files: usize) -> WorkspaceFunctionContext {
+        let open_path = workspace.join("open_a.sh");
+        let open_doc = WorkspaceOpenDocument {
+            uri: types::Url::from_file_path(&open_path).unwrap(),
+            document: Arc::new(
+                TextDocument::new(
+                    "# shuck: source=vendored/edge.sh\nsource \"$DIR/edge.sh\"\nedge_fn\n"
+                        .to_owned(),
+                    1,
+                )
+                .with_language_id("shellscript"),
+            ),
+        };
+        let open_b = WorkspaceOpenDocument {
+            uri: types::Url::from_file_path(workspace.join("open_b.sh")).unwrap(),
+            document: Arc::new(
+                TextDocument::new("b() { :; }\n".to_owned(), 1).with_language_id("shellscript"),
+            ),
+        };
+        WorkspaceFunctionContext {
+            workspace_roots: vec![workspace.to_path_buf()],
+            settings_workspace_roots: vec![workspace.to_path_buf()],
+            workspace_settings: Vec::new(),
+            global_options: ClientOptions::default(),
+            open_documents: vec![open_doc, open_b],
+            encoding: PositionEncoding::UTF16,
+            max_files,
+            cache: Arc::new(WorkspaceFunctionIndexCache::default()),
+            epoch: 0,
+            cancellation: RequestCancellationToken::default(),
+        }
+    }
+
+    fn populate_workspace(workspace: &Path) {
+        std::fs::write(workspace.join("open_a.sh"), "stale() { :; }\n").unwrap();
+        std::fs::write(workspace.join("open_b.sh"), "stale() { :; }\n").unwrap();
+        for index in 0..4 {
+            std::fs::write(
+                workspace.join(format!("closed_{index}.sh")),
+                "closed() { :; }\n",
+            )
+            .unwrap();
+        }
+        std::fs::create_dir_all(workspace.join("vendored")).unwrap();
+        std::fs::write(workspace.join(".gitignore"), "vendored/\n").unwrap();
+        std::fs::write(workspace.join("vendored/edge.sh"), "edge_fn() { :; }\n").unwrap();
+    }
+
+    #[test]
+    fn max_files_is_a_hard_bound_and_marks_partial_builds() {
+        let tempdir = tempfile::tempdir().unwrap();
+        let workspace = std::fs::canonicalize(tempdir.path()).unwrap();
+        populate_workspace(&workspace);
+
+        for max_files in [1, 3, 5] {
+            let context = context_for(&workspace, max_files);
+            let built = WorkspaceFunctionIndex::build(&context).unwrap();
+            assert!(built.file_count() <= max_files);
+            assert!(!built.is_complete());
+        }
+    }
+
+    #[test]
+    fn generous_limit_indexes_open_discovered_and_edge_targets() {
+        let tempdir = tempfile::tempdir().unwrap();
+        let workspace = std::fs::canonicalize(tempdir.path()).unwrap();
+        populate_workspace(&workspace);
+
+        let built = WorkspaceFunctionIndex::build(&context_for(&workspace, 100)).unwrap();
+        assert_eq!(built.file_count(), 7);
+        assert!(built.contains(&workspace.join("vendored/edge.sh")));
+        assert!(built.is_complete());
+    }
+
+    #[test]
+    fn open_unsaved_source_target_participates_without_disk_file() {
+        let tempdir = tempfile::tempdir().unwrap();
+        let workspace = std::fs::canonicalize(tempdir.path()).unwrap();
+        let caller_path = workspace.join("caller.sh");
+        let target_path = workspace.join("new_target.sh");
+        let caller_source = "source new_target.sh\nfrom_buffer\n";
+        let caller = WorkspaceOpenDocument {
+            uri: types::Url::from_file_path(&caller_path).unwrap(),
+            document: Arc::new(
+                TextDocument::new(caller_source.to_owned(), 1).with_language_id("shellscript"),
+            ),
+        };
+        let target = WorkspaceOpenDocument {
+            uri: types::Url::from_file_path(&target_path).unwrap(),
+            document: Arc::new(
+                TextDocument::new("from_buffer() { :; }\n".to_owned(), 2)
+                    .with_language_id("shellscript"),
+            ),
+        };
+        let context = WorkspaceFunctionContext {
+            workspace_roots: vec![workspace.clone()],
+            settings_workspace_roots: vec![workspace.clone()],
+            workspace_settings: Vec::new(),
+            global_options: ClientOptions::default(),
+            open_documents: vec![caller, target],
+            encoding: PositionEncoding::UTF16,
+            max_files: 100,
+            cache: Arc::new(WorkspaceFunctionIndexCache::default()),
+            epoch: 0,
+            cancellation: RequestCancellationToken::default(),
+        };
+
+        let built = WorkspaceFunctionIndex::build(&context).unwrap();
+        let caller_facts = built
+            .graph
+            .files()
+            .find_map(|(path, facts)| (path == caller_path).then_some(facts))
+            .unwrap();
+        assert_eq!(caller_facts.source_edges.len(), 1);
+        assert_eq!(caller_facts.source_edges[0].path, target_path);
+        let target_facts = built
+            .graph
+            .files()
+            .find_map(|(path, facts)| (path == target_path).then_some(facts))
+            .unwrap();
+        assert_eq!(target_facts.definitions.len(), 1);
+        let call = caller_facts
+            .call_sites
+            .iter()
+            .find(|call| call.callee.as_str() == "from_buffer")
+            .unwrap();
+        let call_span = call.name_span;
+        let resolved = built.resolve_call_site(&caller_path, call_span).unwrap();
+        assert_eq!(resolved.path, target_path);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn open_unsaved_source_target_resolves_through_symlinked_workspace_root() {
+        use std::os::unix::fs::symlink;
+
+        let tempdir = tempfile::tempdir().unwrap();
+        let real_workspace = tempdir.path().join("real");
+        let linked_workspace = tempdir.path().join("linked");
+        std::fs::create_dir(&real_workspace).unwrap();
+        let real_workspace = std::fs::canonicalize(real_workspace).unwrap();
+        symlink(&real_workspace, &linked_workspace).unwrap();
+
+        let caller_path = linked_workspace.join("caller.sh");
+        let target_path = linked_workspace.join("new_target.sh");
+        std::fs::write(real_workspace.join("caller.sh"), "stale\n").unwrap();
+        let caller = WorkspaceOpenDocument {
+            uri: types::Url::from_file_path(&caller_path).unwrap(),
+            document: Arc::new(
+                TextDocument::new("source new_target.sh\nfrom_buffer\n".to_owned(), 1)
+                    .with_language_id("shellscript"),
+            ),
+        };
+        let target_uri = types::Url::from_file_path(&target_path).unwrap();
+        let target = WorkspaceOpenDocument {
+            uri: target_uri.clone(),
+            document: Arc::new(
+                TextDocument::new("from_buffer() { :; }\n".to_owned(), 2)
+                    .with_language_id("shellscript"),
+            ),
+        };
+        let context = WorkspaceFunctionContext {
+            workspace_roots: vec![linked_workspace.clone()],
+            settings_workspace_roots: vec![linked_workspace.clone(), real_workspace.clone()],
+            workspace_settings: Vec::new(),
+            global_options: ClientOptions::default(),
+            open_documents: vec![caller, target],
+            encoding: PositionEncoding::UTF16,
+            max_files: 100,
+            cache: Arc::new(WorkspaceFunctionIndexCache::default()),
+            epoch: 0,
+            cancellation: RequestCancellationToken::default(),
+        };
+
+        let built = WorkspaceFunctionIndex::build(&context).unwrap();
+        let canonical_caller = real_workspace.join("caller.sh");
+        let canonical_target = real_workspace.join("new_target.sh");
+        let facts = built
+            .graph
+            .files()
+            .find_map(|(path, facts)| (path == canonical_caller).then_some(facts))
+            .unwrap();
+        let call = facts
+            .call_sites
+            .iter()
+            .find(|call| call.callee.as_str() == "from_buffer")
+            .unwrap();
+        assert_eq!(
+            built
+                .resolve_call_site(&canonical_caller, call.name_span)
+                .unwrap()
+                .path,
+            canonical_target
+        );
+        assert_eq!(built.file(&canonical_target).unwrap().uri(), &target_uri);
+    }
+
+    #[test]
+    fn closed_file_freshness_uses_indexed_content_hash() {
+        let tempdir = tempfile::tempdir().unwrap();
+        let workspace = std::fs::canonicalize(tempdir.path()).unwrap();
+        let file = workspace.join("closed.sh");
+        std::fs::write(&file, "one() { :; }\n").unwrap();
+        let context = WorkspaceFunctionContext {
+            workspace_roots: vec![workspace.clone()],
+            settings_workspace_roots: vec![workspace.clone()],
+            workspace_settings: Vec::new(),
+            global_options: ClientOptions::default(),
+            open_documents: Vec::new(),
+            encoding: PositionEncoding::UTF16,
+            max_files: 100,
+            cache: Arc::new(WorkspaceFunctionIndexCache::default()),
+            epoch: 0,
+            cancellation: RequestCancellationToken::default(),
+        };
+        let built = WorkspaceFunctionIndex::build(&context).unwrap();
+        assert!(built.closed_file_is_current(&file));
+        std::fs::write(&file, "two() { :; }\n").unwrap();
+        assert!(!built.closed_file_is_current(&file));
+    }
+
+    #[test]
+    fn workspace_source_paths_layer_over_global_client_options() {
+        let tempdir = tempfile::tempdir().unwrap();
+        let workspace = std::fs::canonicalize(tempdir.path()).unwrap();
+        std::fs::create_dir(workspace.join("scripts")).unwrap();
+        std::fs::create_dir(workspace.join("lib")).unwrap();
+        let caller = workspace.join("scripts/main.sh");
+        let target = workspace.join("lib/util.sh");
+        std::fs::write(&caller, "source util.sh\nfrom_root\n").unwrap();
+        std::fs::write(&target, "from_root() { :; }\n").unwrap();
+
+        let global_options = ClientOptions {
+            lint: Some(LintConfig {
+                source_paths: Some(vec!["missing".to_owned()]),
+                ..LintConfig::default()
+            }),
+            ..ClientOptions::default()
+        };
+        let workspace_options = ClientOptions {
+            lint: Some(LintConfig {
+                source_paths: Some(vec!["lib".to_owned()]),
+                ..LintConfig::default()
+            }),
+            ..ClientOptions::default()
+        };
+        let context = WorkspaceFunctionContext {
+            workspace_roots: vec![workspace.clone()],
+            settings_workspace_roots: vec![workspace.clone()],
+            workspace_settings: vec![WorkspaceSettingsSnapshot {
+                root: workspace.clone(),
+                canonical_root: Some(workspace.clone()),
+                options: Some(workspace_options),
+            }],
+            global_options,
+            open_documents: Vec::new(),
+            encoding: PositionEncoding::UTF16,
+            max_files: 100,
+            cache: Arc::new(WorkspaceFunctionIndexCache::default()),
+            epoch: 0,
+            cancellation: RequestCancellationToken::default(),
+        };
+
+        let built = WorkspaceFunctionIndex::build(&context).unwrap();
+        let facts = built
+            .graph
+            .files()
+            .find_map(|(path, facts)| (path == caller).then_some(facts))
+            .unwrap();
+        let call = facts
+            .call_sites
+            .iter()
+            .find(|call| call.callee.as_str() == "from_root")
+            .unwrap();
+        assert_eq!(
+            built
+                .resolve_call_site(&caller, call.name_span)
+                .unwrap()
+                .path,
+            target
+        );
+    }
+
+    #[test]
+    fn malformed_project_config_marks_the_index_incomplete() {
+        let tempdir = tempfile::tempdir().unwrap();
+        let workspace = std::fs::canonicalize(tempdir.path()).unwrap();
+        std::fs::write(workspace.join(".shuck.toml"), "[lint\n").unwrap();
+        std::fs::write(workspace.join("main.sh"), "main() { :; }\n").unwrap();
+        let context = WorkspaceFunctionContext {
+            workspace_roots: vec![workspace.clone()],
+            settings_workspace_roots: vec![workspace.clone()],
+            workspace_settings: Vec::new(),
+            global_options: ClientOptions::default(),
+            open_documents: Vec::new(),
+            encoding: PositionEncoding::UTF16,
+            max_files: 100,
+            cache: Arc::new(WorkspaceFunctionIndexCache::default()),
+            epoch: 0,
+            cancellation: RequestCancellationToken::default(),
+        };
+
+        let resolution = SourcePathsCache::default().resolve(&workspace.join("main.sh"), &context);
+        assert!(!resolution.complete);
+        let built = WorkspaceFunctionIndex::build(&context).unwrap();
+        assert!(!built.is_complete());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn project_root_resolution_failure_marks_source_paths_incomplete() {
+        use std::os::unix::fs::symlink;
+
+        let tempdir = tempfile::tempdir().unwrap();
+        let workspace = std::fs::canonicalize(tempdir.path()).unwrap();
+        std::fs::write(workspace.join(".shuck.toml"), "").unwrap();
+        let loop_path = workspace.join("loop");
+        symlink("loop", &loop_path).unwrap();
+        let context = WorkspaceFunctionContext {
+            workspace_roots: vec![workspace.clone()],
+            settings_workspace_roots: vec![workspace.clone()],
+            workspace_settings: Vec::new(),
+            global_options: ClientOptions::default(),
+            open_documents: Vec::new(),
+            encoding: PositionEncoding::UTF16,
+            max_files: 100,
+            cache: Arc::new(WorkspaceFunctionIndexCache::default()),
+            epoch: 0,
+            cancellation: RequestCancellationToken::default(),
+        };
+
+        let mut source_paths = SourcePathsCache::default();
+        assert!(
+            source_paths
+                .resolve(&workspace.join("main.sh"), &context)
+                .complete
+        );
+        let resolution = source_paths.resolve(&loop_path.join("main.sh"), &context);
+        assert!(!resolution.complete);
+    }
+
+    #[test]
+    fn cancelled_build_does_not_scan_or_populate_the_cache() {
+        let tempdir = tempfile::tempdir().unwrap();
+        let workspace = std::fs::canonicalize(tempdir.path()).unwrap();
+        populate_workspace(&workspace);
+        let context = context_for(&workspace, 100);
+        context.cancellation.cancel();
+
+        assert!(workspace_function_index(&context).is_none());
+        assert!(context.cache.get(context.epoch).is_none());
+    }
+}

--- a/specs/025-cross-file-call-hierarchy.md
+++ b/specs/025-cross-file-call-hierarchy.md
@@ -4,17 +4,24 @@
 
 Implemented (v1).
 
-Delivered: the workspace call-graph index (`FileCallFacts` / `WorkspaceCallIndex`
-in `shuck-semantic`), the shared source-edge resolver, and session-scoped
-`incomingCalls` / `outgoingCalls` handlers that build the index over open
+Delivered: the pure workspace call graph (`FileCallFacts` / `WorkspaceCallIndex`
+in `shuck-semantic`), the shared server-owned `WorkspaceFunctionIndex`, the
+source-edge resolver, and session-scoped `incomingCalls` / `outgoingCalls`
+handlers that build the index over open
 buffers plus discovered workspace files (plus files reachable only through
 resolved source edges, e.g. gitignored vendored targets) and answer both
-directions across files. The built index is cached on the session behind an
+directions across files. `WorkspaceFunctionIndex` owns discovery, open-buffer
+overlay, layered source-path settings, span-to-range source metadata,
+completeness state, and closed-file content hashes so other cross-file editor
+features can reuse the same graph rather than rebuilding call-hierarchy-specific
+variants. The built index is cached on the session behind an
 epoch counter and invalidated by any document, workspace, or configuration
-change, so expanding a call tree reuses one build. Call sites the semantic
-model binds in-file stay binding-accurate (definition order and shadowing are
-honored), while source edges retain their positions so later sourced and local
-definitions override earlier ones; only sites without an effective local
+change, so expanding a call tree reuses one build. Index population checks for
+cancellation between files and phases, and aborted builds do not populate the
+cache. Call sites the semantic model binds in-file stay binding-accurate
+(definition order and shadowing are honored), while source edges retain their
+positions so later sourced and local definitions override earlier ones; only
+sites without an effective local
 binding are matched by name across source edges. Function nodes carry their
 exact definition byte range through `CallHierarchyItem.data`, keeping
 same-named redefinitions distinct across preparation, incoming calls, and
@@ -22,8 +29,9 @@ outgoing calls. Top-level MODULE nodes also round-trip through that payload, so
 their outgoing calls expand. Edges come from all determinable sources
 (literal-resolvable paths and `source=` directives with and without
 `lint=true`), resolved against the annotating file's own directory and the
-configured `[lint] source-paths` roots (memoized per project root, matching
-`shuck check`). The indexed-file count is hard-bounded by
+configured `[lint] source-paths` roots after project, global client, and
+workspace client layers are applied. Open unsaved source targets participate
+without requiring stale disk content. The indexed-file count is hard-bounded by
 `server.callHierarchy.maxFiles` (default 10k): one budget is shared by all
 three population phases — open buffers, closed-file discovery, and source-edge
 expansion — and every insertion checks it, so a runaway workspace degrades to a


### PR DESCRIPTION
## Summary

- extract workspace shell discovery, open-buffer overlay, source-edge resolution, caching, and span-to-range metadata into a server-owned `WorkspaceFunctionIndex`
- layer project, global client, and workspace client source-path settings consistently
- retain completeness and content-freshness metadata for future mutation features, and cooperatively abandon canceled builds without caching them
- migrate call hierarchy to the shared index while preserving exact same-named definition identity and non-file URI fallback behavior

## Why

This is shared preparation for #1203, #1204, #1205, #1206, #1207, and #1210. Those features need one binding-accurate source graph instead of separate feature-specific workspace resolvers.

No feature issue is closed by this PR, and no call-hierarchy behavior change is intended.

## Review

A dedicated review pass found and verified fixes for symlinked unsaved source targets, fail-closed completeness on configuration and project-root errors (including cache hits), and accurate cancellation documentation. The final review found no remaining actionable issues.

## Validation

- `cargo test -q -p shuck-semantic -p shuck-server`
- `cargo clippy -p shuck-server --all-targets --no-deps -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`