### PR TITLE
perf(ast): box fat AST enum payloads

### DIFF
--- a/crates/shuck-ast/src/ast.rs
+++ b/crates/shuck-ast/src/ast.rs
@@ -517,37 +517,37 @@ pub enum BinaryOp {
 #[derive(Debug, Clone)]
 pub enum CompoundCommand {
     /// If statement
-    If(IfCommand),
+    If(Box<IfCommand>),
     /// For loop
-    For(ForCommand),
+    For(Box<ForCommand>),
     /// Zsh repeat loop
-    Repeat(RepeatCommand),
+    Repeat(Box<RepeatCommand>),
     /// Zsh foreach loop
-    Foreach(ForeachCommand),
+    Foreach(Box<ForeachCommand>),
     /// C-style for loop: for ((init; cond; step))
     ArithmeticFor(Box<ArithmeticForCommand>),
     /// While loop
-    While(WhileCommand),
+    While(Box<WhileCommand>),
     /// Until loop
-    Until(UntilCommand),
+    Until(Box<UntilCommand>),
     /// Case statement
-    Case(CaseCommand),
+    Case(Box<CaseCommand>),
     /// Select loop
-    Select(SelectCommand),
+    Select(Box<SelectCommand>),
     /// Subshell (commands in parentheses)
     Subshell(StmtSeq),
     /// Brace group
     BraceGroup(StmtSeq),
     /// Arithmetic command ((expression))
-    Arithmetic(ArithmeticCommand),
+    Arithmetic(Box<ArithmeticCommand>),
     /// Time command - measure execution time
-    Time(TimeCommand),
+    Time(Box<TimeCommand>),
     /// Conditional expression [[ ... ]]
-    Conditional(ConditionalCommand),
+    Conditional(Box<ConditionalCommand>),
     /// Coprocess: `coproc [NAME] command`
-    Coproc(CoprocCommand),
+    Coproc(Box<CoprocCommand>),
     /// Zsh always/finally-style cleanup block.
-    Always(AlwaysCommand),
+    Always(Box<AlwaysCommand>),
 }
 
 /// Coprocess command - runs a command with bidirectional communication.
@@ -2487,8 +2487,8 @@ pub enum HeredocBodyPart {
     },
     ArithmeticExpansion {
         expression: SourceText,
-        expression_ast: Option<ArithmeticExprNode>,
-        expression_word_ast: Word,
+        expression_ast: Option<Box<ArithmeticExprNode>>,
+        expression_word_ast: Box<Word>,
         syntax: ArithmeticExpansionSyntax,
     },
     Parameter(Box<ParameterExpansion>),
@@ -2805,7 +2805,7 @@ pub enum WordPart {
     /// Literal text
     Literal(LiteralText),
     /// Zsh glob with one classic trailing qualifier group such as `*(.)`.
-    ZshQualifiedGlob(ZshQualifiedGlob),
+    ZshQualifiedGlob(Box<ZshQualifiedGlob>),
     /// Single-quoted literal content, including `$'...'` ANSI-C quoting.
     SingleQuoted { value: SourceText, dollar: bool },
     /// Double-quoted content with nested expansions.
@@ -2834,29 +2834,29 @@ pub enum WordPart {
     /// Parameter expansion with operator ${var:-default}, ${var:=default}, etc.
     /// `colon_variant` distinguishes `:-` (unset-or-empty) from `-` (unset-only).
     ParameterExpansion {
-        reference: VarRef,
+        reference: Box<VarRef>,
         operator: Box<ParameterOp>,
-        operand: Option<SourceText>,
+        operand: Option<Box<SourceText>>,
         operand_word_ast: Option<Box<Word>>,
         colon_variant: bool,
     },
     /// Length expansion ${#var}
-    Length(VarRef),
+    Length(Box<VarRef>),
     /// Array element access `${arr[index]}` or `${arr[@]}` or `${arr[*]}`
-    ArrayAccess(VarRef),
+    ArrayAccess(Box<VarRef>),
     /// Array length `${#arr[@]}` or `${#arr[*]}`
-    ArrayLength(VarRef),
+    ArrayLength(Box<VarRef>),
     /// Array indices `${!arr[@]}` or `${!arr[*]}`
-    ArrayIndices(VarRef),
+    ArrayIndices(Box<VarRef>),
     /// Substring extraction `${var:offset}` or `${var:offset:length}`
     Substring {
-        reference: VarRef,
-        offset: SourceText,
+        reference: Box<VarRef>,
+        offset: Box<SourceText>,
         /// Typed arithmetic view of `offset` when it parses as arithmetic.
         offset_ast: Option<Box<ArithmeticExprNode>>,
         /// Parsed shell-word view of `offset`.
         offset_word_ast: Box<Word>,
-        length: Option<SourceText>,
+        length: Option<Box<SourceText>>,
         /// Typed arithmetic view of `length` when it parses as arithmetic.
         length_ast: Option<Box<ArithmeticExprNode>>,
         /// Parsed shell-word view of `length`.
@@ -2864,13 +2864,13 @@ pub enum WordPart {
     },
     /// Array slice `${arr[@]:offset:length}`
     ArraySlice {
-        reference: VarRef,
-        offset: SourceText,
+        reference: Box<VarRef>,
+        offset: Box<SourceText>,
         /// Typed arithmetic view of `offset` when it parses as arithmetic.
         offset_ast: Option<Box<ArithmeticExprNode>>,
         /// Parsed shell-word view of `offset`.
         offset_word_ast: Box<Word>,
-        length: Option<SourceText>,
+        length: Option<Box<SourceText>>,
         /// Typed arithmetic view of `length` when it parses as arithmetic.
         length_ast: Option<Box<ArithmeticExprNode>>,
         /// Parsed shell-word view of `length`.
@@ -2879,9 +2879,9 @@ pub enum WordPart {
     /// Indirect expansion `${!var}` - expands to value of variable named by var's value
     /// Optionally composed with an operator: `${!var:-default}`, `${!var:=val}`, etc.
     IndirectExpansion {
-        reference: VarRef,
+        reference: Box<VarRef>,
         operator: Option<Box<ParameterOp>>,
-        operand: Option<SourceText>,
+        operand: Option<Box<SourceText>>,
         operand_word_ast: Option<Box<Word>>,
         colon_variant: bool,
     },
@@ -2895,7 +2895,10 @@ pub enum WordPart {
         is_input: bool,
     },
     /// Parameter transformation `${var@op}` where op is Q, E, P, A, K, a, u, U, L
-    Transformation { reference: VarRef, operator: char },
+    Transformation {
+        reference: Box<VarRef>,
+        operator: char,
+    },
 }
 
 impl WordPart {
@@ -3217,7 +3220,7 @@ fn fmt_word_part_with_source_mode(
                     f,
                     "{}-{}}}",
                     c,
-                    display_source_text(operand.as_ref(), source)
+                    display_source_text(operand.as_deref(), source)
                 )?
             }
             ParameterOp::AssignDefault => {
@@ -3228,7 +3231,7 @@ fn fmt_word_part_with_source_mode(
                     f,
                     "{}={}}}",
                     c,
-                    display_source_text(operand.as_ref(), source)
+                    display_source_text(operand.as_deref(), source)
                 )?
             }
             ParameterOp::UseReplacement => {
@@ -3239,7 +3242,7 @@ fn fmt_word_part_with_source_mode(
                     f,
                     "{}+{}}}",
                     c,
-                    display_source_text(operand.as_ref(), source)
+                    display_source_text(operand.as_deref(), source)
                 )?
             }
             ParameterOp::Error => {
@@ -3250,7 +3253,7 @@ fn fmt_word_part_with_source_mode(
                     f,
                     "{}?{}}}",
                     c,
-                    display_source_text(operand.as_ref(), source)
+                    display_source_text(operand.as_deref(), source)
                 )?
             }
             ParameterOp::RemovePrefixShort { pattern } => {
@@ -3415,7 +3418,7 @@ fn fmt_word_part_with_source_mode(
                     reference_syntax,
                     c,
                     op_char,
-                    display_source_text(operand.as_ref(), source)
+                    display_source_text(operand.as_deref(), source)
                 )?
             } else {
                 write!(f, "${{!{}}}", reference_syntax)?
@@ -3550,7 +3553,7 @@ fn part_is_source_backed(part: &WordPart) -> bool {
         } => {
             reference.is_source_backed()
                 && operator_is_source_backed(operator)
-                && operand.as_ref().is_none_or(SourceText::is_source_backed)
+                && operand.as_deref().is_none_or(SourceText::is_source_backed)
         }
         WordPart::Length(reference)
         | WordPart::ArrayAccess(reference)
@@ -3575,7 +3578,7 @@ fn part_is_source_backed(part: &WordPart) -> bool {
         } => {
             reference.is_source_backed()
                 && operator.is_none()
-                && operand.as_ref().is_none_or(SourceText::is_source_backed)
+                && operand.as_deref().is_none_or(SourceText::is_source_backed)
         }
         WordPart::CommandSubstitution { .. }
         | WordPart::Variable(_)
@@ -3829,7 +3832,7 @@ pub enum RedirectTarget {
     /// Standard redirect operand like a path or file descriptor.
     Word(Word),
     /// Heredoc delimiter metadata plus decoded body.
-    Heredoc(Heredoc),
+    Heredoc(Box<Heredoc>),
 }
 
 /// Heredoc delimiter metadata and decoded body.
@@ -4159,7 +4162,7 @@ mod tests {
             WordPart::Variable("name".into())
         ])));
         assert!(word_is_standalone_variable_like(&word(vec![
-            WordPart::Length(plain_ref("name"))
+            WordPart::Length(Box::new(plain_ref("name")))
         ])));
         assert!(!word_is_standalone_variable_like(&word(vec![
             WordPart::Literal(LiteralText::owned("prefix")),
@@ -4424,9 +4427,9 @@ mod tests {
                 ),
                 WordPartNode::new(
                     WordPart::ParameterExpansion {
-                        reference: plain_ref("PREFIXED_VERSION"),
+                        reference: Box::new(plain_ref("PREFIXED_VERSION")),
                         operator: Box::new(ParameterOp::UseDefault),
-                        operand: Some("$PROVIDED_VERSION".into()),
+                        operand: Some(Box::new("$PROVIDED_VERSION".into())),
                         operand_word_ast: Some(Box::new(word(vec![WordPart::Variable(
                             "PROVIDED_VERSION".into(),
                         )]))),
@@ -4579,42 +4582,44 @@ mod tests {
 
     #[test]
     fn word_display_length() {
-        let w = word(vec![WordPart::Length(plain_ref("var"))]);
+        let w = word(vec![WordPart::Length(Box::new(plain_ref("var")))]);
         assert_eq!(format!("{w}"), "${#var}");
     }
 
     #[test]
     fn word_display_array_access() {
-        let w = word(vec![WordPart::ArrayAccess(indexed_ref("arr", "0"))]);
+        let w = word(vec![WordPart::ArrayAccess(Box::new(indexed_ref(
+            "arr", "0",
+        )))]);
         assert_eq!(format!("{w}"), "${arr[0]}");
     }
 
     #[test]
     fn word_display_array_length() {
-        let w = word(vec![WordPart::ArrayLength(selector_ref(
+        let w = word(vec![WordPart::ArrayLength(Box::new(selector_ref(
             "arr",
             SubscriptSelector::At,
-        ))]);
+        )))]);
         assert_eq!(format!("{w}"), "${#arr[@]}");
     }
 
     #[test]
     fn word_display_array_indices() {
-        let w = word(vec![WordPart::ArrayIndices(selector_ref(
+        let w = word(vec![WordPart::ArrayIndices(Box::new(selector_ref(
             "arr",
             SubscriptSelector::At,
-        ))]);
+        )))]);
         assert_eq!(format!("{w}"), "${!arr[@]}");
     }
 
     #[test]
     fn word_display_substring_with_length() {
         let w = word(vec![WordPart::Substring {
-            reference: plain_ref("var"),
-            offset: "2".into(),
+            reference: Box::new(plain_ref("var")),
+            offset: Box::new("2".into()),
             offset_ast: None,
             offset_word_ast: Box::new(Word::literal("2")),
-            length: Some("3".into()),
+            length: Some(Box::new("3".into())),
             length_ast: None,
             length_word_ast: Some(Box::new(Word::literal("3"))),
         }]);
@@ -4624,8 +4629,8 @@ mod tests {
     #[test]
     fn word_display_substring_without_length() {
         let w = word(vec![WordPart::Substring {
-            reference: plain_ref("var"),
-            offset: "2".into(),
+            reference: Box::new(plain_ref("var")),
+            offset: Box::new("2".into()),
             offset_ast: None,
             offset_word_ast: Box::new(Word::literal("2")),
             length: None,
@@ -4638,11 +4643,11 @@ mod tests {
     #[test]
     fn word_display_array_slice_with_length() {
         let w = word(vec![WordPart::ArraySlice {
-            reference: selector_ref("arr", SubscriptSelector::At),
-            offset: "1".into(),
+            reference: Box::new(selector_ref("arr", SubscriptSelector::At)),
+            offset: Box::new("1".into()),
             offset_ast: None,
             offset_word_ast: Box::new(Word::literal("1")),
-            length: Some("2".into()),
+            length: Some(Box::new("2".into())),
             length_ast: None,
             length_word_ast: Some(Box::new(Word::literal("2"))),
         }]);
@@ -4652,8 +4657,8 @@ mod tests {
     #[test]
     fn word_display_array_slice_without_length() {
         let w = word(vec![WordPart::ArraySlice {
-            reference: selector_ref("arr", SubscriptSelector::At),
-            offset: "1".into(),
+            reference: Box::new(selector_ref("arr", SubscriptSelector::At)),
+            offset: Box::new("1".into()),
             offset_ast: None,
             offset_word_ast: Box::new(Word::literal("1")),
             length: None,
@@ -4666,7 +4671,7 @@ mod tests {
     #[test]
     fn word_display_indirect_expansion() {
         let w = word(vec![WordPart::IndirectExpansion {
-            reference: plain_ref("ref"),
+            reference: Box::new(plain_ref("ref")),
             operator: None,
             operand: None,
             operand_word_ast: None,
@@ -4695,7 +4700,7 @@ mod tests {
 
     #[test]
     fn word_render_syntax_preserves_raw_quoted_subscript() {
-        let w = word(vec![WordPart::ArrayAccess(VarRef {
+        let w = word(vec![WordPart::ArrayAccess(Box::new(VarRef {
             name: "assoc".into(),
             name_span: Span::new(),
             subscript: Some(Box::new(Subscript {
@@ -4707,7 +4712,7 @@ mod tests {
                 arithmetic_ast: None,
             })),
             span: Span::new(),
-        })]);
+        }))]);
         assert_eq!(format!("{w}"), "${assoc[\"key\"]}");
         assert_eq!(w.render_syntax(""), "${assoc[\"key\"]}");
     }
@@ -4715,7 +4720,7 @@ mod tests {
     #[test]
     fn word_display_transformation() {
         let w = word(vec![WordPart::Transformation {
-            reference: plain_ref("var"),
+            reference: Box::new(plain_ref("var")),
             operator: 'Q',
         }]);
         assert_eq!(format!("{w}"), "${var@Q}");
@@ -4806,9 +4811,9 @@ mod tests {
     #[test]
     fn word_display_parameter_expansion_use_default_colon() {
         let w = word(vec![WordPart::ParameterExpansion {
-            reference: plain_ref("var"),
+            reference: Box::new(plain_ref("var")),
             operator: Box::new(ParameterOp::UseDefault),
-            operand: Some("fallback".into()),
+            operand: Some(Box::new("fallback".into())),
             operand_word_ast: Some(Box::new(Word::literal("fallback"))),
             colon_variant: true,
         }]);
@@ -4818,9 +4823,9 @@ mod tests {
     #[test]
     fn word_display_parameter_expansion_use_default_no_colon() {
         let w = word(vec![WordPart::ParameterExpansion {
-            reference: plain_ref("var"),
+            reference: Box::new(plain_ref("var")),
             operator: Box::new(ParameterOp::UseDefault),
-            operand: Some("fallback".into()),
+            operand: Some(Box::new("fallback".into())),
             operand_word_ast: Some(Box::new(Word::literal("fallback"))),
             colon_variant: false,
         }]);
@@ -4830,9 +4835,9 @@ mod tests {
     #[test]
     fn word_display_parameter_expansion_assign_default() {
         let w = word(vec![WordPart::ParameterExpansion {
-            reference: plain_ref("var"),
+            reference: Box::new(plain_ref("var")),
             operator: Box::new(ParameterOp::AssignDefault),
-            operand: Some("val".into()),
+            operand: Some(Box::new("val".into())),
             operand_word_ast: Some(Box::new(Word::literal("val"))),
             colon_variant: true,
         }]);
@@ -4842,9 +4847,9 @@ mod tests {
     #[test]
     fn word_display_parameter_expansion_use_replacement() {
         let w = word(vec![WordPart::ParameterExpansion {
-            reference: plain_ref("var"),
+            reference: Box::new(plain_ref("var")),
             operator: Box::new(ParameterOp::UseReplacement),
-            operand: Some("alt".into()),
+            operand: Some(Box::new("alt".into())),
             operand_word_ast: Some(Box::new(Word::literal("alt"))),
             colon_variant: true,
         }]);
@@ -4854,9 +4859,9 @@ mod tests {
     #[test]
     fn word_display_parameter_expansion_error() {
         let w = word(vec![WordPart::ParameterExpansion {
-            reference: plain_ref("var"),
+            reference: Box::new(plain_ref("var")),
             operator: Box::new(ParameterOp::Error),
-            operand: Some("msg".into()),
+            operand: Some(Box::new("msg".into())),
             operand_word_ast: Some(Box::new(Word::literal("msg"))),
             colon_variant: true,
         }]);
@@ -4867,7 +4872,7 @@ mod tests {
     fn word_display_parameter_expansion_prefix_suffix() {
         // RemovePrefixShort
         let w = word(vec![WordPart::ParameterExpansion {
-            reference: plain_ref("var"),
+            reference: Box::new(plain_ref("var")),
             operator: Box::new(ParameterOp::RemovePrefixShort {
                 pattern: pattern(vec![PatternPart::Literal("pat".into())]),
             }),
@@ -4879,7 +4884,7 @@ mod tests {
 
         // RemovePrefixLong
         let w = word(vec![WordPart::ParameterExpansion {
-            reference: plain_ref("var"),
+            reference: Box::new(plain_ref("var")),
             operator: Box::new(ParameterOp::RemovePrefixLong {
                 pattern: pattern(vec![PatternPart::Literal("pat".into())]),
             }),
@@ -4891,7 +4896,7 @@ mod tests {
 
         // RemoveSuffixShort
         let w = word(vec![WordPart::ParameterExpansion {
-            reference: plain_ref("var"),
+            reference: Box::new(plain_ref("var")),
             operator: Box::new(ParameterOp::RemoveSuffixShort {
                 pattern: pattern(vec![PatternPart::Literal("pat".into())]),
             }),
@@ -4903,7 +4908,7 @@ mod tests {
 
         // RemoveSuffixLong
         let w = word(vec![WordPart::ParameterExpansion {
-            reference: plain_ref("var"),
+            reference: Box::new(plain_ref("var")),
             operator: Box::new(ParameterOp::RemoveSuffixLong {
                 pattern: pattern(vec![PatternPart::Literal("pat".into())]),
             }),
@@ -4917,7 +4922,7 @@ mod tests {
     #[test]
     fn word_display_parameter_expansion_replace() {
         let w = word(vec![WordPart::ParameterExpansion {
-            reference: plain_ref("var"),
+            reference: Box::new(plain_ref("var")),
             operator: Box::new(ParameterOp::ReplaceFirst {
                 pattern: pattern(vec![PatternPart::Literal("old".into())]),
                 replacement: "new".into(),
@@ -4930,7 +4935,7 @@ mod tests {
         assert_eq!(format!("{w}"), "${var/old/new}");
 
         let w = word(vec![WordPart::ParameterExpansion {
-            reference: plain_ref("var"),
+            reference: Box::new(plain_ref("var")),
             operator: Box::new(ParameterOp::ReplaceAll {
                 pattern: pattern(vec![PatternPart::Literal("old".into())]),
                 replacement: "new".into(),
@@ -4947,7 +4952,7 @@ mod tests {
     fn word_display_parameter_expansion_case() {
         let check = |op: ParameterOp, expected: &str| {
             let w = word(vec![WordPart::ParameterExpansion {
-                reference: plain_ref("var"),
+                reference: Box::new(plain_ref("var")),
                 operator: Box::new(op),
                 operand: None,
                 operand_word_ast: None,
@@ -5170,11 +5175,11 @@ mod tests {
             fd_var_span: None,
             kind: RedirectKind::HereDoc,
             span: Span::new(),
-            target: RedirectTarget::Heredoc(Heredoc {
+            target: RedirectTarget::Heredoc(Box::new(Heredoc {
                 delimiter,
                 body: HeredocBody::literal_with_span("body", Span::new())
                     .with_mode(HeredocBodyMode::Literal),
-            }),
+            })),
         };
 
         let heredoc = redirect.heredoc().expect("expected heredoc payload");
@@ -5426,19 +5431,19 @@ mod tests {
 
     #[test]
     fn compound_command_arithmetic() {
-        let cmd = CompoundCommand::Arithmetic(ArithmeticCommand {
+        let cmd = CompoundCommand::Arithmetic(Box::new(ArithmeticCommand {
             span: Span::new(),
             left_paren_span: Span::new(),
             expr_span: Some(Span::new()),
             expr_ast: None,
             right_paren_span: Span::new(),
-        });
+        }));
         assert!(matches!(cmd, CompoundCommand::Arithmetic(_)));
     }
 
     #[test]
     fn compound_command_conditional() {
-        let cmd = CompoundCommand::Conditional(ConditionalCommand {
+        let cmd = CompoundCommand::Conditional(Box::new(ConditionalCommand {
             expression: ConditionalExpr::Unary(ConditionalUnaryExpr {
                 op: ConditionalUnaryOp::RegularFile,
                 op_span: Span::new(),
@@ -5447,7 +5452,7 @@ mod tests {
             span: Span::new(),
             left_bracket_span: Span::new(),
             right_bracket_span: Span::new(),
-        });
+        }));
         if let CompoundCommand::Conditional(command) = &cmd {
             let ConditionalExpr::Unary(expr) = &command.expression else {
                 panic!("expected unary conditional");

--- a/crates/shuck-formatter/src/render_plan/shape.rs
+++ b/crates/shuck-formatter/src/render_plan/shape.rs
@@ -1,6 +1,5 @@
 use shuck_ast::{
-    Command, CompoundCommand, ForCommand, IfCommand, IfSyntax, RepeatCommand, SelectCommand, Span,
-    Stmt, StmtSeq, StmtTerminator, UntilCommand, WhileCommand,
+    Command, CompoundCommand, IfCommand, IfSyntax, Span, Stmt, StmtSeq, StmtTerminator,
 };
 
 use crate::command::{stmt_format_span, stmt_span};
@@ -377,13 +376,23 @@ fn command_allows_done_without_semicolon(command: &Command) -> bool {
 fn compound_allows_done_without_semicolon(command: &CompoundCommand) -> bool {
     match command {
         CompoundCommand::Case(_) => true,
-        CompoundCommand::BraceGroup(commands)
-        | CompoundCommand::For(ForCommand { body: commands, .. })
-        | CompoundCommand::Repeat(RepeatCommand { body: commands, .. })
-        | CompoundCommand::While(WhileCommand { body: commands, .. })
-        | CompoundCommand::Until(UntilCommand { body: commands, .. })
-        | CompoundCommand::Select(SelectCommand { body: commands, .. }) => {
+        CompoundCommand::BraceGroup(commands) => {
             brace_group_last_stmt_allows_done_without_semicolon(commands)
+        }
+        CompoundCommand::For(command) => {
+            brace_group_last_stmt_allows_done_without_semicolon(&command.body)
+        }
+        CompoundCommand::Repeat(command) => {
+            brace_group_last_stmt_allows_done_without_semicolon(&command.body)
+        }
+        CompoundCommand::While(command) => {
+            brace_group_last_stmt_allows_done_without_semicolon(&command.body)
+        }
+        CompoundCommand::Until(command) => {
+            brace_group_last_stmt_allows_done_without_semicolon(&command.body)
+        }
+        CompoundCommand::Select(command) => {
+            brace_group_last_stmt_allows_done_without_semicolon(&command.body)
         }
         CompoundCommand::ArithmeticFor(command) => {
             brace_group_last_stmt_allows_done_without_semicolon(&command.body)

--- a/crates/shuck-formatter/src/word/core.rs
+++ b/crates/shuck-formatter/src/word/core.rs
@@ -701,7 +701,7 @@ pub(super) fn render_word_part(
             rendered,
             reference,
             operator.as_ref(),
-            operand.as_ref(),
+            operand.as_ref().map(|v| &**v),
             *colon_variant,
             Some(span),
             env,

--- a/crates/shuck-formatter/src/word/heredoc.rs
+++ b/crates/shuck-formatter/src/word/heredoc.rs
@@ -110,7 +110,7 @@ pub(super) fn render_heredoc_body_part(
                 push_arithmetic_expansion(
                     rendered,
                     expression,
-                    expression_ast.as_ref(),
+                    expression_ast.as_deref(),
                     *syntax,
                     context,
                 );

--- a/crates/shuck-linter/src/facts/arithmetic.rs
+++ b/crates/shuck-linter/src/facts/arithmetic.rs
@@ -1040,7 +1040,7 @@ pub(crate) fn collect_base_prefix_spans_in_arithmetic_word_part(
             collect_base_prefix_spans_in_var_ref(reference, source, spans);
             collect_base_prefix_spans_in_arithmetic_fragment(
                 operand_word_ast.as_deref(),
-                operand.as_ref(),
+                operand.as_ref().map(|v| &**v),
                 source,
                 spans,
             );

--- a/crates/shuck-linter/src/facts/conditionals.rs
+++ b/crates/shuck-linter/src/facts/conditionals.rs
@@ -1831,7 +1831,7 @@ pub(crate) fn collect_status_parameter_spans_in_word_part(
             collect_status_parameter_spans_in_var_ref(reference, source, spans);
             collect_status_parameter_spans_in_fragment(
                 operand_word_ast.as_deref(),
-                operand.as_ref(),
+                operand.as_ref().map(|v| &**v),
                 source,
                 spans,
             );

--- a/crates/shuck-linter/src/facts/substitutions.rs
+++ b/crates/shuck-linter/src/facts/substitutions.rs
@@ -371,7 +371,7 @@ pub(crate) fn collect_heredoc_body_substitution_occurrences<'a>(
     for part in parts {
         match &part.kind {
             shuck_ast::HeredocBodyPart::ArithmeticExpansion { expression_ast, .. } => {
-                visit_arithmetic_words_in_expression(expression_ast.as_ref(), false, occurrences);
+                visit_arithmetic_words_in_expression(expression_ast.as_deref(), false, occurrences);
             }
             shuck_ast::HeredocBodyPart::CommandSubstitution { body, syntax } => {
                 occurrences.push(SubstitutionOccurrence {

--- a/crates/shuck-linter/src/facts/surface.rs
+++ b/crates/shuck-linter/src/facts/surface.rs
@@ -1142,7 +1142,7 @@ impl<'a> SurfaceFragmentSink<'a> {
                 );
                 self.collect_parameter_operator_patterns(
                     operator,
-                    operand.as_ref(),
+                    operand.as_ref().map(|v| &**v),
                     operand_word_ast.as_deref(),
                     context,
                 );
@@ -1218,7 +1218,7 @@ impl<'a> SurfaceFragmentSink<'a> {
                     });
                 self.collect_parameter_operator_patterns(
                     operator,
-                    operand.as_ref(),
+                    operand.as_ref().map(|v| &**v),
                     operand_word_ast.as_deref(),
                     context,
                 );
@@ -1311,7 +1311,7 @@ impl<'a> SurfaceFragmentSink<'a> {
                         .push(LegacyArithmeticFragmentFact { span: part.span });
                     collect_positional_parameter_operator_spans_in_arithmetic(
                         part.span,
-                        expression_ast.as_ref(),
+                        expression_ast.as_deref(),
                         expression,
                         self.source,
                         &mut self.facts.positional_parameter_operator_spans,
@@ -1332,7 +1332,7 @@ impl<'a> SurfaceFragmentSink<'a> {
                 } => {
                     collect_positional_parameter_operator_spans_in_arithmetic(
                         part.span,
-                        expression_ast.as_ref(),
+                        expression_ast.as_deref(),
                         expression,
                         self.source,
                         &mut self.facts.positional_parameter_operator_spans,

--- a/crates/shuck-linter/src/facts/words/traversal.rs
+++ b/crates/shuck-linter/src/facts/words/traversal.rs
@@ -842,11 +842,11 @@ mod tests {
         };
         let word = Word {
             parts: vec![WordPartNode::new(
-                WordPart::ZshQualifiedGlob(ZshQualifiedGlob {
+                WordPart::ZshQualifiedGlob(Box::new(ZshQualifiedGlob {
                     span: span_for(source, 0, source.len()),
                     segments: vec![ZshGlobSegment::Pattern(pattern)],
                     qualifiers: None,
-                }),
+                })),
                 span_for(source, 0, source.len()),
             )],
             span: span_for(source, 0, source.len()),

--- a/crates/shuck-parser/src/parser/brace_syntax.rs
+++ b/crates/shuck-parser/src/parser/brace_syntax.rs
@@ -978,11 +978,11 @@ impl<'a> Parser<'a> {
 
         Some(self.word_with_parts(
             vec![WordPartNode::new(
-                WordPart::ZshQualifiedGlob(ZshQualifiedGlob {
+                WordPart::ZshQualifiedGlob(Box::new(ZshQualifiedGlob {
                     span,
                     segments,
                     qualifiers,
-                }),
+                })),
                 span,
             )],
             span,

--- a/crates/shuck-parser/src/parser/commands/case.rs
+++ b/crates/shuck-parser/src/parser/commands/case.rs
@@ -63,12 +63,12 @@ impl<'a> Parser<'a> {
         self.advance();
 
         self.pop_depth();
-        Ok(CompoundCommand::Case(CaseCommand {
+        Ok(CompoundCommand::Case(Box::new(CaseCommand {
             word,
             cases,
             esac_span,
             span: start_span.merge(self.current_span),
-        }))
+        })))
     }
 
     pub(super) fn parse_case_patterns(&mut self) -> Result<Vec<Pattern>> {

--- a/crates/shuck-parser/src/parser/commands/compound.rs
+++ b/crates/shuck-parser/src/parser/commands/compound.rs
@@ -19,11 +19,11 @@ impl<'a> Parser<'a> {
         // time with no command is valid in bash (just outputs timing header)
         let command = self.parse_pipeline()?.map(Box::new);
 
-        Ok(CompoundCommand::Time(TimeCommand {
+        Ok(CompoundCommand::Time(Box::new(TimeCommand {
             posix_format,
             command,
             span: start_span.merge(self.current_span),
-        }))
+        })))
     }
 
     /// Parse a coproc command: `coproc [NAME] command`
@@ -70,12 +70,12 @@ impl<'a> Parser<'a> {
         let body = self.parse_pipeline()?;
         let body = body.ok_or_else(|| self.error("coproc: missing command"))?;
 
-        Ok(CompoundCommand::Coproc(CoprocCommand {
+        Ok(CompoundCommand::Coproc(Box::new(CoprocCommand {
             name,
             name_span,
             body: Box::new(body),
             span: start_span.merge(self.current_span),
-        }))
+        })))
     }
 
     /// Check if current token is ;; (case terminator)
@@ -191,11 +191,11 @@ impl<'a> Parser<'a> {
                 BraceBodyContext::Ordinary,
             )?;
             (
-                CompoundCommand::Always(AlwaysCommand {
+                CompoundCommand::Always(Box::new(AlwaysCommand {
                     body,
                     always_body,
                     span: left_brace_span.merge(always_right_brace_span),
-                }),
+                })),
                 always_right_brace_span,
             )
         } else {

--- a/crates/shuck-parser/src/parser/commands/conditionals.rs
+++ b/crates/shuck-parser/src/parser/commands/conditionals.rs
@@ -24,12 +24,12 @@ impl<'a> Parser<'a> {
             _ => return Err(self.error("expected ']]' to close conditional expression")),
         };
 
-        Ok(CompoundCommand::Conditional(ConditionalCommand {
+        Ok(CompoundCommand::Conditional(Box::new(ConditionalCommand {
             expression,
             span: left_bracket_span.merge(right_bracket_span),
             left_bracket_span,
             right_bracket_span,
-        }))
+        })))
     }
 
     pub(super) fn skip_conditional_newlines(&mut self) {
@@ -764,13 +764,13 @@ impl<'a> Parser<'a> {
             .parse_explicit_arithmetic_span(expr_span, "invalid arithmetic command")
             .ok()
             .flatten();
-        Ok(CompoundCommand::Arithmetic(ArithmeticCommand {
+        Ok(CompoundCommand::Arithmetic(Box::new(ArithmeticCommand {
             span: left_paren_span.merge(right_paren_span),
             left_paren_span,
             expr_span,
             expr_ast,
             right_paren_span,
-        }))
+        })))
     }
 
     pub(super) fn scan_arithmetic_command_close(&self, left_paren_span: Span) -> Option<Span> {

--- a/crates/shuck-parser/src/parser/commands/if_clause.rs
+++ b/crates/shuck-parser/src/parser/commands/if_clause.rs
@@ -197,13 +197,13 @@ impl<'a> Parser<'a> {
         }
 
         self.pop_depth();
-        Ok(CompoundCommand::If(IfCommand {
+        Ok(CompoundCommand::If(Box::new(IfCommand {
             condition,
             then_branch,
             elif_branches,
             else_branch,
             syntax,
             span: start_span.merge(self.current_span),
-        }))
+        })))
     }
 }

--- a/crates/shuck-parser/src/parser/commands/loops.rs
+++ b/crates/shuck-parser/src/parser/commands/loops.rs
@@ -256,13 +256,13 @@ impl<'a> Parser<'a> {
         };
 
         self.pop_depth();
-        Ok(CompoundCommand::For(ForCommand {
+        Ok(CompoundCommand::For(Box::new(ForCommand {
             targets: targets.into_vec(),
             words: words.map(SmallVec::into_vec),
             body,
             syntax,
             span: start_span.merge(end_span),
-        }))
+        })))
     }
 
     pub(super) fn parse_for_targets(
@@ -490,12 +490,12 @@ impl<'a> Parser<'a> {
         };
 
         self.pop_depth();
-        Ok(CompoundCommand::Repeat(RepeatCommand {
+        Ok(CompoundCommand::Repeat(Box::new(RepeatCommand {
             count,
             body,
             syntax,
             span: start_span.merge(end_span),
-        }))
+        })))
     }
 
     /// Parse a zsh foreach loop.
@@ -630,14 +630,14 @@ impl<'a> Parser<'a> {
         };
 
         self.pop_depth();
-        Ok(CompoundCommand::Foreach(ForeachCommand {
+        Ok(CompoundCommand::Foreach(Box::new(ForeachCommand {
             variable,
             variable_span,
             words: words.into_vec(),
             body,
             syntax,
             span: start_span.merge(end_span),
-        }))
+        })))
     }
 
     /// Parse select loop: select var in list; do body; done
@@ -710,14 +710,14 @@ impl<'a> Parser<'a> {
         self.advance();
 
         self.pop_depth();
-        Ok(CompoundCommand::Select(SelectCommand {
+        Ok(CompoundCommand::Select(Box::new(SelectCommand {
             variable,
             variable_span,
             words: words.into_vec(),
             body,
             done_span,
             span: start_span.merge(self.current_span),
-        }))
+        })))
     }
 
     /// Parse C-style arithmetic for loop inner: for ((init; cond; step)); do body; done
@@ -964,12 +964,12 @@ impl<'a> Parser<'a> {
         };
 
         self.pop_depth();
-        Ok(CompoundCommand::While(WhileCommand {
+        Ok(CompoundCommand::While(Box::new(WhileCommand {
             condition,
             body,
             done_span,
             span: start_span.merge(end_span),
-        }))
+        })))
     }
 
     /// Parse an until loop
@@ -1043,11 +1043,11 @@ impl<'a> Parser<'a> {
         };
 
         self.pop_depth();
-        Ok(CompoundCommand::Until(UntilCommand {
+        Ok(CompoundCommand::Until(Box::new(UntilCommand {
             condition,
             body,
             done_span,
             span: start_span.merge(end_span),
-        }))
+        })))
     }
 }

--- a/crates/shuck-parser/src/parser/heredocs.rs
+++ b/crates/shuck-parser/src/parser/heredocs.rs
@@ -98,7 +98,7 @@ impl<'a> Parser<'a> {
                 RedirectKind::HereDoc
             },
             span: operator_span.merge(delimiter.span),
-            target: RedirectTarget::Heredoc(Heredoc { delimiter, body }),
+            target: RedirectTarget::Heredoc(Box::new(Heredoc { delimiter, body })),
         });
 
         // Advance so re-injected rest-of-line tokens are picked up.

--- a/crates/shuck-parser/src/parser/tests/mod.rs
+++ b/crates/shuck-parser/src/parser/tests/mod.rs
@@ -425,7 +425,7 @@ fn expect_parameter_operation_part(
             operator,
             operand,
             ..
-        } => (reference, operator.as_ref(), operand.as_ref()),
+        } => (reference, operator.as_ref(), operand.as_ref().map(|v| &**v)),
         WordPart::Parameter(parameter) => match &parameter.syntax {
             ParameterExpansionSyntax::Bourne(BourneParameterExpansion::Operation {
                 reference,
@@ -466,7 +466,7 @@ fn expect_indirect_expansion_part(
         } => (
             reference,
             operator.as_deref(),
-            operand.as_ref(),
+            operand.as_ref().map(|v| &**v),
             *colon_variant,
         ),
         WordPart::Parameter(parameter) => match &parameter.syntax {

--- a/crates/shuck-parser/src/parser/word/heredocs.rs
+++ b/crates/shuck-parser/src/parser/word/heredocs.rs
@@ -35,8 +35,8 @@ impl<'a> Parser<'a> {
                 syntax,
             } => HeredocBodyPart::ArithmeticExpansion {
                 expression,
-                expression_ast: expression_ast.map(|ast| *ast),
-                expression_word_ast: *expression_word_ast,
+                expression_ast,
+                expression_word_ast,
                 syntax,
             },
             WordPart::Parameter(parameter) => HeredocBodyPart::Parameter(parameter),

--- a/crates/shuck-parser/src/parser/word/parameters.rs
+++ b/crates/shuck-parser/src/parser/word/parameters.rs
@@ -20,21 +20,23 @@ impl<'a> Parser<'a> {
                 operand_word_ast,
                 colon_variant,
             } => Some(BourneParameterExpansion::Operation {
-                reference,
+                reference: *reference,
                 operator: self.enrich_parameter_operator(operator),
-                operand,
+                operand: operand.map(|operand| *operand),
                 operand_word_ast,
                 colon_variant,
             }),
             WordPart::Length(reference) | WordPart::ArrayLength(reference) => {
-                Some(BourneParameterExpansion::Length { reference })
+                Some(BourneParameterExpansion::Length {
+                    reference: *reference,
+                })
             }
-            WordPart::ArrayAccess(reference) => {
-                Some(BourneParameterExpansion::Access { reference })
-            }
-            WordPart::ArrayIndices(reference) => {
-                Some(BourneParameterExpansion::Indices { reference })
-            }
+            WordPart::ArrayAccess(reference) => Some(BourneParameterExpansion::Access {
+                reference: *reference,
+            }),
+            WordPart::ArrayIndices(reference) => Some(BourneParameterExpansion::Indices {
+                reference: *reference,
+            }),
             WordPart::Substring {
                 reference,
                 offset,
@@ -53,11 +55,11 @@ impl<'a> Parser<'a> {
                 length_ast,
                 length_word_ast,
             } => Some(BourneParameterExpansion::Slice {
-                reference,
-                offset,
+                reference: *reference,
+                offset: *offset,
                 offset_ast,
                 offset_word_ast,
-                length,
+                length: length.map(|length| *length),
                 length_ast,
                 length_word_ast,
             }),
@@ -68,9 +70,9 @@ impl<'a> Parser<'a> {
                 operand_word_ast,
                 colon_variant,
             } => Some(BourneParameterExpansion::Indirect {
-                reference,
+                reference: *reference,
                 operator: operator.map(|operator| self.enrich_parameter_operator(operator)),
-                operand,
+                operand: operand.map(|operand| *operand),
                 operand_word_ast,
                 colon_variant,
             }),
@@ -81,7 +83,7 @@ impl<'a> Parser<'a> {
                 reference,
                 operator,
             } => Some(BourneParameterExpansion::Transformation {
-                reference,
+                reference: *reference,
                 operator,
             }),
             WordPart::Variable(name) if raw_body_text == name.as_str() => {

--- a/crates/shuck-parser/src/parser/word/render.rs
+++ b/crates/shuck-parser/src/parser/word/render.rs
@@ -51,7 +51,7 @@ impl<'a> Parser<'a> {
                 } => {
                     reference.is_source_backed()
                         && self.parameter_operator_is_source_backed(operator)
-                        && operand.as_ref().is_none_or(SourceText::is_source_backed)
+                        && operand.as_deref().is_none_or(SourceText::is_source_backed)
                 }
                 WordPart::Length(reference)
                 | WordPart::ArrayAccess(reference)
@@ -72,7 +72,7 @@ impl<'a> Parser<'a> {
                 } => {
                     reference.is_source_backed()
                         && offset.is_source_backed()
-                        && length.as_ref().is_none_or(SourceText::is_source_backed)
+                        && length.as_deref().is_none_or(SourceText::is_source_backed)
                 }
                 WordPart::IndirectExpansion {
                     reference,
@@ -82,7 +82,7 @@ impl<'a> Parser<'a> {
                 } => {
                     reference.is_source_backed()
                         && operator.is_none()
-                        && operand.as_ref().is_none_or(SourceText::is_source_backed)
+                        && operand.as_deref().is_none_or(SourceText::is_source_backed)
                 }
             }
     }
@@ -273,7 +273,7 @@ impl<'a> Parser<'a> {
                 self.push_parameter_operator_syntax(
                     out,
                     operator,
-                    operand.as_ref(),
+                    operand.as_ref().map(|v| &**v),
                     *colon_variant,
                 );
                 out.push('}');
@@ -333,7 +333,7 @@ impl<'a> Parser<'a> {
                     self.push_parameter_operator_syntax(
                         out,
                         operator,
-                        operand.as_ref(),
+                        operand.as_ref().map(|v| &**v),
                         *colon_variant,
                     );
                 }

--- a/crates/shuck-parser/src/parser/words/decode.rs
+++ b/crates/shuck-parser/src/parser/words/decode.rs
@@ -961,9 +961,9 @@ impl<'a> Parser<'a> {
                             .and_then(Subscript::selector)
                             .is_some()
                         {
-                            WordPart::ArrayLength(reference)
+                            WordPart::ArrayLength(Box::new(reference))
                         } else {
-                            WordPart::Length(reference)
+                            WordPart::Length(Box::new(reference))
                         };
                         let part = self.parameter_word_part_from_legacy(
                             part,
@@ -975,9 +975,9 @@ impl<'a> Parser<'a> {
                     } else {
                         Self::consume_word_char_if(&mut chars, &mut cursor, '}');
                         let part = self.parameter_word_part_from_legacy(
-                            WordPart::Length(
+                            WordPart::Length(Box::new(
                                 self.parameter_var_ref(part_start, "${#", &var_name, None, cursor),
-                            ),
+                            )),
                             part_start,
                             cursor,
                             source_backed,
@@ -1051,7 +1051,7 @@ impl<'a> Parser<'a> {
                                 .and_then(Subscript::selector)
                                 .is_some()
                             {
-                                WordPart::ArrayIndices(reference)
+                                WordPart::ArrayIndices(Box::new(reference))
                             } else {
                                 self.indirect_expansion_word_part(reference, None, None, false)
                             },
@@ -1599,43 +1599,43 @@ impl<'a> Parser<'a> {
                                 let operator = Self::next_word_char_unwrap(&mut chars, &mut cursor);
                                 Self::consume_word_char_if(&mut chars, &mut cursor, '}');
                                 WordPart::Transformation {
-                                    reference: self.parameter_var_ref(
+                                    reference: Box::new(self.parameter_var_ref(
                                         part_start,
                                         "${",
                                         &var_name,
                                         Some(subscript),
                                         cursor,
-                                    ),
+                                    )),
                                     operator,
                                 }
                             } else {
                                 Self::consume_word_char_if(&mut chars, &mut cursor, '}');
-                                WordPart::ArrayAccess(self.parameter_var_ref(
+                                WordPart::ArrayAccess(Box::new(self.parameter_var_ref(
                                     part_start,
                                     "${",
                                     &var_name,
                                     Some(subscript),
                                     cursor,
-                                ))
+                                )))
                             }
                         } else {
                             Self::consume_word_char_if(&mut chars, &mut cursor, '}');
-                            WordPart::ArrayAccess(self.parameter_var_ref(
+                            WordPart::ArrayAccess(Box::new(self.parameter_var_ref(
                                 part_start,
                                 "${",
                                 &var_name,
                                 Some(subscript),
                                 cursor,
-                            ))
+                            )))
                         }
                     } else {
-                        WordPart::ArrayAccess(self.parameter_var_ref(
+                        WordPart::ArrayAccess(Box::new(self.parameter_var_ref(
                             part_start,
                             "${",
                             &var_name,
                             Some(subscript),
                             cursor,
-                        ))
+                        )))
                     };
 
                     let part = self.parameter_word_part_from_legacy(
@@ -1719,13 +1719,13 @@ impl<'a> Parser<'a> {
                                 raw_index,
                                 SubscriptInterpretation::Contextual,
                             );
-                            WordPart::ArrayAccess(self.parameter_var_ref(
+                            WordPart::ArrayAccess(Box::new(self.parameter_var_ref(
                                 part_start,
                                 "$",
                                 &var_name,
                                 Some(subscript),
                                 cursor,
-                            ))
+                            )))
                         } else {
                             WordPart::Variable(var_name.into())
                         };

--- a/crates/shuck-parser/src/parser/words/expansion.rs
+++ b/crates/shuck-parser/src/parser/words/expansion.rs
@@ -436,9 +436,9 @@ impl<'a> Parser<'a> {
             .parse_optional_source_text_as_word(operand.as_ref())
             .map(Box::new);
         WordPart::ParameterExpansion {
-            reference,
+            reference: Box::new(reference),
             operator: Box::new(operator),
-            operand,
+            operand: operand.map(Box::new),
             operand_word_ast,
             colon_variant,
         }
@@ -455,9 +455,9 @@ impl<'a> Parser<'a> {
             .parse_optional_source_text_as_word(operand.as_ref())
             .map(Box::new);
         WordPart::IndirectExpansion {
-            reference,
+            reference: Box::new(reference),
             operator: operator.map(Box::new),
-            operand,
+            operand: operand.map(Box::new),
             operand_word_ast,
             colon_variant,
         }
@@ -481,11 +481,11 @@ impl<'a> Parser<'a> {
             .parse_optional_source_text_as_word(length.as_ref())
             .map(Box::new);
         WordPart::Substring {
-            reference,
-            offset,
+            reference: Box::new(reference),
+            offset: Box::new(offset),
             offset_ast,
             offset_word_ast,
-            length,
+            length: length.map(Box::new),
             length_ast,
             length_word_ast,
         }
@@ -688,8 +688,9 @@ impl<'a> Parser<'a> {
                         let operator = Self::next_word_char_unwrap(chars, cursor);
                         Self::consume_word_char_if(chars, cursor, '}');
                         WordPart::Transformation {
-                            reference: self
-                                .parameter_var_ref(part_start, "${", var_name, None, *cursor),
+                            reference: Box::new(
+                                self.parameter_var_ref(part_start, "${", var_name, None, *cursor),
+                            ),
                             operator,
                         }
                     } else {
@@ -734,11 +735,11 @@ impl<'a> Parser<'a> {
             .parse_optional_source_text_as_word(length.as_ref())
             .map(Box::new);
         WordPart::ArraySlice {
-            reference,
-            offset,
+            reference: Box::new(reference),
+            offset: Box::new(offset),
             offset_ast,
             offset_word_ast,
-            length,
+            length: length.map(Box::new),
             length_ast,
             length_word_ast,
         }

--- a/crates/shuck-semantic/src/builder/inert.rs
+++ b/crates/shuck-semantic/src/builder/inert.rs
@@ -160,7 +160,7 @@ mod tests {
 
     #[test]
     fn inert_zsh_qualified_glob_short_circuits() {
-        let word = word(vec![WordPart::ZshQualifiedGlob(
+        let word = word(vec![WordPart::ZshQualifiedGlob(Box::new(
             shuck_ast::ZshQualifiedGlob {
                 span: Span::new(),
                 segments: vec![
@@ -180,7 +180,7 @@ mod tests {
                 ],
                 qualifiers: None,
             },
-        )]);
+        ))]);
 
         assert!(word_is_semantically_inert(&word));
     }
@@ -189,14 +189,14 @@ mod tests {
     fn pattern_with_expanding_word_is_not_inert() {
         let pattern = pattern(vec![PatternPart::Word(word(vec![
             WordPart::ParameterExpansion {
-                reference: VarRef {
+                reference: Box::new(VarRef {
                     name: "name".into(),
                     name_span: Span::new(),
                     subscript: None,
                     span: Span::new(),
-                },
+                }),
                 operator: Box::new(ParameterOp::UseDefault),
-                operand: Some(SourceText::from("fallback")),
+                operand: Some(Box::new(SourceText::from("fallback"))),
                 operand_word_ast: Some(Box::new(Word::literal("fallback"))),
                 colon_variant: true,
             },

--- a/crates/shuck-semantic/src/builder/words.rs
+++ b/crates/shuck-semantic/src/builder/words.rs
@@ -421,7 +421,7 @@ impl<'a, 'idx, 'observer> SemanticModelBuilder<'a, 'idx, 'observer> {
                 }
                 self.visit_parameter_operator_operand(
                     operator,
-                    operand.as_ref(),
+                    operand.as_ref().map(|v| &**v),
                     operand_word_ast.as_deref(),
                     kind,
                     flow,
@@ -493,7 +493,7 @@ impl<'a, 'idx, 'observer> SemanticModelBuilder<'a, 'idx, 'observer> {
                 if let Some(operator) = operator {
                     self.visit_parameter_operator_operand(
                         operator,
-                        operand.as_ref(),
+                        operand.as_ref().map(|v| &**v),
                         operand_word_ast.as_deref(),
                         kind,
                         flow,
@@ -601,7 +601,7 @@ impl<'a, 'idx, 'observer> SemanticModelBuilder<'a, 'idx, 'observer> {
             }
             HeredocBodyPart::ArithmeticExpansion { expression_ast, .. } => {
                 self.visit_optional_arithmetic_expr_into(
-                    expression_ast.as_ref(),
+                    expression_ast.as_deref(),
                     flow,
                     nested_regions,
                 );


### PR DESCRIPTION
## Summary

Type-shrinking pass on the AST driven by `-Zprint-type-sizes` variant analysis. The hot container types carried their largest (mostly rare) variants inline:

- `CompoundCommand::If` (536 B) set the size of every `Command` (536 B) and `Stmt` (696 B)
- `RedirectTarget::Heredoc` (256 B) set every `Redirect` to 400 B
- The `Substring`/`ArraySlice`/`ParameterExpansion`/`IndirectExpansion` families (223–303 B) set every `WordPart` to 304 B

Statement and word-part vectors copy these on every push/append/clone, so the oversized layouts were the main remaining feeder of the allocator+memcpy hotspot.

Following the existing `ArithmeticFor(Box<_>)` precedent, this boxes: all compound-command payloads except `Subshell`/`BraceGroup`; the heredoc redirect target; heredoc arithmetic-expansion fields; zsh qualified globs; and the `VarRef`/`SourceText` fields of the substring, array-slice, parameter-operator, indirect, length, array-access, and transformation expansions.

## Type sizes

| Type | Before | After |
|---|---:|---:|
| `Stmt` | 696 B | **360 B** |
| `Command` | 536 B | **200 B** |
| `WordPart` | 304 B | **128 B** |
| `WordPartNode` | 352 B | **176 B** |
| `Redirect` | 400 B | **240 B** |

## Measured impact (xwmx/nb fixture, interleaved A/B vs main)

| Metric | Before | After | Delta |
|---|---|---|---|
| Lint wall / iteration | 150.3 ms | 141.3 ms | **−6.0%** |
| Total allocated bytes (2 iters) | 604 MB | 533 MB | **−11.8%** |
| Allocation count | 1.286 M | 1.309 M | +1.7% |

Diagnostics unchanged.

## Testing

- `cargo test` (full workspace) passes
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean (pinned 1.94.1 toolchain)
- `make test-large-corpus SHUCK_LARGE_CORPUS_SAMPLE_PERCENT=10` conformance passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)