### PR TITLE
perf(ast)!: store source positions as u32

### DIFF
--- a/crates/shuck-ast/src/ast.rs
+++ b/crates/shuck-ast/src/ast.rs
@@ -2712,7 +2712,7 @@ enum RenderMode {
 }
 
 fn syntax_source_slice(span: Span, source: &str) -> Option<&str> {
-    (span.start.offset < span.end.offset && span.end.offset <= source.len())
+    (span.start.offset() < span.end.offset() && span.end.offset() <= source.len())
         .then(|| span.slice(source))
 }
 
@@ -3051,7 +3051,7 @@ fn fmt_pattern_part_with_source_mode(
     match part {
         PatternPart::Literal(text) => match (mode, source) {
             (RenderMode::Syntax, Some(source))
-                if text.is_source_backed() && span.end.offset <= source.len() =>
+                if text.is_source_backed() && span.end.offset() <= source.len() =>
             {
                 f.write_str(text.syntax_str(source, span))?
             }
@@ -3060,7 +3060,7 @@ fn fmt_pattern_part_with_source_mode(
         PatternPart::AnyString => f.write_str("*")?,
         PatternPart::AnyChar => f.write_str("?")?,
         PatternPart::CharClass(text) => match source {
-            Some(source) if span.end.offset <= source.len() => f.write_str(span.slice(source))?,
+            Some(source) if span.end.offset() <= source.len() => f.write_str(span.slice(source))?,
             _ => f.write_str(display_source_text(Some(text), source))?,
         },
         PatternPart::Group { kind, patterns } => {
@@ -3092,7 +3092,7 @@ fn fmt_word_part_with_source_mode(
         && let Some(source) = source
         && part_prefers_source_slice_in_syntax(part)
         && part_is_source_backed(part)
-        && span.end.offset <= source.len()
+        && span.end.offset() <= source.len()
     {
         f.write_str(span.slice(source))?;
         return Ok(());
@@ -3101,7 +3101,7 @@ fn fmt_word_part_with_source_mode(
     match part {
         WordPart::Literal(text) => match (mode, source) {
             (RenderMode::Syntax, Some(source))
-                if text.is_source_backed() && span.end.offset <= source.len() =>
+                if text.is_source_backed() && span.end.offset() <= source.len() =>
             {
                 f.write_str(trim_unescaped_trailing_whitespace(span.slice(source)))?;
             }
@@ -3110,7 +3110,7 @@ fn fmt_word_part_with_source_mode(
         WordPart::ZshQualifiedGlob(glob) => {
             if let Some(source) = source
                 && zsh_qualified_glob_is_source_backed(glob)
-                && glob.span.end.offset <= source.len()
+                && glob.span.end.offset() <= source.len()
             {
                 f.write_str(trim_unescaped_trailing_whitespace(glob.span.slice(source)))?;
             } else {
@@ -3128,7 +3128,7 @@ fn fmt_word_part_with_source_mode(
                 Some(source)
                     if value.is_source_backed()
                         && part_is_source_backed(part)
-                        && span.end.offset <= source.len() =>
+                        && span.end.offset() <= source.len() =>
                 {
                     f.write_str(span.slice(source))?;
                 }
@@ -3149,7 +3149,9 @@ fn fmt_word_part_with_source_mode(
                 }
             }
             RenderMode::Syntax => match source {
-                Some(source) if part_is_source_backed(part) && span.end.offset <= source.len() => {
+                Some(source)
+                    if part_is_source_backed(part) && span.end.offset() <= source.len() =>
+                {
                     f.write_str(span.slice(source))?;
                 }
                 _ => {
@@ -3177,7 +3179,7 @@ fn fmt_word_part_with_source_mode(
         },
         WordPart::Variable(name) => write!(f, "${}", name)?,
         WordPart::CommandSubstitution { body, syntax } => match source {
-            Some(source) if span.end.offset <= source.len() => f.write_str(span.slice(source))?,
+            Some(source) if span.end.offset() <= source.len() => f.write_str(span.slice(source))?,
             _ => match syntax {
                 CommandSubstitutionSyntax::DollarParen => write!(f, "$({:?})", body)?,
                 CommandSubstitutionSyntax::Backtick => write!(f, "`{:?}`", body)?,
@@ -3186,7 +3188,7 @@ fn fmt_word_part_with_source_mode(
         WordPart::ArithmeticExpansion {
             expression, syntax, ..
         } => match source {
-            Some(source) if expression.is_source_backed() && span.end.offset <= source.len() => {
+            Some(source) if expression.is_source_backed() && span.end.offset() <= source.len() => {
                 f.write_str(span.slice(source))?
             }
             _ => match syntax {
@@ -3333,7 +3335,7 @@ fn fmt_word_part_with_source_mode(
             f.write_str("}")?;
         }
         WordPart::ArrayAccess(reference) => match source {
-            Some(source) if reference.is_source_backed() && span.end.offset <= source.len() => {
+            Some(source) if reference.is_source_backed() && span.end.offset() <= source.len() => {
                 f.write_str(span.slice(source))?
             }
             _ => {
@@ -3426,7 +3428,7 @@ fn fmt_word_part_with_source_mode(
         }
         WordPart::PrefixMatch { prefix, kind } => write!(f, "${{!{}{}}}", prefix, kind.as_char())?,
         WordPart::ProcessSubstitution { body, is_input } => match source {
-            Some(source) if span.end.offset <= source.len() => f.write_str(span.slice(source))?,
+            Some(source) if span.end.offset() <= source.len() => f.write_str(span.slice(source))?,
             _ => {
                 let prefix = if *is_input { "<" } else { ">" };
                 write!(f, "{}({:?})", prefix, body)?
@@ -3453,7 +3455,7 @@ fn fmt_heredoc_body_part_with_source(
 ) -> fmt::Result {
     if let Some(source) = source
         && heredoc_body_part_is_source_backed(part)
-        && span.end.offset <= source.len()
+        && span.end.offset() <= source.len()
     {
         f.write_str(span.slice(source))?;
         return Ok(());
@@ -4223,42 +4225,9 @@ mod tests {
 
     #[test]
     fn zsh_force_glob_span_helper_finds_nested_expansion_spans() {
-        let outer_span = Span::from_positions(
-            Position {
-                line: 1,
-                column: 1,
-                offset: 0,
-            },
-            Position {
-                line: 1,
-                column: 22,
-                offset: 21,
-            },
-        );
-        let forced_span = Span::from_positions(
-            Position {
-                line: 1,
-                column: 10,
-                offset: 9,
-            },
-            Position {
-                line: 1,
-                column: 19,
-                offset: 18,
-            },
-        );
-        let other_span = Span::from_positions(
-            Position {
-                line: 1,
-                column: 20,
-                offset: 19,
-            },
-            Position {
-                line: 1,
-                column: 21,
-                offset: 20,
-            },
-        );
+        let outer_span = Span::from_positions(Position::at(1, 1, 0), Position::at(1, 22, 21));
+        let forced_span = Span::from_positions(Position::at(1, 10, 9), Position::at(1, 19, 18));
+        let other_span = Span::from_positions(Position::at(1, 20, 19), Position::at(1, 21, 20));
         let word = Word {
             parts: vec![WordPartNode::new(
                 WordPart::DoubleQuoted {
@@ -4316,16 +4285,8 @@ mod tests {
 
     fn span_for_source(source: &str) -> Span {
         Span::from_positions(
-            Position {
-                line: 1,
-                column: 1,
-                offset: 0,
-            },
-            Position {
-                line: 1,
-                column: source.chars().count() + 1,
-                offset: source.len(),
-            },
+            Position::at(1, 1, 0),
+            Position::at(1, source.chars().count() + 1, source.len()),
         )
     }
 
@@ -4453,18 +4414,7 @@ mod tests {
 
     #[test]
     fn word_render_syntax_preserves_source_backed_braced_variable() {
-        let span = Span::from_positions(
-            Position {
-                line: 1,
-                column: 1,
-                offset: 0,
-            },
-            Position {
-                line: 1,
-                column: 5,
-                offset: 4,
-            },
-        );
+        let span = Span::from_positions(Position::at(1, 1, 0), Position::at(1, 5, 4));
         let w = Word {
             parts: vec![WordPartNode::new(WordPart::Variable("1".into()), span)],
             span,
@@ -4476,18 +4426,7 @@ mod tests {
 
     #[test]
     fn word_render_syntax_trims_source_backed_literal_delimiters() {
-        let span = Span::from_positions(
-            Position {
-                line: 1,
-                column: 1,
-                offset: 0,
-            },
-            Position {
-                line: 1,
-                column: 5,
-                offset: 4,
-            },
-        );
+        let span = Span::from_positions(Position::at(1, 1, 0), Position::at(1, 5, 4));
         let w = Word {
             parts: vec![WordPartNode::new(
                 WordPart::Literal(LiteralText::source()),

--- a/crates/shuck-ast/src/span.rs
+++ b/crates/shuck-ast/src/span.rs
@@ -7,11 +7,11 @@
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub struct Position {
     /// 1-based line number
-    pub line: usize,
+    line: u32,
     /// 1-based column number (byte offset within line)
-    pub column: usize,
+    column: u32,
     /// 0-based byte offset from start of input
-    pub offset: usize,
+    offset: u32,
 }
 
 impl Position {
@@ -24,9 +24,40 @@ impl Position {
         }
     }
 
+    /// Create a position from explicit line, column, and byte offset values.
+    #[inline]
+    pub fn at(line: usize, column: usize, offset: usize) -> Self {
+        debug_assert!(line <= u32::MAX as usize);
+        debug_assert!(column <= u32::MAX as usize);
+        debug_assert!(offset <= u32::MAX as usize);
+        Self {
+            line: line as u32,
+            column: column as u32,
+            offset: offset as u32,
+        }
+    }
+
+    /// 1-based line number.
+    #[inline]
+    pub fn line(&self) -> usize {
+        self.line as usize
+    }
+
+    /// 1-based column number (byte offset within line).
+    #[inline]
+    pub fn column(&self) -> usize {
+        self.column as usize
+    }
+
+    /// 0-based byte offset from start of input.
+    #[inline]
+    pub fn offset(&self) -> usize {
+        self.offset as usize
+    }
+
     /// Advance position by one character.
     pub fn advance(&mut self, ch: char) {
-        self.offset += ch.len_utf8();
+        self.offset += ch.len_utf8() as u32;
         if ch == '\n' {
             self.line += 1;
             self.column = 1;
@@ -55,11 +86,11 @@ impl Position {
         }
 
         let len = bytes.len();
-        self.offset += len;
-        self.line += newline_count;
+        self.offset += len as u32;
+        self.line += newline_count as u32;
         self.column = match last_newline {
-            Some(idx) => len - idx,
-            None => self.column + len,
+            Some(idx) => (len - idx) as u32,
+            None => self.column + len as u32,
         };
         self
     }
@@ -138,20 +169,20 @@ impl Span {
     /// Slice the source text covered by this span.
     #[inline]
     pub fn slice<'a>(&self, source: &'a str) -> &'a str {
-        slice_with_byte_offsets(source, self.start.offset, self.end.offset)
+        slice_with_byte_offsets(source, self.start.offset as usize, self.end.offset as usize)
     }
 
     /// Convert this span to a [`TextRange`] using only the byte offsets.
     pub fn to_range(self) -> TextRange {
         TextRange::new(
-            TextSize::new(self.start.offset as u32),
-            TextSize::new(self.end.offset as u32),
+            TextSize::new(self.start.offset),
+            TextSize::new(self.end.offset),
         )
     }
 
     /// Get the starting line number.
     pub fn line(&self) -> usize {
-        self.start.line
+        self.start.line as usize
     }
 }
 
@@ -318,39 +349,19 @@ mod tests {
 
     #[test]
     fn test_position_display() {
-        let pos = Position {
-            line: 5,
-            column: 10,
-            offset: 50,
-        };
+        let pos = Position::at(5, 10, 50);
         assert_eq!(format!("{}", pos), "5:10");
     }
 
     #[test]
     fn test_span_merge() {
         let span1 = Span {
-            start: Position {
-                line: 1,
-                column: 1,
-                offset: 0,
-            },
-            end: Position {
-                line: 1,
-                column: 5,
-                offset: 4,
-            },
+            start: Position::at(1, 1, 0),
+            end: Position::at(1, 5, 4),
         };
         let span2 = Span {
-            start: Position {
-                line: 1,
-                column: 10,
-                offset: 9,
-            },
-            end: Position {
-                line: 2,
-                column: 3,
-                offset: 15,
-            },
+            start: Position::at(1, 10, 9),
+            end: Position::at(2, 3, 15),
         };
         let merged = span1.merge(span2);
         assert_eq!(merged.start.offset, 0);
@@ -360,30 +371,14 @@ mod tests {
     #[test]
     fn test_span_display() {
         let single_line = Span {
-            start: Position {
-                line: 3,
-                column: 1,
-                offset: 0,
-            },
-            end: Position {
-                line: 3,
-                column: 10,
-                offset: 9,
-            },
+            start: Position::at(3, 1, 0),
+            end: Position::at(3, 10, 9),
         };
         assert_eq!(format!("{}", single_line), "line 3");
 
         let multi_line = Span {
-            start: Position {
-                line: 1,
-                column: 1,
-                offset: 0,
-            },
-            end: Position {
-                line: 5,
-                column: 1,
-                offset: 50,
-            },
+            start: Position::at(1, 1, 0),
+            end: Position::at(5, 1, 50),
         };
         assert_eq!(format!("{}", multi_line), "lines 1-5");
     }
@@ -391,18 +386,7 @@ mod tests {
     #[test]
     fn span_slice_handles_non_char_boundaries() {
         let source = "a─b";
-        let span = Span::from_positions(
-            Position {
-                line: 1,
-                column: 2,
-                offset: 1,
-            },
-            Position {
-                line: 1,
-                column: 3,
-                offset: 3,
-            },
-        );
+        let span = Span::from_positions(Position::at(1, 2, 1), Position::at(1, 3, 3));
 
         assert_eq!(span.slice(source), "─");
     }

--- a/crates/shuck-benchmark/benches/editor.rs
+++ b/crates/shuck-benchmark/benches/editor.rs
@@ -61,26 +61,26 @@ fn hover_probes(source: &str, semantic: &SemanticModel) -> Vec<usize> {
         semantic
             .bindings()
             .iter()
-            .filter(|binding| binding.span.start.offset < binding.span.end.offset)
+            .filter(|binding| binding.span.start.offset() < binding.span.end.offset())
             .take(64)
-            .map(|binding| binding.span.start.offset),
+            .map(|binding| binding.span.start.offset()),
     );
     probes.extend(
         semantic
             .references()
             .iter()
-            .filter(|reference| reference.span.start.offset < reference.span.end.offset)
+            .filter(|reference| reference.span.start.offset() < reference.span.end.offset())
             .take(64)
-            .map(|reference| reference.span.start.offset),
+            .map(|reference| reference.span.start.offset()),
     );
     for binding in semantic.function_definition_bindings().take(32) {
         probes.extend(
             semantic
                 .call_sites_for(&binding.name)
                 .iter()
-                .filter(|site| site.name_span.start.offset < site.name_span.end.offset)
+                .filter(|site| site.name_span.start.offset() < site.name_span.end.offset())
                 .take(2)
-                .map(|site| site.name_span.start.offset),
+                .map(|site| site.name_span.start.offset()),
         );
     }
     probes.extend(miss_probes(source).take(16));

--- a/crates/shuck-benchmark/benches/semantic.rs
+++ b/crates/shuck-benchmark/benches/semantic.rs
@@ -29,18 +29,18 @@ fn prepare_scope_lookup_input(source: &'static str) -> PreparedScopeLookupInput 
     for offset in semantic
         .scopes()
         .iter()
-        .map(|scope| scope.span.start.offset)
+        .map(|scope| scope.span.start.offset())
         .chain(
             semantic
                 .bindings()
                 .iter()
-                .map(|binding| binding.span.start.offset),
+                .map(|binding| binding.span.start.offset()),
         )
         .chain(
             semantic
                 .references()
                 .iter()
-                .map(|reference| reference.span.start.offset),
+                .map(|reference| reference.span.start.offset()),
         )
     {
         if seen.insert(offset) {

--- a/crates/shuck-cli/src/commands/check/display.rs
+++ b/crates/shuck-cli/src/commands/check/display.rs
@@ -58,8 +58,8 @@ pub(super) fn display_lint_diagnostics_for_file(
             relative_path: file.relative_path.clone(),
             absolute_path: file.absolute_path.clone(),
             span: DisplaySpan::new(
-                DisplayPosition::new(diagnostic.span.start.line, diagnostic.span.start.column),
-                DisplayPosition::new(diagnostic.span.end.line, diagnostic.span.end.column),
+                DisplayPosition::new(diagnostic.span.start.line(), diagnostic.span.start.column()),
+                DisplayPosition::new(diagnostic.span.end.line(), diagnostic.span.end.column()),
             ),
             message: diagnostic.message.clone(),
             kind: DisplayedDiagnosticKind::Lint {
@@ -174,8 +174,8 @@ pub(super) fn push_lint_diagnostics(
             relative_path: relative_path.to_path_buf(),
             absolute_path: absolute_path.to_path_buf(),
             span: DisplaySpan::new(
-                DisplayPosition::new(diagnostic.span.start.line, diagnostic.span.start.column),
-                DisplayPosition::new(diagnostic.span.end.line, diagnostic.span.end.column),
+                DisplayPosition::new(diagnostic.span.start.line(), diagnostic.span.start.column()),
+                DisplayPosition::new(diagnostic.span.end.line(), diagnostic.span.end.column()),
             ),
             message: diagnostic.message.clone(),
             kind: DisplayedDiagnosticKind::Lint {

--- a/crates/shuck-cli/src/commands/check/embedded.rs
+++ b/crates/shuck-cli/src/commands/check/embedded.rs
@@ -157,10 +157,10 @@ fn remap_embedded_lint_diagnostics(
             absolute_path: pending.file.absolute_path.clone(),
             span: remap_embedded_span(
                 embedded,
-                diagnostic.span.start.line,
-                diagnostic.span.start.column,
-                diagnostic.span.end.line,
-                diagnostic.span.end.column,
+                diagnostic.span.start.line(),
+                diagnostic.span.start.column(),
+                diagnostic.span.end.line(),
+                diagnostic.span.end.column(),
             ),
             message: prefixed_embedded_message(embedded, &diagnostic.message),
             kind: DisplayedDiagnosticKind::Lint {

--- a/crates/shuck-cli/src/shellcheck_compat/mod.rs
+++ b/crates/shuck-cli/src/shellcheck_compat/mod.rs
@@ -1048,17 +1048,17 @@ fn map_diagnostic(
     let level = level_for_diagnostic(diagnostic.rule, diagnostic.severity, code);
     let fix = compat_fix_for_diagnostic(
         code,
-        diagnostic.span.start.line,
-        diagnostic.span.start.column,
-        diagnostic.span.end.line,
-        diagnostic.span.end.column,
+        diagnostic.span.start.line(),
+        diagnostic.span.start.column(),
+        diagnostic.span.end.line(),
+        diagnostic.span.end.column(),
     );
     threshold.allows(level).then(|| CompatDiagnostic {
         file: display_path(path, cwd),
-        line: diagnostic.span.start.line,
-        end_line: diagnostic.span.end.line,
-        column: diagnostic.span.start.column,
-        end_column: diagnostic.span.end.column,
+        line: diagnostic.span.start.line(),
+        end_line: diagnostic.span.end.line(),
+        column: diagnostic.span.start.column(),
+        end_column: diagnostic.span.end.column(),
         level,
         code,
         message: diagnostic.message,

--- a/crates/shuck-cli/tests/large_corpus.rs
+++ b/crates/shuck-cli/tests/large_corpus.rs
@@ -2403,10 +2403,10 @@ fn shuck_compatibility_records(
                     rule_codes: Vec::new(),
                     shellcheck_code: shellcheck_code.clone(),
                     range: DiagnosticRange {
-                        line: diag.span.start.line,
-                        end_line: diag.span.end.line,
-                        column: diag.span.start.column,
-                        end_column: diag.span.end.column,
+                        line: diag.span.start.line(),
+                        end_line: diag.span.end.line(),
+                        column: diag.span.start.column(),
+                        end_column: diag.span.end.column(),
                     },
                     message: diag.message.clone(),
                 })
@@ -3203,10 +3203,11 @@ fn extract_large_corpus_zsh_option_state(
     }
 
     for stmt in output.file.body.iter() {
-        if semantic.zsh_options_at(stmt.span.start.offset).is_none() {
+        if semantic.zsh_options_at(stmt.span.start.offset()).is_none() {
             return Err(format!(
                 "missing zsh option snapshot at {}:{}",
-                stmt.span.start.line, stmt.span.start.column
+                stmt.span.start.line(),
+                stmt.span.start.column()
             ));
         }
     }

--- a/crates/shuck-formatter/src/command/groups.rs
+++ b/crates/shuck-formatter/src/command/groups.rs
@@ -81,14 +81,14 @@ pub(super) fn group_verbatim_span_impl(
         return inner;
     }
 
-    let Some(open_offset) = source[..inner.start.offset].rfind(open) else {
+    let Some(open_offset) = source[..inner.start.offset()].rfind(open) else {
         return inner;
     };
     let wrapper_prefix_start = open_offset + open.len_utf8();
-    if !source_map.contains_comment_between(wrapper_prefix_start, inner.start.offset) {
+    if !source_map.contains_comment_between(wrapper_prefix_start, inner.start.offset()) {
         return inner;
     }
-    let Some(close_offset) = find_group_close_offset(source, inner.end.offset, close) else {
+    let Some(close_offset) = find_group_close_offset(source, inner.end.offset(), close) else {
         return inner;
     };
 
@@ -107,7 +107,7 @@ pub(crate) fn group_open_suffix<'a>(
     let (_, line_end) = source_map.line_bounds_for_offset(open_offset)?;
     let suffix_start = open_offset + open.len_utf8();
     let comment = source_map.first_source_comment_between(suffix_start, line_end)?;
-    let prefix = source_map.slice_between(suffix_start, comment.span().start.offset)?;
+    let prefix = source_map.slice_between(suffix_start, comment.span().start.offset())?;
     if !prefix.chars().all(char::is_whitespace) {
         return None;
     }
@@ -191,7 +191,7 @@ pub(crate) fn stmt_start_after_operator(
             '(',
             ')',
         ),
-        _ => command_format_span(&stmt.command).start.offset,
+        _ => command_format_span(&stmt.command).start.offset(),
     }
 }
 
@@ -207,13 +207,13 @@ fn group_open_offset_after_operator(
     let search_end = commands
         .first()
         .map(|first| stmt_group_attachment_start_offset(first, source_map))
-        .unwrap_or_else(|| stmt_span(stmt).end.offset);
+        .unwrap_or_else(|| stmt_span(stmt).end.offset());
 
     find_group_open_offset_between(source, operator_end, search_end, open)
         .or_else(|| {
-            group_attachment_span(commands, source_map, open, close).map(|span| span.start.offset)
+            group_attachment_span(commands, source_map, open, close).map(|span| span.start.offset())
         })
-        .unwrap_or_else(|| command_format_span(&stmt.command).start.offset)
+        .unwrap_or_else(|| command_format_span(&stmt.command).start.offset())
 }
 
 fn find_group_open_offset_between(
@@ -316,7 +316,7 @@ fn stmt_group_attachment_start_offset(
     stmt_group_attachment_or_verbatim_span(stmt, source_map)
         .unwrap_or_else(|| stmt_verbatim_span_with_source_map(stmt, source_map))
         .start
-        .offset
+        .offset()
 }
 
 fn stmt_group_attachment_end_offset_with_heredoc<F>(
@@ -330,17 +330,15 @@ where
     if let Some(span) =
         stmt_group_attachment_or_verbatim_span_with_heredoc(stmt, source_map, stmt_contains_heredoc)
     {
-        return span.end.offset;
+        return span.end.offset();
     }
 
     match &stmt.command {
-        Command::Function(_) | Command::AnonymousFunction(_) => stmt_span(stmt).end.offset,
-        _ if stmt_contains_heredoc(stmt) => {
-            stmt_verbatim_span_with_source_map(stmt, source_map)
-                .end
-                .offset
-        }
-        _ => stmt_span(stmt).end.offset,
+        Command::Function(_) | Command::AnonymousFunction(_) => stmt_span(stmt).end.offset(),
+        _ if stmt_contains_heredoc(stmt) => stmt_verbatim_span_with_source_map(stmt, source_map)
+            .end
+            .offset(),
+        _ => stmt_span(stmt).end.offset(),
     }
 }
 

--- a/crates/shuck-formatter/src/command/render_policy.rs
+++ b/crates/shuck-formatter/src/command/render_policy.rs
@@ -59,8 +59,8 @@ pub(crate) fn span_render_end_line(
     source: &str,
     source_map: &crate::comments::SourceMap<'_>,
 ) -> usize {
-    let mut end = span.end.offset.min(source.len());
-    while end > span.start.offset
+    let mut end = span.end.offset().min(source.len());
+    while end > span.start.offset()
         && source
             .as_bytes()
             .get(end - 1)
@@ -69,8 +69,8 @@ pub(crate) fn span_render_end_line(
         end -= 1;
     }
 
-    if end == span.start.offset {
-        span.start.line
+    if end == span.start.offset() {
+        span.start.line()
     } else {
         source_map.line_number_for_offset(end - 1)
     }
@@ -82,8 +82,8 @@ pub(crate) fn stmt_has_trailing_comment(
 ) -> bool {
     let raw = stmt_span(stmt);
     let formatted = stmt_format_span(stmt);
-    raw.end.offset > formatted.end.offset
-        && source_map.contains_comment_between(formatted.end.offset, raw.end.offset)
+    raw.end.offset() > formatted.end.offset()
+        && source_map.contains_comment_between(formatted.end.offset(), raw.end.offset())
 }
 
 pub(crate) fn should_render_verbatim_with_heredoc(
@@ -265,7 +265,7 @@ fn close_keyword_at_span_end(
     span: Span,
     keyword: &str,
 ) -> Option<Span> {
-    let span_end = span.end.offset.min(source.len());
+    let span_end = span.end.offset().min(source.len());
     let start = span_end.checked_sub(keyword.len())?;
     (source.get(start..span_end) == Some(keyword))
         .then(|| source_map.span_for_offsets(start, span_end))
@@ -277,7 +277,7 @@ pub(crate) fn normalized_close_keyword_span(
     span: Span,
     keyword: &str,
 ) -> Span {
-    let start = span.start.offset.min(source.len());
+    let start = span.start.offset().min(source.len());
     let end = start.saturating_add(keyword.len()).min(source.len());
     if source.get(start..end) == Some(keyword) {
         source_map.span_for_offsets(start, end)
@@ -287,7 +287,7 @@ pub(crate) fn normalized_close_keyword_span(
 }
 
 fn span_starts_with_keyword(source: &str, span: Span, keyword: &str) -> bool {
-    let start = span.start.offset.min(source.len());
+    let start = span.start.offset().min(source.len());
     let end = start.saturating_add(keyword.len()).min(source.len());
     source.get(start..end) == Some(keyword)
 }
@@ -344,7 +344,7 @@ where
     } else {
         stmt_attachment_span_with_heredoc(stmt, source, source_map, options, stmt_contains_heredoc)
             .start
-            .line
+            .line()
     }
 }
 
@@ -367,15 +367,15 @@ where
         matching_group_close(open),
         stmt_contains_heredoc,
     )
-    .map(|span| span.start.line)
+    .map(|span| span.start.line())
     .or_else(|| {
-        find_empty_group_open_offset(source, stmt_span(stmt).start.offset, open)
+        find_empty_group_open_offset(source, stmt_span(stmt).start.offset(), open)
             .map(|offset| source_map.line_number_for_offset(offset))
     })
     .unwrap_or_else(|| {
         stmt_attachment_span_with_heredoc(stmt, source, source_map, options, stmt_contains_heredoc)
             .start
-            .line
+            .line()
     })
 }
 
@@ -384,16 +384,16 @@ fn stmt_has_alignment_sensitive_padding(
     source_map: &crate::comments::SourceMap<'_>,
 ) -> bool {
     let mut spans = stmt_token_spans(stmt);
-    spans.retain(|span| span != &Span::new() && span.start.offset < span.end.offset);
-    spans.sort_by_key(|span| span.start.offset);
+    spans.retain(|span| span != &Span::new() && span.start.offset() < span.end.offset());
+    spans.sort_by_key(|span| span.start.offset());
     spans.windows(2).any(|window| {
         let [left, right] = window else {
             return false;
         };
-        if right.start.offset <= left.end.offset {
+        if right.start.offset() <= left.end.offset() {
             return false;
         }
-        source_map.has_alignment_padding_between(left.end.offset, right.start.offset)
+        source_map.has_alignment_padding_between(left.end.offset(), right.start.offset())
     })
 }
 
@@ -404,16 +404,16 @@ pub(crate) fn case_item_was_inline_in_source(item: &CaseItem) -> bool {
 
     item.patterns
         .last()
-        .is_some_and(|pattern| pattern.span.end.line == stmt_span(stmt).start.line)
+        .is_some_and(|pattern| pattern.span.end.line() == stmt_span(stmt).start.line())
         && item
             .terminator_span
-            .is_some_and(|span| span.start.line == stmt_format_span(stmt).end.line)
+            .is_some_and(|span| span.start.line() == stmt_format_span(stmt).end.line())
 }
 
 pub(crate) fn case_item_body_upper_bound(item: &CaseItem, fallback: usize) -> Option<usize> {
     Some(
         item.terminator_span
-            .map(|span| span.start.offset)
+            .map(|span| span.start.offset())
             .unwrap_or(fallback),
     )
 }

--- a/crates/shuck-formatter/src/command/spans.rs
+++ b/crates/shuck-formatter/src/command/spans.rs
@@ -359,8 +359,8 @@ fn synthetic_simple_command_verbatim_span(
     source_map: &SourceMap<'_>,
 ) -> Span {
     let source = source_map.source();
-    let start = command.span.start.offset.min(source.len());
-    let end = command.span.end.offset.min(source.len());
+    let start = command.span.start.offset().min(source.len());
+    let end = command.span.end.offset().min(source.len());
     let Some(raw) = source.get(start..end) else {
         return command.span;
     };
@@ -414,7 +414,7 @@ fn word_uses_synthetic_source(word: &Word, source: &str) -> bool {
     }
     let rendered = word.render_syntax(source);
     let raw = source
-        .get(word.span.start.offset.min(source.len())..word.span.end.offset.min(source.len()));
+        .get(word.span.start.offset().min(source.len())..word.span.end.offset().min(source.len()));
     raw.is_none_or(|raw| raw != rendered)
 }
 

--- a/crates/shuck-formatter/src/command/structure.rs
+++ b/crates/shuck-formatter/src/command/structure.rs
@@ -15,7 +15,7 @@ pub(crate) fn branch_open_keyword_start(
 ) -> Option<usize> {
     let first = sequence.first()?;
     SourceView::new(source)
-        .last_uncommented_shell_keyword_before(stmt_span(first).start.offset, keyword)
+        .last_uncommented_shell_keyword_before(stmt_span(first).start.offset(), keyword)
 }
 
 pub(crate) fn if_next_branch_region_with_body_end(
@@ -36,14 +36,14 @@ pub(crate) fn if_next_branch_region_with_body_end(
 
     if let Some((condition, _)) = command.elif_branches.get(branch_index) {
         let keyword = SourceView::new(source)
-            .branch_keyword_offset(current_branch_end, condition.span.start.offset, "elif")
-            .unwrap_or(condition.span.start.offset);
+            .branch_keyword_offset(current_branch_end, condition.span.start.offset(), "elif")
+            .unwrap_or(condition.span.start.offset());
         Some((current_branch_end, keyword))
     } else if branch_index == command.elif_branches.len() {
         command.else_branch.as_ref().map(|body| {
             let keyword = SourceView::new(source)
-                .branch_keyword_offset(current_branch_end, body.span.start.offset, "else")
-                .unwrap_or(body.span.start.offset);
+                .branch_keyword_offset(current_branch_end, body.span.start.offset(), "else")
+                .unwrap_or(body.span.start.offset());
             (current_branch_end, keyword)
         })
     } else {

--- a/crates/shuck-formatter/src/command/syntax.rs
+++ b/crates/shuck-formatter/src/command/syntax.rs
@@ -44,7 +44,7 @@ pub(crate) fn trim_unescaped_trailing_whitespace(text: &str) -> &str {
 }
 
 pub(crate) fn render_source_text_to_buf(text: &SourceText, source: &str, rendered: &mut String) {
-    if !text.is_source_backed() || text.span().end.offset <= source.len() {
+    if !text.is_source_backed() || text.span().end.offset() <= source.len() {
         rendered.push_str(text.slice(source));
     }
 }
@@ -76,12 +76,12 @@ pub(crate) fn binary_operator(operator: &shuck_ast::BinaryOp) -> &'static str {
 }
 
 pub(crate) fn slice_span(source: &str, span: Option<Span>) -> &str {
-    span.and_then(|span| source.get(span.start.offset..span.end.offset))
+    span.and_then(|span| source.get(span.start.offset()..span.end.offset()))
         .unwrap_or("")
 }
 
 pub(crate) fn extend_heredoc_body_span(span: Span, source: &str) -> Span {
-    let mut end = span.end.offset;
+    let mut end = span.end.offset();
     while end < source.len() {
         let byte = source.as_bytes()[end];
         end += 1;
@@ -89,6 +89,6 @@ pub(crate) fn extend_heredoc_body_span(span: Span, source: &str) -> Span {
             break;
         }
     }
-    let end_position = span.start.advanced_by(&source[span.start.offset..end]);
+    let end_position = span.start.advanced_by(&source[span.start.offset()..end]);
     Span::from_positions(span.start, end_position)
 }

--- a/crates/shuck-formatter/src/comments.rs
+++ b/crates/shuck-formatter/src/comments.rs
@@ -142,11 +142,11 @@ impl<'a> SourceMap<'a> {
             .map(usize::from)
             .unwrap_or(0);
         let text = self.source.get(start..end).unwrap_or("");
-        let start_position = Position {
+        let start_position = Position::at(
             line,
-            column: self.source[line_start..start].chars().count() + 1,
-            offset: start,
-        };
+            self.source[line_start..start].chars().count() + 1,
+            start,
+        );
         let end_position = start_position.advanced_by(text);
         Span::from_positions(start_position, end_position)
     }
@@ -207,10 +207,10 @@ impl<'a> SourceMap<'a> {
 
     #[must_use]
     pub(crate) fn suffix_comment_after_span(&self, span: Span) -> Option<SourceComment<'a>> {
-        if span.start.line != span.end.line {
+        if span.start.line() != span.end.line() {
             return None;
         }
-        let start = span.end.offset.min(self.source.len());
+        let start = span.end.offset().min(self.source.len());
         let (_, line_end) = self.line_bounds_for_offset(start)?;
         let comment_start = self.first_comment_between(start, line_end)?;
         let prefix = self.source.get(start..comment_start)?;
@@ -278,8 +278,8 @@ impl<'a> SourceMap<'a> {
 
     #[must_use]
     pub(crate) fn operator_starts_or_ends_line(&self, operator_span: Span) -> bool {
-        let start = operator_span.start.offset;
-        let end = operator_span.end.offset;
+        let start = operator_span.start.offset();
+        let end = operator_span.end.offset();
         if start >= end || end > self.source.len() {
             return false;
         }
@@ -498,7 +498,7 @@ impl<'a> CommentAttachmentModel<'a> {
             .filter(|comment| !indexer.region_index().is_heredoc(comment.range.start()))
             .filter_map(|comment| source_map.source_comment_for_indexed(comment))
             .collect::<Vec<_>>();
-        comments.sort_by_key(|comment| comment.span().start.offset);
+        comments.sort_by_key(|comment| comment.span().start.offset());
 
         Self {
             comments: comments.into_boxed_slice(),
@@ -518,7 +518,7 @@ impl<'a> CommentAttachmentModel<'a> {
                 .iter()
                 .copied()
                 .filter(|comment| {
-                    upper_bound.is_none_or(|limit| comment.span().end.offset <= limit)
+                    upper_bound.is_none_or(|limit| comment.span().end.offset() <= limit)
                 })
                 .filter(|comment| {
                     skip_span.is_none_or(|span| !span_contains_comment(span, *comment))
@@ -542,10 +542,10 @@ impl<'a> CommentAttachmentModel<'a> {
     ) -> &[SourceComment<'a>] {
         let start_index = self
             .comments
-            .partition_point(|comment| comment.span().start.offset < lower_bound);
+            .partition_point(|comment| comment.span().start.offset() < lower_bound);
         let end_index = upper_bound.map_or(self.comments.len(), |limit| {
             self.comments
-                .partition_point(|comment| comment.span().start.offset < limit)
+                .partition_point(|comment| comment.span().start.offset() < limit)
         });
 
         &self.comments[start_index..end_index.max(start_index)]
@@ -648,10 +648,10 @@ fn compute_sequence_attachment<'a>(
         return attachment;
     }
 
-    let first_child_start = child_spans[0].start.offset;
+    let first_child_start = child_spans[0].start.offset();
     let last_child_end = child_spans
         .last()
-        .map(|span| span.end.offset)
+        .map(|span| span.end.offset())
         .unwrap_or(first_child_start);
     let limit_end = upper_bound.unwrap_or(usize::MAX);
     let mut child_cursor = 0;
@@ -659,8 +659,8 @@ fn compute_sequence_attachment<'a>(
     let mut index = 0;
     while index < items.len() {
         let comment = items[index];
-        let start = comment.span.start.offset;
-        let end = comment.span.end.offset;
+        let start = comment.span.start.offset();
+        let end = comment.span.end.offset();
         if start >= limit_end {
             break;
         }
@@ -673,17 +673,17 @@ fn compute_sequence_attachment<'a>(
             continue;
         }
 
-        while child_cursor < child_spans.len() && child_spans[child_cursor].end.offset <= start {
+        while child_cursor < child_spans.len() && child_spans[child_cursor].end.offset() <= start {
             child_cursor += 1;
         }
 
         let prev = child_cursor.checked_sub(1);
         let next = child_spans
             .get(child_cursor)
-            .and_then(|span| (span.start.offset >= end).then_some(child_cursor));
+            .and_then(|span| (span.start.offset() >= end).then_some(child_cursor));
         let current = child_spans.get(child_cursor);
         let inside_current =
-            current.is_some_and(|span| span.start.offset <= start && end <= span.end.offset);
+            current.is_some_and(|span| span.start.offset() <= start && end <= span.end.offset());
 
         if inside_current {
             index += 1;
@@ -692,8 +692,8 @@ fn compute_sequence_attachment<'a>(
 
         if comment.inline {
             if let Some(prev_idx) = prev
-                && child_spans[prev_idx].end.line == comment.line
-                && child_spans[prev_idx].start.offset <= start
+                && child_spans[prev_idx].end.line() == comment.line
+                && child_spans[prev_idx].start.offset() <= start
             {
                 attachment.trailing_mut(prev_idx).push(comment);
                 index += 1;
@@ -703,7 +703,7 @@ fn compute_sequence_attachment<'a>(
             match (prev, next) {
                 (Some(prev_idx), next_idx)
                     if next_idx.is_none_or(|next_idx| prev_idx + 1 == next_idx)
-                        && child_spans[prev_idx].end.line == comment.line =>
+                        && child_spans[prev_idx].end.line() == comment.line =>
                 {
                     attachment.trailing_mut(prev_idx).push(comment);
                 }
@@ -715,7 +715,7 @@ fn compute_sequence_attachment<'a>(
 
         if end <= first_child_start {
             let run_end = advance_comment_run(items, index, limit_end, skip_span, |candidate| {
-                candidate.span.end.offset <= first_child_start
+                candidate.span.end.offset() <= first_child_start
             });
             for item in &items[index..run_end] {
                 attachment.leading_mut(0).push(*item);
@@ -723,11 +723,11 @@ fn compute_sequence_attachment<'a>(
             index = run_end;
         } else if let Some(next_idx) = next {
             let gap_start = prev
-                .map(|prev_idx| child_spans[prev_idx].end.offset)
+                .map(|prev_idx| child_spans[prev_idx].end.offset())
                 .unwrap_or(0);
-            let gap_end = child_spans[next_idx].start.offset;
+            let gap_end = child_spans[next_idx].start.offset();
             let run_end = advance_comment_run(items, index, limit_end, skip_span, |candidate| {
-                candidate.span.start.offset >= gap_start && candidate.span.end.offset <= gap_end
+                candidate.span.start.offset() >= gap_start && candidate.span.end.offset() <= gap_end
             });
             for item in &items[index..run_end] {
                 attachment.leading_mut(next_idx).push(*item);
@@ -735,7 +735,7 @@ fn compute_sequence_attachment<'a>(
             index = run_end;
         } else if start >= last_child_end {
             let run_end = advance_comment_run(items, index, limit_end, skip_span, |candidate| {
-                candidate.span.start.offset >= last_child_end
+                candidate.span.start.offset() >= last_child_end
             });
             for item in &items[index..run_end] {
                 attachment.dangling.push(*item);
@@ -759,9 +759,9 @@ fn advance_comment_run<'a>(
     let mut index = start_index;
     while index < items.len() {
         let comment = items[index];
-        if comment.span.start.offset >= limit_end
+        if comment.span.start.offset() >= limit_end
             || comment.inline
-            || comment.span.end.offset > limit_end
+            || comment.span.end.offset() > limit_end
             || skip_span.is_some_and(|span| span_contains_comment(span, comment))
             || !belongs(comment)
         {
@@ -773,7 +773,8 @@ fn advance_comment_run<'a>(
 }
 
 fn span_contains_comment(span: Span, comment: SourceComment<'_>) -> bool {
-    span.start.offset <= comment.span.start.offset && comment.span.end.offset <= span.end.offset
+    span.start.offset() <= comment.span.start.offset()
+        && comment.span.end.offset() <= span.end.offset()
 }
 
 fn contains_offset_in_range(offsets: &[usize], start: usize, end: usize) -> bool {
@@ -848,7 +849,7 @@ mod tests {
         let starts = attachments
             .comments
             .iter()
-            .map(|comment| comment.span().start.offset)
+            .map(|comment| comment.span().start.offset())
             .collect::<Vec<_>>();
 
         assert!(!starts.contains(&source.find("# not a comment").unwrap()));

--- a/crates/shuck-formatter/src/facts.rs
+++ b/crates/shuck-formatter/src/facts.rs
@@ -67,8 +67,8 @@ struct FactSpan {
 impl FactSpan {
     fn new(span: Span) -> Self {
         Self {
-            start: span.start.offset,
-            end: span.end.offset,
+            start: span.start.offset(),
+            end: span.end.offset(),
         }
     }
 
@@ -1315,7 +1315,7 @@ impl<'source> FormatterFacts<'source> {
                 .first_comment_offset()
                 .unwrap_or(end)
         } else {
-            self.if_close_span(command).start.offset
+            self.if_close_span(command).start.offset()
         }
     }
 
@@ -1850,11 +1850,11 @@ impl<'source, 'options> FormatterFactsBuilder<'source, 'options> {
         facts.open_end_offset = if let Some(open) = site.group_open_char {
             facts
                 .group_open_suffix_span
-                .map(|span| span.end.offset)
+                .map(|span| span.end.offset())
                 .or_else(|| {
                     facts
                         .group_attachment_span
-                        .map(|span| span.start.offset.saturating_add(open.len_utf8()))
+                        .map(|span| span.start.offset().saturating_add(open.len_utf8()))
                 })
         } else {
             site.open_end_offset
@@ -1883,12 +1883,12 @@ impl<'source, 'options> FormatterFactsBuilder<'source, 'options> {
             })
         };
         let sequence_limit = group_attachment_span
-            .map(|span| span.end.offset)
+            .map(|span| span.end.offset())
             .or(site.upper_bound);
 
         let comment_lower_bound = sequence_comment_lower_bound(sequence, self.source_map());
         let lower_bound = group_attachment_span
-            .map(|span| span.start.offset.min(comment_lower_bound))
+            .map(|span| span.start.offset().min(comment_lower_bound))
             .unwrap_or(comment_lower_bound);
 
         if sequence.is_empty() {
@@ -1933,9 +1933,9 @@ impl<'source, 'options> FormatterFactsBuilder<'source, 'options> {
                 .unwrap_or_else(|| FactSpan::from(stmt_span(current)));
             let break_start = current
                 .terminator_span
-                .map(|span| span.end.offset)
-                .unwrap_or_else(|| stmt_span(current).end.offset);
-            let next_start = self.facts.stmt(next).attachment_span().start.offset;
+                .map(|span| span.end.offset())
+                .unwrap_or_else(|| stmt_span(current).end.offset());
+            let next_start = self.facts.stmt(next).attachment_span().start.offset();
             if self.facts.contains_newline_between(break_start, next_start) {
                 self.facts.breaks.background.insert(break_key);
             }
@@ -1973,7 +1973,7 @@ impl<'source, 'options> FormatterFactsBuilder<'source, 'options> {
                     .inline_group_sequences
                     .insert(FactSpan::from(commands.span));
             }
-            let _ = self.visit_sequence(commands, Some(stmt_span(stmt).end.offset), Some(open));
+            let _ = self.visit_sequence(commands, Some(stmt_span(stmt).end.offset()), Some(open));
         }
 
         let mut layout = self
@@ -2125,7 +2125,7 @@ impl<'source, 'options> FormatterFactsBuilder<'source, 'options> {
             for item in rest {
                 let next_start = stmt_start_after_operator(
                     item.stmt,
-                    item.operator_span.end.offset,
+                    item.operator_span.end.offset(),
                     self.source,
                     self.source_map(),
                 );
@@ -2136,10 +2136,10 @@ impl<'source, 'options> FormatterFactsBuilder<'source, 'options> {
                     .operator_starts_or_ends_line(item.operator_span)
                     || self
                         .facts
-                        .contains_newline_between(item.operator_span.end.offset, next_start)
+                        .contains_newline_between(item.operator_span.end.offset(), next_start)
                     || (stmt_is_multiline_conditional(previous)
-                        && previous_span.start.line < item.operator_span.start.line
-                        && item.operator_span.end.line == next_start_line
+                        && previous_span.start.line() < item.operator_span.start.line()
+                        && item.operator_span.end.line() == next_start_line
                         && !stmt_can_follow_multiline_conditional_inline(item.stmt))
                 {
                     self.facts
@@ -2215,10 +2215,10 @@ impl<'source, 'options> FormatterFactsBuilder<'source, 'options> {
             LayoutCompoundCommand::Coproc(command) => self.visit_stmt(command.body.as_ref()),
             LayoutCompoundCommand::Always(command) => {
                 let mut summary =
-                    self.visit_sequence(&command.body, Some(command.span.end.offset), Some('{'));
+                    self.visit_sequence(&command.body, Some(command.span.end.offset()), Some('{'));
                 summary.merge(self.visit_sequence(
                     &command.always_body,
-                    Some(command.span.end.offset),
+                    Some(command.span.end.offset()),
                     Some('{'),
                 ));
                 self.record_inline_group_sequence(&command.body, '{', '}');
@@ -2230,10 +2230,10 @@ impl<'source, 'options> FormatterFactsBuilder<'source, 'options> {
 
     fn visit_if(&mut self, command: &IfCommand) -> LayoutSummary {
         let condition_upper_bound = match command.syntax {
-            shuck_ast::IfSyntax::ThenFi { then_span, .. } => Some(then_span.start.offset),
+            shuck_ast::IfSyntax::ThenFi { then_span, .. } => Some(then_span.start.offset()),
             shuck_ast::IfSyntax::Brace {
                 left_brace_span, ..
-            } => Some(left_brace_span.start.offset),
+            } => Some(left_brace_span.start.offset()),
         };
         let mut summary = self.visit_sequence(&command.condition, condition_upper_bound, None);
         let brace_syntax = matches!(command.syntax, shuck_ast::IfSyntax::Brace { .. });
@@ -2275,7 +2275,7 @@ impl<'source, 'options> FormatterFactsBuilder<'source, 'options> {
                     '}',
                     |stmt| self.layout.stmt(stmt).contains_heredoc,
                 )
-                .map(|span| span.start.offset)
+                .map(|span| span.start.offset())
             } else {
                 body_site.open_keyword_start(self.source)
             };
@@ -2288,7 +2288,7 @@ impl<'source, 'options> FormatterFactsBuilder<'source, 'options> {
             }
         }
         if let Some(else_branch) = &command.else_branch {
-            let upper_bound = self.facts.if_close_span(command).start.offset;
+            let upper_bound = self.facts.if_close_span(command).start.offset();
             let site = CompoundBodySite::if_else_branch(command, else_branch, upper_bound);
             summary.merge(self.visit_compound_body_site(site));
         }
@@ -2413,7 +2413,7 @@ impl<'source, 'options> FormatterFactsBuilder<'source, 'options> {
             summary.merge(self.visit_word(&entry.word));
         }
 
-        summary.merge(self.visit_function_body(function.body.as_ref(), function.span.end.offset));
+        summary.merge(self.visit_function_body(function.body.as_ref(), function.span.end.offset()));
         summary
     }
 
@@ -2423,7 +2423,7 @@ impl<'source, 'options> FormatterFactsBuilder<'source, 'options> {
             summary.merge(self.visit_word(argument));
         }
 
-        summary.merge(self.visit_function_body(function.body.as_ref(), function.span.end.offset));
+        summary.merge(self.visit_function_body(function.body.as_ref(), function.span.end.offset()));
         summary
     }
 
@@ -2581,7 +2581,7 @@ impl<'source, 'options> FormatterFactsBuilder<'source, 'options> {
                     CommandSubstitutionSyntax::DollarParen | CommandSubstitutionSyntax::Backtick
                 ) =>
             {
-                let mut summary = self.visit_sequence(body, Some(span.end.offset), None);
+                let mut summary = self.visit_sequence(body, Some(span.end.offset()), None);
                 summary.contains_multiline_literal_source |= summary.contains_comments
                     && raw_source_slice(span, self.source).is_some_and(|raw| {
                         raw.contains('\n')
@@ -2590,7 +2590,7 @@ impl<'source, 'options> FormatterFactsBuilder<'source, 'options> {
                 summary
             }
             WordPart::ProcessSubstitution { body, .. } => {
-                let mut summary = self.visit_sequence(body, span.end.offset.checked_sub(1), None);
+                let mut summary = self.visit_sequence(body, span.end.offset().checked_sub(1), None);
                 summary.contains_multiline_literal_source |= summary.contains_comments
                     && raw_source_slice(span, self.source).is_some_and(|raw| raw.contains('\n'));
                 summary
@@ -2705,7 +2705,7 @@ impl<'source, 'options> FormatterFactsBuilder<'source, 'options> {
                     CommandSubstitutionSyntax::DollarParen | CommandSubstitutionSyntax::Backtick
                 ) =>
             {
-                self.visit_sequence(body, Some(span.end.offset), None)
+                self.visit_sequence(body, Some(span.end.offset()), None)
             }
             HeredocBodyPart::ArithmeticExpansion {
                 expression_ast: Some(expr),
@@ -3023,8 +3023,8 @@ impl<'source, 'options> FormatterFactsBuilder<'source, 'options> {
             .cached_close(command.span)
             .or_else(|| case_close_span(command, self.source_map()));
         let body_fallback_upper_bound = esac_span
-            .map(|span| span.start.offset)
-            .unwrap_or(command.span.end.offset);
+            .map(|span| span.start.offset())
+            .unwrap_or(command.span.end.offset());
         let suffix_comments_before_esac = command
             .cases
             .last()
@@ -3072,29 +3072,28 @@ impl<'source, 'options> FormatterFactsBuilder<'source, 'options> {
         let first_pattern_start = item
             .patterns
             .first()
-            .map(|pattern| pattern.span.start.offset);
+            .map(|pattern| pattern.span.start.offset());
         let mut prefix_comments = first_pattern_start
             .map(|start| {
                 let mut comments = sequence
                     .leading_for(0)
                     .iter()
                     .copied()
-                    .filter(|comment| comment.span().start.offset < start)
+                    .filter(|comment| comment.span().start.offset() < start)
                     .collect::<Vec<_>>();
                 for comment in
                     case_item_source_prefix_comments(self.source, self.source_map(), start)
                 {
-                    if !comments
-                        .iter()
-                        .any(|existing| existing.span().start.offset == comment.span().start.offset)
-                    {
+                    if !comments.iter().any(|existing| {
+                        existing.span().start.offset() == comment.span().start.offset()
+                    }) {
                         comments.push(comment);
                     }
                 }
                 comments
             })
             .unwrap_or_default();
-        prefix_comments.sort_by_key(|comment| comment.span().start.offset);
+        prefix_comments.sort_by_key(|comment| comment.span().start.offset());
 
         CaseItemFacts {
             suffix_comment_start_line: case_suffix_comment_start_line(item),
@@ -3219,9 +3218,9 @@ fn pipeline_has_explicit_line_break(
 
     for (statement, operator_span) in statements.iter().skip(1).zip(operators.iter()) {
         let next_start =
-            stmt_start_after_operator(statement, operator_span.end.offset, source, source_map);
+            stmt_start_after_operator(statement, operator_span.end.offset(), source, source_map);
         if source_map.operator_starts_or_ends_line(*operator_span)
-            || source_map.contains_newline_between(operator_span.end.offset, next_start)
+            || source_map.contains_newline_between(operator_span.end.offset(), next_start)
         {
             return true;
         }
@@ -3231,7 +3230,7 @@ fn pipeline_has_explicit_line_break(
 }
 
 fn sequence_comment_lower_bound(sequence: &StmtSeq, source_map: &SourceMap<'_>) -> usize {
-    let mut lower_bound = sequence.span.start.offset;
+    let mut lower_bound = sequence.span.start.offset();
     for comment in &sequence.leading_comments {
         if source_map
             .source_comment(*comment)
@@ -3266,23 +3265,23 @@ fn group_close_offset(
     close_char: char,
     close_len: usize,
 ) -> usize {
-    let fallback = span.end.offset.saturating_sub(close_len);
+    let fallback = span.end.offset().saturating_sub(close_len);
     let search_end = upper_bound
         .map(|offset| offset.saturating_add(close_len))
-        .unwrap_or(span.end.offset)
+        .unwrap_or(span.end.offset())
         .min(source.len())
-        .max(span.start.offset);
+        .max(span.start.offset());
     source
-        .get(span.start.offset..search_end)
+        .get(span.start.offset()..search_end)
         .and_then(|text| text.rfind(close_char))
-        .map_or(fallback, |offset| span.start.offset + offset)
+        .map_or(fallback, |offset| span.start.offset() + offset)
 }
 
 fn sequence_body_content_end(body: &StmtSeq, source: &str, indexer: &Indexer) -> usize {
     let mut end = body
         .last()
-        .map(|stmt| stmt_span(stmt).end.offset)
-        .unwrap_or(body.span.end.offset);
+        .map(|stmt| stmt_span(stmt).end.offset())
+        .unwrap_or(body.span.end.offset());
     if let Some(stmt) = body.last() {
         for redirect in &stmt.redirects {
             let Some(heredoc) = redirect.heredoc() else {
@@ -3292,7 +3291,7 @@ fn sequence_body_content_end(body: &StmtSeq, source: &str, indexer: &Indexer) ->
                 .region_index()
                 .heredoc_closing_marker_range(heredoc.body.span.to_range())
                 .map(|range| usize::from(range.end()))
-                .unwrap_or(heredoc.body.span.end.offset);
+                .unwrap_or(heredoc.body.span.end.offset());
             end = end.max(heredoc_end);
         }
     }
@@ -3377,14 +3376,12 @@ fn stmt_first_content_offset(
 ) -> usize {
     match &stmt.command {
         Command::Binary(command) => stmt_first_content_offset(&command.left, source_map, layout),
-        _ => {
-            stmt_group_attachment_or_verbatim_span_with_heredoc(stmt, source_map, |stmt| {
-                layout.stmt(stmt).contains_heredoc
-            })
-            .unwrap_or_else(|| stmt_verbatim_span_with_source_map(stmt, source_map))
-            .start
-            .offset
-        }
+        _ => stmt_group_attachment_or_verbatim_span_with_heredoc(stmt, source_map, |stmt| {
+            layout.stmt(stmt).contains_heredoc
+        })
+        .unwrap_or_else(|| stmt_verbatim_span_with_source_map(stmt, source_map))
+        .start
+        .offset(),
     }
 }
 
@@ -3434,11 +3431,11 @@ fn case_has_blank_line_after_in(command: &CaseCommand, source: &str) -> bool {
         .cases
         .first()
         .and_then(|item| item.patterns.first())
-        .map(|pattern| pattern.span.start.offset)
+        .map(|pattern| pattern.span.start.offset())
     else {
         return false;
     };
-    let start = command.word.span.end.offset.min(source.len());
+    let start = command.word.span.end.offset().min(source.len());
     let end = first_pattern_start.min(source.len());
     let Some(prefix) = source.get(start..end) else {
         return false;
@@ -3459,7 +3456,7 @@ fn case_item_has_blank_line_before(previous: &CaseItem, item: &CaseItem, source:
     let Some(end) = item
         .patterns
         .first()
-        .map(|pattern| pattern.span.start.offset)
+        .map(|pattern| pattern.span.start.offset())
     else {
         return false;
     };
@@ -3470,13 +3467,17 @@ fn case_item_source_end_offset(item: &CaseItem, source: &str) -> Option<usize> {
     let content_end = item
         .body
         .last()
-        .map(|stmt| stmt_format_span(stmt).end.offset)
-        .or_else(|| item.patterns.last().map(|pattern| pattern.span.end.offset))?;
+        .map(|stmt| stmt_format_span(stmt).end.offset())
+        .or_else(|| {
+            item.patterns
+                .last()
+                .map(|pattern| pattern.span.end.offset())
+        })?;
     if let Some(terminator_span) = item.terminator_span
-        && terminator_span.end.offset >= content_end
-        && terminator_span.end.offset <= source.len()
+        && terminator_span.end.offset() >= content_end
+        && terminator_span.end.offset() <= source.len()
     {
-        return Some(terminator_span.end.offset);
+        return Some(terminator_span.end.offset());
     }
     let stmt_end = content_end.min(source.len());
     let line_end = source[stmt_end..]
@@ -3495,9 +3496,9 @@ fn case_item_source_end_offset(item: &CaseItem, source: &str) -> Option<usize> {
 
 fn case_suffix_comment_start_line(item: &CaseItem) -> Option<usize> {
     item.terminator_span
-        .map(|span| span.end.line)
-        .or_else(|| item.body.last().map(|stmt| stmt_span(stmt).end.line))
-        .or_else(|| item.patterns.last().map(|pattern| pattern.span.end.line))
+        .map(|span| span.end.line())
+        .or_else(|| item.body.last().map(|stmt| stmt_span(stmt).end.line()))
+        .or_else(|| item.patterns.last().map(|pattern| pattern.span.end.line()))
 }
 
 fn case_has_blank_line_before_esac(
@@ -3511,7 +3512,7 @@ fn case_has_blank_line_before_esac(
     let Some(start) = case_item_source_end_offset(last_item, source) else {
         return false;
     };
-    let Some(esac_start) = esac_span.map(|span| span.start.offset) else {
+    let Some(esac_start) = esac_span.map(|span| span.start.offset()) else {
         return false;
     };
     gap_has_blank_line(source, start, esac_start)
@@ -3523,7 +3524,7 @@ fn case_item_has_blank_line_after_pattern(
     first_body_line: usize,
     first_body_stmt_line: usize,
 ) -> bool {
-    let Some(pattern_line) = item.patterns.last().map(|pattern| pattern.span.end.line) else {
+    let Some(pattern_line) = item.patterns.last().map(|pattern| pattern.span.end.line()) else {
         return false;
     };
     let stmt_line = if first_body_line <= pattern_line {
@@ -3547,7 +3548,7 @@ fn case_item_has_blank_line_before_terminator(
     source: &str,
     content_end: usize,
 ) -> bool {
-    let Some(terminator_start) = item.terminator_span.map(|span| span.start.offset) else {
+    let Some(terminator_start) = item.terminator_span.map(|span| span.start.offset()) else {
         return false;
     };
     !item.body.is_empty() && gap_has_empty_physical_line(source, content_end, terminator_start)
@@ -3559,12 +3560,12 @@ fn case_item_pattern_suffix_comment<'source>(
     source: &'source str,
     source_map: &SourceMap<'source>,
 ) -> Option<SourceComment<'source>> {
-    let start = item.patterns.last()?.span.end.offset.min(source.len());
+    let start = item.patterns.last()?.span.end.offset().min(source.len());
     let end = item
         .body
         .first()
-        .map(|stmt| stmt_span(stmt).start.offset)
-        .or_else(|| item.terminator_span.map(|span| span.start.offset))
+        .map(|stmt| stmt_span(stmt).start.offset())
+        .or_else(|| item.terminator_span.map(|span| span.start.offset()))
         .or(upper_bound)
         .unwrap_or(source.len())
         .min(source.len());
@@ -3574,7 +3575,7 @@ fn case_item_pattern_suffix_comment<'source>(
     let (_, source_line_end) = source_map.line_bounds_for_offset(start)?;
     let line_end = source_line_end.min(end);
     let comment = source_map.first_source_comment_between(start, line_end)?;
-    let before = source_map.slice_between(start, comment.span().start.offset)?;
+    let before = source_map.slice_between(start, comment.span().start.offset())?;
     if !before.contains(')') {
         return None;
     }
@@ -3586,7 +3587,7 @@ fn case_item_terminator_suffix_comment<'source>(
     source_map: &SourceMap<'source>,
 ) -> Option<SourceComment<'source>> {
     let span = item.terminator_span?;
-    if span.start.line != span.end.line {
+    if span.start.line() != span.end.line() {
         return None;
     }
     source_map.suffix_comment_after_span(span)
@@ -3645,7 +3646,7 @@ fn suffix_comment_from_span<'source>(
     if !comment.starts_with('#') {
         return None;
     }
-    let absolute_start = span.start.offset + leading_padding;
+    let absolute_start = span.start.offset() + leading_padding;
     let absolute_end = absolute_start + comment.len();
     source_map.source_comment_for_offsets(absolute_start, absolute_end)
 }
@@ -3657,7 +3658,7 @@ fn condition_separator_suffix_comment<'source>(
     source_map: &SourceMap<'source>,
 ) -> Option<SourceComment<'source>> {
     let start = condition.last().map(condition_stmt_command_end)?;
-    let end = then_span.start.offset.min(source.len());
+    let end = then_span.start.offset().min(source.len());
     if start >= end {
         return None;
     }
@@ -3682,12 +3683,12 @@ fn condition_separator_suffix_comment<'source>(
 }
 
 fn condition_stmt_command_end(stmt: &Stmt) -> usize {
-    let mut end = command_format_span(&stmt.command).end.offset;
+    let mut end = command_format_span(&stmt.command).end.offset();
     if end == 0 {
-        end = stmt_span(stmt).end.offset;
+        end = stmt_span(stmt).end.offset();
     }
     for redirect in &stmt.redirects {
-        end = end.max(redirect.span.end.offset);
+        end = end.max(redirect.span.end.offset());
     }
     end
 }
@@ -3704,7 +3705,7 @@ fn if_branch_upper_bound(
             .branch_prefix_first_comment_offset(start, end)
             .unwrap_or(end)
     } else {
-        facts.if_close_span(command).start.offset
+        facts.if_close_span(command).start.offset()
     }
 }
 
@@ -3718,8 +3719,8 @@ fn if_next_branch_region(
 
 fn branch_body_content_end(body: &StmtSeq) -> usize {
     body.last()
-        .map(|stmt| stmt_span(stmt).end.offset)
-        .unwrap_or(body.span.end.offset)
+        .map(|stmt| stmt_span(stmt).end.offset())
+        .unwrap_or(body.span.end.offset())
 }
 
 #[cfg(test)]
@@ -3827,7 +3828,7 @@ mod tests {
             _ => panic!("expected inner brace group"),
         };
 
-        let sequence = facts.sequence(inner, Some(body[0].span.end.offset));
+        let sequence = facts.sequence(inner, Some(body[0].span.end.offset()));
         let span = sequence
             .group_open_suffix_span()
             .expect("expected group open suffix span");
@@ -4081,7 +4082,7 @@ mod tests {
             _ => panic!("expected subshell condition"),
         };
 
-        let sequence = facts.sequence(subshell, Some(stmt_span(condition_stmt).end.offset));
+        let sequence = facts.sequence(subshell, Some(stmt_span(condition_stmt).end.offset()));
         let attachment_span = group_attachment_span_with_heredoc(
             subshell.as_slice(),
             facts.source_map(),
@@ -4124,7 +4125,7 @@ mod tests {
         let Command::Compound(CompoundCommand::BraceGroup(body)) = &function.body.command else {
             panic!("expected brace group body");
         };
-        let sequence = facts.sequence(body, Some(function.span.end.offset));
+        let sequence = facts.sequence(body, Some(function.span.end.offset()));
         let leading = sequence.leading_for(0);
 
         assert_eq!(leading.len(), 1);

--- a/crates/shuck-formatter/src/facts/case.rs
+++ b/crates/shuck-formatter/src/facts/case.rs
@@ -112,13 +112,17 @@ fn case_item_key(item: &CaseItem) -> FactSpan {
     let start = item
         .patterns
         .first()
-        .map(|pattern| pattern.span.start.offset)
-        .unwrap_or(item.body.span.start.offset);
+        .map(|pattern| pattern.span.start.offset())
+        .unwrap_or(item.body.span.start.offset());
     let end = item
         .terminator_span
-        .map(|span| span.end.offset)
-        .or_else(|| item.body.last().map(|stmt| stmt_span(stmt).end.offset))
-        .or_else(|| item.patterns.last().map(|pattern| pattern.span.end.offset))
-        .unwrap_or(item.body.span.end.offset);
+        .map(|span| span.end.offset())
+        .or_else(|| item.body.last().map(|stmt| stmt_span(stmt).end.offset()))
+        .or_else(|| {
+            item.patterns
+                .last()
+                .map(|pattern| pattern.span.end.offset())
+        })
+        .unwrap_or(item.body.span.end.offset());
     FactSpan::from_offsets(start, end)
 }

--- a/crates/shuck-formatter/src/render_plan/body_site.rs
+++ b/crates/shuck-formatter/src/render_plan/body_site.rs
@@ -316,9 +316,11 @@ impl<'a> CompoundBodySite<'a> {
         let close_span = cached_close_span.or_else(|| {
             done_close_span(source_map.source(), source_map, enclosing_span, done_span)
         });
-        let upper_bound = close_span.map(|span| span.start.offset).unwrap_or_else(|| {
-            done_span.map_or(enclosing_span.end.offset, |span| span.start.offset)
-        });
+        let upper_bound = close_span
+            .map(|span| span.start.offset())
+            .unwrap_or_else(|| {
+                done_span.map_or(enclosing_span.end.offset(), |span| span.start.offset())
+            });
         Self {
             body,
             enclosing_span,
@@ -332,7 +334,7 @@ impl<'a> CompoundBodySite<'a> {
         Self {
             body,
             enclosing_span,
-            bounds: CompoundBodyBounds::shared(enclosing_span.end.offset),
+            bounds: CompoundBodyBounds::shared(enclosing_span.end.offset()),
             open: CompoundBodyOpen::Direct,
             close_span: None,
         }
@@ -358,8 +360,8 @@ impl<'a> CompoundBodySite<'a> {
             body,
             enclosing_span,
             bounds: CompoundBodyBounds::split(
-                right_brace_span.start.offset,
-                enclosing_span.end.offset,
+                right_brace_span.start.offset(),
+                enclosing_span.end.offset(),
             ),
             open: CompoundBodyOpen::Group('{'),
             close_span: Some(close_span),

--- a/crates/shuck-formatter/src/render_plan/case_layout.rs
+++ b/crates/shuck-formatter/src/render_plan/case_layout.rs
@@ -13,7 +13,7 @@ pub(crate) fn case_item_body_terminator_was_inline_in_source(item: &CaseItem) ->
         return false;
     };
     item.terminator_span
-        .is_some_and(|span| span.start.line == stmt_format_span(stmt).end.line)
+        .is_some_and(|span| span.start.line() == stmt_format_span(stmt).end.line())
 }
 
 pub(crate) fn case_item_pattern_body_terminator_was_inline_in_source(
@@ -29,16 +29,16 @@ pub(crate) fn case_item_pattern_body_terminator_was_inline_in_source(
     let Some(terminator_span) = item.terminator_span else {
         return false;
     };
-    let pattern_end = pattern.span.end.offset.min(source.len());
-    let stmt_start = stmt_span(stmt).start.offset.min(source.len());
-    let stmt_end = stmt_format_span(stmt).end.offset.min(source.len());
-    let terminator_start = terminator_span.start.offset.min(source.len());
-    let pattern_and_body_share_line = pattern.span.end.line == stmt_span(stmt).start.line
+    let pattern_end = pattern.span.end.offset().min(source.len());
+    let stmt_start = stmt_span(stmt).start.offset().min(source.len());
+    let stmt_end = stmt_format_span(stmt).end.offset().min(source.len());
+    let terminator_start = terminator_span.start.offset().min(source.len());
+    let pattern_and_body_share_line = pattern.span.end.line() == stmt_span(stmt).start.line()
         || source
             .get(pattern_end..stmt_start)
             .is_some_and(|gap| !gap.contains('\n') && !gap.contains('\r'));
-    let body_and_terminator_share_line = terminator_span.start.line
-        == stmt_format_span(stmt).end.line
+    let body_and_terminator_share_line = terminator_span.start.line()
+        == stmt_format_span(stmt).end.line()
         || source
             .get(stmt_end..terminator_start)
             .is_some_and(|gap| !gap.contains('\n') && !gap.contains('\r'))
@@ -51,7 +51,7 @@ fn case_item_source_line_has_terminator_after_body(
     stmt: &Stmt,
     source: &str,
 ) -> bool {
-    let stmt_end = stmt_format_span(stmt).end.offset.min(source.len());
+    let stmt_end = stmt_format_span(stmt).end.offset().min(source.len());
     let line_end = source[stmt_end..]
         .find(['\n', '\r'])
         .map_or(source.len(), |offset| stmt_end + offset);
@@ -103,8 +103,8 @@ fn case_item_if_close_shares_terminator(
         return false;
     };
     let fi_span = facts.if_close_span(command);
-    let fi_end = fi_span.end.offset.min(source.len());
-    let terminator_start = terminator_span.start.offset.min(source.len());
+    let fi_end = fi_span.end.offset().min(source.len());
+    let terminator_start = terminator_span.start.offset().min(source.len());
     source
         .get(fi_end..terminator_start)
         .is_some_and(|gap| !gap.contains('\n') && !gap.contains('\r'))
@@ -122,8 +122,8 @@ fn case_item_case_close_shares_terminator(
     let Some(esac_span) = facts.case_command(command).esac_span() else {
         return false;
     };
-    let esac_end = esac_span.end.offset.min(source.len());
-    let terminator_start = terminator_span.start.offset.min(source.len());
+    let esac_end = esac_span.end.offset().min(source.len());
+    let terminator_start = terminator_span.start.offset().min(source.len());
     source
         .get(esac_end..terminator_start)
         .is_some_and(|gap| !gap.contains('\n') && !gap.contains('\r'))
@@ -139,7 +139,7 @@ pub(crate) fn case_item_body_was_inline_without_terminator(item: &CaseItem) -> b
     let Some(stmt) = item.body.first() else {
         return false;
     };
-    pattern.span.end.line == stmt_span(stmt).start.line
+    pattern.span.end.line() == stmt_span(stmt).start.line()
 }
 
 pub(crate) fn case_close_shares_line_with_last_item(
@@ -156,8 +156,8 @@ pub(crate) fn case_close_shares_line_with_last_item(
     let Some(terminator_span) = last_item.terminator_span else {
         return false;
     };
-    let terminator_end = terminator_span.end.offset.min(source.len());
-    let esac_start = esac_span.start.offset.min(source.len());
+    let terminator_end = terminator_span.end.offset().min(source.len());
+    let esac_start = esac_span.start.offset().min(source.len());
     source
         .get(terminator_end..esac_start)
         .is_some_and(|gap| !gap.contains('\n') && !gap.contains('\r'))
@@ -173,7 +173,7 @@ pub(crate) fn case_item_started_inline_without_terminator(item: &CaseItem) -> bo
     let [stmt] = item.body.as_slice() else {
         return false;
     };
-    pattern.span.end.line == stmt_span(stmt).start.line
+    pattern.span.end.line() == stmt_span(stmt).start.line()
 }
 
 pub(crate) fn case_item_pattern_starts_on_case_header(
@@ -182,7 +182,7 @@ pub(crate) fn case_item_pattern_starts_on_case_header(
 ) -> bool {
     item.patterns
         .first()
-        .is_some_and(|pattern| pattern.span.start.line == command.span.start.line)
+        .is_some_and(|pattern| pattern.span.start.line() == command.span.start.line())
 }
 
 pub(crate) fn case_item_pattern_close_paren_on_own_line(
@@ -197,16 +197,16 @@ pub(crate) fn case_item_pattern_close_paren_on_own_line(
         .body
         .first()
         .map(stmt_span)
-        .map(|span| span.start.offset)
-        .or_else(|| item.terminator_span.map(|span| span.start.offset))
-        .unwrap_or(item.body.span.start.offset);
-    let Some(slice) = source.get(first_pattern.span.start.offset..end) else {
+        .map(|span| span.start.offset())
+        .or_else(|| item.terminator_span.map(|span| span.start.offset()))
+        .unwrap_or(item.body.span.start.offset());
+    let Some(slice) = source.get(first_pattern.span.start.offset()..end) else {
         return false;
     };
     let Some(close_offset) = slice.rfind(')') else {
         return false;
     };
-    let close_offset = first_pattern.span.start.offset + close_offset;
+    let close_offset = first_pattern.span.start.offset() + close_offset;
     let Some((line_start, _)) = source_map.line_bounds_for_offset(close_offset) else {
         return false;
     };
@@ -228,14 +228,14 @@ pub(crate) fn case_item_close_paren_shares_line_with_body(
     let Some(first_stmt) = item.body.first() else {
         return false;
     };
-    let stmt_start = stmt_span(first_stmt).start.offset.min(source.len());
-    let Some(slice) = source.get(first_pattern.span.start.offset..stmt_start) else {
+    let stmt_start = stmt_span(first_stmt).start.offset().min(source.len());
+    let Some(slice) = source.get(first_pattern.span.start.offset()..stmt_start) else {
         return false;
     };
     let Some(close_offset) = slice.rfind(')') else {
         return false;
     };
-    let close_offset = first_pattern.span.start.offset + close_offset;
+    let close_offset = first_pattern.span.start.offset() + close_offset;
     !source_map.contains_newline_between(close_offset + 1, stmt_start)
 }
 
@@ -259,7 +259,7 @@ pub(crate) fn case_prefix_comment_uses_body_indent(
     disabled_case_pattern_context: bool,
     body_indent_context: bool,
 ) -> bool {
-    let Some(comment_indent) = source_map.line_indent_before_offset(comment.span().start.offset)
+    let Some(comment_indent) = source_map.line_indent_before_offset(comment.span().start.offset())
     else {
         return false;
     };
@@ -292,7 +292,7 @@ fn case_prefix_comment_follows_terminator(
     source_map: &SourceMap<'_>,
     comment: &SourceComment<'_>,
 ) -> bool {
-    let Some((line_start, _)) = source_map.line_bounds_for_offset(comment.span().start.offset)
+    let Some((line_start, _)) = source_map.line_bounds_for_offset(comment.span().start.offset())
     else {
         return false;
     };

--- a/crates/shuck-formatter/src/render_plan/conditions.rs
+++ b/crates/shuck-formatter/src/render_plan/conditions.rs
@@ -17,7 +17,7 @@ pub(crate) fn if_condition_starts_after_keyword(
     command
         .condition
         .first()
-        .is_some_and(|stmt| facts.stmt(stmt).rendered_start_line() > command.span.start.line)
+        .is_some_and(|stmt| facts.stmt(stmt).rendered_start_line() > command.span.start.line())
 }
 
 pub(crate) fn if_condition_has_explicit_statement_break(
@@ -32,7 +32,7 @@ pub(crate) fn if_condition_has_explicit_statement_break(
     }
     condition_sequence_has_explicit_statement_break(
         &command.condition,
-        then_span.start.offset,
+        then_span.start.offset(),
         source,
         source_map,
     )
@@ -44,8 +44,8 @@ fn raw_if_condition_starts_with_negation_continuation(
     source: &str,
     facts: &FormatterFacts,
 ) -> bool {
-    let condition_start = command.span.start.offset.saturating_add("if".len());
-    let condition_end = then_span.start.offset.min(source.len());
+    let condition_start = command.span.start.offset().saturating_add("if".len());
+    let condition_end = then_span.start.offset().min(source.len());
     let Some(raw) = source.get(condition_start..condition_end) else {
         return false;
     };
@@ -74,7 +74,7 @@ fn condition_sequence_has_explicit_statement_break(
         if !matches!(stmt.command, Command::Simple(_)) {
             return false;
         }
-        let start = stmt_span(stmt).start.offset;
+        let start = stmt_span(stmt).start.offset();
         let command_end = condition_stmt_command_end(stmt).min(upper_bound);
         return source
             .get(start..command_end)
@@ -82,19 +82,19 @@ fn condition_sequence_has_explicit_statement_break(
     }
 
     condition.as_slice().windows(2).any(|pair| {
-        let previous_start = stmt_span(&pair[0]).start.offset;
-        let next_start = stmt_span(&pair[1]).start.offset;
+        let previous_start = stmt_span(&pair[0]).start.offset();
+        let next_start = stmt_span(&pair[1]).start.offset();
         source_map.contains_newline_between(previous_start, next_start)
     })
 }
 
 fn condition_stmt_command_end(stmt: &Stmt) -> usize {
-    let mut end = command_format_span(&stmt.command).end.offset;
+    let mut end = command_format_span(&stmt.command).end.offset();
     if end == 0 {
-        end = stmt_span(stmt).end.offset;
+        end = stmt_span(stmt).end.offset();
     }
     for redirect in &stmt.redirects {
-        end = end.max(redirect.span.end.offset);
+        end = end.max(redirect.span.end.offset());
     }
     end
 }
@@ -106,7 +106,7 @@ pub(crate) fn elif_condition_has_explicit_statement_break(
     source_map: &SourceMap<'_>,
 ) -> bool {
     let upper_bound =
-        branch_open_keyword_start(body, source, "then").unwrap_or(body.span.start.offset);
+        branch_open_keyword_start(body, source, "then").unwrap_or(body.span.start.offset());
     condition_sequence_has_explicit_statement_break(condition, upper_bound, source, source_map)
 }
 
@@ -142,7 +142,7 @@ fn has_unescaped_line_break(text: &str) -> bool {
 pub(crate) fn loop_condition_starts_after_keyword(condition: &StmtSeq, span: Span) -> bool {
     condition
         .first()
-        .is_some_and(|stmt| stmt_span(stmt).start.line > span.start.line)
+        .is_some_and(|stmt| stmt_span(stmt).start.line() > span.start.line())
 }
 
 pub(crate) fn condition_keyword_on_previous_non_empty_line(
@@ -155,7 +155,7 @@ pub(crate) fn condition_keyword_on_previous_non_empty_line(
         return false;
     };
     let Some((mut line_start, _)) =
-        source_map.line_bounds_for_offset(stmt_span(first).start.offset)
+        source_map.line_bounds_for_offset(stmt_span(first).start.offset())
     else {
         return false;
     };
@@ -184,8 +184,8 @@ pub(crate) fn raw_grouped_if_condition(
     if !if_condition_starts_after_keyword(command, then_span, source, facts) {
         return None;
     }
-    let start = command.span.start.offset.checked_add("if".len())?;
-    let end = then_span.start.offset;
+    let start = command.span.start.offset().checked_add("if".len())?;
+    let end = then_span.start.offset();
     if start >= end || end > source.len() {
         return None;
     }
@@ -194,7 +194,7 @@ pub(crate) fn raw_grouped_if_condition(
         return None;
     }
     let outer_indent = source_map
-        .line_indent_before_offset(command.span.start.offset)
+        .line_indent_before_offset(command.span.start.offset())
         .unwrap_or("");
     Some(strip_outer_indent_after_first_line(raw, outer_indent))
 }
@@ -226,11 +226,11 @@ fn stmt_renders_with_subshell_open(stmt: &Stmt) -> bool {
     if stmt.negated {
         return false;
     }
-    let command_start = command_format_span(&stmt.command).start.offset;
+    let command_start = command_format_span(&stmt.command).start.offset();
     if stmt
         .redirects
         .iter()
-        .any(|redirect| redirect.span.start.offset < command_start)
+        .any(|redirect| redirect.span.start.offset() < command_start)
     {
         return false;
     }

--- a/crates/shuck-formatter/src/render_plan/if_case.rs
+++ b/crates/shuck-formatter/src/render_plan/if_case.rs
@@ -76,7 +76,7 @@ fn then_fi_if_style(
     fi_span: Span,
     context: RenderContext<'_, '_>,
 ) -> IfLayoutStyle {
-    let fi_upper_bound = fi_span.start.offset;
+    let fi_upper_bound = fi_span.start.offset();
     let no_elifs = command.elif_branches.is_empty();
 
     if no_elifs
@@ -218,7 +218,7 @@ pub(crate) fn case_can_format_inline(
                     || case_item_body_was_inline_without_terminator(item))
                 && !context
                     .facts
-                    .sequence(&item.body, Some(command.span.end.offset))
+                    .sequence(&item.body, Some(command.span.end.offset()))
                     .has_comments()
     })
 }

--- a/crates/shuck-formatter/src/render_plan/mod.rs
+++ b/crates/shuck-formatter/src/render_plan/mod.rs
@@ -75,7 +75,7 @@ mod layout_plan_tests {
     }
 
     fn function_body(function: &FunctionDef) -> (&Stmt, usize) {
-        (function.body.as_ref(), function.span.end.offset)
+        (function.body.as_ref(), function.span.end.offset())
     }
 
     #[test]

--- a/crates/shuck-formatter/src/render_plan/shape.rs
+++ b/crates/shuck-formatter/src/render_plan/shape.rs
@@ -14,7 +14,7 @@ pub(crate) fn can_inline_body(
         context,
         commands,
         enclosing_span,
-        Some(enclosing_span.end.offset),
+        Some(enclosing_span.end.offset()),
     )
 }
 
@@ -37,7 +37,8 @@ pub(crate) fn can_inline_body_with_upper_bound(
         return false;
     }
 
-    context.options.compact_layout() || stmt_span(command).start.line == enclosing_span.start.line
+    context.options.compact_layout()
+        || stmt_span(command).start.line() == enclosing_span.start.line()
 }
 
 pub(crate) fn can_inline_stmt(context: RenderContext<'_, '_>, stmt: &Stmt) -> bool {
@@ -74,7 +75,7 @@ pub(crate) fn can_inline_else_branch_close(
         || !can_inline_stmt(context, stmt)
         || context
             .facts
-            .sequence(body, Some(fi_span.start.offset))
+            .sequence(body, Some(fi_span.start.offset()))
             .has_comments()
     {
         return false;
@@ -86,8 +87,8 @@ pub(crate) fn can_inline_else_branch_close(
         return false;
     };
     let else_line = context.source_map().line_number_for_offset(else_offset);
-    let body_line = stmt_span(stmt).start.line;
-    else_line == body_line && body_line == fi_span.start.line
+    let body_line = stmt_span(stmt).start.line();
+    else_line == body_line && body_line == fi_span.start.line()
 }
 
 pub(crate) fn can_inline_if_chain(
@@ -95,7 +96,7 @@ pub(crate) fn can_inline_if_chain(
     command: &IfCommand,
     fi_span: Span,
 ) -> bool {
-    if command.elif_branches.is_empty() || command.span.start.line != fi_span.end.line {
+    if command.elif_branches.is_empty() || command.span.start.line() != fi_span.end.line() {
         return false;
     }
 
@@ -120,7 +121,7 @@ pub(crate) fn can_inline_if_chain(
     }
 
     command.else_branch.as_ref().is_none_or(|body| {
-        can_inline_body_with_upper_bound(context, body, command.span, Some(fi_span.start.offset))
+        can_inline_body_with_upper_bound(context, body, command.span, Some(fi_span.start.offset()))
     })
 }
 
@@ -130,7 +131,7 @@ pub(crate) fn then_branch_starts_with_inline_if(
     then_span: Span,
     fi_span: Span,
 ) -> bool {
-    if command.span.start.line != fi_span.end.line {
+    if command.span.start.line() != fi_span.end.line() {
         return false;
     }
     let [stmt] = command.then_branch.as_slice() else {
@@ -143,7 +144,7 @@ pub(crate) fn then_branch_starts_with_inline_if(
         return false;
     };
     matches!(inner.syntax, IfSyntax::ThenFi { .. })
-        && then_span.end.line == inner.span.start.line
+        && then_span.end.line() == inner.span.start.line()
         && !context
             .facts
             .sequence(
@@ -164,7 +165,7 @@ pub(crate) fn can_inline_group(
 
     can_inline_stmt(context, command)
         && can_inline_body(context, commands, stmt_span(command))
-        && (stmt_span(command).start.line == stmt_span(command).end.line
+        && (stmt_span(command).start.line() == stmt_span(command).end.line()
             || group_delimiters_attach_to_wrapped_body(context, commands, open_char))
 }
 
@@ -193,8 +194,8 @@ pub(crate) fn group_delimiters_attach_to_wrapped_body(
         return false;
     };
 
-    group_span.start.line == stmt_format_span(first).start.line
-        && group_span.end.line == stmt_format_span(last).end.line
+    group_span.start.line() == stmt_format_span(first).start.line()
+        && group_span.end.line() == stmt_format_span(last).end.line()
 }
 
 pub(crate) fn can_inline_source_line_subshell(
@@ -211,7 +212,7 @@ pub(crate) fn can_inline_source_line_subshell(
     {
         return false;
     }
-    if commands.span.start.line != commands.span.end.line {
+    if commands.span.start.line() != commands.span.end.line() {
         return false;
     }
 
@@ -250,8 +251,8 @@ pub(crate) fn can_format_multiline_subshell_inline(
         return false;
     }
 
-    let first_start = stmt_span(stmt).start.offset.min(context.source.len());
-    let open_end = group_span.start.offset.saturating_add('('.len_utf8());
+    let first_start = stmt_span(stmt).start.offset().min(context.source.len());
+    let open_end = group_span.start.offset().saturating_add('('.len_utf8());
     if context
         .source
         .get(open_end..first_start)
@@ -264,7 +265,7 @@ pub(crate) fn can_format_multiline_subshell_inline(
         group_close_offset(context.source, group_span, upper_bound, ')', ')'.len_utf8());
     let stmt_end = stmt_span(stmt)
         .end
-        .offset
+        .offset()
         .min(close_offset)
         .min(context.source.len());
     context
@@ -287,7 +288,7 @@ pub(crate) fn body_starts_with_inline_do_brace_group(
     else {
         return false;
     };
-    source_line_before_offset_ends_with_do(context.source, group_span.start.offset)
+    source_line_before_offset_ends_with_do(context.source, group_span.start.offset())
 }
 
 pub(crate) fn body_starts_with_inline_do_if(
@@ -300,7 +301,7 @@ pub(crate) fn body_starts_with_inline_do_if(
     if !matches!(command.syntax, IfSyntax::ThenFi { .. }) {
         return false;
     }
-    source_line_before_offset_ends_with_do(context.source, command.span.start.offset)
+    source_line_before_offset_ends_with_do(context.source, command.span.start.offset())
 }
 
 pub(crate) fn inline_do_brace_group_done_separator(
@@ -323,7 +324,7 @@ pub(crate) fn inline_do_brace_group_done_separator(
     };
     let between = context
         .source
-        .get(group_span.end.offset..enclosing_span.end.offset)
+        .get(group_span.end.offset()..enclosing_span.end.offset())
         .unwrap_or_default()
         .trim_start_matches([' ', '\t', '\r']);
     if between.starts_with(';') {
@@ -408,14 +409,14 @@ fn group_close_offset(
     close_char: char,
     close_len: usize,
 ) -> usize {
-    let fallback = span.end.offset.saturating_sub(close_len);
+    let fallback = span.end.offset().saturating_sub(close_len);
     let search_end = upper_bound
         .map(|offset| offset.saturating_add(close_len))
-        .unwrap_or(span.end.offset)
+        .unwrap_or(span.end.offset())
         .min(source.len())
-        .max(span.start.offset);
+        .max(span.start.offset());
     source
-        .get(span.start.offset..search_end)
+        .get(span.start.offset()..search_end)
         .and_then(|text| text.rfind(close_char))
-        .map_or(fallback, |offset| span.start.offset + offset)
+        .map_or(fallback, |offset| span.start.offset() + offset)
 }

--- a/crates/shuck-formatter/src/source.rs
+++ b/crates/shuck-formatter/src/source.rs
@@ -19,7 +19,7 @@ impl<'source> SourceView<'source> {
     }
 
     pub(crate) fn span_slice(self, span: Span) -> Option<&'source str> {
-        if span.start.offset >= span.end.offset || span.end.offset > self.source.len() {
+        if span.start.offset() >= span.end.offset() || span.end.offset() > self.source.len() {
             return None;
         }
         Some(span.slice(self.source))
@@ -98,8 +98,8 @@ impl<'source> SourceView<'source> {
     }
 
     pub(crate) fn last_shell_keyword_start(self, span: Span, keyword: &str) -> Option<usize> {
-        let upper = span.end.offset.min(self.source.len());
-        let lower = span.start.offset.min(upper);
+        let upper = span.end.offset().min(self.source.len());
+        let lower = span.start.offset().min(upper);
         self.last_shell_keyword_start_between(lower, upper, keyword)
     }
 

--- a/crates/shuck-formatter/src/streaming/branches.rs
+++ b/crates/shuck-formatter/src/streaming/branches.rs
@@ -12,7 +12,7 @@ pub(super) fn if_branch_upper_bound(
             .branch_prefix_first_comment_offset(start, end)
             .unwrap_or(end)
     } else {
-        facts.if_close_span(command).start.offset
+        facts.if_close_span(command).start.offset()
     }
 }
 
@@ -30,8 +30,8 @@ fn if_next_branch_region(
 fn branch_body_content_end(body: &StmtSeq, source: &str, facts: &FormatterFacts<'_>) -> usize {
     let mut end = body
         .last()
-        .map(|stmt| stmt_span(stmt).end.offset)
-        .unwrap_or(body.span.end.offset);
+        .map(|stmt| stmt_span(stmt).end.offset())
+        .unwrap_or(body.span.end.offset());
     if let Some(stmt) = body.last() {
         for redirect in &stmt.redirects {
             let Some(heredoc) = redirect.heredoc() else {
@@ -40,7 +40,7 @@ fn branch_body_content_end(body: &StmtSeq, source: &str, facts: &FormatterFacts<
             let heredoc_end = facts
                 .heredoc_closing_marker_bounds(heredoc)
                 .map(|(_, line_end)| line_end)
-                .unwrap_or(heredoc.body.span.end.offset);
+                .unwrap_or(heredoc.body.span.end.offset());
             end = end.max(heredoc_end);
         }
     }
@@ -81,8 +81,8 @@ pub(super) fn unmodeled_branch_background_operator(
         return None;
     }
 
-    let body_end = body.span.end.offset.min(upper_bound).min(source.len());
-    let stmt_start = stmt_span(last).start.offset.min(body_end);
+    let body_end = body.span.end.offset().min(upper_bound).min(source.len());
+    let stmt_start = stmt_span(last).start.offset().min(body_end);
     if let Some(body_tail) = source.get(stmt_start..body_end)
         && let Some(operator) = trailing_unmodeled_background_operator(body_tail)
     {
@@ -91,7 +91,7 @@ pub(super) fn unmodeled_branch_background_operator(
 
     let start = stmt_span(last)
         .end
-        .offset
+        .offset()
         .min(upper_bound)
         .min(source.len());
     let end = upper_bound.min(source.len());

--- a/crates/shuck-formatter/src/streaming/comments_alignment.rs
+++ b/crates/shuck-formatter/src/streaming/comments_alignment.rs
@@ -30,7 +30,7 @@ where
         operator_end: usize,
     ) {
         let preserve_blank_before_comments = comments.first().is_some_and(|comment| {
-            gap_has_blank_line(self.source(), operator_end, comment.span().start.offset)
+            gap_has_blank_line(self.source(), operator_end, comment.span().start.offset())
         });
         if preserve_blank_before_comments {
             self.newline();
@@ -184,7 +184,7 @@ impl CommentAlignmentFacts {
         comment: &SourceComment<'_>,
     ) -> Self {
         let source_indent_column = source_map
-            .line_indent_before_offset(comment.span().start.offset)
+            .line_indent_before_offset(comment.span().start.offset())
             .map_or(0, |indent| indent.chars().count());
         Self {
             source_indent_column,
@@ -337,12 +337,13 @@ fn close_suffix_comment_alignment_entries(
     source_map: &SourceMap<'_>,
     comment: &SourceComment<'_>,
 ) -> Option<Vec<CloseSuffixAlignmentEntry>> {
-    let (line_start, line_end) = source_map.line_bounds_for_offset(comment.span().start.offset)?;
+    let (line_start, line_end) =
+        source_map.line_bounds_for_offset(comment.span().start.offset())?;
     let mut entries = vec![close_suffix_alignment_entry(
         source,
         line_start,
         line_end,
-        Some(comment.span().start.offset),
+        Some(comment.span().start.offset()),
     )?];
 
     let mut previous_start = line_start;
@@ -419,9 +420,10 @@ pub(super) fn trailing_comment_alignment_column(
     comment: &SourceComment<'_>,
     current_indent_column: usize,
 ) -> Option<usize> {
-    let (line_start, line_end) = source_map.line_bounds_for_offset(comment.span().start.offset)?;
+    let (line_start, line_end) =
+        source_map.line_bounds_for_offset(comment.span().start.offset())?;
     let mut widths = vec![trimmed_line_width(
-        source.get(line_start..comment.span().start.offset)?,
+        source.get(line_start..comment.span().start.offset())?,
     )?];
 
     let mut previous_start = line_start;
@@ -470,11 +472,11 @@ fn trailing_comment_tab_indent_adjust(
     comment: &SourceComment<'_>,
 ) -> usize {
     let Some((line_start, line_end)) =
-        source_map.line_bounds_for_offset(comment.span().start.offset)
+        source_map.line_bounds_for_offset(comment.span().start.offset())
     else {
         return 0;
     };
-    let Some(current_line) = source.get(line_start..comment.span().start.offset) else {
+    let Some(current_line) = source.get(line_start..comment.span().start.offset()) else {
         return 0;
     };
     let current_tabs = leading_tabs_only_indent_width(current_line);
@@ -1051,11 +1053,12 @@ fn comment_precedes_close_keyword_at_same_indent(
     source_map: &SourceMap<'_>,
     comment: &SourceComment<'_>,
 ) -> bool {
-    let Some(comment_indent) = source_map.line_indent_before_offset(comment.span().start.offset)
+    let Some(comment_indent) = source_map.line_indent_before_offset(comment.span().start.offset())
     else {
         return false;
     };
-    let Some((_, comment_line_end)) = source_map.line_bounds_for_offset(comment.span().end.offset)
+    let Some((_, comment_line_end)) =
+        source_map.line_bounds_for_offset(comment.span().end.offset())
     else {
         return false;
     };

--- a/crates/shuck-formatter/src/streaming/compounds.rs
+++ b/crates/shuck-formatter/src/streaming/compounds.rs
@@ -1,7 +1,7 @@
 use super::*;
 
 fn arithmetic_command_is_followed_by_inline_branch_keyword(span: Span, source: &str) -> bool {
-    let Some(after) = source.get(span.end.offset.min(source.len())..) else {
+    let Some(after) = source.get(span.end.offset().min(source.len())..) else {
         return false;
     };
     let trimmed = after.trim_start_matches([' ', '\t', '\r']);
@@ -84,7 +84,7 @@ where
         raw_condition: &str,
     ) -> Result<()> {
         let source = self.source();
-        let fi_upper_bound = fi_span.start.offset;
+        let fi_upper_bound = fi_span.start.offset();
         self.write_text("if");
         self.write_text(raw_condition);
         self.write_text("then");
@@ -113,11 +113,11 @@ where
         fi_span: Span,
     ) -> Result<()> {
         let source = self.source();
-        let fi_upper_bound = fi_span.start.offset;
+        let fi_upper_bound = fi_span.start.offset();
         self.write_text("if");
         self.newline();
         self.with_indent(|formatter| {
-            formatter.format_stmt_sequence(&command.condition, Some(then_span.start.offset))
+            formatter.format_stmt_sequence(&command.condition, Some(then_span.start.offset()))
         })?;
         self.newline();
         self.write_text("then");
@@ -184,7 +184,7 @@ where
                 self.format_inline_stmts(&command.then_branch)?;
                 self.write_text("; else");
                 let site =
-                    CompoundBodySite::if_else_branch(command, else_branch, fi_span.start.offset);
+                    CompoundBodySite::if_else_branch(command, else_branch, fi_span.start.offset());
                 self.format_if_branch_body_site(site)?;
                 let then_upper_bound = if_branch_upper_bound(
                     command,
@@ -239,7 +239,7 @@ where
         layout: ExpandedIfLayout,
     ) -> Result<()> {
         let source = self.source();
-        let fi_upper_bound = fi_span.start.offset;
+        let fi_upper_bound = fi_span.start.offset();
         self.write_text(then_separator);
         let then_upper_bound =
             if_branch_upper_bound(command, 0, source, self.source_map(), self.facts());
@@ -376,7 +376,7 @@ where
             self.write_text("elif");
             self.newline();
             self.with_indent(|formatter| {
-                formatter.format_stmt_sequence(condition, Some(body.span.start.offset))
+                formatter.format_stmt_sequence(condition, Some(body.span.start.offset()))
             })?;
             self.newline();
             self.write_text("then");
@@ -427,7 +427,7 @@ where
         let Some(first) = condition.first() else {
             return Vec::new();
         };
-        let condition_start = stmt_span(first).start.offset;
+        let condition_start = stmt_span(first).start.offset();
         if keyword_offset >= condition_start {
             return Vec::new();
         }
@@ -545,7 +545,7 @@ where
         }
         if let Some(body) = &command.else_branch {
             self.write_text(" else ");
-            let site = CompoundBodySite::if_else_branch(command, body, command.span.end.offset);
+            let site = CompoundBodySite::if_else_branch(command, body, command.span.end.offset());
             self.format_brace_group(site.body(), site.bounds().render_limit())?;
         }
         Ok(())
@@ -587,7 +587,7 @@ where
             self.write_text(" in");
             self.write_word_list_preserving_breaks_after(
                 words,
-                in_span.map(|span| span.end.offset),
+                in_span.map(|span| span.end.offset()),
             );
         }
     }
@@ -849,8 +849,8 @@ where
             return;
         };
         let source = self.source();
-        let start = command.word.span.end.offset.min(source.len());
-        let end = first_pattern.span.start.offset.min(source.len());
+        let start = command.word.span.end.offset().min(source.len());
+        let end = first_pattern.span.start.offset().min(source.len());
         let Some(between) = source.get(start..end) else {
             return;
         };
@@ -876,7 +876,7 @@ where
         let first_pattern_start = item
             .patterns
             .first()
-            .map(|pattern| pattern.span.start.offset);
+            .map(|pattern| pattern.span.start.offset());
         let item_facts = self.facts().case_item(item);
         let prefix_comments = item_facts.prefix_comments().to_vec();
         let pattern_suffix_comment = item_facts.pattern_suffix_comment();
@@ -896,7 +896,7 @@ where
                 let previous = &item.patterns[index - 1];
                 if self
                     .facts()
-                    .contains_newline_between(previous.span.end.offset, word.span.start.offset)
+                    .contains_newline_between(previous.span.end.offset(), word.span.start.offset())
                 {
                     self.write_text(" |");
                     self.line_continuation();
@@ -958,7 +958,7 @@ where
             self.write_case_terminator(item);
         } else {
             let body_sequence = self.facts().sequence(&item.body, upper_bound);
-            let pattern_line = item.patterns.last().map(|pattern| pattern.span.end.line);
+            let pattern_line = item.patterns.last().map(|pattern| pattern.span.end.line());
             let body_has_later_comments = pattern_line.is_some_and(|pattern_line| {
                 (0..item.body.len()).any(|index| {
                     body_sequence
@@ -1046,14 +1046,14 @@ where
         if !item.body.is_empty() {
             return Vec::new();
         }
-        let Some(end) = item.terminator_span.map(|span| span.start.offset) else {
+        let Some(end) = item.terminator_span.map(|span| span.start.offset()) else {
             return Vec::new();
         };
         let start = item
             .patterns
             .last()
-            .map(|pattern| pattern.span.end.offset)
-            .unwrap_or(item.body.span.start.offset);
+            .map(|pattern| pattern.span.end.offset())
+            .unwrap_or(item.body.span.start.offset());
         let Some(slice) = self.source().get(start..end) else {
             return Vec::new();
         };
@@ -1092,8 +1092,8 @@ where
             previous_line = comment_line;
         }
         let esac_line = esac_span
-            .map(|span| span.start.line)
-            .unwrap_or(command.span.end.line);
+            .map(|span| span.start.line())
+            .unwrap_or(command.span.end.line());
         self.write_line_breaks(line_gap_break_count(previous_line, esac_line));
     }
 
@@ -1110,7 +1110,7 @@ where
                 self.source(),
                 self.source_map(),
                 comment,
-                first_pattern.span.start.offset,
+                first_pattern.span.start.offset(),
                 disabled_case_pattern_context,
                 body_indent_context,
             );
@@ -1127,7 +1127,7 @@ where
             let target_line = comments
                 .get(index + 1)
                 .map(SourceComment::line)
-                .unwrap_or(first_pattern.span.start.line);
+                .unwrap_or(first_pattern.span.start.line());
             self.write_line_breaks(line_gap_break_count(comment.line(), target_line));
         }
     }
@@ -1222,7 +1222,7 @@ where
     pub(super) fn format_arithmetic(&mut self, command: &ArithmeticCommand) -> Result<()> {
         let expression_source = command
             .expr_span
-            .and_then(|span| self.source().get(span.start.offset..span.end.offset));
+            .and_then(|span| self.source().get(span.start.offset()..span.end.offset()));
         if let Some(expr) = command.expr_ast.as_ref()
             && !expression_source.is_some_and(|source| source.contains('\n'))
         {
@@ -1236,7 +1236,7 @@ where
         }
         let rendered = self
             .source()
-            .get(command.span.start.offset..command.span.end.offset)
+            .get(command.span.start.offset()..command.span.end.offset())
             .unwrap_or_default();
         let mut formatted = format_arithmetic_command_source(rendered);
         if arithmetic_command_is_followed_by_inline_branch_keyword(command.span, self.source()) {
@@ -1335,9 +1335,9 @@ where
     }
 
     pub(super) fn format_always(&mut self, command: &AlwaysCommand) -> Result<()> {
-        self.format_brace_group(&command.body, Some(command.span.end.offset))?;
+        self.format_brace_group(&command.body, Some(command.span.end.offset()))?;
         self.write_text(" always ");
-        self.format_brace_group(&command.always_body, Some(command.span.end.offset))
+        self.format_brace_group(&command.always_body, Some(command.span.end.offset()))
     }
 
     pub(super) fn format_function(&mut self, function: &FunctionDef) -> Result<()> {
@@ -1345,12 +1345,12 @@ where
         self.format_named_function_header(function);
         if self.options().function_next_line() {
             self.newline();
-            self.format_function_body(function.body.as_ref(), function.span.end.offset)
+            self.format_function_body(function.body.as_ref(), function.span.end.offset())
         } else {
             self.write_space();
             self.format_function_body_with_header_comment(
                 function.body.as_ref(),
-                function.span.end.offset,
+                function.span.end.offset(),
                 header_comment,
             )
         }
@@ -1369,7 +1369,7 @@ where
         } else {
             self.write_space();
         }
-        self.format_function_body(function.body.as_ref(), function.span.end.offset)?;
+        self.format_function_body(function.body.as_ref(), function.span.end.offset())?;
         if !function.args.is_empty() {
             for argument in &function.args {
                 self.write_space();
@@ -1607,7 +1607,7 @@ where
     ) -> Option<usize> {
         let first = commands.first()?;
         let source = self.source();
-        let start = stmt_span(first).start.offset.min(source.len());
+        let start = stmt_span(first).start.offset().min(source.len());
         let (line_start, line_end) = self.source_map().line_bounds_for_offset(start)?;
         let width = inline_comment_code_width(source, line_start, line_end, None)?;
         Some(width + 1)
@@ -1622,8 +1622,8 @@ where
         }
 
         let source = self.source();
-        let header_end = function.header.span().end.offset;
-        let body_start = stmt_span(function.body.as_ref()).start.offset;
+        let header_end = function.header.span().end.offset();
+        let body_start = stmt_span(function.body.as_ref()).start.offset();
         if header_end >= body_start || header_end >= source.len() {
             return None;
         }
@@ -1635,13 +1635,13 @@ where
             .map(|offset| header_end + offset)
             .unwrap_or(body_start);
         let comment = source_map.first_source_comment_between(header_end, line_end)?;
-        let before_comment = source_map.slice_between(header_end, comment.span().start.offset)?;
+        let before_comment = source_map.slice_between(header_end, comment.span().start.offset())?;
         if before_comment.contains('{') {
             return None;
         }
         let suffix_start = header_end;
         let comment_text = source_map
-            .slice_between(suffix_start, comment.span().end.offset)?
+            .slice_between(suffix_start, comment.span().end.offset())?
             .trim_end_matches([' ', '\t', '\r'])
             .to_string();
         (!comment_text.is_empty()).then(|| (comment.span(), comment_text))

--- a/crates/shuck-formatter/src/streaming/gaps.rs
+++ b/crates/shuck-formatter/src/streaming/gaps.rs
@@ -10,9 +10,9 @@ pub(super) fn stmt_semicolon_terminator_starts_on_continuation_line(
     let render_end = stmt
         .redirects
         .last()
-        .map(|redirect| redirect.span.end.offset)
-        .unwrap_or_else(|| command_format_span(&stmt.command).end.offset);
-    source_map.contains_newline_between(render_end, terminator_span.start.offset)
+        .map(|redirect| redirect.span.end.offset())
+        .unwrap_or_else(|| command_format_span(&stmt.command).end.offset());
+    source_map.contains_newline_between(render_end, terminator_span.start.offset())
 }
 
 pub(super) fn stmt_rendered_end_line_after_format(
@@ -26,7 +26,7 @@ pub(super) fn stmt_rendered_end_line_after_format(
         && stmt_semicolon_terminator_starts_on_continuation_line(stmt, source_map)
         && let Some(terminator_span) = stmt.terminator_span
     {
-        return terminator_span.start.line;
+        return terminator_span.start.line();
     }
     match &stmt.command {
         Command::Binary(command) => {
@@ -41,14 +41,14 @@ pub(super) fn stmt_rendered_end_line_after_format(
         _ if stmt.redirects.is_empty() && stmt.terminator.is_none() => {
             if let Some((commands, open)) = command_group_commands(&stmt.command)
                 && let Some(span) = facts
-                    .sequence(commands, Some(stmt_span(stmt).end.offset))
+                    .sequence(commands, Some(stmt_span(stmt).end.offset()))
                     .group_attachment_span()
             {
                 let close = matching_group_close(open);
                 let close_offset = group_close_offset(
                     source,
                     span,
-                    Some(stmt_span(stmt).end.offset),
+                    Some(stmt_span(stmt).end.offset()),
                     close,
                     close.len_utf8(),
                 );
@@ -73,16 +73,16 @@ pub(super) fn group_close_offset(
     close_char: char,
     close_len: usize,
 ) -> usize {
-    let fallback = span.end.offset.saturating_sub(close_len);
+    let fallback = span.end.offset().saturating_sub(close_len);
     let search_end = upper_bound
         .map(|offset| offset.saturating_add(close_len))
-        .unwrap_or(span.end.offset)
+        .unwrap_or(span.end.offset())
         .min(source.len())
-        .max(span.start.offset);
+        .max(span.start.offset());
     source
-        .get(span.start.offset..search_end)
+        .get(span.start.offset()..search_end)
         .and_then(|text| text.rfind(close_char))
-        .map_or(fallback, |offset| span.start.offset + offset)
+        .map_or(fallback, |offset| span.start.offset() + offset)
 }
 
 pub(super) fn trim_trailing_gap_before_offset(source: &str, mut offset: usize) -> usize {

--- a/crates/shuck-formatter/src/streaming/redirects.rs
+++ b/crates/shuck-formatter/src/streaming/redirects.rs
@@ -123,8 +123,8 @@ where
             let body = if !self.options.simplify()
                 && !self.options.minify()
                 && !heredoc_body_contains_command_substitution(&heredoc.body)
-                && heredoc.body.span.end.offset <= source.len()
-                && heredoc.body.span.start.offset <= heredoc.body.span.end.offset
+                && heredoc.body.span.end.offset() <= source.len()
+                && heredoc.body.span.start.offset() <= heredoc.body.span.end.offset()
             {
                 heredoc.body.span.slice(source).to_owned()
             } else {
@@ -158,7 +158,7 @@ where
 
 fn raw_redirect_source_slice<'a>(redirect: &Redirect, source: &'a str) -> Option<&'a str> {
     let span = redirect.span;
-    (span.start.offset < span.end.offset && span.end.offset <= source.len())
+    (span.start.offset() < span.end.offset() && span.end.offset() <= source.len())
         .then(|| span.slice(source))
 }
 
@@ -199,7 +199,7 @@ pub(super) fn append_both_redirect_pair_matches_source(
         return true;
     }
     if raw.starts_with(">>") {
-        let Some(operator_start) = redirect.span.start.offset.checked_sub(1) else {
+        let Some(operator_start) = redirect.span.start.offset().checked_sub(1) else {
             return false;
         };
         return source
@@ -216,16 +216,16 @@ fn redirect_target_starts_on_continuation_line(
 ) -> bool {
     let target_start = redirect
         .word_target()
-        .map(|word| word.span.start.offset)
+        .map(|word| word.span.start.offset())
         .or_else(|| {
             redirect
                 .heredoc()
-                .map(|heredoc| heredoc.delimiter.span.start.offset)
+                .map(|heredoc| heredoc.delimiter.span.start.offset())
         });
     let Some(target_start) = target_start else {
         return false;
     };
-    facts.has_continuation_line_start_between(redirect.span.start.offset, target_start)
+    facts.has_continuation_line_start_between(redirect.span.start.offset(), target_start)
 }
 
 fn should_render_explicit_fd(fd: i32, kind: RedirectKind) -> bool {
@@ -315,10 +315,13 @@ pub(super) fn redirect_list_starts_on_continuation_line(
     let Some(redirect) = redirects.first() else {
         return false;
     };
-    if command_span == Span::new() || redirect.span.start.offset <= command_span.end.offset {
+    if command_span == Span::new() || redirect.span.start.offset() <= command_span.end.offset() {
         return false;
     }
-    facts.has_continuation_line_start_between(command_span.end.offset, redirect.span.start.offset)
+    facts.has_continuation_line_start_between(
+        command_span.end.offset(),
+        redirect.span.start.offset(),
+    )
 }
 
 pub(super) fn redirect_is_attached_process_substitution(
@@ -326,7 +329,7 @@ pub(super) fn redirect_is_attached_process_substitution(
     redirect: &Redirect,
     source: &str,
 ) -> bool {
-    let start = redirect.span.start.offset;
+    let start = redirect.span.start.offset();
     let bytes = source.as_bytes();
     let attached_after_equals = start > 0 && bytes.get(start - 1).is_some_and(|byte| *byte == b'=')
         || start > 1

--- a/crates/shuck-formatter/src/streaming/statements.rs
+++ b/crates/shuck-formatter/src/streaming/statements.rs
@@ -11,19 +11,19 @@ pub(super) enum SimpleCommandPart<'a> {
 impl SimpleCommandPart<'_> {
     fn start_offset(&self, command: &SimpleCommand) -> usize {
         match self {
-            Self::Assignment(assignment) => assignment.span.start.offset,
-            Self::Name => command.name.span.start.offset,
-            Self::Argument(word) => word.span.start.offset,
-            Self::Redirect(redirect) => redirect.span.start.offset,
+            Self::Assignment(assignment) => assignment.span.start.offset(),
+            Self::Name => command.name.span.start.offset(),
+            Self::Argument(word) => word.span.start.offset(),
+            Self::Redirect(redirect) => redirect.span.start.offset(),
         }
     }
 
     fn end_offset(&self, command: &SimpleCommand) -> usize {
         match self {
-            Self::Assignment(assignment) => assignment.span.end.offset,
-            Self::Name => command.name.span.end.offset,
-            Self::Argument(word) => word.span.end.offset,
-            Self::Redirect(redirect) => redirect.span.end.offset,
+            Self::Assignment(assignment) => assignment.span.end.offset(),
+            Self::Name => command.name.span.end.offset(),
+            Self::Argument(word) => word.span.end.offset(),
+            Self::Redirect(redirect) => redirect.span.end.offset(),
         }
     }
 
@@ -147,11 +147,11 @@ where
                     .leading_for(0)
                     .iter()
                     .copied()
-                    .filter(|comment| comment.span().end.offset <= span.start.offset)
+                    .filter(|comment| comment.span().end.offset() <= span.start.offset())
                     .collect::<Vec<_>>();
                 self.emit_leading_comments(
                     &leading,
-                    self.facts().stmt(first).render_span().start.line,
+                    self.facts().stmt(first).render_span().start.line(),
                 );
             }
             self.write_verbatim(span.slice(source));
@@ -171,7 +171,7 @@ where
                         .leading_for(index)
                         .iter()
                         .copied()
-                        .filter(|comment| comment.span().start.offset >= min_offset)
+                        .filter(|comment| comment.span().start.offset() >= min_offset)
                         .collect::<Vec<_>>();
                     self.emit_leading_comments(&leading, next_line);
                 } else {
@@ -244,7 +244,7 @@ where
             && stmt
                 .redirects
                 .iter()
-                .all(|redirect| redirect.span.start.offset < command_span.start.offset);
+                .all(|redirect| redirect.span.start.offset() < command_span.start.offset());
 
         if emit_redirects_first {
             self.format_redirect_list(&stmt.redirects);
@@ -262,10 +262,10 @@ where
                 self.format_simple_command_with_redirects(command, &stmt.redirects);
             }
             Command::Compound(CompoundCommand::BraceGroup(commands)) => {
-                self.format_brace_group(commands, Some(stmt_span(stmt).end.offset))?;
+                self.format_brace_group(commands, Some(stmt_span(stmt).end.offset()))?;
             }
             Command::Compound(CompoundCommand::Subshell(commands)) => {
-                self.format_subshell(commands, Some(stmt_span(stmt).end.offset))?;
+                self.format_subshell(commands, Some(stmt_span(stmt).end.offset()))?;
             }
             _ => self.format_command(&stmt.command)?,
         }
@@ -346,9 +346,9 @@ where
     pub(super) fn format_assignments(&mut self, assignments: &[Assignment]) -> Option<usize> {
         let mut previous_end = None;
         for assignment in assignments {
-            self.write_command_gap(previous_end, assignment.span.start.offset);
+            self.write_command_gap(previous_end, assignment.span.start.offset());
             self.write_assignment(assignment);
-            previous_end = Some(assignment.span.end.offset);
+            previous_end = Some(assignment.span.end.offset());
         }
         previous_end
     }
@@ -469,7 +469,7 @@ where
         let Some(previous_end) = previous_end else {
             return;
         };
-        if previous_end == redirect.span.start.offset {
+        if previous_end == redirect.span.start.offset() {
             if redirect_has_adjacent_numeric_fd_prefix(
                 previous_part,
                 redirect,
@@ -483,7 +483,7 @@ where
             }
             return;
         }
-        self.write_command_gap(Some(previous_end), redirect.span.start.offset);
+        self.write_command_gap(Some(previous_end), redirect.span.start.offset());
     }
 
     pub(super) fn format_builtin_command(&mut self, command: &BuiltinCommand) -> Result<()> {
@@ -501,36 +501,36 @@ where
     ) -> Result<()> {
         let mut previous_end = self.format_assignments(assignments);
         let name_span = Span::from_positions(start, start.advanced_by(name));
-        self.write_command_gap(previous_end, name_span.start.offset);
+        self.write_command_gap(previous_end, name_span.start.offset());
         self.write_text(name);
-        previous_end = Some(name_span.end.offset);
+        previous_end = Some(name_span.end.offset());
         if let Some(primary) = primary {
-            self.write_command_gap(previous_end, primary.span.start.offset);
+            self.write_command_gap(previous_end, primary.span.start.offset());
             self.write_word(primary);
-            previous_end = Some(primary.span.end.offset);
+            previous_end = Some(primary.span.end.offset());
         }
         for argument in extra_args {
-            self.write_command_gap(previous_end, argument.span.start.offset);
+            self.write_command_gap(previous_end, argument.span.start.offset());
             self.write_word(argument);
-            previous_end = Some(argument.span.end.offset);
+            previous_end = Some(argument.span.end.offset());
         }
         Ok(())
     }
 
     pub(super) fn format_decl_clause(&mut self, command: &DeclClause) -> Result<()> {
         let mut previous_end = self.format_assignments(&command.assignments);
-        self.write_command_gap(previous_end, command.variant_span.start.offset);
+        self.write_command_gap(previous_end, command.variant_span.start.offset());
         self.write_text(command.variant.as_ref());
-        previous_end = Some(command.variant_span.end.offset);
+        previous_end = Some(command.variant_span.end.offset());
         for operand in &command.operands {
             let span = match operand {
                 DeclOperand::Flag(word) | DeclOperand::Dynamic(word) => word.span,
                 DeclOperand::Name(name) => name.span,
                 DeclOperand::Assignment(assignment) => assignment.span,
             };
-            self.write_command_gap(previous_end, span.start.offset);
+            self.write_command_gap(previous_end, span.start.offset());
             self.write_decl_operand(operand);
-            previous_end = Some(span.end.offset);
+            previous_end = Some(span.end.offset());
         }
         Ok(())
     }
@@ -562,7 +562,7 @@ where
         let mut previous_end = first_previous_end;
         for word in words {
             if let Some(previous_end) = previous_end {
-                self.write_command_gap(Some(previous_end), word.span.start.offset);
+                self.write_command_gap(Some(previous_end), word.span.start.offset());
             } else {
                 self.write_space();
             }
@@ -866,21 +866,21 @@ where
             self.source_map()
                 .source_comment(*comment)
                 .is_some_and(|comment| {
-                    !comment.inline() && comment.span().start.offset >= operator_span.end.offset
+                    !comment.inline() && comment.span().start.offset() >= operator_span.end.offset()
                 })
         }) {
             return;
         }
         let command_start = interstitial_comment_end(
             stmt,
-            operator_span.end.offset,
+            operator_span.end.offset(),
             self.source(),
             self.source_map(),
         );
-        if command_start <= operator_span.end.offset {
+        if command_start <= operator_span.end.offset() {
             return;
         }
-        let comments = self.own_line_comments_in_region(operator_span.end.offset, command_start);
+        let comments = self.own_line_comments_in_region(operator_span.end.offset(), command_start);
         for comment in comments {
             self.with_extra_prefix_indent(self.pipeline_continuation_indent, |formatter| {
                 formatter.write_text(&comment.text);
@@ -906,7 +906,7 @@ where
         stmt: &Stmt,
         operator_span: Span,
     ) -> Result<()> {
-        self.format_pipeline_stmt_with_leading_comment_start(stmt, Some(operator_span.end.offset))
+        self.format_pipeline_stmt_with_leading_comment_start(stmt, Some(operator_span.end.offset()))
     }
 
     pub(super) fn format_pipeline_stmt_with_leading_comment_start(
@@ -915,7 +915,7 @@ where
         min_comment_start: Option<usize>,
     ) -> Result<()> {
         let stmt_facts = self.facts().stmt(stmt);
-        let statement_start = stmt_facts.attachment_span().start.offset;
+        let statement_start = stmt_facts.attachment_span().start.offset();
         let next_line = stmt_facts.rendered_start_line();
         let leading = stmt
             .leading_comments
@@ -923,9 +923,9 @@ where
             .filter_map(|comment| self.source_map().source_comment(*comment))
             .filter(|comment| {
                 !comment.inline()
-                    && comment.span().end.offset <= statement_start
+                    && comment.span().end.offset() <= statement_start
                     && min_comment_start
-                        .is_none_or(|min_start| comment.span().start.offset >= min_start)
+                        .is_none_or(|min_start| comment.span().start.offset() >= min_start)
             })
             .collect::<Vec<_>>();
         if let Some(operator_end) = min_comment_start {
@@ -989,14 +989,14 @@ where
     ) -> bool {
         let command_start = interstitial_comment_end(
             stmt,
-            operator_span.end.offset,
+            operator_span.end.offset(),
             self.source(),
             self.source_map(),
         );
-        if command_start <= operator_span.end.offset {
+        if command_start <= operator_span.end.offset() {
             return false;
         }
-        let comments = self.own_line_comments_in_region(operator_span.end.offset, command_start);
+        let comments = self.own_line_comments_in_region(operator_span.end.offset(), command_start);
         let emitted = !comments.is_empty();
         for comment in comments {
             self.write_text(&comment.text);
@@ -1130,14 +1130,14 @@ fn redirect_has_adjacent_numeric_fd_prefix(
     let Some(SimpleCommandPart::Argument(word)) = previous_part else {
         return false;
     };
-    if word.span.end.offset != redirect.span.start.offset {
+    if word.span.end.offset() != redirect.span.start.offset() {
         return false;
     }
-    let Some(raw) = source.get(word.span.start.offset..word.span.end.offset) else {
+    let Some(raw) = source.get(word.span.start.offset()..word.span.end.offset()) else {
         return false;
     };
     raw.chars().all(|ch| ch.is_ascii_digit())
-        && word.span.start.offset > command.name.span.end.offset
+        && word.span.start.offset() > command.name.span.end.offset()
 }
 
 fn sequence_verbatim_span(statements: &StmtSeq, source_map: &SourceMap<'_>) -> Option<Span> {

--- a/crates/shuck-formatter/src/streaming/substitutions.rs
+++ b/crates/shuck-formatter/src/streaming/substitutions.rs
@@ -181,8 +181,8 @@ pub(super) fn normalize_scalar_assignment_unquoted_continuations(
         return None;
     };
     if !facts.has_raw_continuation_backslash_between(
-        assignment.span.start.offset,
-        assignment.span.end.offset,
+        assignment.span.start.offset(),
+        assignment.span.end.offset(),
     ) {
         return None;
     }
@@ -311,10 +311,10 @@ pub(super) fn pipeline_operator_breaks(
     let mut breaks = Vec::with_capacity(operators.len());
     for (statement, (_, operator_span)) in statements.iter().skip(1).zip(operators.iter()) {
         let next_start =
-            interstitial_comment_end(statement, operator_span.end.offset, source, source_map);
+            interstitial_comment_end(statement, operator_span.end.offset(), source, source_map);
         breaks.push(
             source_map.operator_starts_or_ends_line(*operator_span)
-                || source_map.contains_newline_between(operator_span.end.offset, next_start),
+                || source_map.contains_newline_between(operator_span.end.offset(), next_start),
         );
     }
 
@@ -532,12 +532,12 @@ pub(super) fn conditional_binary_has_explicit_rhs_break(
     }
     source_map.operator_starts_or_ends_line(expression.op_span)
         || source_map.contains_newline_between(
-            expression.left.span().end.offset,
-            expression.op_span.start.offset,
+            expression.left.span().end.offset(),
+            expression.op_span.start.offset(),
         )
         || source_map.contains_newline_between(
-            expression.op_span.end.offset,
-            expression.right.span().start.offset,
+            expression.op_span.end.offset(),
+            expression.right.span().start.offset(),
         )
 }
 

--- a/crates/shuck-formatter/src/word/command_substitution.rs
+++ b/crates/shuck-formatter/src/word/command_substitution.rs
@@ -10,14 +10,14 @@ pub(super) fn push_raw_word_with_normalized_command_redirect_spacing(
 ) {
     let mut spans = Vec::new();
     collect_raw_command_substitution_spans(word.parts.as_slice(), &mut spans);
-    spans.sort_by_key(|span| span.start.offset);
-    let mut cursor = word.span.start.offset;
-    let word_end = word.span.end.offset.min(source.len());
+    spans.sort_by_key(|span| span.start.offset());
+    let mut cursor = word.span.start.offset();
+    let word_end = word.span.end.offset().min(source.len());
     let source_view = SourceView::new(source);
     let mut wrote_span = false;
     for span in spans {
-        let start = span.start.offset;
-        let end = span.end.offset;
+        let start = span.start.offset();
+        let end = span.end.offset();
         if start < cursor || end > word_end || start >= end {
             continue;
         }
@@ -1353,7 +1353,7 @@ pub(super) fn render_process_substitution(
     let has_heredoc = stmt_seq_has_heredoc(context.facts, body);
     let mut nested = String::new();
     context
-        .format_stmt_sequence_to_buf(body, span.end.offset.checked_sub(1), &mut nested)
+        .format_stmt_sequence_to_buf(body, span.end.offset().checked_sub(1), &mut nested)
         .ok()?;
 
     let prefix = if is_input { '<' } else { '>' };
@@ -1385,7 +1385,7 @@ pub(super) fn render_process_substitution(
             rendered.push(')');
         } else {
             let outer_levels =
-                source_indent_units_before_offset(source, span.start.offset, options);
+                source_indent_units_before_offset(source, span.start.offset(), options);
             rendered.push(prefix);
             rendered.push_str("(\n");
             push_indented_rendered_block(rendered, trimmed, options, outer_levels + 1);

--- a/crates/shuck-formatter/src/word/core.rs
+++ b/crates/shuck-formatter/src/word/core.rs
@@ -5,17 +5,17 @@ use super::raw_rewrites::*;
 use super::*;
 
 pub(crate) fn word_gap_end_before_trailing_continuation(word: &Word, source: &str) -> usize {
-    let span_end = word.span.end.offset;
+    let span_end = word.span.end.offset();
     let part_end = word
         .parts
         .iter()
-        .map(|part| part.span.end.offset)
+        .map(|part| part.span.end.offset())
         .max()
         .unwrap_or(span_end);
     if part_end >= span_end {
         return span_end;
     }
-    let Some(last_part) = word.parts.iter().max_by_key(|part| part.span.end.offset) else {
+    let Some(last_part) = word.parts.iter().max_by_key(|part| part.span.end.offset()) else {
         return span_end;
     };
     if !matches!(
@@ -286,7 +286,7 @@ pub(super) fn word_part_has_escaped_command_substitution(
             CommandSubstitutionSyntax::DollarParen => {
                 raw_source_slice(span, source).is_some_and(|raw| raw.starts_with("\\$("))
                     || source
-                        .get(..span.start.offset)
+                        .get(..span.start.offset())
                         .is_some_and(|prefix| prefix.ends_with('\\'))
             }
         },
@@ -570,7 +570,7 @@ pub(super) fn render_word_part(
                     let fallback = RawCommandSubstitutionCommentFallback {
                         raw,
                         body,
-                        span_start: span.start.offset,
+                        span_start: span.start.offset(),
                         context: env,
                     };
                     if commented_command_substitution_can_use_structural_formatter(body) {
@@ -578,7 +578,7 @@ pub(super) fn render_word_part(
                         if render_command_substitution(
                             rendered,
                             body,
-                            span.end.offset,
+                            span.end.offset(),
                             env,
                             layout,
                             1,
@@ -606,7 +606,7 @@ pub(super) fn render_word_part(
                 } else if render_command_substitution(
                     rendered,
                     body,
-                    span.end.offset,
+                    span.end.offset(),
                     env,
                     layout,
                     1,
@@ -620,7 +620,7 @@ pub(super) fn render_word_part(
             } else if render_command_substitution(
                 rendered,
                 body,
-                span.end.offset,
+                span.end.offset(),
                 env,
                 command_substitution_layout(
                     None,
@@ -648,7 +648,7 @@ pub(super) fn render_word_part(
                             rendered,
                             raw,
                             source,
-                            span.start.offset,
+                            span.start.offset(),
                             options,
                         );
                     } else {

--- a/crates/shuck-formatter/src/word/heredoc.rs
+++ b/crates/shuck-formatter/src/word/heredoc.rs
@@ -63,7 +63,7 @@ pub(super) fn render_heredoc_body_part(
             } else if render_heredoc_body_command_substitution(
                 rendered,
                 body,
-                span.end.offset,
+                span.end.offset(),
                 source,
                 options,
                 facts,
@@ -82,7 +82,7 @@ pub(super) fn render_heredoc_body_part(
                 if render_command_substitution(
                     rendered,
                     body,
-                    span.end.offset,
+                    span.end.offset(),
                     context,
                     layout,
                     embedded_command_indent_levels,
@@ -137,14 +137,14 @@ pub(super) fn escaped_heredoc_expansion_source(
         return Some(raw);
     }
 
-    let start = span.start.offset;
+    let start = span.start.offset();
     if start > 0
         && source
             .as_bytes()
             .get(start - 1)
             .is_some_and(|byte| *byte == b'\\')
     {
-        return source.get(start - 1..span.end.offset);
+        return source.get(start - 1..span.end.offset());
     }
 
     None

--- a/crates/shuck-formatter/src/word/parameter.rs
+++ b/crates/shuck-formatter/src/word/parameter.rs
@@ -315,10 +315,14 @@ pub(super) fn raw_parameter_replacement_parts<'a>(
     }
 
     let span = raw_parameter_span?;
-    let raw_parameter = source.get(span.start.offset..span.end.offset)?;
+    let raw_parameter = source.get(span.start.offset()..span.end.offset())?;
     let raw = raw_parameter.strip_prefix("${")?.strip_suffix('}')?;
-    let raw_body_start = span.start.offset.checked_add("${".len())?;
-    let reference_end = reference.name_span.end.offset.checked_sub(raw_body_start)?;
+    let raw_body_start = span.start.offset().checked_add("${".len())?;
+    let reference_end = reference
+        .name_span
+        .end
+        .offset()
+        .checked_sub(raw_body_start)?;
     let operator = if replace_all { "//" } else { "/" };
     let after_operator = raw.get(reference_end..)?.strip_prefix(operator)?;
     Some(split_raw_parameter_replacement(after_operator))

--- a/crates/shuck-formatter/src/word/raw_rewrites.rs
+++ b/crates/shuck-formatter/src/word/raw_rewrites.rs
@@ -1576,7 +1576,7 @@ pub(super) fn raw_pattern_source_slice<'a>(pattern: &Pattern, source: &'a str) -
 }
 
 pub(super) fn raw_source_slice(span: shuck_ast::Span, source: &str) -> Option<&str> {
-    if span.start.offset >= span.end.offset || span.end.offset > source.len() {
+    if span.start.offset() >= span.end.offset() || span.end.offset() > source.len() {
         return None;
     }
 

--- a/crates/shuck-indexer/src/close_delimiter_index.rs
+++ b/crates/shuck-indexer/src/close_delimiter_index.rs
@@ -704,13 +704,13 @@ impl<'source> CloseDelimiterCollector<'source> {
     }
 
     fn delimiter_range_from_span(&self, span: Span, text: &str) -> Option<TextRange> {
-        let start = span.start.offset;
+        let start = span.start.offset();
         let start_end = start.checked_add(text.len())?;
         if self.source.get(start..start_end) == Some(text) {
             return Some(text_range(start, start_end));
         }
 
-        let end = span.end.offset;
+        let end = span.end.offset();
         let end_start = end.checked_sub(text.len())?;
         if self.source.get(end_start..end) == Some(text) {
             return Some(text_range(end_start, end));

--- a/crates/shuck-indexer/src/region_index.rs
+++ b/crates/shuck-indexer/src/region_index.rs
@@ -1105,7 +1105,7 @@ fn push_range(ranges: &mut Vec<TextRange>, range: TextRange) {
 }
 
 fn heredoc_closing_marker_range(heredoc: &Heredoc, source: &str) -> Option<TextRange> {
-    let mut start = heredoc.body.span.end.offset.min(source.len());
+    let mut start = heredoc.body.span.end.offset().min(source.len());
     if source
         .as_bytes()
         .get(start)

--- a/crates/shuck-linter/src/checker.rs
+++ b/crates/shuck-linter/src/checker.rs
@@ -40,8 +40,8 @@ impl DiagnosticKey {
     fn new(rule: Rule, span: Span) -> Self {
         Self {
             rule,
-            start: span.start.offset,
-            end: span.end.offset,
+            start: span.start.offset(),
+            end: span.end.offset(),
         }
     }
 }
@@ -139,7 +139,7 @@ impl<'a> Checker<'a> {
         let line = self
             .indexer
             .line_index()
-            .line_number(TextSize::new(span.start.offset as u32));
+            .line_number(TextSize::new(span.start.offset() as u32));
         let Ok(line) = u32::try_from(line) else {
             return false;
         };

--- a/crates/shuck-linter/src/facts/arithmetic.rs
+++ b/crates/shuck-linter/src/facts/arithmetic.rs
@@ -275,7 +275,7 @@ pub(crate) fn zsh_option_map_binding_has_prior_assoc_lookup_blocker(
     semantic.bindings_for(owner_name).iter().copied().any(|id| {
         let candidate = semantic.binding(id);
         candidate.scope == binding.scope
-            && candidate.span.start.offset < binding.span.start.offset
+            && candidate.span.start.offset() < binding.span.start.offset()
             && zsh_option_map_binding_blocks_assoc_lookup(candidate)
             && !zsh_option_map_binding_origin(owner_name, candidate, source)
     })
@@ -1584,7 +1584,7 @@ pub(crate) fn var_ref_subscript_has_assoc_semantics(
         return false;
     }
 
-    let scope = semantic.scope_at(subscript.span().start.offset);
+    let scope = semantic.scope_at(subscript.span().start.offset());
     var_ref_name_has_visible_assoc_binding_at(reference, semantic, scope)
 }
 
@@ -1754,7 +1754,7 @@ pub(crate) fn collect_arithmetic_update_operator_spans_in_nested_command_body(
         .command_topology()
         .body(body)
         .for_each_command_visit(true, |_, visit| {
-            let scope = semantic.scope_at(visit.stmt.span.start.offset);
+            let scope = semantic.scope_at(visit.stmt.span.start.offset());
             collect_arithmetic_update_operator_spans_in_command(
                 visit.command,
                 semantic,
@@ -1996,7 +1996,7 @@ fn arithmetic_update_operator_fix_fact(
 }
 
 fn arithmetic_prefix_update_operand_span(operator_span: Span, source: &str) -> Option<Span> {
-    let start = operator_span.end.offset;
+    let start = operator_span.end.offset();
     let end = scan_arithmetic_lvalue_end(source, start)?;
     (end > start).then(|| {
         Span::from_positions(
@@ -2007,7 +2007,7 @@ fn arithmetic_prefix_update_operand_span(operator_span: Span, source: &str) -> O
 }
 
 fn arithmetic_postfix_update_operand_span(operator_span: Span, source: &str) -> Option<Span> {
-    let end = operator_span.start.offset;
+    let end = operator_span.start.offset();
     let start = scan_arithmetic_lvalue_start(source, end)?;
     (start < end).then(|| {
         let start_position = position_at_offset_on_same_line(operator_span.start, start);
@@ -2138,11 +2138,11 @@ fn is_arithmetic_identifier_continue(byte: u8) -> bool {
 }
 
 fn position_at_offset_on_same_line(anchor: Position, offset: usize) -> Position {
-    Position {
-        line: anchor.line,
-        column: anchor.column.saturating_sub(anchor.offset - offset),
+    Position::at(
+        anchor.line(),
+        anchor.column().saturating_sub(anchor.offset() - offset),
         offset,
-    }
+    )
 }
 
 pub(crate) fn find_operator_span(
@@ -2180,8 +2180,8 @@ pub(crate) fn double_paren_grouping_anchor(span: Span, source: &str) -> Option<S
         }
         span.start
     } else if text.starts_with('(')
-        && span.start.offset > 0
-        && source.as_bytes().get(span.start.offset - 1) == Some(&b'(')
+        && span.start.offset() > 0
+        && source.as_bytes().get(span.start.offset() - 1) == Some(&b'(')
     {
         let stripped = text.strip_prefix('(')?;
         let body_start =
@@ -2192,11 +2192,11 @@ pub(crate) fn double_paren_grouping_anchor(span: Span, source: &str) -> Option<S
         if !has_grouping_operator {
             return None;
         }
-        Position {
-            line: span.start.line,
-            column: span.start.column - 1,
-            offset: span.start.offset - 1,
-        }
+        Position::at(
+            span.start.line(),
+            span.start.column() - 1,
+            span.start.offset() - 1,
+        )
     } else {
         return None;
     };

--- a/crates/shuck-linter/src/facts/arrays.rs
+++ b/crates/shuck-linter/src/facts/arrays.rs
@@ -117,7 +117,7 @@ impl<'a, 'src> PlainUnindexedArrayReferenceContext<'a, 'src> {
         }
 
         self.semantic
-            .shell_behavior_at(reference.span.start.offset)
+            .shell_behavior_at(reference.span.start.offset())
             .array_reference_policy()
     }
 
@@ -127,7 +127,7 @@ impl<'a, 'src> PlainUnindexedArrayReferenceContext<'a, 'src> {
             .to_vec();
         candidate_bindings.into_iter().any(|binding_id| {
             let binding = self.semantic.binding(binding_id);
-            binding.span.start.offset <= reference.span.start.offset
+            binding.span.start.offset() <= reference.span.start.offset()
                 && self
                     .same_simple_command_is_assignment_only(binding.span, reference.span)
                     .is_some_and(|assignment_only| {
@@ -168,7 +168,9 @@ impl<'a, 'src> PlainUnindexedArrayReferenceContext<'a, 'src> {
         let reference_binding = self.resolved_binding_id(reference.id);
         self.presence_test_ends_by_binding(&reference.name)
             .get(&reference_binding)
-            .is_some_and(|ends| ends.partition_point(|end| *end < reference.span.start.offset) > 0)
+            .is_some_and(|ends| {
+                ends.partition_point(|end| *end < reference.span.start.offset()) > 0
+            })
     }
 
     fn presence_test_ends_by_binding(
@@ -183,7 +185,7 @@ impl<'a, 'src> PlainUnindexedArrayReferenceContext<'a, 'src> {
                 by_binding
                     .entry(binding_id)
                     .or_default()
-                    .push(test.command_span().end.offset);
+                    .push(test.command_span().end.offset());
             }
 
             for test in self.facts.assignments().presence_test_names(name) {
@@ -194,7 +196,7 @@ impl<'a, 'src> PlainUnindexedArrayReferenceContext<'a, 'src> {
                 by_binding
                     .entry(binding_id)
                     .or_default()
-                    .push(test.command_span().end.offset);
+                    .push(test.command_span().end.offset());
             }
 
             for ends in by_binding.values_mut() {
@@ -242,7 +244,7 @@ impl<'a, 'src> PlainUnindexedArrayReferenceContext<'a, 'src> {
                     })
                     .collect::<Vec<_>>();
                 bindings.sort_unstable_by_key(|binding_id| {
-                    self.semantic.binding(*binding_id).span.start.offset
+                    self.semantic.binding(*binding_id).span.start.offset()
                 });
                 bindings
             })
@@ -277,10 +279,10 @@ impl<'a, 'src> PlainUnindexedArrayReferenceContext<'a, 'src> {
         reference_span: Span,
     ) -> Option<bool> {
         let binding_ancestors = self
-            .simple_command_ancestors(binding_span.start.offset)
+            .simple_command_ancestors(binding_span.start.offset())
             .to_vec();
         let reference_ancestors = self
-            .simple_command_ancestors(reference_span.start.offset)
+            .simple_command_ancestors(reference_span.start.offset())
             .to_vec();
 
         for reference_ancestor in reference_ancestors {
@@ -303,7 +305,7 @@ pub(crate) struct SimpleCommandAncestor {
 }
 
 pub(crate) fn span_is_within(outer: Span, inner: Span) -> bool {
-    outer.start.offset <= inner.start.offset && inner.end.offset <= outer.end.offset
+    outer.start.offset() <= inner.start.offset() && inner.end.offset() <= outer.end.offset()
 }
 
 pub(crate) fn loop_header_word_quote(facts: &LinterFacts<'_>, span: Span) -> Option<WordQuote> {
@@ -440,7 +442,7 @@ pub(crate) fn has_unclosed_assoc_key_prefix(word: &Word, source: &str) -> bool {
     }
 
     let mut excluded = expansion_part_spans(word);
-    excluded.sort_by_key(|span| span.start.offset);
+    excluded.sort_by_key(|span| span.start.offset());
     let mut excluded = excluded.into_iter().peekable();
 
     let mut bracket_depth = 0_i32;
@@ -450,16 +452,16 @@ pub(crate) fn has_unclosed_assoc_key_prefix(word: &Word, source: &str) -> bool {
     let mut saw_equals = false;
 
     for (offset, ch) in text.char_indices() {
-        let absolute_offset = word.span.start.offset + offset;
+        let absolute_offset = word.span.start.offset() + offset;
         while matches!(
             excluded.peek(),
-            Some(span) if absolute_offset >= span.end.offset
+            Some(span) if absolute_offset >= span.end.offset()
         ) {
             excluded.next();
         }
         if matches!(
             excluded.peek(),
-            Some(span) if absolute_offset >= span.start.offset && absolute_offset < span.end.offset
+            Some(span) if absolute_offset >= span.start.offset() && absolute_offset < span.end.offset()
         ) {
             continue;
         }

--- a/crates/shuck-linter/src/facts/assignments.rs
+++ b/crates/shuck-linter/src/facts/assignments.rs
@@ -701,7 +701,7 @@ pub(crate) fn build_assignment_spacing_spans(
         collect_assignment_spacing_spans_in_command(fact.command(), source, &mut spans);
     }
 
-    spans.sort_unstable_by_key(|span| (span.start.offset, span.end.offset));
+    spans.sort_unstable_by_key(|span| (span.start.offset(), span.end.offset()));
     spans.dedup();
     spans
 }
@@ -933,14 +933,14 @@ fn is_assignment_spacing_exempt_target(target: &str) -> bool {
 fn first_word_start_after(command_span: Span, assignments: &[Assignment], source: &str) -> Span {
     let start = assignments
         .last()
-        .map_or(command_span.start.offset, |assignment| {
-            assignment.span.end.offset
+        .map_or(command_span.start.offset(), |assignment| {
+            assignment.span.end.offset()
         });
-    let end = command_span.end.offset.min(source.len());
+    let end = command_span.end.offset().min(source.len());
     let next = first_command_word_offset_in_gap(source, start, end);
     let position = command_span
         .start
-        .advanced_by(&source[command_span.start.offset..next]);
+        .advanced_by(&source[command_span.start.offset()..next]);
     Span::from_positions(position, position)
 }
 
@@ -967,10 +967,10 @@ fn horizontal_whitespace_span_between(
     end: Position,
     source: &str,
 ) -> Option<Span> {
-    if start.offset >= end.offset || end.offset > source.len() {
+    if start.offset() >= end.offset() || end.offset() > source.len() {
         return None;
     }
-    let gap = source.get(start.offset..end.offset)?;
+    let gap = source.get(start.offset()..end.offset())?;
     if gap_is_assignment_spacing_whitespace(gap) {
         Some(Span::from_positions(start, end))
     } else {
@@ -1005,7 +1005,7 @@ fn gap_is_assignment_spacing_whitespace(gap: &str) -> bool {
 }
 
 fn span_is_empty(span: Span) -> bool {
-    span.start.offset == span.end.offset
+    span.start.offset() == span.end.offset()
 }
 
 #[cfg_attr(shuck_profiling, inline(never))]
@@ -1214,7 +1214,7 @@ fn spacey_time_assignment_fact(
         return Some(fact);
     }
 
-    let prefix = source.get(command.span.start.offset..inner.name.span.start.offset)?;
+    let prefix = source.get(command.span.start.offset()..inner.name.span.start.offset())?;
     if prefix.trim() != "time" {
         return None;
     }
@@ -1252,11 +1252,11 @@ pub(crate) fn zsh_declaration_brace_assignment_target(
     let Some(target_end) = prefix.find("+=").or_else(|| prefix.find('=')) else {
         return false;
     };
-    let target_end_offset = word.span.start.offset + target_end;
+    let target_end_offset = word.span.start.offset() + target_end;
 
     word.brace_syntax()
         .iter()
-        .any(|brace| brace.expands() && brace.span.end.offset <= target_end_offset)
+        .any(|brace| brace.expands() && brace.span.end.offset() <= target_end_offset)
 }
 
 pub(crate) fn bare_command_name_assignment_span<'a>(
@@ -1711,14 +1711,14 @@ pub(crate) fn build_env_prefix_scope_spans(
 
     scope_spans
         .assignment_scope_spans
-        .sort_by_key(|span| (span.start.offset, span.end.offset));
+        .sort_by_key(|span| (span.start.offset(), span.end.offset()));
     scope_spans
         .expansion_scope_spans
-        .sort_by_key(|span| (span.start.offset, span.end.offset));
+        .sort_by_key(|span| (span.start.offset(), span.end.offset()));
     scope_spans.expansion_fix_facts.sort_by_key(|fact| {
         (
-            fact.diagnostic_span.start.offset,
-            fact.diagnostic_span.end.offset,
+            fact.diagnostic_span.start.offset(),
+            fact.diagnostic_span.end.offset(),
         )
     });
     scope_spans
@@ -1747,15 +1747,15 @@ pub(crate) fn env_prefix_expansion_fix_seed(
     let first_assignment = assignments.first()?;
     let last_assignment = assignments.last()?;
     let prefix = source.get(
-        line_start_offset(source, first_assignment.span.start.offset)
-            ..first_assignment.span.start.offset,
+        line_start_offset(source, first_assignment.span.start.offset())
+            ..first_assignment.span.start.offset(),
     )?;
     if !prefix.bytes().all(|byte| matches!(byte, b' ' | b'\t')) {
         return None;
     }
 
     let body_start = skip_env_prefix_separator(source, last_assignment.span.end)?;
-    if body_start.offset <= last_assignment.span.end.offset {
+    if body_start.offset() <= last_assignment.span.end.offset() {
         return None;
     }
 
@@ -1776,7 +1776,7 @@ pub(crate) fn line_start_offset(source: &str, offset: usize) -> usize {
 
 pub(crate) fn skip_env_prefix_separator(source: &str, start: Position) -> Option<Position> {
     let mut position = start;
-    let mut tail = source.get(start.offset..)?;
+    let mut tail = source.get(start.offset()..)?;
     while let Some(ch) = tail.chars().next() {
         if matches!(ch, ' ' | '\t' | '\r' | '\n') {
             position.advance(ch);
@@ -2323,8 +2323,8 @@ pub(crate) fn build_nonpersistent_assignment_spans(
         if let Some(extra_reset_sites) = &extra_reset_sites
             && extra_reset_sites.iter().any(|reset| {
                 reset.name == effect.name
-                    && reset.span.start.offset > effect.assignment_span.end.offset
-                    && reset.flow_span.end.offset <= effect.later_use_span.start.offset
+                    && reset.span.start.offset() > effect.assignment_span.end.offset()
+                    && reset.flow_span.end.offset() <= effect.later_use_span.start.offset()
                     && nonpersistent_reset_site_covers_later_use(
                         semantic,
                         semantic_analysis,
@@ -2361,11 +2361,11 @@ pub(crate) fn build_nonpersistent_assignment_spans(
 
     let mut seen = FxHashSet::default();
     later_use_sites.retain(|site| seen.insert((FactSpan::new(site.span), site.name.clone())));
-    later_use_sites.sort_by_key(|site| (site.span.start.offset, site.span.end.offset));
+    later_use_sites.sort_by_key(|site| (site.span.start.offset(), site.span.end.offset()));
 
     seen.clear();
     assignment_sites.retain(|site| seen.insert((FactSpan::new(site.span), site.name.clone())));
-    assignment_sites.sort_by_key(|site| (site.span.start.offset, site.span.end.offset));
+    assignment_sites.sort_by_key(|site| (site.span.start.offset(), site.span.end.offset()));
 
     NonpersistentAssignmentSpans {
         subshell_assignment_sites: assignment_sites,
@@ -2379,7 +2379,7 @@ pub(crate) fn nonpersistent_assignment_reaches_later_use(
 ) -> bool {
     let assignment_scope = semantic.binding(effect.assignment_binding).scope;
     let assignment_transient = semantic.innermost_transient_scope_within_function(assignment_scope);
-    let later_use_scope = semantic.scope_at(effect.later_use_span.start.offset);
+    let later_use_scope = semantic.scope_at(effect.later_use_span.start.offset());
     let later_use_transient = semantic.innermost_transient_scope_within_function(later_use_scope);
     if let Some(later_use_transient) = later_use_transient {
         let Some(assignment_transient) = assignment_transient else {
@@ -2398,13 +2398,13 @@ pub(crate) fn nonpersistent_assignment_reaches_later_use(
 }
 
 pub(crate) fn zsh_later_use_is_parameter_subscript_flag(source: &str, span: Span) -> bool {
-    if span.start.offset + 1 != span.end.offset {
+    if span.start.offset() + 1 != span.end.offset() {
         return false;
     }
 
     let bytes = source.as_bytes();
-    let start = span.start.offset;
-    let end = span.end.offset;
+    let start = span.start.offset();
+    let end = span.end.offset();
     if start == 0
         || end >= bytes.len()
         || bytes[start - 1] != b'('
@@ -2451,7 +2451,7 @@ pub(crate) fn nonpersistent_reset_site_covers_later_use(
     }
 
     let Some(later_use_command) =
-        semantic.innermost_command_id_at(effect.later_use_span.start.offset)
+        semantic.innermost_command_id_at(effect.later_use_span.start.offset())
     else {
         return false;
     };
@@ -2464,7 +2464,7 @@ pub(crate) fn nonpersistent_reset_site_covers_later_use(
     let assignment_scope = semantic.binding(effect.assignment_binding).scope;
     let entry = semantic_analysis.flow_entry_block_for_binding_scopes(
         &[assignment_scope],
-        effect.later_use_span.start.offset,
+        effect.later_use_span.start.offset(),
     );
     later_use_blocks.iter().copied().all(|target| {
         semantic_analysis.blocks_cover_all_paths_to_block(entry, target, &reset_blocks)
@@ -2472,7 +2472,7 @@ pub(crate) fn nonpersistent_reset_site_covers_later_use(
 }
 
 pub(crate) fn span_contains(outer: Span, inner: Span) -> bool {
-    outer.start.offset <= inner.start.offset && inner.end.offset <= outer.end.offset
+    outer.start.offset() <= inner.start.offset() && inner.end.offset() <= outer.end.offset()
 }
 
 pub(crate) fn build_subshell_loop_assignment_report_spans(
@@ -2648,15 +2648,20 @@ pub(crate) fn build_nonpersistent_assignment_extra_reset_sites(
         left.name
             .as_str()
             .cmp(right.name.as_str())
-            .then_with(|| left.span.start.offset.cmp(&right.span.start.offset))
-            .then_with(|| left.span.end.offset.cmp(&right.span.end.offset))
+            .then_with(|| left.span.start.offset().cmp(&right.span.start.offset()))
+            .then_with(|| left.span.end.offset().cmp(&right.span.end.offset()))
             .then_with(|| {
                 left.flow_span
                     .start
-                    .offset
-                    .cmp(&right.flow_span.start.offset)
+                    .offset()
+                    .cmp(&right.flow_span.start.offset())
             })
-            .then_with(|| left.flow_span.end.offset.cmp(&right.flow_span.end.offset))
+            .then_with(|| {
+                left.flow_span
+                    .end
+                    .offset()
+                    .cmp(&right.flow_span.end.offset())
+            })
             .then_with(|| left.command_id.index().cmp(&right.command_id.index()))
     });
     resets.dedup_by(|left, right| {
@@ -2683,12 +2688,13 @@ pub(crate) fn reset_flow_span_for_command(
             if span_contains(parent_span, command_span)
                 && !semantic_analysis.block_ids_for_span(parent_span).is_empty()
             {
-                let before_command = &source[parent_span.start.offset..command_span.start.offset];
+                let before_command =
+                    &source[parent_span.start.offset()..command_span.start.offset()];
                 if text_ends_with_pipeline_operator(before_command.trim_end()) {
                     let previous_len = pipeline_span
-                        .map(|span: Span| span.end.offset - span.start.offset)
+                        .map(|span: Span| span.end.offset() - span.start.offset())
                         .unwrap_or(usize::MAX);
-                    let parent_len = parent_span.end.offset - parent_span.start.offset;
+                    let parent_len = parent_span.end.offset() - parent_span.start.offset();
                     if parent_len < previous_len {
                         pipeline_span = Some(parent_span);
                     }
@@ -2822,7 +2828,7 @@ pub(crate) fn binding_command_is_unconditional_in_function(
     semantic_analysis: &SemanticAnalysis<'_>,
     binding: &Binding,
 ) -> bool {
-    let Some(current) = semantic.innermost_command_id_at(binding.span.start.offset) else {
+    let Some(current) = semantic.innermost_command_id_at(binding.span.start.offset()) else {
         return true;
     };
 
@@ -2979,7 +2985,7 @@ pub(crate) fn fallback_function_binding_is_callable_from_function_body(
     binding: BindingId,
 ) -> bool {
     let binding = semantic.binding(binding);
-    if binding.span.start.offset <= call_name_span.start.offset {
+    if binding.span.start.offset() <= call_name_span.start.offset() {
         return true;
     }
 
@@ -2994,7 +3000,7 @@ pub(crate) fn fallback_function_binding_is_callable_from_function_body(
         semantic,
         semantic_analysis,
         command_function_scope,
-        binding.span.start.offset,
+        binding.span.start.offset(),
     )
 }
 
@@ -3012,7 +3018,8 @@ pub(crate) fn function_scope_may_run_before_offset(
                 let name = &semantic.binding(function_binding).name;
                 semantic_analysis.resolved_function_call_sites(name).any(
                     |(site, resolved_binding)| {
-                        resolved_binding == function_binding && site.name_span.start.offset < offset
+                        resolved_binding == function_binding
+                            && site.name_span.start.offset() < offset
                     },
                 )
             })
@@ -3114,23 +3121,23 @@ pub(crate) fn binary_child_pipe_tail_relation(
     let parent_span = semantic.command_syntax_span(parent);
     let child_span = semantic.command_syntax_span(child);
     if child_span.start == parent_span.start {
-        let after_child = &source[child_span.end.offset..parent_span.end.offset];
+        let after_child = &source[child_span.end.offset()..parent_span.end.offset()];
         return text_starts_with_pipeline_operator(after_child.trim_start()).map(|_| false);
     }
 
-    let before_child = &source[parent_span.start.offset..child_span.start.offset];
+    let before_child = &source[parent_span.start.offset()..child_span.start.offset()];
     let before_child = before_child.trim_end();
     text_ends_with_pipeline_operator(before_child).then_some(true)
 }
 
 pub(crate) fn command_is_textual_pipeline_tail_operand(command_span: Span, source: &str) -> bool {
-    let before_command = &source[..command_span.start.offset];
+    let before_command = &source[..command_span.start.offset()];
     let before_command = before_command.trim_end();
     if !text_ends_with_pipeline_operator(before_command) {
         return false;
     }
 
-    let after_command = &source[command_span.end.offset..];
+    let after_command = &source[command_span.end.offset()..];
     let after_command = after_command.trim_start();
     !after_command.starts_with('|')
 }
@@ -3334,13 +3341,13 @@ pub(crate) fn build_innermost_command_ids_by_offset(
 
         while let Some(command) = commands.get(next_command) {
             let span = command.span();
-            if span.start.offset > offset {
+            if span.start.offset() > offset {
                 break;
             }
 
-            pop_finished_commands(&mut active_commands, span.start.offset);
+            pop_finished_commands(&mut active_commands, span.start.offset());
             active_commands.push(OpenCommand {
-                end_offset: span.end.offset,
+                end_offset: span.end.offset(),
                 id: command.id(),
             });
             next_command += 1;
@@ -3416,7 +3423,7 @@ pub(crate) fn build_dollar_question_after_command_spans(
 
     let mut seen = FxHashSet::default();
     spans.retain(|span| seen.insert(FactSpan::new(*span)));
-    spans.sort_by_key(|span| (span.start.offset, span.end.offset));
+    spans.sort_by_key(|span| (span.start.offset(), span.end.offset()));
     spans
 }
 
@@ -3524,7 +3531,8 @@ pub(crate) fn word_for_declaration_value_span(command: &Command, span: Span) -> 
     };
 
     command.args.iter().find(|word| {
-        span.start.offset >= word.span.start.offset && span.end.offset <= word.span.end.offset
+        span.start.offset() >= word.span.start.offset()
+            && span.end.offset() <= word.span.end.offset()
     })
 }
 
@@ -3542,7 +3550,8 @@ pub(crate) fn word_parts_in_span(word: &Word, span: Span) -> Vec<&WordPartNode> 
     word.parts
         .iter()
         .filter(|part| {
-            span.start.offset <= part.span.start.offset && part.span.end.offset <= span.end.offset
+            span.start.offset() <= part.span.start.offset()
+                && part.span.end.offset() <= span.end.offset()
         })
         .collect()
 }

--- a/crates/shuck-linter/src/facts/braces.rs
+++ b/crates/shuck-linter/src/facts/braces.rs
@@ -59,10 +59,10 @@ pub(crate) fn build_literal_brace_spans(
         &mut scratch,
     );
     spans.retain(|span| {
-        !region_index.is_expansion_brace_edge(TextSize::new(span.start.offset as u32))
+        !region_index.is_expansion_brace_edge(TextSize::new(span.start.offset() as u32))
     });
-    spans.sort_by_key(|span| (span.start.offset, span.end.offset));
-    spans.dedup_by_key(|span| (span.start.offset, span.end.offset));
+    spans.sort_by_key(|span| (span.start.offset(), span.end.offset()));
+    spans.dedup_by_key(|span| (span.start.offset(), span.end.offset()));
     spans
 }
 
@@ -95,7 +95,7 @@ pub(crate) fn collect_literal_brace_spans_for_word(
     scratch.dynamic_exclusions.clear();
     collect_dynamic_brace_exclusions(
         &word.parts,
-        word.span.start.offset,
+        word.span.start.offset(),
         source,
         region_index,
         &mut scratch.dynamic_exclusions,
@@ -177,11 +177,9 @@ pub(crate) fn literal_brace_word_span_is_reportable(
     span: Span,
     nested_escaped_templates: &[Span],
 ) -> bool {
-    !nested_escaped_templates
-        .iter()
-        .copied()
-        .any(|body| body.start.offset <= span.start.offset && span.start.offset < body.end.offset)
-        && !word_span_is_inside_command_substitution(nodes, fact, fact_store, span)
+    !nested_escaped_templates.iter().copied().any(|body| {
+        body.start.offset() <= span.start.offset() && span.start.offset() < body.end.offset()
+    }) && !word_span_is_inside_command_substitution(nodes, fact, fact_store, span)
 }
 
 pub(crate) fn word_span_is_inside_command_substitution(
@@ -218,8 +216,8 @@ pub(crate) fn is_find_exec_placeholder_word(
     }
 
     commands.iter().any(|command| {
-        command.stmt().span.start.offset <= occurrence_span(nodes, fact).start.offset
-            && command.stmt().span.end.offset >= occurrence_span(nodes, fact).end.offset
+        command.stmt().span.start.offset() <= occurrence_span(nodes, fact).start.offset()
+            && command.stmt().span.end.offset() >= occurrence_span(nodes, fact).end.offset()
             && is_find_exec_command(command, source)
     }) || line_has_find_exec_placeholder_context(locator, occurrence_span(nodes, fact))
 }
@@ -257,15 +255,15 @@ pub(crate) fn line_has_find_exec_placeholder_context(
     brace_span: Span,
 ) -> bool {
     let source = locator.source();
-    let Some(line_range) = locator.line_range(brace_span.start.line) else {
+    let Some(line_range) = locator.line_range(brace_span.start.line()) else {
         return false;
     };
     let line_start_offset = usize::from(line_range.start());
     let line_text = line_range.slice(source);
-    let Some(relative_start) = brace_span.start.offset.checked_sub(line_start_offset) else {
+    let Some(relative_start) = brace_span.start.offset().checked_sub(line_start_offset) else {
         return false;
     };
-    let Some(relative_end) = brace_span.end.offset.checked_sub(line_start_offset) else {
+    let Some(relative_end) = brace_span.end.offset().checked_sub(line_start_offset) else {
         return false;
     };
     if relative_end > line_text.len() {
@@ -447,7 +445,7 @@ pub(crate) fn collect_brace_character_spans(
         if !matches!(ch, '{' | '}') {
             continue;
         }
-        let absolute_offset = span.start.offset + offset;
+        let absolute_offset = span.start.offset() + offset;
         if has_odd_backslash_run_before(source, absolute_offset) {
             continue;
         }
@@ -462,10 +460,10 @@ pub(crate) fn collect_brace_character_spans(
 pub(crate) fn brace_span_has_escaped_dollar_prefix(span: Span, source: &str) -> bool {
     let span_text = span.slice(source);
     if span_text.starts_with("${") {
-        return has_odd_backslash_run_before(source, span.start.offset);
+        return has_odd_backslash_run_before(source, span.start.offset());
     }
 
-    has_escaped_dollar_before(source, span.start.offset)
+    has_escaped_dollar_before(source, span.start.offset())
 }
 
 pub(crate) fn brace_syntax_with_whitespace_is_literal(
@@ -574,8 +572,8 @@ pub(crate) fn collect_unclassified_literal_brace_spans(
         word.brace_syntax()
             .iter()
             .map(|brace| DynamicBraceExcludedSpan {
-                start_offset: brace.span.start.offset - span.start.offset,
-                end_offset: brace.span.end.offset - span.start.offset,
+                start_offset: brace.span.start.offset() - span.start.offset(),
+                end_offset: brace.span.end.offset() - span.start.offset(),
                 kind: DynamicBraceExcludedSpanKind::RuntimeShellSyntax,
             }),
     );
@@ -707,11 +705,11 @@ pub(crate) fn collect_uncovered_command_brace_spans(
 
         scratch
             .covered_spans
-            .sort_by_key(|span| (span.start.offset, span.end.offset));
+            .sort_by_key(|span| (span.start.offset(), span.end.offset()));
 
-        let mut cursor = command_span.start.offset;
+        let mut cursor = command_span.start.offset();
         for span in scratch.covered_spans.iter().copied() {
-            if span.start.offset > cursor {
+            if span.start.offset() > cursor {
                 collect_raw_literal_brace_spans(
                     RawLiteralBraceScan {
                         locator,
@@ -719,16 +717,16 @@ pub(crate) fn collect_uncovered_command_brace_spans(
                         excluded_ranges: heredoc_ranges,
                     },
                     cursor,
-                    span.start.offset,
+                    span.start.offset(),
                     out,
                     &mut scratch.relevant_excluded_ranges,
                     &mut scratch.unmatched_spans,
                 );
             }
-            cursor = cursor.max(span.end.offset);
+            cursor = cursor.max(span.end.offset());
         }
 
-        if command_span.end.offset > cursor {
+        if command_span.end.offset() > cursor {
             collect_raw_literal_brace_spans(
                 RawLiteralBraceScan {
                     locator,
@@ -736,7 +734,7 @@ pub(crate) fn collect_uncovered_command_brace_spans(
                     excluded_ranges: heredoc_ranges,
                 },
                 cursor,
-                command_span.end.offset,
+                command_span.end.offset(),
                 out,
                 &mut scratch.relevant_excluded_ranges,
                 &mut scratch.unmatched_spans,
@@ -747,26 +745,26 @@ pub(crate) fn collect_uncovered_command_brace_spans(
 
 pub(crate) fn redirect_fd_var_brace_span(redirect: &Redirect, source: &str) -> Option<Span> {
     let fd_var_span = redirect.fd_var_span?;
-    let start_offset = fd_var_span.start.offset.checked_sub('{'.len_utf8())?;
-    let end_offset = fd_var_span.end.offset.checked_add('}'.len_utf8())?;
-    if source.get(start_offset..fd_var_span.start.offset)? != "{" {
+    let start_offset = fd_var_span.start.offset().checked_sub('{'.len_utf8())?;
+    let end_offset = fd_var_span.end.offset().checked_add('}'.len_utf8())?;
+    if source.get(start_offset..fd_var_span.start.offset())? != "{" {
         return None;
     }
-    if source.get(fd_var_span.end.offset..end_offset)? != "}" {
+    if source.get(fd_var_span.end.offset()..end_offset)? != "}" {
         return None;
     }
 
     Some(Span::from_positions(
-        Position {
-            line: fd_var_span.start.line,
-            column: fd_var_span.start.column.checked_sub(1)?,
-            offset: start_offset,
-        },
-        Position {
-            line: fd_var_span.end.line,
-            column: fd_var_span.end.column + 1,
-            offset: end_offset,
-        },
+        Position::at(
+            fd_var_span.start.line(),
+            fd_var_span.start.column().checked_sub(1)?,
+            start_offset,
+        ),
+        Position::at(
+            fd_var_span.end.line(),
+            fd_var_span.end.column() + 1,
+            end_offset,
+        ),
     ))
 }
 
@@ -1091,15 +1089,15 @@ pub(crate) fn command_substitution_body_offsets(
     if text.starts_with("$(") && text.ends_with(')') && text.len() >= 3 {
         return Some((
             span,
-            span.start.offset + "$(".len(),
-            span.end.offset - ')'.len_utf8(),
+            span.start.offset() + "$(".len(),
+            span.end.offset() - ')'.len_utf8(),
         ));
     }
     if text.starts_with('`') && text.ends_with('`') && text.len() >= 2 {
         return Some((
             span,
-            span.start.offset + '`'.len_utf8(),
-            span.end.offset - '`'.len_utf8(),
+            span.start.offset() + '`'.len_utf8(),
+            span.end.offset() - '`'.len_utf8(),
         ));
     }
     None
@@ -1337,8 +1335,8 @@ pub(crate) fn collect_dynamic_brace_exclusions(
             WordPart::Literal(_) => {}
             WordPart::DoubleQuoted { .. } if !part.span.slice(source).starts_with("\\\"") => {
                 out.push(DynamicBraceExcludedSpan {
-                    start_offset: part.span.start.offset - word_base_offset,
-                    end_offset: part.span.end.offset - word_base_offset,
+                    start_offset: part.span.start.offset() - word_base_offset,
+                    end_offset: part.span.end.offset() - word_base_offset,
                     kind: DynamicBraceExcludedSpanKind::Quoted,
                 });
             }
@@ -1353,8 +1351,8 @@ pub(crate) fn collect_dynamic_brace_exclusions(
             }
             WordPart::SingleQuoted { .. } => {
                 out.push(DynamicBraceExcludedSpan {
-                    start_offset: part.span.start.offset - word_base_offset,
-                    end_offset: part.span.end.offset - word_base_offset,
+                    start_offset: part.span.start.offset() - word_base_offset,
+                    end_offset: part.span.end.offset() - word_base_offset,
                     kind: DynamicBraceExcludedSpanKind::Quoted,
                 });
             }
@@ -1387,12 +1385,12 @@ pub(crate) fn runtime_shell_dynamic_brace_exclusion(
     word_base_offset: usize,
     region_index: &RegionIndex,
 ) -> DynamicBraceExcludedSpan {
-    let start_offset = part.span.start.offset - word_base_offset;
-    let mut end_offset = part.span.end.offset - word_base_offset;
+    let start_offset = part.span.start.offset() - word_base_offset;
+    let mut end_offset = part.span.end.offset() - word_base_offset;
 
     let part_range = TextRange::new(
-        TextSize::new(part.span.start.offset as u32),
-        TextSize::new(part.span.end.offset as u32),
+        TextSize::new(part.span.start.offset() as u32),
+        TextSize::new(part.span.end.offset() as u32),
     );
     if let Some(pair) = region_index.first_dollar_brace_pair_in(part_range) {
         let pair_end_relative = pair.end().to_u32() as usize - word_base_offset;
@@ -1477,7 +1475,7 @@ pub(crate) fn collect_raw_escaped_parameter_brace_edge_spans(
     let span = word.span;
     let text = span.slice(source);
     excluded.clear();
-    collect_raw_escaped_parameter_exclusions(&word.parts, span.start.offset, source, excluded);
+    collect_raw_escaped_parameter_exclusions(&word.parts, span.start.offset(), source, excluded);
     excluded.sort_by_key(|span| (span.start_offset, span.end_offset));
 
     let mut excluded_index = 0usize;
@@ -1561,13 +1559,13 @@ pub(crate) fn brace_pair_matches_nonliteral_syntax(
     open_offset: usize,
     close_offset: usize,
 ) -> bool {
-    let absolute_open_offset = word.span.start.offset + open_offset;
-    let absolute_close_offset = word.span.start.offset + close_offset + '}'.len_utf8();
+    let absolute_open_offset = word.span.start.offset() + open_offset;
+    let absolute_close_offset = word.span.start.offset() + close_offset + '}'.len_utf8();
 
     word.brace_syntax().iter().any(|brace| {
         brace.kind != BraceSyntaxKind::Literal
-            && brace.span.start.offset == absolute_open_offset
-            && brace.span.end.offset == absolute_close_offset
+            && brace.span.start.offset() == absolute_open_offset
+            && brace.span.end.offset() == absolute_close_offset
     })
 }
 
@@ -1596,8 +1594,8 @@ pub(crate) fn collect_raw_escaped_parameter_exclusions(
             | WordPart::ZshQualifiedGlob(_) => {}
             WordPart::DoubleQuoted { .. } if !part.span.slice(source).starts_with("\\\"") => {
                 out.push(DynamicBraceExcludedSpan {
-                    start_offset: part.span.start.offset - word_base_offset,
-                    end_offset: part.span.end.offset - word_base_offset,
+                    start_offset: part.span.start.offset() - word_base_offset,
+                    end_offset: part.span.end.offset() - word_base_offset,
                     kind: DynamicBraceExcludedSpanKind::Quoted,
                 });
             }
@@ -1605,8 +1603,8 @@ pub(crate) fn collect_raw_escaped_parameter_exclusions(
             WordPart::SingleQuoted { .. }
             | WordPart::CommandSubstitution { .. }
             | WordPart::ProcessSubstitution { .. } => out.push(DynamicBraceExcludedSpan {
-                start_offset: part.span.start.offset - word_base_offset,
-                end_offset: part.span.end.offset - word_base_offset,
+                start_offset: part.span.start.offset() - word_base_offset,
+                end_offset: part.span.end.offset() - word_base_offset,
                 kind: DynamicBraceExcludedSpanKind::Quoted,
             }),
         }

--- a/crates/shuck-linter/src/facts/builder.rs
+++ b/crates/shuck-linter/src/facts/builder.rs
@@ -323,7 +323,7 @@ impl<'a, 'analysis> LinterFactsBuilder<'a, 'analysis> {
                 &mut ifs_literal_backslash_assignment_value_spans,
             );
             let normalized = command::normalize_command(visit.command, self.source);
-            let command_start_offset = command_span(visit.command).start.offset;
+            let command_start_offset = command_span(visit.command).start.offset();
             let scope = context.scope();
             let command_shell_behavior =
                 effective_command_shell_behavior(self.semantic, command_start_offset, &normalized);
@@ -609,10 +609,10 @@ impl<'a, 'analysis> LinterFactsBuilder<'a, 'analysis> {
         }
 
         arithmetic_update_operator_spans
-            .sort_unstable_by_key(|span| (span.start.offset, span.end.offset));
+            .sort_unstable_by_key(|span| (span.start.offset(), span.end.offset()));
         arithmetic_update_operator_spans.dedup();
         redundant_return_status_spans
-            .sort_unstable_by_key(|span| (span.start.offset, span.end.offset));
+            .sort_unstable_by_key(|span| (span.start.offset(), span.end.offset()));
         redundant_return_status_spans.dedup_by_key(|span| FactSpan::new(*span));
         sort_and_dedup_spans(&mut arithmetic_summary.arithmetic_expansion_spans);
         sort_and_dedup_spans(&mut arithmetic_summary.arithmetic_index_subscript_spans);
@@ -626,7 +626,7 @@ impl<'a, 'analysis> LinterFactsBuilder<'a, 'analysis> {
                 Vec::new()
             };
         arithmetic_literal_spans
-            .sort_unstable_by_key(|(span, kind)| (span.start.offset, span.end.offset, *kind));
+            .sort_unstable_by_key(|(span, kind)| (span.start.offset(), span.end.offset(), *kind));
         arithmetic_literal_spans.dedup();
         let arithmetic_literal_facts = arithmetic_literal_spans
             .iter()
@@ -635,7 +635,7 @@ impl<'a, 'analysis> LinterFactsBuilder<'a, 'analysis> {
                     *span,
                     *kind,
                     self.semantic
-                        .shell_behavior_at(span.start.offset)
+                        .shell_behavior_at(span.start.offset())
                         .arithmetic_literals(),
                 )
             })
@@ -870,7 +870,7 @@ impl<'a, 'analysis> LinterFactsBuilder<'a, 'analysis> {
             };
             let behavior = self
                 .semantic
-                .shell_behavior_at(span.start.offset)
+                .shell_behavior_at(span.start.offset())
                 .subscript_indexing();
             *fragment = (*fragment).with_subscript_index_behavior(behavior);
         }
@@ -884,7 +884,7 @@ impl<'a, 'analysis> LinterFactsBuilder<'a, 'analysis> {
             &arithmetic_only_suppressed_subscript_spans,
         );
         let heredoc_summary =
-            build_heredoc_fact_summary(&commands, locator, self.file.span.end.offset);
+            build_heredoc_fact_summary(&commands, locator, self.file.span.end.offset());
         let plus_equals_assignment_spans = build_plus_equals_assignment_spans(&commands);
         let literal_brace_spans = build_literal_brace_spans(
             &word_nodes,
@@ -1025,7 +1025,7 @@ impl<'a, 'analysis> LinterFactsBuilder<'a, 'analysis> {
             &commands,
             commands
                 .iter()
-                .map(|command| command.span().start.offset)
+                .map(|command| command.span().start.offset())
                 .collect(),
         );
         attach_positional_parameter_trim_fixes(
@@ -1039,7 +1039,7 @@ impl<'a, 'analysis> LinterFactsBuilder<'a, 'analysis> {
             self.semantic
                 .bindings()
                 .iter()
-                .map(|binding| binding.span.start.offset)
+                .map(|binding| binding.span.start.offset())
                 .collect(),
         );
         let assignment_value_target_index = build_assignment_value_target_index(&commands);
@@ -1072,7 +1072,7 @@ impl<'a, 'analysis> LinterFactsBuilder<'a, 'analysis> {
                 .map(|escaped| escaped.reference_span),
         );
         backtick_escaped_parameter_reference_spans
-            .sort_by_key(|span| (span.start.offset, span.end.offset));
+            .sort_by_key(|span| (span.start.offset(), span.end.offset()));
         backtick_escaped_parameter_reference_spans.dedup();
         let backtick_double_escaped_parameter_spans =
             word_spans::backtick_double_escaped_parameter_spans(
@@ -1277,14 +1277,14 @@ fn attach_positional_parameter_trim_fixes(
         commands,
         fragments
             .iter()
-            .map(|fragment| fragment.span().start.offset)
+            .map(|fragment| fragment.span().start.offset())
             .collect(),
     );
     let mut fragment_indices_by_command = FxHashMap::<CommandId, Vec<usize>>::default();
     for (index, fragment) in fragments.iter().enumerate() {
         let Some(command_id) = precomputed_command_id_for_offset(
             &command_ids_by_fragment_offset,
-            fragment.span().start.offset,
+            fragment.span().start.offset(),
         ) else {
             continue;
         };
@@ -1306,16 +1306,16 @@ fn attach_positional_parameter_trim_fixes(
         if command.is_nested_word_command() {
             continue;
         }
-        indices.sort_unstable_by_key(|index| fragments[*index].span().start.offset);
+        indices.sort_unstable_by_key(|index| fragments[*index].span().start.offset());
         let first_span = fragments[indices[0]].span();
-        if command.span().start.line != first_span.start.line {
+        if command.span().start.line() != first_span.start.line() {
             continue;
         }
 
-        let line_start = source[..command.span().start.offset]
+        let line_start = source[..command.span().start.offset()]
             .rfind('\n')
             .map_or(0, |offset| offset + 1);
-        let indent = &source[line_start..command.span().start.offset];
+        let indent = &source[line_start..command.span().start.offset()];
         if !indent.bytes().all(|byte| matches!(byte, b' ' | b'\t'))
             || previous_line_ends_with_control_operator(source, line_start)
         {
@@ -1535,7 +1535,7 @@ pub(crate) fn build_c006_suppressing_reference_offsets_by_name(
                 offsets_by_name
                     .entry(reference.name.clone())
                     .or_default()
-                    .push(reference.span.start.offset);
+                    .push(reference.span.start.offset());
             }
         }
     }
@@ -1554,16 +1554,19 @@ pub(crate) fn c006_subscript_reference_suppresses_later_references(
     innermost_command_ids_by_offset: &CommandOffsetLookup,
     reference: &Reference,
 ) -> bool {
-    precomputed_command_id_for_offset(innermost_command_ids_by_offset, reference.span.start.offset)
-        .and_then(|id| {
-            command_fact_indices_by_id
-                .get(id.index())
-                .copied()
-                .flatten()
-                .and_then(|index| commands.get(index))
-        })
-        .and_then(CommandFact::static_utility_name)
-        .is_none_or(|name| !matches!(name, "unset" | "[" | "[[" | "test"))
+    precomputed_command_id_for_offset(
+        innermost_command_ids_by_offset,
+        reference.span.start.offset(),
+    )
+    .and_then(|id| {
+        command_fact_indices_by_id
+            .get(id.index())
+            .copied()
+            .flatten()
+            .and_then(|index| commands.get(index))
+    })
+    .and_then(CommandFact::static_utility_name)
+    .is_none_or(|name| !matches!(name, "unset" | "[" | "[[" | "test"))
 }
 
 pub(crate) fn stmt_seq_contains_nested_control_flow(
@@ -1642,7 +1645,7 @@ pub(crate) fn build_linebreak_in_test_site(
     }
     let insert_offset = linebreak_in_test_insert_offset(current_span, source)?;
 
-    let between = source.get(current_span.end.offset..next.span().start.offset)?;
+    let between = source.get(current_span.end.offset()..next.span().start.offset())?;
     if !between.chars().all(|char| matches!(char, ' ' | '\t')) {
         return None;
     }
@@ -1660,9 +1663,9 @@ pub(crate) fn build_linebreak_in_test_site(
 pub(crate) fn linebreak_in_test_insert_offset(span: Span, source: &str) -> Option<usize> {
     let text = span.slice(source);
     if text.ends_with("\r\n") {
-        Some(span.end.offset - 2)
+        Some(span.end.offset() - 2)
     } else if text.ends_with('\n') {
-        Some(span.end.offset - 1)
+        Some(span.end.offset() - 1)
     } else {
         None
     }
@@ -1773,7 +1776,7 @@ pub(crate) fn sort_and_dedup_case_pattern_expansions(
 ) {
     let mut seen = FxHashSet::default();
     expansions.retain(|fact| seen.insert(FactSpan::new(fact.span())));
-    expansions.sort_by_key(|fact| (fact.span().start.offset, fact.span().end.offset));
+    expansions.sort_by_key(|fact| (fact.span().start.offset(), fact.span().end.offset()));
 }
 
 #[cfg(test)]

--- a/crates/shuck-linter/src/facts/command_options/read.rs
+++ b/crates/shuck-linter/src/facts/command_options/read.rs
@@ -175,10 +175,10 @@ fn read_attached_array_target_name_use(
 fn read_option_attached_target_span(span: Span, source: &str, start: usize, end: usize) -> Span {
     let start_pos = span
         .start
-        .advanced_by(&source[span.start.offset..span.start.offset + start]);
+        .advanced_by(&source[span.start.offset()..span.start.offset() + start]);
     let end_pos = span
         .start
-        .advanced_by(&source[span.start.offset..span.start.offset + end]);
+        .advanced_by(&source[span.start.offset()..span.start.offset() + end]);
     Span::from_positions(start_pos, end_pos)
 }
 

--- a/crates/shuck-linter/src/facts/commands.rs
+++ b/crates/shuck-linter/src/facts/commands.rs
@@ -386,7 +386,7 @@ impl<'facts, 'a> CommandFactRef<'facts, 'a> {
         let Some(word) = self.command_name_word() else {
             return false;
         };
-        let Some(before) = source.get(..word.span.start.offset) else {
+        let Some(before) = source.get(..word.span.start.offset()) else {
             return false;
         };
 
@@ -508,14 +508,14 @@ pub(crate) fn command_span_with_redirects_and_shellcheck_tail(
     let mut end = body_name.span.end;
 
     for word in command.body_args() {
-        if word.span.end.offset > end.offset {
+        if word.span.end.offset() > end.offset() {
             end = word.span.end;
         }
     }
 
     for redirect in command.redirect_facts() {
         let redirect_end = redirect.redirect().span.end;
-        if redirect_end.offset > end.offset {
+        if redirect_end.offset() > end.offset() {
             end = redirect_end;
         }
     }
@@ -680,7 +680,7 @@ pub(crate) fn extend_over_shellcheck_trailing_inline_space(
     end: Position,
     source: &str,
 ) -> Position {
-    let tail = &source[end.offset..];
+    let tail = &source[end.offset()..];
     let spaces_len = tail
         .char_indices()
         .take_while(|(_, ch)| matches!(ch, ' ' | '\t'))
@@ -713,7 +713,7 @@ pub(crate) fn build_background_semicolon_spans(
     let case_terminator_starts = case_items
         .iter()
         .filter_map(CaseItemFact::terminator_span)
-        .map(|span| span.start.offset)
+        .map(|span| span.start.offset())
         .collect::<FxHashSet<_>>();
     let mut spans = commands
         .iter()
@@ -738,12 +738,12 @@ pub(crate) fn background_semicolon_span(
         return None;
     }
 
-    let semicolon_offset = source[terminator_span.end.offset..]
+    let semicolon_offset = source[terminator_span.end.offset()..]
         .char_indices()
         .find_map(|(relative, ch)| match ch {
             ' ' | '\t' | '\r' => None,
             '\n' | '#' => Some(None),
-            ';' => Some(Some(terminator_span.end.offset + relative)),
+            ';' => Some(Some(terminator_span.end.offset() + relative)),
             _ => Some(None),
         })??;
 
@@ -796,22 +796,22 @@ pub(crate) fn repeated_echo_argument_space_span(
     right: Span,
     source: &str,
 ) -> Option<Span> {
-    if left.end.line != right.start.line {
+    if left.end.line() != right.start.line() {
         return None;
     }
 
     // Some spans can collapse a backslash-newline continuation onto one logical
     // line. S037 only cares about repeated spaces on the same physical line.
-    let context_start = source[..left.end.offset]
+    let context_start = source[..left.end.offset()]
         .char_indices()
         .next_back()
-        .map_or(left.end.offset, |(idx, _)| idx);
-    let context = source.get(context_start..right.start.offset)?;
+        .map_or(left.end.offset(), |(idx, _)| idx);
+    let context = source.get(context_start..right.start.offset())?;
     if context.chars().any(|ch| matches!(ch, '\n' | '\r')) {
         return None;
     }
 
-    let gap = source.get(left.end.offset..right.start.offset)?;
+    let gap = source.get(left.end.offset()..right.start.offset())?;
     if gap.len() < 4 || !gap.chars().all(|ch| ch == ' ') {
         return None;
     }
@@ -1207,7 +1207,7 @@ pub(crate) fn for_each_nested_command<'facts, 'a>(
         None => return,
     };
     for other in commands.iter_from(start) {
-        if other.span().start.offset > outer_span.end.offset {
+        if other.span().start.offset() > outer_span.end.offset() {
             break;
         }
         if contains_span(outer_span, other.span()) {
@@ -1347,12 +1347,12 @@ pub(crate) fn collect_command_conditional_path_words<'a>(
 }
 
 pub(crate) fn contains_span(outer: Span, inner: Span) -> bool {
-    outer.start.offset <= inner.start.offset && inner.end.offset <= outer.end.offset
+    outer.start.offset() <= inner.start.offset() && inner.end.offset() <= outer.end.offset()
 }
 
 pub(crate) fn contains_span_strictly(outer: Span, inner: Span) -> bool {
     contains_span(outer, inner)
-        && (outer.start.offset < inner.start.offset || inner.end.offset < outer.end.offset)
+        && (outer.start.offset() < inner.start.offset() || inner.end.offset() < outer.end.offset())
 }
 
 pub(crate) fn build_backtick_command_name_spans(commands: &[CommandFact<'_>]) -> Vec<Span> {
@@ -1368,7 +1368,7 @@ pub(crate) fn build_backtick_command_name_spans(commands: &[CommandFact<'_>]) ->
 
     let mut seen = FxHashSet::default();
     spans.retain(|span| seen.insert(FactSpan::new(*span)));
-    spans.sort_by_key(|span| (span.start.offset, span.end.offset));
+    spans.sort_by_key(|span| (span.start.offset(), span.end.offset()));
     spans
 }
 
@@ -1506,12 +1506,12 @@ pub(crate) fn command_fact_for_semantic_span_matching<'facts, 'a>(
                 .filter(|command| {
                     let command_span = command.span();
                     predicate(command)
-                        && span.start.offset <= command_span.start.offset
-                        && command_span.end.offset <= span.end.offset
+                        && span.start.offset() <= command_span.start.offset()
+                        && command_span.end.offset() <= span.end.offset()
                 })
                 .max_by_key(|command| {
                     let span = command.span();
-                    (span.end.offset, std::cmp::Reverse(span.start.offset))
+                    (span.end.offset(), std::cmp::Reverse(span.start.offset()))
                 })
         })
 }
@@ -1623,9 +1623,9 @@ pub(crate) fn compare_command_parent_entries(
 ) -> std::cmp::Ordering {
     left_span
         .start
-        .offset
-        .cmp(&right_span.start.offset)
-        .then_with(|| right_span.end.offset.cmp(&left_span.end.offset))
+        .offset()
+        .cmp(&right_span.start.offset())
+        .then_with(|| right_span.end.offset().cmp(&left_span.end.offset()))
         .then_with(|| right_id.index().cmp(&left_id.index()))
 }
 
@@ -1662,7 +1662,7 @@ pub(crate) fn command_slot_count(commands: &[CommandFact<'_>]) -> usize {
 pub(crate) fn sort_and_dedup_spans(spans: &mut Vec<Span>) {
     let mut seen = FxHashSet::default();
     spans.retain(|span| seen.insert(FactSpan::new(*span)));
-    spans.sort_by_key(|span| (span.start.offset, span.end.offset));
+    spans.sort_by_key(|span| (span.start.offset(), span.end.offset()));
 }
 
 pub(crate) fn trim_trailing_whitespace_span(span: Span, source: &str) -> Span {

--- a/crates/shuck-linter/src/facts/comments.rs
+++ b/crates/shuck-linter/src/facts/comments.rs
@@ -345,19 +345,11 @@ pub(crate) fn shebang_space_after_hash_in_line(line: &str) -> Option<(usize, usi
 }
 
 pub(crate) fn point_span(line_number: usize, column: usize, offset: usize) -> Span {
-    Span::at(Position {
-        line: line_number,
-        column,
-        offset,
-    })
+    Span::at(Position::at(line_number, column, offset))
 }
 
 pub(crate) fn line_prefix_span(line_number: usize, offset: usize, prefix: &str) -> Span {
-    let start = Position {
-        line: line_number,
-        column: 1,
-        offset,
-    };
+    let start = Position::at(line_number, 1, offset);
     let end = start.advanced_by(prefix);
     Span::from_positions(start, end)
 }
@@ -369,11 +361,7 @@ pub(crate) fn line_slice_span(
     slice_start: usize,
     slice_len: usize,
 ) -> Span {
-    let line_start = Position {
-        line: line_number,
-        column: 1,
-        offset: line_offset,
-    };
+    let line_start = Position::at(line_number, 1, line_offset);
     let start = line_start.advanced_by(&line[..slice_start]);
     let end = start.advanced_by(&line[slice_start..slice_start + slice_len]);
     Span::from_positions(start, end)
@@ -385,11 +373,7 @@ pub(crate) fn line_with_ending_span(
     line: &str,
     line_ending: &str,
 ) -> Span {
-    let start = Position {
-        line: line_number,
-        column: 1,
-        offset,
-    };
+    let start = Position::at(line_number, 1, offset);
     let end = start.advanced_by(line).advanced_by(line_ending);
     Span::from_positions(start, end)
 }
@@ -502,11 +486,7 @@ pub(crate) fn shebang_short_option_cluster_enables_errexit(word: &str) -> bool {
 }
 
 pub(crate) fn line_span(line_number: usize, offset: usize, line: &str) -> Span {
-    let start = Position {
-        line: line_number,
-        column: 1,
-        offset,
-    };
+    let start = Position::at(line_number, 1, offset);
     let end = start.advanced_by(line);
     Span::from_positions(start, end)
 }
@@ -541,11 +521,7 @@ pub(crate) fn build_commented_continuation_comment_spans(
             }
             let caret_offset = comment_start + trimmed_comment_text.len();
 
-            let line_start_position = Position {
-                line,
-                column: 1,
-                offset: line_start,
-            };
+            let line_start_position = Position::at(line, 1, line_start);
             let caret = line_start_position.advanced_by(&source[line_start..caret_offset]);
             Some(Span::at(caret))
         })
@@ -704,11 +680,7 @@ pub(crate) fn build_trailing_directive_comment_spans(
                 return None;
             }
 
-            let line_start_position = Position {
-                line,
-                column: 1,
-                offset: line_start,
-            };
+            let line_start_position = Position::at(line, 1, line_start);
             let start = line_start_position.advanced_by(&source[line_start..comment_start]);
             let end = start.advanced_by("#");
             Some(Span::from_positions(start, end))
@@ -750,11 +722,7 @@ pub(crate) fn build_todo_comment_facts(
                 return None;
             }
 
-            let line_start_position = Position {
-                line,
-                column: 1,
-                offset: line_start,
-            };
+            let line_start_position = Position::at(line, 1, line_start);
             let content_start_position =
                 line_start_position.advanced_by(&source[line_start..content_start]);
             let content_span = Span::from_positions(
@@ -776,7 +744,7 @@ pub(crate) fn case_item_label_comment(
             return false;
         };
 
-        if pattern.span.end.line != line || comment_start < pattern.span.end.offset {
+        if pattern.span.end.line() != line || comment_start < pattern.span.end.offset() {
             return false;
         }
 
@@ -784,7 +752,7 @@ pub(crate) fn case_item_label_comment(
             return true;
         };
 
-        stmt.span.start.line != line
+        stmt.span.start.line() != line
     })
 }
 

--- a/crates/shuck-linter/src/facts/conditional_portability.rs
+++ b/crates/shuck-linter/src/facts/conditional_portability.rs
@@ -187,7 +187,8 @@ pub(crate) fn build_conditional_portability_facts<'a>(
 
 fn span_is_within_any(span: Span, containers: &[Span]) -> bool {
     containers.iter().any(|container| {
-        container.start.offset <= span.start.offset && span.end.offset <= container.end.offset
+        container.start.offset() <= span.start.offset()
+            && span.end.offset() <= container.end.offset()
     })
 }
 

--- a/crates/shuck-linter/src/facts/conditionals.rs
+++ b/crates/shuck-linter/src/facts/conditionals.rs
@@ -948,42 +948,42 @@ fn redundant_return_status_delete_span(stmt: &Stmt, command_span: Span, source: 
     } else {
         command_span.end
     };
-    let line_start = source[..command_span.start.offset]
+    let line_start = source[..command_span.start.offset()]
         .rfind('\n')
         .map_or(0, |offset| offset + 1);
-    let delete_start = if source[line_start..command_span.start.offset]
+    let delete_start = if source[line_start..command_span.start.offset()]
         .bytes()
         .all(|byte| matches!(byte, b' ' | b'\t'))
     {
         line_start
     } else {
-        command_span.start.offset
+        command_span.start.offset()
     };
 
-    let line_end = source[command_end.offset..]
+    let line_end = source[command_end.offset()..]
         .find('\n')
-        .map_or(source.len(), |offset| command_end.offset + offset);
-    let suffix = &source[command_end.offset..line_end];
-    let delete_end = if delete_start < command_span.start.offset
+        .map_or(source.len(), |offset| command_end.offset() + offset);
+    let suffix = &source[command_end.offset()..line_end];
+    let delete_end = if delete_start < command_span.start.offset()
         && suffix.bytes().all(|byte| matches!(byte, b' ' | b'\t'))
     {
         line_end.saturating_add((line_end < source.len()) as usize)
     } else {
-        command_end.offset
+        command_end.offset()
     };
 
-    let delete_start_position = Position {
-        line: command_span.start.line,
-        column: command_span
+    let delete_start_position = Position::at(
+        command_span.start.line(),
+        command_span
             .start
-            .column
-            .saturating_sub(command_span.start.offset - delete_start),
-        offset: delete_start,
-    };
-    let delete_end_position = if delete_end == command_end.offset {
+            .column()
+            .saturating_sub(command_span.start.offset() - delete_start),
+        delete_start,
+    );
+    let delete_end_position = if delete_end == command_end.offset() {
         command_end
     } else {
-        command_end.advanced_by(&source[command_end.offset..delete_end])
+        command_end.advanced_by(&source[command_end.offset()..delete_end])
     };
 
     Span::from_positions(delete_start_position, delete_end_position)
@@ -1292,7 +1292,7 @@ pub(crate) fn stmt_plain_assignment_only_name(stmt: &Stmt) -> Option<&Name> {
         return None;
     };
     if !command.args.is_empty()
-        || command.name.span.start.offset != command.name.span.end.offset
+        || command.name.span.start.offset() != command.name.span.end.offset()
         || command.assignments.len() != 1
     {
         return None;
@@ -1311,7 +1311,7 @@ pub(crate) fn stmt_is_assignment_only_unquoted_status_capture(stmt: &Stmt) -> bo
     };
 
     command.args.is_empty()
-        && command.name.span.start.offset == command.name.span.end.offset
+        && command.name.span.start.offset() == command.name.span.end.offset()
         && !command.assignments.is_empty()
         && command
             .assignments
@@ -1340,7 +1340,7 @@ pub(crate) fn stmt_is_plain_command_with_standalone_status_argument(stmt: &Stmt)
 
     match &stmt.command {
         Command::Simple(command) => {
-            command.name.span.start.offset != command.name.span.end.offset
+            command.name.span.start.offset() != command.name.span.end.offset()
                 && (word_is_unquoted_standalone_status_capture(&command.name)
                     || command
                         .args

--- a/crates/shuck-linter/src/facts/core.rs
+++ b/crates/shuck-linter/src/facts/core.rs
@@ -38,8 +38,8 @@ pub struct FactSpan {
 impl FactSpan {
     pub fn new(span: Span) -> Self {
         Self {
-            start: span.start.offset,
-            end: span.end.offset,
+            start: span.start.offset(),
+            end: span.end.offset(),
         }
     }
 }
@@ -413,16 +413,16 @@ impl<'facts, 'a> CommandFacts<'facts, 'a> {
         self,
         outer: Span,
     ) -> impl Iterator<Item = CommandFactRef<'facts, 'a>> {
-        let start_offset = outer.start.offset;
-        let end_offset = outer.end.offset;
+        let start_offset = outer.start.offset();
+        let end_offset = outer.end.offset();
         let start = self
             .commands
-            .partition_point(|fact| fact.span().start.offset < start_offset);
+            .partition_point(|fact| fact.span().start.offset() < start_offset);
         let store = self.store;
         self.commands[start..]
             .iter()
-            .take_while(move |fact| fact.span().start.offset <= end_offset)
-            .filter(move |fact| fact.span().end.offset <= end_offset)
+            .take_while(move |fact| fact.span().start.offset() <= end_offset)
+            .filter(move |fact| fact.span().end.offset() <= end_offset)
             .map(move |fact| CommandFactRef::new(fact, store))
     }
 }

--- a/crates/shuck-linter/src/facts/escape_scan.rs
+++ b/crates/shuck-linter/src/facts/escape_scan.rs
@@ -87,8 +87,8 @@ fn build_sorted_single_quoted_bounds(
         .map(|fragment| {
             let span = fragment.span();
             SingleQuotedFragmentBounds {
-                start: span.start.offset,
-                end: span.end.offset,
+                start: span.start.offset(),
+                end: span.end.offset(),
             }
         })
         .collect();
@@ -420,8 +420,8 @@ fn is_regex_like_context(context: Option<ExpansionContext>) -> bool {
 }
 
 fn span_within_single_quoted_fragment(span: Span, bounds: &[SingleQuotedFragmentBounds]) -> bool {
-    let span_start = span.start.offset;
-    let span_end = span.end.offset;
+    let span_start = span.start.offset();
+    let span_end = span.end.offset();
     let index = bounds.partition_point(|b| b.start <= span_start);
     if index == 0 {
         return false;
@@ -431,9 +431,9 @@ fn span_within_single_quoted_fragment(span: Span, bounds: &[SingleQuotedFragment
 }
 
 fn span_within_any(span: Span, hosts: &[Span]) -> bool {
-    hosts
-        .iter()
-        .any(|host| span.start.offset >= host.start.offset && span.end.offset <= host.end.offset)
+    hosts.iter().any(|host| {
+        span.start.offset() >= host.start.offset() && span.end.offset() <= host.end.offset()
+    })
 }
 
 fn lookup_command_fact<'facts, 'a>(
@@ -620,7 +620,7 @@ echo foo\tbar
                     .copied()
                     .find(|escape| {
                         escape.escaped_byte() == b't'
-                            && escape.span().start.line == 2
+                            && escape.span().start.line() == 2
                             && escape.source_kind() == EscapeScanSourceKind::WordLiteralPart
                     })
                     .expect("expected grep argument match");
@@ -631,7 +631,7 @@ echo foo\tbar
                     .copied()
                     .find(|escape| {
                         escape.escaped_byte() == b't'
-                            && escape.span().start.line == 3
+                            && escape.span().start.line() == 3
                             && escape.source_kind() == EscapeScanSourceKind::WordLiteralPart
                     })
                     .expect("expected ordinary argument match");
@@ -658,7 +658,7 @@ echo foo\.bar
                     .copied()
                     .find(|escape| {
                         escape.escaped_byte() == b'.'
-                            && escape.span().start.line == 2
+                            && escape.span().start.line() == 2
                             && escape.source_kind() == EscapeScanSourceKind::WordLiteralPart
                     })
                     .expect("expected tr operand match");
@@ -669,7 +669,7 @@ echo foo\.bar
                     .copied()
                     .find(|escape| {
                         escape.escaped_byte() == b'.'
-                            && escape.span().start.line == 3
+                            && escape.span().start.line() == 3
                             && escape.source_kind() == EscapeScanSourceKind::WordLiteralPart
                     })
                     .expect("expected ordinary word match");
@@ -696,7 +696,7 @@ name="${name//[^a-zA-Z0-9_\-]/}"
                     .copied()
                     .find(|escape| {
                         escape.escaped_byte() == b'-'
-                            && escape.span().start.line == 2
+                            && escape.span().start.line() == 2
                             && escape.source_kind() == EscapeScanSourceKind::PatternCharClass
                     })
                     .expect("expected case-pattern char class match");
@@ -706,7 +706,7 @@ name="${name//[^a-zA-Z0-9_\-]/}"
                     .copied()
                     .find(|escape| {
                         escape.escaped_byte() == b'-'
-                            && escape.span().start.line == 3
+                            && escape.span().start.line() == 3
                             && escape.source_kind()
                                 == EscapeScanSourceKind::ParameterPatternCharClass
                     })

--- a/crates/shuck-linter/src/facts/functions.rs
+++ b/crates/shuck-linter/src/facts/functions.rs
@@ -202,7 +202,7 @@ pub(crate) fn build_function_doc_content_facts<'a>(
                 source,
                 line_index,
                 comment_index,
-                function_span.start.line,
+                function_span.start.line(),
             );
             let summary = summaries.remove(&function_scope).unwrap_or_default();
             let uses_positional_parameters = positional_parameter_facts
@@ -352,7 +352,7 @@ fn binding_targets_prior_local(
         .any(|candidate| {
             let candidate = semantic.binding(*candidate);
             candidate.id != binding.id
-                && candidate.span.start.offset < binding.span.start.offset
+                && candidate.span.start.offset() < binding.span.start.offset()
                 && candidate.attributes.contains(BindingAttributes::LOCAL)
                 && semantic.enclosing_function_scope(candidate.scope) == Some(function_scope)
         })
@@ -480,11 +480,7 @@ fn leading_function_doc_block(
             break;
         };
 
-        let line_start_position = Position {
-            line,
-            column: 1,
-            offset: line_start,
-        };
+        let line_start_position = Position::at(line, 1, line_start);
         let comment_start_position =
             line_start_position.advanced_by(&source[line_start..comment_start]);
         let comment_end_position =
@@ -547,7 +543,7 @@ fn build_function_scopes_using_positional_parameters(
         if reference_has_local_positional_reset(
             semantic,
             reference.scope,
-            reference.span.start.offset,
+            reference.span.start.offset(),
             &local_reset_offsets_by_scope,
         ) {
             continue;
@@ -566,7 +562,7 @@ fn is_positional_parameter_reference_name(name: &str) -> bool {
 }
 
 fn span_line_count(span: Span) -> usize {
-    span.end.line.saturating_sub(span.start.line) + 1
+    span.end.line().saturating_sub(span.start.line()) + 1
 }
 
 #[cfg_attr(shuck_profiling, inline(never))]
@@ -724,13 +720,13 @@ pub(crate) fn build_completion_registered_function_scopes(
                 continue;
             };
             if same_branch_registrations.iter().any(|later_command| {
-                later_command.span().start.offset > command.span().start.offset
+                later_command.span().start.offset() > command.span().start.offset()
                     && nearest_structural_parent_command(semantic, later_command.id())
                         == Some(parent)
                     && same_structural_branch_between(
                         source,
-                        command.span().end.offset,
-                        later_command.span().start.offset,
+                        command.span().end.offset(),
+                        later_command.span().start.offset(),
                     )
                     && command_registers_completion_function(later_command, source, &candidate.name)
             }) {
@@ -814,7 +810,7 @@ pub(crate) fn extend_completion_registered_function_scopes_through_helpers(
                 .any(|(site, resolved_binding)| {
                     resolved_binding == *binding_id
                         && semantic_analysis
-                            .enclosing_function_scope_at(site.name_span.start.offset)
+                            .enclosing_function_scope_at(site.name_span.start.offset())
                             .is_some_and(|caller_scope| scopes.contains(&caller_scope))
                 });
             let referenced_by_completion_arguments = argument_spec_commands.iter().any(|command| {
@@ -1151,7 +1147,7 @@ pub(crate) fn completion_registered_function_candidate(
         return None;
     };
     let (name, _) = function.static_name_entries().next()?;
-    let scope = semantic.scope_at(function.body.span.start.offset);
+    let scope = semantic.scope_at(function.body.span.start.offset());
 
     Some(CompletionRegisteredFunctionCandidate {
         scope,
@@ -1172,7 +1168,7 @@ pub(crate) fn file_level_completion_function_candidate(
         return None;
     };
     let (name, _) = function.static_name_entries().next()?;
-    let scope = semantic.scope_at(function.body.span.start.offset);
+    let scope = semantic.scope_at(function.body.span.start.offset());
 
     Some(CompletionRegisteredFunctionCandidate {
         scope,
@@ -1188,7 +1184,7 @@ pub(crate) fn external_entrypoint_function_candidate(
         return None;
     };
     let (name, _) = function.static_name_entries().next()?;
-    let scope = semantic.scope_at(function.body.span.start.offset);
+    let scope = semantic.scope_at(function.body.span.start.offset());
     let name_text = name.as_str();
 
     Some(CompletionRegisteredFunctionCandidate {
@@ -1639,10 +1635,10 @@ pub(crate) fn function_parameter_fallback_span(
     if commands.is_empty() {
         return None;
     }
-    if first.span().start.line != second.span().start.line {
+    if first.span().start.line() != second.span().start.line() {
         return None;
     }
-    let tail = source.get(second.span().end.offset..)?;
+    let tail = source.get(second.span().end.offset()..)?;
     if !matches!(next_function_body_delimiter(tail), Some('{') | Some('(')) {
         return None;
     }
@@ -1664,7 +1660,7 @@ pub(crate) fn named_coproc_subshell_fallback_span(command: &CommandFact<'_>) -> 
         return None;
     }
     let body_start = coproc.body.span.start;
-    if coproc.span.start.line != body_start.line {
+    if coproc.span.start.line() != body_start.line() {
         return None;
     }
     Some(Span::from_positions(body_start, body_start))
@@ -1694,7 +1690,7 @@ pub(crate) fn build_function_call_arity_facts<'a>(
     let mut offsets = Vec::new();
     for name in &unique_function_names {
         for (site, _) in semantic_analysis.function_call_arity_sites(name) {
-            offsets.push(site.name_span.start.offset);
+            offsets.push(site.name_span.start.offset());
         }
     }
     if offsets.is_empty() {
@@ -1707,7 +1703,7 @@ pub(crate) fn build_function_call_arity_facts<'a>(
         for (site, binding_id) in semantic_analysis.function_call_arity_sites(name) {
             let Some(command_id) = precomputed_command_id_for_offset(
                 &command_ids_by_offset,
-                site.name_span.start.offset,
+                site.name_span.start.offset(),
             ) else {
                 continue;
             };
@@ -1856,7 +1852,7 @@ pub(crate) fn build_function_positional_parameter_facts(
         .collect::<FxHashMap<_, _>>();
 
     for fragment in positional_parameter_fragments {
-        let fragment_offset = fragment.span().start.offset;
+        let fragment_offset = fragment.span().start.offset();
         let fragment_scope = semantic.scope_at(fragment_offset);
         if reference_has_local_positional_reset(
             semantic,
@@ -1911,7 +1907,7 @@ fn local_positional_reset_offsets_by_scope(
             continue;
         }
 
-        let offset = command.span().start.offset;
+        let offset = command.span().start.offset();
         if let Some(scope) = semantic.innermost_transient_scope_within_function(command.scope()) {
             local_reset_offsets_by_scope
                 .entry(scope)

--- a/crates/shuck-linter/src/facts/heredocs.rs
+++ b/crates/shuck-linter/src/facts/heredocs.rs
@@ -11,7 +11,7 @@ pub(crate) fn build_heredoc_fact_summary(
 
     for command in commands {
         let unused_heredoc_command = command.literal_name() == Some("")
-            && command.body_span().start.offset == command.body_span().end.offset;
+            && command.body_span().start.offset() == command.body_span().end.offset();
         let echo_here_doc_command = command.effective_name_is("echo")
             && command
                 .redirects()
@@ -36,7 +36,7 @@ pub(crate) fn build_heredoc_fact_summary(
             let Some(heredoc) = redirect.heredoc() else {
                 continue;
             };
-            let reaches_file_end = heredoc.body.span.end.offset == file_end;
+            let reaches_file_end = heredoc.body.span.end.offset() == file_end;
             if reaches_file_end {
                 summary.heredoc_missing_end_spans.push(redirect.span);
             }
@@ -136,7 +136,7 @@ pub(crate) fn heredoc_closer_not_alone_span(
     locator: Locator<'_>,
 ) -> Option<Span> {
     let source = locator.source();
-    let mut line_start_offset = body_span.start.offset;
+    let mut line_start_offset = body_span.start.offset();
     for raw_line in body_span.slice(source).split_inclusive('\n') {
         let (candidate_line, tab_prefix_len) = normalized_heredoc_line(raw_line, strip_tabs);
         if !candidate_line.ends_with(delimiter)
@@ -183,7 +183,7 @@ pub(crate) fn heredoc_end_space_span(
     locator: Locator<'_>,
 ) -> Option<Span> {
     let source = locator.source();
-    let line_start_offset = body_span.end.offset;
+    let line_start_offset = body_span.end.offset();
     let remainder = source.get(line_start_offset..)?;
     let raw_line = remainder.split_inclusive('\n').next().unwrap_or(remainder);
     let (candidate_line, tab_prefix_len) = normalized_heredoc_line(raw_line, strip_tabs);
@@ -204,7 +204,7 @@ pub(crate) fn spaced_tabstrip_close_spans(
 ) -> Vec<Span> {
     let source = locator.source();
     let mut spans = Vec::new();
-    let mut line_start_offset = body_span.start.offset;
+    let mut line_start_offset = body_span.start.offset();
     for raw_line in body_span.slice(source).split_inclusive('\n') {
         let line_without_newline = raw_line.trim_end_matches('\n').trim_end_matches('\r');
         if is_spaced_tabstrip_close_line(line_without_newline, delimiter)
@@ -225,7 +225,7 @@ fn indented_heredoc_close_facts(
 ) -> Vec<(Span, Span)> {
     let source = locator.source();
     let mut facts = Vec::new();
-    let mut line_start_offset = body_span.start.offset;
+    let mut line_start_offset = body_span.start.offset();
     for raw_line in body_span.slice(source).split_inclusive('\n') {
         let line_without_newline = raw_line.trim_end_matches('\n').trim_end_matches('\r');
         let trimmed = line_without_newline.trim_start_matches([' ', '\t']);

--- a/crates/shuck-linter/src/facts/misspelling.rs
+++ b/crates/shuck-linter/src/facts/misspelling.rs
@@ -410,8 +410,8 @@ pub(crate) fn scan_possible_variable_misspelling_candidate(
             candidate_match_rank(target_name, binding.name.as_str()).map(|rank| {
                 (
                     rank,
-                    binding.span.start.offset,
-                    binding.span.end.offset,
+                    binding.span.start.offset(),
+                    binding.span.end.offset(),
                     binding.name.as_str(),
                 )
             })
@@ -449,8 +449,8 @@ fn scan_presence_tested_candidate_name<'a>(
             candidate_match_rank(target_name, candidate_name.as_str()).map(|rank| {
                 (
                     rank,
-                    first_span.start.offset,
-                    first_span.end.offset,
+                    first_span.start.offset(),
+                    first_span.end.offset(),
                     candidate_name.as_str(),
                 )
             })
@@ -526,7 +526,7 @@ fn first_presence_test_span(
                 .flatten()
                 .map(|presence| presence.tested_span()),
         )
-        .min_by_key(|span| (span.start.offset, span.end.offset))
+        .min_by_key(|span| (span.start.offset(), span.end.offset()))
 }
 
 fn compare_candidates(
@@ -538,13 +538,13 @@ fn compare_candidates(
     let (_, right_rank, right_entry) = right;
     let ordering = (
         left_rank,
-        left_entry.first_span.start.offset,
-        left_entry.first_span.end.offset,
+        left_entry.first_span.start.offset(),
+        left_entry.first_span.end.offset(),
     )
         .cmp(&(
             right_rank,
-            right_entry.first_span.start.offset,
-            right_entry.first_span.end.offset,
+            right_entry.first_span.start.offset(),
+            right_entry.first_span.end.offset(),
         ));
     if !ordering.is_eq() {
         return ordering;

--- a/crates/shuck-linter/src/facts/model.rs
+++ b/crates/shuck-linter/src/facts/model.rs
@@ -527,7 +527,7 @@ impl<'facts, 'a> CommandFactQueries<'facts, 'a> {
     }
 
     fn command_id_for_exact_span(self, span: Span) -> Option<CommandId> {
-        let mut current = self.innermost_command_id_at(span.start.offset)?;
+        let mut current = self.innermost_command_id_at(span.start.offset())?;
         loop {
             if self.command(current).span() == span {
                 return Some(current);
@@ -959,13 +959,13 @@ impl<'facts, 'a> AssignmentFacts<'facts, 'a> {
             .c006_suppressing_reference_offsets_by_name
             .get(name)
             .is_some_and(|offsets| {
-                offsets.partition_point(|offset| *offset < span.start.offset) > 0
+                offsets.partition_point(|offset| *offset < span.start.offset()) > 0
             })
     }
 
     pub(crate) fn assignment_value_target_name_for_span(self, span: Span) -> Option<&'facts Name> {
-        let query_start = span.start.offset;
-        let query_end = span.end.offset;
+        let query_start = span.start.offset();
+        let query_end = span.end.offset();
         let upper = self
             .facts
             .assignments
@@ -1049,7 +1049,7 @@ impl<'facts, 'a> AssignmentFacts<'facts, 'a> {
                     .flatten()
                     .map(|presence| presence.tested_span()),
             )
-            .min_by_key(|span| (span.start.offset, span.end.offset))
+            .min_by_key(|span| (span.start.offset(), span.end.offset()))
     }
 
     pub(crate) fn subshell_assignment_sites(self) -> &'facts [NamedSpan] {
@@ -1193,7 +1193,7 @@ impl<'facts, 'a> SourceFacts<'facts, 'a> {
                     .command_facts()
                     .structural_commands()
                     .filter_map(|command| command.command_name_word())
-                    .map(|word| word.span.start.offset)
+                    .map(|word| word.span.start.offset())
                     .collect::<Vec<_>>();
                 command_name_offsets.sort_unstable();
                 command_name_offsets.dedup();
@@ -2171,10 +2171,11 @@ pub(crate) fn collect_array_assignment_split_scalar_expansion_spans(
     if !unquoted_command_substitution_spans.is_empty() {
         // commands is sorted by start offset (compare_command_facts_by_offset),
         // so binary-search the subrange whose start lies inside fact_span.
-        let start = commands.partition_point(|c| c.span().start.offset < fact_span.start.offset);
+        let start =
+            commands.partition_point(|c| c.span().start.offset() < fact_span.start.offset());
         for command in &commands[start..] {
             let command_span = command.span();
-            if command_span.start.offset > fact_span.end.offset {
+            if command_span.start.offset() > fact_span.end.offset() {
                 break;
             }
             if !contains_span_strictly(fact_span, command_span) {
@@ -2342,8 +2343,8 @@ pub(crate) fn push_assignment_value_target_entry(
 ) {
     if let Some(value_span) = assignment_value_span(&assignment.value) {
         entries.push(AssignmentValueTargetEntry {
-            value_start: value_span.start.offset,
-            value_end: value_span.end.offset,
+            value_start: value_span.start.offset(),
+            value_end: value_span.end.offset(),
             target_name: assignment.target.name.clone(),
         });
     }

--- a/crates/shuck-linter/src/facts/presence.rs
+++ b/crates/shuck-linter/src/facts/presence.rs
@@ -143,11 +143,11 @@ pub(crate) fn build_presence_tested_names(
     // is the only one that needs a sort because per-command refs come out of a
     // FxHashSet drain in non-deterministic order.
     for spans in nested_command_spans_by_name.values_mut() {
-        debug_assert!(spans.is_sorted_by_key(|span| (span.start.offset, span.end.offset)));
+        debug_assert!(spans.is_sorted_by_key(|span| (span.start.offset(), span.end.offset())));
         spans.dedup();
     }
     for spans in c006_nested_command_spans_by_name.values_mut() {
-        debug_assert!(spans.is_sorted_by_key(|span| (span.start.offset, span.end.offset)));
+        debug_assert!(spans.is_sorted_by_key(|span| (span.start.offset(), span.end.offset())));
         spans.dedup();
     }
 
@@ -159,10 +159,10 @@ pub(crate) fn build_presence_tested_names(
     for names in names_by_name.values_mut() {
         debug_assert!(names.is_sorted_by_key(|fact| {
             (
-                fact.command_span().start.offset,
-                fact.command_span().end.offset,
-                fact.tested_span().start.offset,
-                fact.tested_span().end.offset,
+                fact.command_span().start.offset(),
+                fact.command_span().end.offset(),
+                fact.tested_span().start.offset(),
+                fact.tested_span().end.offset(),
             )
         }));
         names.dedup();
@@ -185,7 +185,7 @@ fn build_outermost_nested_presence_scopes(commands: &[CommandFact<'_>]) -> Vec<O
         let span = command.span();
         let id = command.id();
         let is_nested = command.is_nested_word_command();
-        pop_finished_nested_presence_scopes(&mut active_nested_scopes, span.start.offset);
+        pop_finished_nested_presence_scopes(&mut active_nested_scopes, span.start.offset());
         outermost_scopes[id.index()] = active_nested_scopes
             .first()
             .copied()
@@ -209,7 +209,7 @@ fn command_slot_count(commands: &[CommandFact<'_>]) -> usize {
 fn pop_finished_nested_presence_scopes(active_nested_scopes: &mut Vec<Span>, offset: usize) {
     while active_nested_scopes
         .last()
-        .is_some_and(|span| span.end.offset <= offset)
+        .is_some_and(|span| span.end.offset() <= offset)
     {
         active_nested_scopes.pop();
     }

--- a/crates/shuck-linter/src/facts/redirects.rs
+++ b/crates/shuck-linter/src/facts/redirects.rs
@@ -440,13 +440,13 @@ pub(crate) fn dedup_comparable_name_uses(uses: &mut Vec<ComparableNameUse>) {
 
 pub(crate) fn heredoc_variable_name_span(span: Span, locator: Locator<'_>) -> Span {
     let source = locator.source();
-    let Some(text) = source.get(span.start.offset..span.end.offset) else {
+    let Some(text) = source.get(span.start.offset()..span.end.offset()) else {
         return span;
     };
     let Some(relative_start) = text.find('$') else {
         return span;
     };
-    let start_offset = span.start.offset + relative_start + '$'.len_utf8();
+    let start_offset = span.start.offset() + relative_start + '$'.len_utf8();
     let Some(start) = locator.position_at_offset(start_offset) else {
         return span;
     };
@@ -733,7 +733,7 @@ pub(crate) fn comparable_redirect_name_uses(
 
 pub(crate) fn brace_fd_redirection_span(redirect: &Redirect, source: &str) -> Option<Span> {
     let brace_span = redirect_fd_var_brace_span(redirect, source)?;
-    let gap = source.get(brace_span.end.offset..redirect.span.start.offset)?;
+    let gap = source.get(brace_span.end.offset()..redirect.span.start.offset())?;
     brace_fd_gap_allows_attachment(gap)
         .then(|| Span::from_positions(brace_span.start, redirect.span.end))
 }
@@ -871,7 +871,7 @@ pub(super) fn duplicate_redirect_facts(
         let Some(span) = duplicate_redirect_report_span(redirect, source) else {
             continue;
         };
-        if seen_spans.insert((span.start.offset, span.end.offset)) {
+        if seen_spans.insert((span.start.offset(), span.end.offset())) {
             let written_fds = duplicate_redirect_fds(redirect, source);
             let fully_overwritten = !written_fds.is_empty()
                 && written_fds
@@ -898,15 +898,15 @@ pub(super) fn duplicate_redirect_facts(
 }
 
 fn redirect_deletion_span(span: Span, source: &str) -> Span {
-    let whitespace_start = source[..span.start.offset]
+    let whitespace_start = source[..span.start.offset()]
         .rfind(|ch| !matches!(ch, ' ' | '\t'))
         .map_or(0, |offset| offset + 1);
-    let removed_whitespace = span.start.offset - whitespace_start;
-    let start = shuck_ast::Position {
-        line: span.start.line,
-        column: span.start.column - removed_whitespace,
-        offset: whitespace_start,
-    };
+    let removed_whitespace = span.start.offset() - whitespace_start;
+    let start = shuck_ast::Position::at(
+        span.start.line(),
+        span.start.column() - removed_whitespace,
+        whitespace_start,
+    );
     Span::from_positions(start, span.end)
 }
 
@@ -1084,7 +1084,7 @@ fn append_redirect_is_output_both(redirect: &Redirect, source: &str) -> bool {
     let Some(target) = redirect.word_target() else {
         return false;
     };
-    let Some(prefix) = source.get(redirect.span.start.offset..target.span.start.offset) else {
+    let Some(prefix) = source.get(redirect.span.start.offset()..target.span.start.offset()) else {
         return false;
     };
     prefix
@@ -1108,7 +1108,7 @@ fn csh_both_output_redirect_span_and_target<'a>(
         .fd
         .map(|fd| redirect.span.start.advanced_by(&fd.to_string()))
         .unwrap_or(redirect.span.start);
-    let prefix = source.get(operator_start.offset..target.span.start.offset)?;
+    let prefix = source.get(operator_start.offset()..target.span.start.offset())?;
 
     let (span, target_text) = if prefix == ">&" {
         (

--- a/crates/shuck-linter/src/facts/simple_tests.rs
+++ b/crates/shuck-linter/src/facts/simple_tests.rs
@@ -304,7 +304,7 @@ pub(crate) fn build_glued_closing_bracket_insert_offset(
     source: &str,
 ) -> Option<usize> {
     build_glued_closing_bracket_operand_word(command, source)
-        .map(|operand| operand.span.end.offset - 1)
+        .map(|operand| operand.span.end.offset() - 1)
 }
 
 pub(crate) fn build_missing_space_before_bracket_close_fact(
@@ -379,7 +379,7 @@ fn missing_space_before_conditional_bracket_close_offsets(
     command: &ConditionalCommand,
     source: &str,
 ) -> Option<(usize, usize)> {
-    let insert_offset = command.right_bracket_span.start.offset;
+    let insert_offset = command.right_bracket_span.start.offset();
     let previous = source[..insert_offset].chars().next_back()?;
     if previous.is_whitespace()
         || (previous == ')'
@@ -391,7 +391,7 @@ fn missing_space_before_conditional_bracket_close_offsets(
         return None;
     }
 
-    Some((command.right_bracket_span.end.offset, insert_offset))
+    Some((command.right_bracket_span.end.offset(), insert_offset))
 }
 
 fn conditional_expression_ends_with_parenthesized_group(
@@ -401,7 +401,7 @@ fn conditional_expression_ends_with_parenthesized_group(
     loop {
         match expression {
             ConditionalExpr::Parenthesized(parenthesized) => {
-                return parenthesized.right_paren_span.end.offset == end_offset;
+                return parenthesized.right_paren_span.end.offset() == end_offset;
             }
             ConditionalExpr::Binary(binary) => {
                 expression = &binary.right;
@@ -427,8 +427,8 @@ fn missing_space_before_bracket_close_word_offsets(
     }
 
     let close_run_len = unescaped_final_closing_bracket_len(text)?;
-    let insert_offset = word.span.end.offset.checked_sub(close_run_len)?;
-    Some((word.span.end.offset, insert_offset))
+    let insert_offset = word.span.end.offset().checked_sub(close_run_len)?;
+    Some((word.span.end.offset(), insert_offset))
 }
 
 fn unescaped_final_closing_bracket_len(text: &str) -> Option<usize> {
@@ -466,14 +466,14 @@ pub(crate) fn build_jammed_test_bracket_fact(
     }
 
     let start = command.name.span.start;
-    let end = Position {
-        offset: start.offset + bracket_len,
-        line: start.line,
-        column: start.column + bracket_len,
-    };
+    let end = Position::at(
+        start.line(),
+        start.column() + bracket_len,
+        start.offset() + bracket_len,
+    );
     Some((
         Span::from_positions(start, end),
-        command.name.span.start.offset + bracket_len,
+        command.name.span.start.offset() + bracket_len,
     ))
 }
 
@@ -1328,11 +1328,11 @@ pub(crate) fn subshell_body_analysis<'a>(
 
 pub(crate) fn subshell_anchor_span(span: Span, locator: Locator<'_>) -> Span {
     let source = locator.source();
-    let Some(open_paren_offset) = leading_open_paren_offset(source, span.start.offset) else {
+    let Some(open_paren_offset) = leading_open_paren_offset(source, span.start.offset()) else {
         return span;
     };
 
-    let end_offset = trim_trailing_whitespace_offset(source, span.end.offset);
+    let end_offset = trim_trailing_whitespace_offset(source, span.end.offset());
     Span::from_positions(
         locator.position_at_offset_unchecked(open_paren_offset),
         locator.position_at_offset_unchecked(end_offset),

--- a/crates/shuck-linter/src/facts/surface.rs
+++ b/crates/shuck-linter/src/facts/surface.rs
@@ -642,17 +642,17 @@ impl<'a> SurfaceFragmentSink<'a> {
     pub(crate) fn finish(mut self) -> SurfaceFragmentFacts {
         self.facts
             .plain_unindexed_references
-            .sort_by_key(|span| (span.start.offset, span.end.offset));
+            .sort_by_key(|span| (span.start.offset(), span.end.offset()));
         self.facts
             .plain_unindexed_references
-            .dedup_by_key(|span| (span.start.offset, span.end.offset));
+            .dedup_by_key(|span| (span.start.offset(), span.end.offset()));
         self.facts
     }
 
     fn opening_backtick_is_escaped(&self, span: Span) -> bool {
         let source = self.source.as_bytes();
-        let start = span.start.offset;
-        let Some(fragment) = self.source.get(start..span.end.offset) else {
+        let start = span.start.offset();
+        let Some(fragment) = self.source.get(start..span.end.offset()) else {
             return false;
         };
         let Some(first_backtick) = fragment.find('`') else {
@@ -1814,10 +1814,10 @@ fn single_quoted_body_contains_expansion(body: &str) -> bool {
 }
 
 fn continued_line_chain_start(target: Position, source: &str) -> Option<Position> {
-    let mut line_start_offset = source[..target.offset]
+    let mut line_start_offset = source[..target.offset()]
         .rfind('\n')
         .map_or(0, |index| index + 1);
-    let mut line = target.line;
+    let mut line = target.line();
     let original_start = line_start_offset;
 
     while line_start_offset > 0 {
@@ -1833,11 +1833,7 @@ fn continued_line_chain_start(target: Position, source: &str) -> Option<Position
         line -= 1;
     }
 
-    (line_start_offset != original_start).then_some(Position {
-        line,
-        column: 1,
-        offset: line_start_offset,
-    })
+    (line_start_offset != original_start).then_some(Position::at(line, 1, line_start_offset))
 }
 
 fn shellcheck_collapsed_position(
@@ -1845,9 +1841,9 @@ fn shellcheck_collapsed_position(
     target: Position,
     source: &str,
 ) -> Position {
-    let mut line = chain_start.line;
-    let mut column = chain_start.column;
-    let prefix = &source[chain_start.offset..target.offset];
+    let mut line = chain_start.line();
+    let mut column = chain_start.column();
+    let prefix = &source[chain_start.offset()..target.offset()];
     let mut index = 0usize;
 
     while index < prefix.len() {
@@ -1874,11 +1870,7 @@ fn shellcheck_collapsed_position(
         index += ch.len_utf8();
     }
 
-    Position {
-        line,
-        column,
-        offset: target.offset,
-    }
+    Position::at(line, column, target.offset())
 }
 
 fn adjust_end_column(span: Span, display_escape_count: usize) -> Span {
@@ -1886,8 +1878,12 @@ fn adjust_end_column(span: Span, display_escape_count: usize) -> Span {
         return span;
     }
 
-    let mut end = span.end;
-    end.column = end.column.saturating_sub(display_escape_count);
+    let end = span.end;
+    let end = Position::at(
+        end.line(),
+        end.column().saturating_sub(display_escape_count),
+        end.offset(),
+    );
     Span::from_positions(span.start, end)
 }
 
@@ -2629,7 +2625,7 @@ fn positional_parameter_part_has_identifier_like_prefix(
         return false;
     };
 
-    let prefix = &source[word.span.start.offset..part.span.start.offset];
+    let prefix = &source[word.span.start.offset()..part.span.start.offset()];
     prefix_starts_with_identifier_like_text(prefix)
 }
 
@@ -2736,7 +2732,7 @@ fn build_subscript_reference_spans_with_filter(
 }
 
 fn span_contains(outer: Span, inner: Span) -> bool {
-    outer.start.offset <= inner.start.offset && inner.end.offset <= outer.end.offset
+    outer.start.offset() <= inner.start.offset() && inner.end.offset() <= outer.end.offset()
 }
 
 fn word_looks_like_unset_array_target(word: &Word, source: &str) -> bool {
@@ -3122,7 +3118,7 @@ fn collect_split_suspect_closing_quote_spans(
         let Some(span) = closing_quote_span(current, source) else {
             continue;
         };
-        if span.start.column == 1
+        if span.start.column() == 1
             || (index > 0
                 && double_quoted_part_is_empty(&word.parts[index - 1], source)
                 && has_later_words)

--- a/crates/shuck-linter/src/facts/tests/braces.rs
+++ b/crates/shuck-linter/src/facts/tests/braces.rs
@@ -14,7 +14,7 @@ echo \\${${name}}/\\${fallback}
             .words()
             .literal_brace_spans()
             .iter()
-            .map(|span| (span.start.line, span.start.column))
+            .map(|span| (span.start.line(), span.start.column()))
             .collect::<Vec<_>>();
 
         assert_eq!(

--- a/crates/shuck-linter/src/facts/tests/commands.rs
+++ b/crates/shuck-linter/src/facts/tests/commands.rs
@@ -518,17 +518,17 @@ amoeba=\"\" [ \"${AMOEBA:-yes}\" = \"yes\" ]
     let line2 = facts
         .commands()
         .iter()
-        .find(|fact| fact.literal_name() == Some("[") && fact.span().start.line == 2)
+        .find(|fact| fact.literal_name() == Some("[") && fact.span().start.line() == 2)
         .expect("expected inline test command");
     let line3 = facts
         .commands()
         .iter()
-        .find(|fact| fact.literal_name() == Some("[") && fact.span().start.line == 3)
+        .find(|fact| fact.literal_name() == Some("[") && fact.span().start.line() == 3)
         .expect("expected redirected bracket command");
     let line4 = facts
         .commands()
         .iter()
-        .find(|fact| fact.literal_name() == Some("[") && fact.span().start.line == 4)
+        .find(|fact| fact.literal_name() == Some("[") && fact.span().start.line() == 4)
         .expect("expected plain bracket command");
 
     assert!(line2.bracket_command_name_needs_separator(source));
@@ -1060,10 +1060,10 @@ EC2_REGION=\"`echo \\\"$EC2_AVAIL_ZONE\\\" | sed -e 's:\\([0-9][0-9]*\\)[a-z]*\\
         let spans = facts.words().echo_to_sed_substitution_spans();
         assert_eq!(spans.len(), 1);
         let span = spans[0];
-        assert_eq!(span.start.line, 2);
-        assert_eq!(span.start.column, 14);
-        assert_eq!(span.end.line, 2);
-        assert_eq!(span.end.column, 76);
+        assert_eq!(span.start.line(), 2);
+        assert_eq!(span.start.column(), 14);
+        assert_eq!(span.end.line(), 2);
+        assert_eq!(span.end.column(), 76);
     });
 }
 
@@ -1078,10 +1078,10 @@ A=\"`echo \\\"$A\\\" | sed 's/foo\\\\$/é/'`\"
         let spans = facts.words().echo_to_sed_substitution_spans();
         assert_eq!(spans.len(), 1);
         let span = spans[0];
-        assert_eq!(span.start.line, 2);
-        assert_eq!(span.start.column, 5);
-        assert_eq!(span.end.line, 2);
-        assert_eq!(span.end.column, 33);
+        assert_eq!(span.start.line(), 2);
+        assert_eq!(span.start.column(), 5);
+        assert_eq!(span.end.line(), 2);
+        assert_eq!(span.end.column(), 33);
         assert_eq!(span.slice(source), "echo \\\"$A\\\" | sed 's/foo\\\\$/");
     });
 }

--- a/crates/shuck-linter/src/facts/tests/comments.rs
+++ b/crates/shuck-linter/src/facts/tests/comments.rs
@@ -14,10 +14,10 @@ fn captures_c074_anchor_and_whitespace_span() {
             .space_after_hash_bang_whitespace_span()
             .expect("expected C074 whitespace span");
 
-        assert_eq!(anchor.start.line, 1);
-        assert_eq!(anchor.start.column, 2);
-        assert_eq!(whitespace.start.column, 2);
-        assert_eq!(whitespace.end.column, 4);
+        assert_eq!(anchor.start.line(), 1);
+        assert_eq!(anchor.start.column(), 2);
+        assert_eq!(whitespace.start.column(), 2);
+        assert_eq!(whitespace.end.column(), 4);
         assert_eq!(whitespace.slice(source), " \t");
     });
 }
@@ -49,8 +49,8 @@ fn captures_c075_move_span_with_existing_newline() {
             .shebang_not_on_first_line_fix_span()
             .expect("expected C075 move span");
 
-        assert_eq!(anchor.start.line, 2);
-        assert_eq!(anchor.start.column, 1);
+        assert_eq!(anchor.start.line(), 2);
+        assert_eq!(anchor.start.column(), 1);
         assert_eq!(fix_span.slice(source), "#!/bin/sh\n");
         assert_eq!(
             facts

--- a/crates/shuck-linter/src/facts/tests/conditions.rs
+++ b/crates/shuck-linter/src/facts/tests/conditions.rs
@@ -1048,7 +1048,7 @@ fn records_glued_closing_bracket_operand_spans_for_unary_tests() {
         assert_eq!(
             commands[0]
                 .glued_closing_bracket_operand_span()
-                .map(|span| (span.start.line, span.start.column)),
+                .map(|span| (span.start.line(), span.start.column())),
             Some((2, 6))
         );
         assert_eq!(
@@ -1060,7 +1060,7 @@ fn records_glued_closing_bracket_operand_spans_for_unary_tests() {
         assert_eq!(
             commands[1]
                 .glued_closing_bracket_operand_span()
-                .map(|span| (span.start.line, span.start.column)),
+                .map(|span| (span.start.line(), span.start.column())),
             Some((3, 8))
         );
         assert_eq!(
@@ -1094,21 +1094,21 @@ if [ \"$x\" = y ]; then :; fi
             .collect::<Vec<_>>();
         let broken = commands
             .iter()
-            .find(|fact| fact.static_utility_name_is("[") && fact.span().start.line == 2)
+            .find(|fact| fact.static_utility_name_is("[") && fact.span().start.line() == 2)
             .expect("expected broken bracket test");
         let continued = commands
             .iter()
-            .find(|fact| fact.static_utility_name_is("[") && fact.span().start.line == 4)
+            .find(|fact| fact.static_utility_name_is("[") && fact.span().start.line() == 4)
             .expect("expected continued bracket test");
         let single_line = commands
             .iter()
-            .find(|fact| fact.static_utility_name_is("[") && fact.span().start.line == 6)
+            .find(|fact| fact.static_utility_name_is("[") && fact.span().start.line() == 6)
             .expect("expected single-line bracket test");
 
         assert_eq!(
             broken
                 .linebreak_in_test_anchor_span()
-                .map(|span| (span.start.line, span.start.column)),
+                .map(|span| (span.start.line(), span.start.column())),
             Some((2, 14))
         );
         assert_eq!(

--- a/crates/shuck-linter/src/facts/tests/flow.rs
+++ b/crates/shuck-linter/src/facts/tests/flow.rs
@@ -44,9 +44,9 @@ fn background_semicolon_facts_report_plain_semicolons() {
 
         assert_eq!(spans.len(), 2);
         assert_eq!(spans[0].slice(source), ";");
-        assert_eq!(spans[0].start.line, 2);
+        assert_eq!(spans[0].start.line(), 2);
         assert_eq!(spans[1].slice(source), ";");
-        assert_eq!(spans[1].start.line, 3);
+        assert_eq!(spans[1].start.line(), 3);
     });
 }
 
@@ -111,11 +111,11 @@ fn commented_continuation_facts_anchor_at_comment_backslash() {
     with_facts(source, None, |_, facts| {
         let spans = facts.source_facts().commented_continuation_comment_spans();
         assert_eq!(spans.len(), 1);
-        assert_eq!(spans[0].start.line, 3);
-        assert_eq!(spans[0].start.column, 11);
+        assert_eq!(spans[0].start.line(), 3);
+        assert_eq!(spans[0].start.column(), 11);
         assert_eq!(spans[0].start, spans[0].end);
         assert_eq!(
-            &source[spans[0].start.offset - 1..spans[0].start.offset],
+            &source[spans[0].start.offset() - 1..spans[0].start.offset()],
             "\\"
         );
     });
@@ -366,7 +366,7 @@ pkg_check() {
     assert_eq!(
         body_spans
             .iter()
-            .map(|span| span.start.line)
+            .map(|span| span.start.line())
             .collect::<Vec<_>>(),
         vec![4, 8]
     );

--- a/crates/shuck-linter/src/facts/tests/functions.rs
+++ b/crates/shuck-linter/src/facts/tests/functions.rs
@@ -642,7 +642,7 @@ complete -F _comp_cmd_later later
                     .command_facts()
                     .command_is_in_completion_registered_function(command.id())
             })
-            .map(|command| command.span().start.line)
+            .map(|command| command.span().start.line())
             .collect::<Vec<_>>();
 
         assert!(!flagged_lines.is_empty());
@@ -669,7 +669,7 @@ compdef __grunt grunt
                     .command_facts()
                     .command_is_in_completion_registered_function(command.id())
             })
-            .map(|command| command.span().start.line)
+            .map(|command| command.span().start.line())
             .collect::<Vec<_>>();
 
         assert!(!flagged_lines.is_empty());
@@ -698,7 +698,7 @@ setup_completion() {
                     .command_facts()
                     .command_is_in_completion_registered_function(command.id())
             })
-            .map(|command| command.span().start.line)
+            .map(|command| command.span().start.line())
             .collect::<Vec<_>>();
 
         assert_eq!(flagged_lines, Vec::<usize>::new());
@@ -726,7 +726,7 @@ compdef __grunt grunt
                     .command_facts()
                     .command_is_in_completion_registered_function(command.id())
             })
-            .map(|command| command.span().start.line)
+            .map(|command| command.span().start.line())
             .collect::<Vec<_>>();
 
         assert_eq!(flagged_lines, Vec::<usize>::new());
@@ -752,7 +752,7 @@ compdef __grunt=grunt
                     .command_facts()
                     .command_is_in_completion_registered_function(command.id())
             })
-            .map(|command| command.span().start.line)
+            .map(|command| command.span().start.line())
             .collect::<Vec<_>>();
 
         assert_eq!(flagged_lines, Vec::<usize>::new());
@@ -778,7 +778,7 @@ compdef -d grunt
                     .command_facts()
                     .command_is_in_completion_registered_function(command.id())
             })
-            .map(|command| command.span().start.line)
+            .map(|command| command.span().start.line())
             .collect::<Vec<_>>();
 
         assert_eq!(flagged_lines, Vec::<usize>::new());
@@ -804,7 +804,7 @@ __grunt() {
                     .command_facts()
                     .command_is_in_completion_registered_function(command.id())
             })
-            .map(|command| command.span().start.line)
+            .map(|command| command.span().start.line())
             .collect::<Vec<_>>();
 
         assert_eq!(flagged_lines, Vec::<usize>::new());
@@ -830,7 +830,7 @@ compdef -P 'grunt-*' __grunt grunt
                     .command_facts()
                     .command_is_in_completion_registered_function(command.id())
             })
-            .map(|command| command.span().start.line)
+            .map(|command| command.span().start.line())
             .collect::<Vec<_>>();
 
         assert!(!flagged_lines.is_empty());
@@ -857,7 +857,7 @@ compdef -P 'grunt-*' -N __grunt grunt
                     .command_facts()
                     .command_is_in_completion_registered_function(command.id())
             })
-            .map(|command| command.span().start.line)
+            .map(|command| command.span().start.line())
             .collect::<Vec<_>>();
 
         assert!(!flagged_lines.is_empty());
@@ -884,7 +884,7 @@ __grunt() {
                     .command_facts()
                     .command_is_in_completion_registered_function(command.id())
             })
-            .map(|command| command.span().start.line)
+            .map(|command| command.span().start.line())
             .collect::<Vec<_>>();
 
         assert!(!flagged_lines.is_empty());

--- a/crates/shuck-linter/src/facts/tests/surface.rs
+++ b/crates/shuck-linter/src/facts/tests/surface.rs
@@ -182,8 +182,8 @@ if [[ \"$@\" =~ x ]]; then :; fi
         );
         assert_eq!(facts.words().positional_parameter_operator_spans().len(), 1);
         let operator_span = facts.words().positional_parameter_operator_spans()[0];
-        assert_eq!(operator_span.start.line, 6);
-        assert_eq!(operator_span.start.column, 7);
+        assert_eq!(operator_span.start.line(), 6);
+        assert_eq!(operator_span.start.column(), 7);
         assert_eq!(operator_span.end, operator_span.start);
 
         let single_quoted = facts
@@ -448,8 +448,8 @@ printf '%s\\n' a'\\'bc
                     .map(|span| {
                         (
                             fragment.span().slice(source),
-                            span.start.line,
-                            span.start.column,
+                            span.start.line(),
+                            span.start.column(),
                         )
                     })
             })
@@ -543,13 +543,13 @@ LD_LIBRARY_PATH=\"$JVM_LD_LIBRARY_PATH\":\\$this_dir \\
             .words()
             .open_double_quote_fragments()
             .iter()
-            .map(|fragment| (fragment.span().start.line, fragment.span().start.column))
+            .map(|fragment| (fragment.span().start.line(), fragment.span().start.column()))
             .collect::<Vec<_>>();
         let close = facts
             .words()
             .suspect_closing_quote_fragments()
             .iter()
-            .map(|fragment| (fragment.span().start.line, fragment.span().start.column))
+            .map(|fragment| (fragment.span().start.line(), fragment.span().start.column()))
             .collect::<Vec<_>>();
 
         assert_eq!(open, vec![(6, 11)]);
@@ -596,13 +596,13 @@ say \"configure\" now
             .words()
             .open_double_quote_fragments()
             .iter()
-            .map(|fragment| (fragment.span().start.line, fragment.span().start.column))
+            .map(|fragment| (fragment.span().start.line(), fragment.span().start.column()))
             .collect::<Vec<_>>();
         let close = facts
             .words()
             .suspect_closing_quote_fragments()
             .iter()
-            .map(|fragment| (fragment.span().start.line, fragment.span().start.column))
+            .map(|fragment| (fragment.span().start.line(), fragment.span().start.column()))
             .collect::<Vec<_>>();
 
         assert_eq!(open, vec![(2, 6)]);
@@ -646,13 +646,13 @@ line two\"\\foo\"tail\"
             .words()
             .open_double_quote_fragments()
             .iter()
-            .map(|fragment| (fragment.span().start.line, fragment.span().start.column))
+            .map(|fragment| (fragment.span().start.line(), fragment.span().start.column()))
             .collect::<Vec<_>>();
         let close = facts
             .words()
             .suspect_closing_quote_fragments()
             .iter()
-            .map(|fragment| (fragment.span().start.line, fragment.span().start.column))
+            .map(|fragment| (fragment.span().start.line(), fragment.span().start.column()))
             .collect::<Vec<_>>();
 
         assert_eq!(open, vec![(2, 6)]);
@@ -673,13 +673,13 @@ line two\"suffix
             .words()
             .open_double_quote_fragments()
             .iter()
-            .map(|fragment| (fragment.span().start.line, fragment.span().start.column))
+            .map(|fragment| (fragment.span().start.line(), fragment.span().start.column()))
             .collect::<Vec<_>>();
         let close = facts
             .words()
             .suspect_closing_quote_fragments()
             .iter()
-            .map(|fragment| (fragment.span().start.line, fragment.span().start.column))
+            .map(|fragment| (fragment.span().start.line(), fragment.span().start.column()))
             .collect::<Vec<_>>();
 
         assert_eq!(open, vec![(2, 8)]);
@@ -700,13 +700,13 @@ line two\"$suffix
             .words()
             .open_double_quote_fragments()
             .iter()
-            .map(|fragment| (fragment.span().start.line, fragment.span().start.column))
+            .map(|fragment| (fragment.span().start.line(), fragment.span().start.column()))
             .collect::<Vec<_>>();
         let close = facts
             .words()
             .suspect_closing_quote_fragments()
             .iter()
-            .map(|fragment| (fragment.span().start.line, fragment.span().start.column))
+            .map(|fragment| (fragment.span().start.line(), fragment.span().start.column()))
             .collect::<Vec<_>>();
 
         assert_eq!(open, vec![(2, 6)]);
@@ -727,13 +727,13 @@ line two\"$suffix
             .words()
             .open_double_quote_fragments()
             .iter()
-            .map(|fragment| (fragment.span().start.line, fragment.span().start.column))
+            .map(|fragment| (fragment.span().start.line(), fragment.span().start.column()))
             .collect::<Vec<_>>();
         let close = facts
             .words()
             .suspect_closing_quote_fragments()
             .iter()
-            .map(|fragment| (fragment.span().start.line, fragment.span().start.column))
+            .map(|fragment| (fragment.span().start.line(), fragment.span().start.column()))
             .collect::<Vec<_>>();
 
         assert_eq!(open, vec![(2, 8)]);
@@ -754,13 +754,13 @@ line two''tail'
             .words()
             .open_double_quote_fragments()
             .iter()
-            .map(|fragment| (fragment.span().start.line, fragment.span().start.column))
+            .map(|fragment| (fragment.span().start.line(), fragment.span().start.column()))
             .collect::<Vec<_>>();
         let close = facts
             .words()
             .suspect_closing_quote_fragments()
             .iter()
-            .map(|fragment| (fragment.span().start.line, fragment.span().start.column))
+            .map(|fragment| (fragment.span().start.line(), fragment.span().start.column()))
             .collect::<Vec<_>>();
 
         assert_eq!(open, vec![(2, 6)]);
@@ -788,13 +788,13 @@ enable_shared_with_static_runtimes=yes
             .words()
             .open_double_quote_fragments()
             .iter()
-            .map(|fragment| (fragment.span().start.line, fragment.span().start.column))
+            .map(|fragment| (fragment.span().start.line(), fragment.span().start.column()))
             .collect::<Vec<_>>();
         let close = facts
             .words()
             .suspect_closing_quote_fragments()
             .iter()
-            .map(|fragment| (fragment.span().start.line, fragment.span().start.column))
+            .map(|fragment| (fragment.span().start.line(), fragment.span().start.column()))
             .collect::<Vec<_>>();
 
         assert_eq!(open, vec![(3, 21), (4, 75)]);
@@ -817,13 +817,13 @@ then \"install\" later
             .words()
             .open_double_quote_fragments()
             .iter()
-            .map(|fragment| (fragment.span().start.line, fragment.span().start.column))
+            .map(|fragment| (fragment.span().start.line(), fragment.span().start.column()))
             .collect::<Vec<_>>();
         let close = facts
             .words()
             .suspect_closing_quote_fragments()
             .iter()
-            .map(|fragment| (fragment.span().start.line, fragment.span().start.column))
+            .map(|fragment| (fragment.span().start.line(), fragment.span().start.column()))
             .collect::<Vec<_>>();
 
         assert_eq!(open, vec![(2, 6), (3, 15), (4, 14)]);
@@ -846,10 +846,10 @@ fn builds_double_paren_grouping_spans() {
             .iter()
             .map(|span| {
                 (
-                    span.start.line,
-                    span.start.column,
-                    span.end.line,
-                    span.end.column,
+                    span.start.line(),
+                    span.start.column(),
+                    span.end.line(),
+                    span.end.column(),
                 )
             })
             .collect::<Vec<_>>();
@@ -3544,7 +3544,7 @@ $cmd[0] arg
             .words()
             .brace_variable_before_bracket_spans()
             .iter()
-            .map(|span| (span.start.line, span.start.column))
+            .map(|span| (span.start.line(), span.start.column()))
             .collect::<Vec<_>>();
 
         assert_eq!(spans, vec![(2, 7), (6, 1)]);

--- a/crates/shuck-linter/src/facts/word_spans/arrays.rs
+++ b/crates/shuck-linter/src/facts/word_spans/arrays.rs
@@ -515,7 +515,7 @@ pub(crate) fn escaped_parameter_template_bodies(
     source: &str,
 ) -> SmallVec<[EscapedParameterTemplateBody; 2]> {
     let mut bodies = SmallVec::new();
-    if word_span.start.offset >= word_span.end.offset || word_span.end.offset > source.len() {
+    if word_span.start.offset() >= word_span.end.offset() || word_span.end.offset() > source.len() {
         return bodies;
     }
 
@@ -528,7 +528,7 @@ pub(crate) fn escaped_parameter_template_bodies(
     while index < text.len() {
         if text[index..].starts_with("\\${") {
             let dollar_offset = index + '\\'.len_utf8();
-            if offset_is_backslash_escaped(word_span.start.offset + dollar_offset, source)
+            if offset_is_backslash_escaped(word_span.start.offset() + dollar_offset, source)
                 && let Some(end_offset) = escaped_parameter_template_end(text, dollar_offset)
             {
                 let body_start = dollar_offset + "${".len();
@@ -564,7 +564,7 @@ pub(crate) fn span_start_inside_escaped_parameter_template(
     bodies
         .iter()
         .copied()
-        .any(|body| body.contains(span.start.offset))
+        .any(|body| body.contains(span.start.offset()))
 }
 
 fn collect_direct_all_elements_array_expansion_spans_with_escaped_templates(
@@ -622,7 +622,7 @@ fn collect_direct_all_elements_array_expansion_spans_with_escaped_templates(
 
 impl EscapedParameterTemplateBody {
     fn contains(self, offset: usize) -> bool {
-        self.span.start.offset <= offset && offset < self.span.end.offset
+        self.span.start.offset() <= offset && offset < self.span.end.offset()
     }
 }
 
@@ -737,7 +737,7 @@ pub(crate) fn normalize_all_elements_array_expansion_span(
     let source = locator.source();
     let text = span.slice(source);
     if text == "$@"
-        && source_starts_with_non_at_selector_subscript(&source[span.end.offset..], shell_dialect)
+        && source_starts_with_non_at_selector_subscript(&source[span.end.offset()..], shell_dialect)
     {
         return None;
     }
@@ -747,7 +747,7 @@ pub(crate) fn normalize_all_elements_array_expansion_span(
         return Some(span);
     }
 
-    let base_offset = span.start.offset;
+    let base_offset = span.start.offset();
     let mut search_from = 0usize;
 
     while let Some(found) = text[search_from..].find('$') {
@@ -794,7 +794,7 @@ pub(crate) fn normalize_direct_all_elements_array_expansion_span(
     let source = locator.source();
     let text = span.slice(source);
     if text == "$@"
-        && source_starts_with_non_at_selector_subscript(&source[span.end.offset..], shell_dialect)
+        && source_starts_with_non_at_selector_subscript(&source[span.end.offset()..], shell_dialect)
     {
         return None;
     }
@@ -804,7 +804,7 @@ pub(crate) fn normalize_direct_all_elements_array_expansion_span(
         return Some(span);
     }
 
-    let base_offset = span.start.offset;
+    let base_offset = span.start.offset();
     let mut search_from = 0usize;
 
     while let Some(found) = text[search_from..].find('$') {
@@ -861,7 +861,7 @@ pub(crate) fn normalize_nested_direct_all_elements_array_expansion_span(
         return None;
     }
 
-    let base_offset = span.start.offset;
+    let base_offset = span.start.offset();
     let bytes = text.as_bytes();
     let mut index = 0usize;
     let mut nested_braced_depth = 0usize;
@@ -981,8 +981,8 @@ pub(crate) fn widen_all_elements_array_expansion_span(
         return None;
     }
 
-    let start_offset = span.start.offset.checked_sub(2)?;
-    if source.as_bytes().get(start_offset..span.start.offset)? != b"${" {
+    let start_offset = span.start.offset().checked_sub(2)?;
+    if source.as_bytes().get(start_offset..span.start.offset())? != b"${" {
         return None;
     }
     if offset_is_backslash_escaped(start_offset, source) {
@@ -1012,8 +1012,8 @@ pub(crate) fn widen_direct_all_elements_array_expansion_span(
         return None;
     }
 
-    let start_offset = span.start.offset.checked_sub(2)?;
-    if source.as_bytes().get(start_offset..span.start.offset)? != b"${" {
+    let start_offset = span.start.offset().checked_sub(2)?;
+    if source.as_bytes().get(start_offset..span.start.offset())? != b"${" {
         return None;
     }
     if offset_is_backslash_escaped(start_offset, source) {
@@ -2207,8 +2207,8 @@ eval \\
         let spans = all_elements_array_expansion_part_spans(&command.args[0], source);
         assert_eq!(spans.len(), 1);
         assert_eq!(spans[0].slice(source), "${shims[@]}");
-        assert_eq!(spans[0].start.column, 5);
-        assert_eq!(spans[0].end.column, 16);
+        assert_eq!(spans[0].start.column(), 5);
+        assert_eq!(spans[0].end.column(), 16);
     }
 
     #[test]

--- a/crates/shuck-linter/src/facts/word_spans/backticks.rs
+++ b/crates/shuck-linter/src/facts/word_spans/backticks.rs
@@ -31,16 +31,19 @@ pub(crate) fn shellcheck_deescaped_backtick_part_span(
 ) -> Option<Span> {
     let source = locator.source();
     let containing_span = containing_backtick_substitution_span(span, backtick_spans)?;
-    let content_start = containing_span.start.offset.saturating_add('`'.len_utf8());
-    let start_removed = backtick_removed_escape_count(source, content_start, span.start.offset)?;
-    let end_removed = backtick_removed_escape_count(source, content_start, span.end.offset)?;
+    let content_start = containing_span
+        .start
+        .offset()
+        .saturating_add('`'.len_utf8());
+    let start_removed = backtick_removed_escape_count(source, content_start, span.start.offset())?;
+    let end_removed = backtick_removed_escape_count(source, content_start, span.end.offset())?;
     if start_removed == 0 && end_removed == 0 {
         return None;
     }
 
     Some(Span::from_positions(
-        locator.position_at_offset(span.start.offset.checked_sub(start_removed)?)?,
-        locator.position_at_offset(span.end.offset.checked_sub(end_removed)?)?,
+        locator.position_at_offset(span.start.offset().checked_sub(start_removed)?)?,
+        locator.position_at_offset(span.end.offset().checked_sub(end_removed)?)?,
     ))
 }
 
@@ -99,8 +102,8 @@ pub(crate) fn backtick_escaped_parameters(
     let mut spans = Vec::new();
 
     for backtick_span in backtick_spans {
-        let mut index = backtick_span.start.offset.saturating_add('`'.len_utf8());
-        let end = backtick_span.end.offset.saturating_sub('`'.len_utf8());
+        let mut index = backtick_span.start.offset().saturating_add('`'.len_utf8());
+        let end = backtick_span.end.offset().saturating_sub('`'.len_utf8());
         let mut in_single_quote = false;
         let mut in_double_quote = false;
         let mut removed_escapes = 0usize;
@@ -187,10 +190,10 @@ pub(crate) fn backtick_escaped_parameters(
 
     spans.sort_by_key(|parameter| {
         (
-            parameter.diagnostic_span.start.offset,
-            parameter.diagnostic_span.end.offset,
-            parameter.reference_span.start.offset,
-            parameter.reference_span.end.offset,
+            parameter.diagnostic_span.start.offset(),
+            parameter.diagnostic_span.end.offset(),
+            parameter.reference_span.start.offset(),
+            parameter.reference_span.end.offset(),
         )
     });
     spans.dedup();
@@ -205,8 +208,8 @@ pub(crate) fn backtick_escaped_parameter_reference_spans(
     let mut spans = Vec::new();
 
     for backtick_span in backtick_spans {
-        let base_offset = backtick_span.start.offset.saturating_add('`'.len_utf8());
-        let end = backtick_span.end.offset.saturating_sub('`'.len_utf8());
+        let base_offset = backtick_span.start.offset().saturating_add('`'.len_utf8());
+        let end = backtick_span.end.offset().saturating_sub('`'.len_utf8());
         let Some(text) = source.get(base_offset..end) else {
             continue;
         };
@@ -233,7 +236,7 @@ pub(crate) fn backtick_escaped_parameter_reference_spans(
         }
     }
 
-    spans.sort_by_key(|span| (span.start.offset, span.end.offset));
+    spans.sort_by_key(|span| (span.start.offset(), span.end.offset()));
     spans.dedup();
     spans
 }
@@ -246,8 +249,8 @@ pub(crate) fn backtick_double_escaped_parameter_spans(
     let mut spans = Vec::new();
 
     for backtick_span in backtick_spans {
-        let mut index = backtick_span.start.offset.saturating_add('`'.len_utf8());
-        let end = backtick_span.end.offset.saturating_sub('`'.len_utf8());
+        let mut index = backtick_span.start.offset().saturating_add('`'.len_utf8());
+        let end = backtick_span.end.offset().saturating_sub('`'.len_utf8());
         let mut in_single_quote = false;
         let mut in_double_quote = false;
 
@@ -302,7 +305,7 @@ pub(crate) fn backtick_double_escaped_parameter_spans(
         }
     }
 
-    spans.sort_by_key(|span| (span.start.offset, span.end.offset));
+    spans.sort_by_key(|span| (span.start.offset(), span.end.offset()));
     spans.dedup();
     spans
 }
@@ -315,7 +318,7 @@ pub(crate) fn escaped_backtick_parameter_is_standalone_command_name(
 ) -> bool {
     let segment_start = backtick_command_segment_start(
         source,
-        backtick_span.start.offset.saturating_add('`'.len_utf8()),
+        backtick_span.start.offset().saturating_add('`'.len_utf8()),
         slash_offset,
     );
     let Some(prefix) = source.get(segment_start..slash_offset) else {
@@ -325,7 +328,7 @@ pub(crate) fn escaped_backtick_parameter_is_standalone_command_name(
         return false;
     }
 
-    let suffix_limit = backtick_span.end.offset.saturating_sub('`'.len_utf8());
+    let suffix_limit = backtick_span.end.offset().saturating_sub('`'.len_utf8());
     escaped_reference_ends_standalone_word(source, expansion_end, suffix_limit)
 }
 
@@ -559,10 +562,10 @@ pub(crate) fn continued_line_chain_start(
     locator: Locator<'_>,
 ) -> Option<Position> {
     let source = locator.source();
-    let original_start = source[..target.offset]
+    let original_start = source[..target.offset()]
         .rfind('\n')
         .map_or(0, |index| index + 1);
-    let containing_line_start = source[..containing_span.start.offset]
+    let containing_line_start = source[..containing_span.start.offset()]
         .rfind('\n')
         .map_or(0, |index| index + 1);
     let mut chain_start = containing_line_start;
@@ -571,9 +574,9 @@ pub(crate) fn continued_line_chain_start(
     let mut in_comment = false;
     let mut previous_char = None;
     let mut trailing_backslashes = 0usize;
-    let mut index = containing_span.start.offset.saturating_add(1);
+    let mut index = containing_span.start.offset().saturating_add(1);
 
-    while index < target.offset {
+    while index < target.offset() {
         if source[index..].starts_with("\r\n") {
             index += "\r\n".len();
             if !in_comment && !in_single_quote && trailing_backslashes % 2 == 1 {
@@ -655,10 +658,10 @@ pub(crate) fn shellcheck_collapsed_position(
     target: Position,
     source: &str,
 ) -> Position {
-    let mut line = chain_start.line;
-    let mut column = chain_start.column;
+    let mut line = chain_start.line();
+    let mut column = chain_start.column();
     let mut in_collapsed_continuation = false;
-    let prefix = &source[chain_start.offset..target.offset];
+    let prefix = &source[chain_start.offset()..target.offset()];
     let mut index = 0usize;
 
     while index < prefix.len() {
@@ -690,11 +693,7 @@ pub(crate) fn shellcheck_collapsed_position(
         index += ch.len_utf8();
     }
 
-    Position {
-        line,
-        column,
-        offset: target.offset,
-    }
+    Position::at(line, column, target.offset())
 }
 
 #[cfg(test)]
@@ -820,10 +819,10 @@ mod tests {
 
         let adjusted = shellcheck_collapsed_backtick_part_span_in_source(span, source);
 
-        assert_eq!(adjusted.start.line, span.start.line);
-        assert_eq!(adjusted.end.line, span.end.line);
-        assert_eq!(adjusted.start.column, span.start.column - 2);
-        assert_eq!(adjusted.end.column, span.end.column - 2);
+        assert_eq!(adjusted.start.line(), span.start.line());
+        assert_eq!(adjusted.end.line(), span.end.line());
+        assert_eq!(adjusted.start.column(), span.start.column() - 2);
+        assert_eq!(adjusted.end.column(), span.end.column() - 2);
     }
 
     #[test]
@@ -833,8 +832,8 @@ mod tests {
 
         let adjusted = shellcheck_collapsed_backtick_part_span_in_source(span, source);
 
-        assert_eq!(adjusted.start.column, span.start.column - 1);
-        assert_eq!(adjusted.end.column, span.end.column - 1);
+        assert_eq!(adjusted.start.column(), span.start.column() - 1);
+        assert_eq!(adjusted.end.column(), span.end.column() - 1);
     }
 
     #[test]

--- a/crates/shuck-linter/src/facts/word_spans/command_substitution.rs
+++ b/crates/shuck-linter/src/facts/word_spans/command_substitution.rs
@@ -132,13 +132,13 @@ pub(crate) fn widen_dollar_paren_command_substitution_span(
 ) -> Option<Span> {
     let source = locator.source();
     let bytes = source.as_bytes();
-    if bytes.get(span.start.offset)? != &b'$' || bytes.get(span.start.offset + 1)? != &b'(' {
+    if bytes.get(span.start.offset())? != &b'$' || bytes.get(span.start.offset() + 1)? != &b'(' {
         return None;
     }
 
     let end_offset = shuck_ast::raw_shell::RawShellScanner::new(source)
-        .skip_balanced_shell_construct(span.start.offset + 2, b'(', b')')?;
-    let start = locator.position_at_offset(span.start.offset)?;
+        .skip_balanced_shell_construct(span.start.offset() + 2, b'(', b')')?;
+    let start = locator.position_at_offset(span.start.offset())?;
     let end = locator.position_at_offset(end_offset)?;
     Some(Span::from_positions(start, end))
 }
@@ -149,13 +149,13 @@ pub(crate) fn widen_backtick_command_substitution_span(
 ) -> Option<Span> {
     let source = locator.source();
     let bytes = source.as_bytes();
-    if bytes.get(span.start.offset)? != &b'`' {
+    if bytes.get(span.start.offset())? != &b'`' {
         return None;
     }
 
     let end_offset = shuck_ast::raw_shell::RawShellScanner::new(source)
-        .skip_legacy_backtick_substitution_body(span.start.offset + 1)?;
-    let start = locator.position_at_offset(span.start.offset)?;
+        .skip_legacy_backtick_substitution_body(span.start.offset() + 1)?;
+    let start = locator.position_at_offset(span.start.offset())?;
     let end = locator.position_at_offset(end_offset)?;
     Some(Span::from_positions(start, end))
 }

--- a/crates/shuck-linter/src/facts/word_spans/globs.rs
+++ b/crates/shuck-linter/src/facts/word_spans/globs.rs
@@ -18,7 +18,7 @@ pub fn word_active_glob_pattern_spans(
 
     let mut spans = Vec::new();
     collect_active_glob_pattern_spans(&word.parts, source, false, pattern_behavior, &mut spans);
-    spans.sort_by_key(|span| (span.start.offset, span.end.offset));
+    spans.sort_by_key(|span| (span.start.offset(), span.end.offset()));
     spans.dedup();
     spans
 }
@@ -44,8 +44,8 @@ pub fn word_unquoted_glob_pattern_spans_outside_brace_expansion(
         .into_iter()
         .filter(|glob_span| {
             !active_brace_spans.iter().any(|brace_span| {
-                brace_span.start.offset <= glob_span.start.offset
-                    && glob_span.end.offset <= brace_span.end.offset
+                brace_span.start.offset() <= glob_span.start.offset()
+                    && glob_span.end.offset() <= brace_span.end.offset()
             })
         })
         .collect()
@@ -73,8 +73,8 @@ pub fn word_active_glob_pattern_spans_outside_brace_expansion(
         .into_iter()
         .filter(|glob_span| {
             !active_brace_spans.iter().any(|brace_span| {
-                brace_span.start.offset <= glob_span.start.offset
-                    && glob_span.end.offset <= brace_span.end.offset
+                brace_span.start.offset() <= glob_span.start.offset()
+                    && glob_span.end.offset() <= brace_span.end.offset()
             })
         })
         .collect()
@@ -123,7 +123,7 @@ pub fn word_suspicious_brace_character_class_spans(word: &Word, source: &str) ->
         .map(|brace| brace.span)
         .collect::<Vec<_>>();
     collect_literal_suspicious_brace_character_class_spans(word, source, &mut spans);
-    spans.sort_unstable_by_key(|span| (span.start.offset, span.end.offset));
+    spans.sort_unstable_by_key(|span| (span.start.offset(), span.end.offset()));
     spans.dedup();
     spans
 }
@@ -577,7 +577,7 @@ pub(crate) fn active_literal_glob_pattern_spans(
         .filter(|glob_span| !span_is_within_any(*glob_span, &spans))
         .collect::<Vec<_>>();
     spans.extend(basic_spans);
-    spans.sort_by_key(|span| (span.start.offset, span.end.offset));
+    spans.sort_by_key(|span| (span.start.offset(), span.end.offset()));
     spans.dedup();
     spans
 }
@@ -724,9 +724,9 @@ fn pattern_operator_may_be_active(behavior: PatternOperatorBehavior) -> bool {
 }
 
 fn span_is_within_any(span: Span, hosts: &[Span]) -> bool {
-    hosts
-        .iter()
-        .any(|host| host.start.offset <= span.start.offset && span.end.offset <= host.end.offset)
+    hosts.iter().any(|host| {
+        host.start.offset() <= span.start.offset() && span.end.offset() <= host.end.offset()
+    })
 }
 
 pub(crate) fn suspicious_bracket_glob_text(text: &str) -> bool {
@@ -894,10 +894,10 @@ pub(crate) fn hyphen_is_range_separator(
 pub(crate) fn span_within_literal(span: Span, source: &str, start: usize, end: usize) -> Span {
     let start_pos = span
         .start
-        .advanced_by(&source[span.start.offset..span.start.offset + start]);
+        .advanced_by(&source[span.start.offset()..span.start.offset() + start]);
     let end_pos = span
         .start
-        .advanced_by(&source[span.start.offset..span.start.offset + end]);
+        .advanced_by(&source[span.start.offset()..span.start.offset() + end]);
     Span::from_positions(start_pos, end_pos)
 }
 
@@ -1111,7 +1111,7 @@ pub(crate) fn word_surface_bytes(
         return None;
     }
 
-    let word_start = word.span.start.offset;
+    let word_start = word.span.start.offset();
     let mut surface = Vec::new();
     let mut source_offsets = Vec::new();
 
@@ -1119,7 +1119,7 @@ pub(crate) fn word_surface_bytes(
         match &part.kind {
             WordPart::Literal(_) => {
                 let part_text = part.span.slice(source);
-                let relative_start = part.span.start.offset.checked_sub(word_start)?;
+                let relative_start = part.span.start.offset().checked_sub(word_start)?;
                 for (index, byte) in part_text.as_bytes().iter().copied().enumerate() {
                     surface.push(byte);
                     source_offsets.push(Some(relative_start + index));

--- a/crates/shuck-linter/src/facts/word_spans/source_scan.rs
+++ b/crates/shuck-linter/src/facts/word_spans/source_scan.rs
@@ -2,7 +2,7 @@ use super::*;
 use shuck_ast::raw_shell;
 
 pub(crate) fn span_contains(outer: Span, inner: Span) -> bool {
-    outer.start.offset <= inner.start.offset && outer.end.offset >= inner.end.offset
+    outer.start.offset() <= inner.start.offset() && outer.end.offset() >= inner.end.offset()
 }
 
 pub(crate) fn advance_shell_char(text: &str, index: usize) -> usize {
@@ -20,30 +20,33 @@ pub(crate) fn collect_scan_span_excluding(
         return;
     }
 
-    let mut cursor = span.start.offset;
+    let mut cursor = span.start.offset();
     for excluded_span in excluded.iter().copied().filter(|excluded_span| {
-        excluded_span.end.offset > span.start.offset && excluded_span.start.offset < span.end.offset
+        excluded_span.end.offset() > span.start.offset()
+            && excluded_span.start.offset() < span.end.offset()
     }) {
-        let segment_end = excluded_span.start.offset.min(span.end.offset);
+        let segment_end = excluded_span.start.offset().min(span.end.offset());
         if cursor < segment_end {
             spans.push(scan_span_segment(span, cursor, segment_end, source));
         }
-        cursor = cursor.max(excluded_span.end.offset).min(span.end.offset);
+        cursor = cursor
+            .max(excluded_span.end.offset())
+            .min(span.end.offset());
     }
 
-    if cursor < span.end.offset {
-        spans.push(scan_span_segment(span, cursor, span.end.offset, source));
+    if cursor < span.end.offset() {
+        spans.push(scan_span_segment(span, cursor, span.end.offset(), source));
     }
 }
 
 pub(crate) fn scan_span_segment(span: Span, start: usize, end: usize, source: &str) -> Span {
-    let segment_start = span.start.advanced_by(&source[span.start.offset..start]);
-    let segment_end = span.start.advanced_by(&source[span.start.offset..end]);
+    let segment_start = span.start.advanced_by(&source[span.start.offset()..start]);
+    let segment_end = span.start.advanced_by(&source[span.start.offset()..end]);
     Span::from_positions(segment_start, segment_end)
 }
 
 pub(crate) fn span_is_backslash_escaped(span: Span, source: &str) -> bool {
-    offset_is_backslash_escaped(span.start.offset, source)
+    offset_is_backslash_escaped(span.start.offset(), source)
 }
 
 pub(crate) fn offset_is_backslash_escaped(offset: usize, source: &str) -> bool {

--- a/crates/shuck-linter/src/facts/words/command_facts.rs
+++ b/crates/shuck-linter/src/facts/words/command_facts.rs
@@ -56,7 +56,7 @@ pub(crate) fn build_function_in_alias_facts(
             }
         }
     }
-    facts.sort_by_key(|fact| (fact.span().start.offset, fact.span().end.offset));
+    facts.sort_by_key(|fact| (fact.span().start.offset(), fact.span().end.offset()));
     facts.dedup_by_key(|fact| FactSpan::new(fact.span()));
     facts
 }
@@ -90,7 +90,7 @@ pub(crate) fn build_alias_definition_expansion_facts(
             })
         })
         .collect::<Vec<_>>();
-    facts.sort_by_key(|fact| (fact.span().start.offset, fact.span().end.offset));
+    facts.sort_by_key(|fact| (fact.span().start.offset(), fact.span().end.offset()));
     facts.dedup_by_key(|fact| FactSpan::new(fact.span()));
     facts
 }
@@ -122,7 +122,7 @@ fn alias_definition_first_active_expansion_span(
                 .iter()
                 .copied()
         })
-        .min_by_key(|span| (span.start.offset, span.end.offset))
+        .min_by_key(|span| (span.start.offset(), span.end.offset()))
 }
 
 pub(crate) fn alias_definition_word_groups_for_command<'a>(
@@ -143,7 +143,7 @@ pub(crate) fn alias_definition_word_groups_for_command<'a>(
         let mut definition_len = 1usize;
         while word_ends_with_literal_equals(last_word, source)
             && let Some(next_word) = body_args.get(index + definition_len).copied()
-            && last_word.span.end.offset == next_word.span.start.offset
+            && last_word.span.end.offset() == next_word.span.start.offset()
         {
             last_word = next_word;
             definition_len += 1;
@@ -172,21 +172,21 @@ pub(crate) fn word_chars_outside_expansions<'a>(
 ) -> impl Iterator<Item = (usize, char)> + 'a {
     let text = word.span.slice(source);
     let mut excluded = expansion_part_spans(word);
-    excluded.sort_by_key(|span| span.start.offset);
+    excluded.sort_by_key(|span| span.start.offset());
     let mut excluded = excluded.into_iter().peekable();
 
     text.char_indices().filter(move |(offset, _)| {
-        let absolute_offset = word.span.start.offset + offset;
+        let absolute_offset = word.span.start.offset() + offset;
         while matches!(
             excluded.peek(),
-            Some(span) if absolute_offset >= span.end.offset
+            Some(span) if absolute_offset >= span.end.offset()
         ) {
             excluded.next();
         }
 
         !matches!(
             excluded.peek(),
-            Some(span) if absolute_offset >= span.start.offset && absolute_offset < span.end.offset
+            Some(span) if absolute_offset >= span.start.offset() && absolute_offset < span.end.offset()
         )
     })
 }
@@ -230,11 +230,11 @@ fn alias_definition_single_quoted_replacement(
 ) -> Option<(Span, Box<str>)> {
     let span = alias_definition_span(words)?;
     let equals_offset = alias_definition_equals_offset(words, source)?;
-    let name = source.get(span.start.offset..equals_offset)?;
+    let name = source.get(span.start.offset()..equals_offset)?;
     if !literal_alias_name_is_fixable(name) {
         return None;
     }
-    let value = source.get(equals_offset + 1..span.end.offset)?;
+    let value = source.get(equals_offset + 1..span.end.offset())?;
     let body = strip_simple_alias_value_quotes(value).unwrap_or(value);
     Some((
         span,
@@ -245,7 +245,7 @@ fn alias_definition_single_quoted_replacement(
 fn alias_definition_equals_offset(words: &[&Word], source: &str) -> Option<usize> {
     words.iter().find_map(|word| {
         word_chars_outside_expansions(word, source)
-            .find_map(|(offset, ch)| (ch == '=').then_some(word.span.start.offset + offset))
+            .find_map(|(offset, ch)| (ch == '=').then_some(word.span.start.offset() + offset))
     })
 }
 
@@ -907,13 +907,13 @@ pub(crate) fn sc2001_like_backtick_sed_script_end(
     let raw_script_end = match script_words {
         [script] => backtick_sed_script_content_end_offset(
             script.span.slice(source),
-            script.span.end.offset,
+            script.span.end.offset(),
         )?,
         [first, .., last]
             if first.span.slice(source).starts_with("\\\"")
                 && last.span.slice(source).ends_with("\\\"") =>
         {
-            last.span.end.offset.checked_sub(2)?
+            last.span.end.offset().checked_sub(2)?
         }
         _ => return None,
     };
@@ -1265,14 +1265,14 @@ pub(crate) fn detect_sudo_family_invoker(
     let Command::Simple(command) = command else {
         return None;
     };
-    let body_start = normalized.body_span.start.offset;
+    let body_start = normalized.body_span.start.offset();
     let scan_all_words = normalized.body_words.is_empty();
 
     std::iter::once(&command.name)
         .chain(command.args.iter())
         // Unresolved sudo-family wrappers intentionally keep the wrapper marker
         // even when there is no statically known inner command.
-        .take_while(|word| scan_all_words || word.span.start.offset < body_start)
+        .take_while(|word| scan_all_words || word.span.start.offset() < body_start)
         .filter_map(|word| static_word_text(word, source))
         .map(|word| word.strip_prefix('\\').unwrap_or(word.as_ref()).to_owned())
         .filter_map(|word| match word.as_str() {

--- a/crates/shuck-linter/src/facts/words/occurrence.rs
+++ b/crates/shuck-linter/src/facts/words/occurrence.rs
@@ -226,18 +226,18 @@ impl<'facts, 'a> WordOccurrenceRef<'facts, 'a> {
                 .iter()
                 .copied()
                 .find(|span| {
-                    span.start.offset <= part_span.start.offset
-                        && span.end.offset >= part_span.end.offset
+                    span.start.offset() <= part_span.start.offset()
+                        && span.end.offset() >= part_span.end.offset()
                 })
         else {
             return false;
         };
 
-        let mut index = backtick_span.start.offset.saturating_add('`'.len_utf8());
-        let limit = part_span.start.offset.min(
+        let mut index = backtick_span.start.offset().saturating_add('`'.len_utf8());
+        let limit = part_span.start.offset().min(
             backtick_span
                 .end
-                .offset
+                .offset()
                 .saturating_sub('`'.len_utf8()),
         );
         let mut in_single_quote = false;
@@ -510,8 +510,8 @@ impl<'facts, 'a> WordOccurrenceRef<'facts, 'a> {
                 if part_span.slice(source) == expected {
                     part_span
                 } else {
-                    let search_start = part_span.start.offset.saturating_sub(1);
-                    let search_end = (part_span.end.offset + 1).min(source.len());
+                    let search_start = part_span.start.offset().saturating_sub(1);
+                    let search_end = (part_span.end.offset() + 1).min(source.len());
                     source
                         .get(search_start..search_end)
                         .and_then(|window| window.find(&expected))
@@ -622,7 +622,7 @@ impl<'facts, 'a> WordOccurrenceRef<'facts, 'a> {
         if self
             .facts
             .semantic
-            .shell_behavior_at(self.span().start.offset)
+            .shell_behavior_at(self.span().start.offset())
             .brace_character_classes()
             .can_expand()
         {
@@ -720,7 +720,7 @@ impl<'facts, 'a> WordOccurrenceRef<'facts, 'a> {
             Some(shuck_ast::BraceExpansionKind::CharacterClass) => self
                 .facts
                 .semantic
-                .shell_behavior_at(brace.span.start.offset)
+                .shell_behavior_at(brace.span.start.offset())
                 .brace_character_classes()
                 .can_expand(),
             None => false,
@@ -732,32 +732,32 @@ pub(crate) fn shellcheck_parameter_span_inside_escaped_quotes(
     span: Span,
     locator: Locator<'_>,
 ) -> Option<Span> {
-    if span.start.line != span.end.line {
+    if span.start.line() != span.end.line() {
         return None;
     }
 
     let source = locator.source();
     let search_start = locator.offset_for_line_column(
-        span.start.line,
-        span.start.column.saturating_sub(2).max(1),
+        span.start.line(),
+        span.start.column().saturating_sub(2).max(1),
     )?;
     let search_end = locator.offset_for_line_column(
-        span.end.line,
-        span.end.column.saturating_add(3),
+        span.end.line(),
+        span.end.column().saturating_add(3),
     )
-    .or_else(|| locator.line_range(span.end.line).map(|range| usize::from(range.end())))?;
+    .or_else(|| locator.line_range(span.end.line()).map(|range| usize::from(range.end())))?;
     let window = source.get(search_start..search_end)?;
     let relative_dollar = window.find('$')?;
     let start_offset = search_start + relative_dollar;
     let start = locator.position_at_offset(start_offset)?;
-    if start.line != span.start.line
-        || start.column < span.start.column
-        || start.column > span.start.column.saturating_add(2)
+    if start.line() != span.start.line()
+        || start.column() < span.start.column()
+        || start.column() > span.start.column().saturating_add(2)
     {
         return None;
     }
 
-    let span_start_offset = locator.offset_for_line_column(span.start.line, span.start.column)?;
+    let span_start_offset = locator.offset_for_line_column(span.start.line(), span.start.column())?;
     let prefix = source.get(span_start_offset..start_offset)?;
     if !prefix.contains('"') && !prefix.contains('\\') {
         return None;
@@ -765,14 +765,14 @@ pub(crate) fn shellcheck_parameter_span_inside_escaped_quotes(
 
     let end_offset = parameter_expansion_end_offset(source, start_offset)?;
     let end = locator.position_at_offset(end_offset)?;
-    if end.line != span.end.line
-        || end.column < span.end.column
-        || end.column > span.end.column.saturating_add(3)
+    if end.line() != span.end.line()
+        || end.column() < span.end.column()
+        || end.column() > span.end.column().saturating_add(3)
     {
         return None;
     }
 
-    if start.column == span.start.column && end.column == span.end.column {
+    if start.column() == span.start.column() && end.column() == span.end.column() {
         return None;
     }
 
@@ -1587,7 +1587,7 @@ fn collect_derived_word_traversal_spans<'a>(
         );
         spans
             .active_expansion_spans
-            .sort_unstable_by_key(|span| (span.start.offset, span.end.offset));
+            .sort_unstable_by_key(|span| (span.start.offset(), span.end.offset()));
         spans.active_expansion_spans.dedup();
     }
 
@@ -2142,7 +2142,7 @@ impl<'out, 'a, 'norm> WordFactCollector<'out, 'a, 'norm> {
             surface_body_arg_start_offset: normalized
                 .body_args()
                 .first()
-                .map(|word| word.span.start.offset),
+                .map(|word| word.span.start.offset()),
             command_shell_behavior,
             command_visits_by_id: outputs.command_visits_by_id,
             word_nodes: outputs.word_nodes,
@@ -2428,7 +2428,7 @@ impl<'out, 'a, 'norm> WordFactCollector<'out, 'a, 'norm> {
                         command
                             .args
                             .iter()
-                            .position(|word| word.span.start.offset == offset)
+                            .position(|word| word.span.start.offset() == offset)
                     })
                     .unwrap_or_else(|| wrapper_target_arg_index.map_or(0, |index| index + 1));
                 let trap_command =

--- a/crates/shuck-linter/src/facts/words/quote_spans.rs
+++ b/crates/shuck-linter/src/facts/words/quote_spans.rs
@@ -391,7 +391,7 @@ pub(crate) fn mixed_quote_trailing_line_join_between_double_quotes_span(
     };
 
     if !mixed_quote_text_ends_with_unescaped_double_quote(prefix)
-        || !source[word.span.end.offset..].starts_with('"')
+        || !source[word.span.end.offset()..].starts_with('"')
     {
         return None;
     }
@@ -459,7 +459,7 @@ pub(crate) fn mixed_quote_following_line_join_suffix_after_word(
         return None;
     }
 
-    let tail = &source[word.span.end.offset..];
+    let tail = &source[word.span.end.offset()..];
     let suffix = tail
         .strip_prefix("\\\r\n\"")
         .map(|_| "\\\r\n")
@@ -489,7 +489,7 @@ pub(crate) fn mixed_quote_chained_line_join_between_double_quotes_spans(
     }
 
     let mut spans = Vec::new();
-    let mut cursor = word.span.end.offset;
+    let mut cursor = word.span.end.offset();
     let mut cursor_position = word.span.end;
     while source[cursor..].starts_with('"') {
         let Some(closing_quote_relative) =

--- a/crates/shuck-linter/src/facts/words/traversal.rs
+++ b/crates/shuck-linter/src/facts/words/traversal.rs
@@ -316,7 +316,7 @@ fn walk_word_parts<'a>(
 fn literal_text_for_context<'a>(text: &'a LiteralText, source: &'a str, span: Span) -> &'a str {
     match text {
         LiteralText::Owned(_) => text.as_str(source, span),
-        LiteralText::Source | LiteralText::CookedSource(_) if span.end.offset <= source.len() => {
+        LiteralText::Source | LiteralText::CookedSource(_) if span.end.offset() <= source.len() => {
             text.as_str(source, span)
         }
         LiteralText::Source | LiteralText::CookedSource(_) => "",

--- a/crates/shuck-linter/src/fix.rs
+++ b/crates/shuck-linter/src/fix.rs
@@ -35,7 +35,7 @@ pub struct Edit {
 
 impl Edit {
     pub fn deletion(span: Span) -> Self {
-        Self::deletion_at(span.start.offset, span.end.offset)
+        Self::deletion_at(span.start.offset(), span.end.offset())
     }
 
     pub fn deletion_at(start: usize, end: usize) -> Self {
@@ -43,7 +43,7 @@ impl Edit {
     }
 
     pub fn replacement(content: impl Into<CompactString>, span: Span) -> Self {
-        Self::replacement_at(span.start.offset, span.end.offset, content)
+        Self::replacement_at(span.start.offset(), span.end.offset(), content)
     }
 
     pub fn replacement_at(start: usize, end: usize, content: impl Into<CompactString>) -> Self {
@@ -274,16 +274,8 @@ mod tests {
 
     fn span(start: usize, end: usize) -> Span {
         Span::from_positions(
-            Position {
-                line: 1,
-                column: start + 1,
-                offset: start,
-            },
-            Position {
-                line: 1,
-                column: end + 1,
-                offset: end,
-            },
+            Position::at(1, start + 1, start),
+            Position::at(1, end + 1, end),
         )
     }
 

--- a/crates/shuck-linter/src/fix_helpers.rs
+++ b/crates/shuck-linter/src/fix_helpers.rs
@@ -50,7 +50,7 @@ fn collect_leading_static_word_prefix_edits_from_part(
         WordPart::Literal(text) => collect_leading_static_word_prefix_edit_from_segment(
             text.syntax_str(source, part.span),
             semantic.as_str(),
-            part.span.start.offset,
+            part.span.start.offset(),
             remaining,
             edits,
         ),
@@ -59,7 +59,7 @@ fn collect_leading_static_word_prefix_edits_from_part(
             collect_leading_static_word_prefix_edit_from_segment(
                 content_span.slice(source),
                 semantic.as_str(),
-                content_span.start.offset,
+                content_span.start.offset(),
                 remaining,
                 edits,
             )

--- a/crates/shuck-linter/src/lib.rs
+++ b/crates/shuck-linter/src/lib.rs
@@ -436,7 +436,7 @@ impl<'a> LinterSemanticArtifacts<'a> {
     ) -> Option<bool> {
         let mut trailing_loop_kind = None;
         self.for_each_command_visit_in_body(body, false, |visit| {
-            if visit.stmt.span.end.offset != eof_offset {
+            if visit.stmt.span.end.offset() != eof_offset {
                 return;
             }
 
@@ -446,7 +446,7 @@ impl<'a> LinterSemanticArtifacts<'a> {
                 _ => return,
             };
 
-            let start_offset = visit.stmt.span.start.offset;
+            let start_offset = visit.stmt.span.start.offset();
             if trailing_loop_kind
                 .as_ref()
                 .is_none_or(|(best_start, _)| start_offset >= *best_start)
@@ -772,7 +772,7 @@ impl<'a> TraversalObserver<'a> for LintTraversalObserver<'a> {
                 .resize(id.index() + 1, None);
         }
         let span = statement_suppression_span(stmt);
-        if span.start.line != 0 && span.end.line != 0 {
+        if span.start.line() != 0 && span.end.line() != 0 {
             self.suppression_command_spans_by_id[id.index()] = Some(span);
         }
     }
@@ -1021,7 +1021,7 @@ fn finalize_diagnostics(result: &mut LinterAnalysisResult<'_>, request: &Analysi
 
     result
         .diagnostics
-        .sort_by_key(|diagnostic| (diagnostic.span.start.offset, diagnostic.span.end.offset));
+        .sort_by_key(|diagnostic| (diagnostic.span.start.offset(), diagnostic.span.end.offset()));
 }
 
 fn resolve_shell(
@@ -1049,7 +1049,7 @@ fn parse_error_position(parse_result: &ParseResult) -> Option<(usize, usize)> {
     parse_result
         .diagnostics
         .first()
-        .map(|diagnostic| (diagnostic.span.start.line, diagnostic.span.start.column))
+        .map(|diagnostic| (diagnostic.span.start.line(), diagnostic.span.start.column()))
 }
 
 fn filter_suppressed_diagnostics(
@@ -1060,7 +1060,7 @@ fn filter_suppressed_diagnostics(
     diagnostics.retain(|diagnostic| {
         let line = indexer
             .line_index()
-            .line_number(TextSize::new(diagnostic.span.start.offset as u32));
+            .line_number(TextSize::new(diagnostic.span.start.offset() as u32));
         let Ok(line) = u32::try_from(line) else {
             return true;
         };
@@ -1093,24 +1093,25 @@ fn sanitize_diagnostic_spans_cold(diagnostics: &mut [Diagnostic], locator: Locat
 #[cold]
 fn sanitize_span(span: Span, locator: Locator<'_>) -> Span {
     let source = locator.source();
-    if span.start.offset <= span.end.offset
-        && span.end.offset <= source.len()
-        && source.is_char_boundary(span.start.offset)
-        && source.is_char_boundary(span.end.offset)
+    if span.start.offset() <= span.end.offset()
+        && span.end.offset() <= source.len()
+        && source.is_char_boundary(span.start.offset())
+        && source.is_char_boundary(span.end.offset())
     {
         return span;
     }
 
-    let offsets_are_bounded = span.start.offset <= source.len() && span.end.offset <= source.len();
+    let offsets_are_bounded =
+        span.start.offset() <= source.len() && span.end.offset() <= source.len();
     let offsets_are_aligned =
-        source.is_char_boundary(span.start.offset) && source.is_char_boundary(span.end.offset);
-    if offsets_are_bounded && offsets_are_aligned && span.start.offset > span.end.offset {
+        source.is_char_boundary(span.start.offset()) && source.is_char_boundary(span.end.offset());
+    if offsets_are_bounded && offsets_are_aligned && span.start.offset() > span.end.offset() {
         return Span::from_positions(span.end, span.start);
     }
 
     let len = source.len();
-    let raw_start = span.start.offset.min(len);
-    let raw_end = span.end.offset.min(len);
+    let raw_start = span.start.offset().min(len);
+    let raw_end = span.end.offset().min(len);
     let (start_offset, end_offset) = if raw_start <= raw_end {
         (
             floor_char_boundary(source, raw_start),
@@ -1311,7 +1312,7 @@ mod tests {
                     return None;
                 };
                 let span = command.name.span;
-                Some(source[span.start.offset..span.end.offset].to_owned())
+                Some(source[span.start.offset()..span.end.offset()].to_owned())
             })
             .collect()
     }
@@ -1451,11 +1452,7 @@ mod tests {
     #[test]
     fn parse_error_position_falls_back_to_first_diagnostic_span() {
         let file = Parser::new("#!/bin/bash\n").parse().unwrap().file;
-        let diagnostic_start = Position {
-            line: 3,
-            column: 2,
-            offset: 14,
-        };
+        let diagnostic_start = Position::at(3, 2, 14);
         let parse_result = ParseResult {
             file,
             diagnostics: vec![ParseDiagnostic {
@@ -2755,7 +2752,7 @@ END
 
             for diagnostic in diagnostics {
                 assert!(
-                    diagnostic.span.start.offset <= diagnostic.span.end.offset,
+                    diagnostic.span.start.offset() <= diagnostic.span.end.offset(),
                     "invalid span ordering for {} with path {:?} and dialect {:?}: {:?}",
                     diagnostic.code(),
                     path,
@@ -2763,7 +2760,7 @@ END
                     diagnostic.span
                 );
                 assert!(
-                    diagnostic.span.end.offset <= source.len(),
+                    diagnostic.span.end.offset() <= source.len(),
                     "span end out of bounds for {} with path {:?} and dialect {:?}: {:?}",
                     diagnostic.code(),
                     path,
@@ -2771,7 +2768,7 @@ END
                     diagnostic.span
                 );
                 assert!(
-                    source.is_char_boundary(diagnostic.span.start.offset),
+                    source.is_char_boundary(diagnostic.span.start.offset()),
                     "span start not on char boundary for {} with path {:?} and dialect {:?}: {:?}",
                     diagnostic.code(),
                     path,
@@ -2779,7 +2776,7 @@ END
                     diagnostic.span
                 );
                 assert!(
-                    source.is_char_boundary(diagnostic.span.end.offset),
+                    source.is_char_boundary(diagnostic.span.end.offset()),
                     "span end not on char boundary for {} with path {:?} and dialect {:?}: {:?}",
                     diagnostic.code(),
                     path,
@@ -3043,8 +3040,8 @@ printf '%s\\n' \"${!args_var}\"
         let diagnostics = lint_for_rule("#!/bin/bash\nrest=1\nREST=2\n", Rule::UnusedAssignment);
 
         assert_eq!(diagnostics.len(), 2);
-        assert_eq!(diagnostics[0].span.start.line, 2);
-        assert_eq!(diagnostics[1].span.start.line, 3);
+        assert_eq!(diagnostics[0].span.start.line(), 2);
+        assert_eq!(diagnostics[1].span.start.line(), 3);
     }
 
     #[test]
@@ -3168,7 +3165,7 @@ f a
         );
 
         assert_eq!(diagnostics.len(), 1);
-        assert_eq!(diagnostics[0].span.start.line, 8);
+        assert_eq!(diagnostics[0].span.start.line(), 8);
         assert_eq!(diagnostics[0].span.slice(
             "#!/bin/bash\nf() {\n  local opts\n  case \"$1\" in\n    a) opts=alpha ;;\n    *) opts=beta ;;\n  esac\n  while IFS= read -r line; do :; done < <(printf '%s\\n' \"$opts\")\n}\nf a\n"
         ), "line");
@@ -3187,7 +3184,7 @@ f
         let diagnostics = lint_for_rule(source, Rule::UnusedAssignment);
 
         assert_eq!(diagnostics.len(), 1);
-        assert_eq!(diagnostics[0].span.start.line, 4);
+        assert_eq!(diagnostics[0].span.start.line(), 4);
         assert_eq!(diagnostics[0].span.slice(source), "foo");
     }
 
@@ -3801,7 +3798,7 @@ f
         let diagnostics = lint(source, &LinterSettings::for_rule(Rule::DeclareCommand));
         assert_eq!(diagnostics.len(), 1);
         assert_eq!(diagnostics[0].span.slice(source), "declare -a values");
-        assert_eq!(diagnostics[0].span.end.line, 2);
+        assert_eq!(diagnostics[0].span.end.line(), 2);
     }
 
     #[test]
@@ -3890,7 +3887,7 @@ fi
         let diagnostics = lint_for_rule(source, Rule::UnusedAssignment);
 
         assert_eq!(diagnostics.len(), 1);
-        assert_eq!(diagnostics[0].span.start.line, 5);
+        assert_eq!(diagnostics[0].span.start.line(), 5);
     }
 
     #[test]
@@ -4087,8 +4084,8 @@ printf '%s\\n' \"${!foo}\"
         assert_eq!(diagnostics.len(), 1);
         assert_eq!(diagnostics[0].rule, Rule::UndefinedVariable);
         assert!(diagnostics[0].message.contains("foo"));
-        assert_eq!(diagnostics[0].span.start.line, 2);
-        assert_eq!(diagnostics[0].span.start.column, 16);
+        assert_eq!(diagnostics[0].span.start.line(), 2);
+        assert_eq!(diagnostics[0].span.start.column(), 16);
     }
 
     #[test]
@@ -4103,8 +4100,8 @@ printf '%s\\n' \"${!tools[$target]}\"
         assert_eq!(diagnostics[0].rule, Rule::UndefinedVariable);
         assert!(diagnostics[0].message.contains("tools"));
         assert!(!diagnostics[0].message.contains("target"));
-        assert_eq!(diagnostics[0].span.start.line, 2);
-        assert_eq!(diagnostics[0].span.start.column, 16);
+        assert_eq!(diagnostics[0].span.start.line(), 2);
+        assert_eq!(diagnostics[0].span.start.column(), 16);
     }
 
     #[test]
@@ -4178,8 +4175,8 @@ printf '%s\\n' \"${missing%%/*}\"
         assert_eq!(diagnostics.len(), 1);
         assert_eq!(diagnostics[0].rule, Rule::UndefinedVariable);
         assert!(diagnostics[0].message.contains("missing"));
-        assert_eq!(diagnostics[0].span.start.line, 2);
-        assert_eq!(diagnostics[0].span.start.column, 16);
+        assert_eq!(diagnostics[0].span.start.line(), 2);
+        assert_eq!(diagnostics[0].span.start.column(), 16);
     }
 
     #[test]
@@ -4195,8 +4192,8 @@ rvm_info=\"
         assert_eq!(diagnostics.len(), 1);
         assert_eq!(diagnostics[0].rule, Rule::UndefinedVariable);
         assert!(diagnostics[0].message.contains("_system_info"));
-        assert_eq!(diagnostics[0].span.start.line, 3);
-        assert_eq!(diagnostics[0].span.start.column, 12);
+        assert_eq!(diagnostics[0].span.start.line(), 3);
+        assert_eq!(diagnostics[0].span.start.column(), 12);
         assert_eq!(diagnostics[0].span.slice(source), "${_system_info}");
     }
 
@@ -4223,8 +4220,8 @@ payload=\"{
             .find(|diagnostic| diagnostic.message.contains("serverfilesdu"))
             .unwrap();
 
-        assert_eq!(diagnostic.span.start.line, 9);
-        assert_eq!(diagnostic.span.start.column, 20);
+        assert_eq!(diagnostic.span.start.line(), 9);
+        assert_eq!(diagnostic.span.start.column(), 20);
         assert_eq!(diagnostic.span.slice(source), "${serverfilesdu}");
     }
 
@@ -4505,7 +4502,7 @@ fi
 
         assert_eq!(diagnostics.len(), 1);
         assert_eq!(diagnostics[0].rule, Rule::UndefinedVariable);
-        assert_eq!(diagnostics[0].span.start.line, 5);
+        assert_eq!(diagnostics[0].span.start.line(), 5);
         assert_eq!(diagnostics[0].span.slice(source), "${db_configure_flags}");
     }
 
@@ -4587,10 +4584,10 @@ printf '%s %s\\n' \"$missing\" \"$also_missing\"
         assert_eq!(diagnostics.len(), 2);
         assert_eq!(diagnostics[0].rule, Rule::UndefinedVariable);
         assert!(diagnostics[0].message.contains("missing"));
-        assert_eq!(diagnostics[0].span.start.line, 3);
+        assert_eq!(diagnostics[0].span.start.line(), 3);
         assert_eq!(diagnostics[1].rule, Rule::UndefinedVariable);
         assert!(diagnostics[1].message.contains("also_missing"));
-        assert_eq!(diagnostics[1].span.start.line, 3);
+        assert_eq!(diagnostics[1].span.start.line(), 3);
     }
 
     #[test]
@@ -4608,13 +4605,13 @@ printf '%s\\n' \"$plain_missing\"
             diagnostics
                 .iter()
                 .any(|diagnostic| diagnostic.message.contains("before_default")
-                    && diagnostic.span.start.line == 2)
+                    && diagnostic.span.start.line() == 2)
         );
         assert!(
             diagnostics
                 .iter()
                 .any(|diagnostic| diagnostic.message.contains("plain_missing")
-                    && diagnostic.span.start.line == 4)
+                    && diagnostic.span.start.line() == 4)
         );
         assert!(
             diagnostics
@@ -5437,8 +5434,8 @@ source \"${BASH_SOURCE[1]}__dep.bash\"
         let diagnostics = lint_path_for_rule(&main, Rule::UnusedAssignment);
 
         assert_eq!(diagnostics.len(), 1);
-        assert_eq!(diagnostics[0].span.start.line, 2);
-        assert_eq!(diagnostics[0].span.start.column, 1);
+        assert_eq!(diagnostics[0].span.start.line(), 2);
+        assert_eq!(diagnostics[0].span.start.column(), 1);
     }
 
     #[test]
@@ -5618,11 +5615,11 @@ printf '%s\\n' two
             diagnostics[0].span.slice(source),
             "if true; then\n  echo one\nfi"
         );
-        assert_eq!(diagnostics[0].span.end.line, 5);
-        assert_eq!(diagnostics[0].span.end.column, 3);
+        assert_eq!(diagnostics[0].span.end.line(), 5);
+        assert_eq!(diagnostics[0].span.end.column(), 3);
         assert_eq!(diagnostics[1].span.slice(source), "printf '%s\\n' two");
-        assert_eq!(diagnostics[1].span.end.line, 6);
-        assert_eq!(diagnostics[1].span.end.column, 18);
+        assert_eq!(diagnostics[1].span.end.line(), 6);
+        assert_eq!(diagnostics[1].span.end.column(), 18);
     }
 
     #[test]
@@ -6241,7 +6238,7 @@ foo=2
 ";
         let diagnostics = lint(source, &LinterSettings::default());
         assert_eq!(diagnostics.len(), 1);
-        assert_eq!(diagnostics[0].span.start.line, 5);
+        assert_eq!(diagnostics[0].span.start.line(), 5);
     }
 
     #[test]

--- a/crates/shuck-linter/src/locator.rs
+++ b/crates/shuck-linter/src/locator.rs
@@ -62,10 +62,10 @@ impl<'a> Locator<'a> {
             .map(usize::from)
             .unwrap_or_default();
 
-        Position {
+        Position::at(
             line,
-            column: self.source[line_start..offset].chars().count() + 1,
+            self.source[line_start..offset].chars().count() + 1,
             offset,
-        }
+        )
     }
 }

--- a/crates/shuck-linter/src/parse_diagnostics.rs
+++ b/crates/shuck-linter/src/parse_diagnostics.rs
@@ -126,8 +126,10 @@ pub(crate) fn collect_parse_rule_diagnostics(
         && let Some(span) = if_bracket_glued_span(locator, parse_diagnostics)
     {
         diagnostics.push(
-            Diagnostic::new(IfBracketGlued, span)
-                .with_fix(Fix::safe_edit(Edit::insertion(span.start.offset + 2, " "))),
+            Diagnostic::new(IfBracketGlued, span).with_fix(Fix::safe_edit(Edit::insertion(
+                span.start.offset() + 2,
+                " ",
+            ))),
         );
     }
     if enabled_rules.contains(crate::Rule::LinebreakBeforeAnd) {
@@ -163,8 +165,9 @@ pub(crate) fn collect_parse_rule_diagnostics(
                 continue;
             };
             diagnostics.push(
-                Diagnostic::new(CPrototypeFragment, span)
-                    .with_fix(Fix::safe_edit(Edit::insertion(span.start.offset + 1, " "))),
+                Diagnostic::new(CPrototypeFragment, span).with_fix(Fix::safe_edit(
+                    Edit::insertion(span.start.offset() + 1, " "),
+                )),
             );
         }
     }
@@ -224,32 +227,32 @@ fn extglob_in_case_pattern_fix(source: &str, part_span: Span) -> Option<Fix> {
 }
 
 fn simple_case_pattern_surface(source: &str, part_span: Span) -> Option<(Span, &str)> {
-    let line_start = source[..part_span.start.offset]
+    let line_start = source[..part_span.start.offset()]
         .rfind('\n')
         .map_or(0, |offset| offset + 1);
-    let pattern_start = simple_case_pattern_start(source, line_start, part_span.start.offset)?;
-    let prefix = &source[pattern_start..part_span.start.offset];
+    let pattern_start = simple_case_pattern_start(source, line_start, part_span.start.offset())?;
+    let prefix = &source[pattern_start..part_span.start.offset()];
     if prefix.is_empty() || prefix.bytes().any(|byte| byte.is_ascii_whitespace()) {
         return None;
     }
 
-    let pattern_end = simple_case_pattern_end(source, part_span.end.offset)?;
+    let pattern_end = simple_case_pattern_end(source, part_span.end.offset())?;
     let pattern_text = &source[pattern_start..pattern_end];
     if pattern_text.bytes().any(|byte| byte.is_ascii_whitespace()) {
         return None;
     }
 
-    let start = Position {
-        line: part_span.start.line,
-        column: part_span
+    let start = Position::at(
+        part_span.start.line(),
+        part_span
             .start
-            .column
-            .saturating_sub(part_span.start.offset - pattern_start),
-        offset: pattern_start,
-    };
+            .column()
+            .saturating_sub(part_span.start.offset() - pattern_start),
+        pattern_start,
+    );
     let end = part_span
         .end
-        .advanced_by(&source[part_span.end.offset..pattern_end]);
+        .advanced_by(&source[part_span.end.offset()..pattern_end]);
 
     Some((Span::from_positions(start, end), pattern_text))
 }
@@ -1156,7 +1159,7 @@ fn if_missing_then_span(
             return None;
         }
 
-        let mut line = diagnostic.span.start.line;
+        let mut line = diagnostic.span.start.line();
         let mut saw_then = false;
         while line > 0 {
             let text = line_text_at(locator, line)?;
@@ -1387,10 +1390,10 @@ fn function_parameter_syntax_span(
         return None;
     }
 
-    let line = line_text_at(locator, diagnostic.span.start.line)?;
+    let line = line_text_at(locator, diagnostic.span.start.line())?;
     let search_end = line
         .char_indices()
-        .nth(diagnostic.span.start.column.saturating_sub(1))
+        .nth(diagnostic.span.start.column().saturating_sub(1))
         .map_or(line.len(), |(index, ch)| index + ch.len_utf8());
     let paren_index = line
         .get(..search_end)
@@ -1399,7 +1402,7 @@ fn function_parameter_syntax_span(
             line.get(search_end..)
                 .and_then(|suffix| suffix.find('(').map(|relative| search_end + relative))
         })?;
-    let line_start = line_start_offset(locator, diagnostic.span.start.line)?;
+    let line_start = line_start_offset(locator, diagnostic.span.start.line())?;
     let start_offset = line_start + paren_index;
     let start = locator.position_at_offset(start_offset)?;
     let end = locator.position_at_offset(start_offset + 1)?;
@@ -1417,7 +1420,7 @@ fn linebreak_before_and_spans(
                 return None;
             }
 
-            leading_control_operator_span(locator, diagnostic.span.start.line)
+            leading_control_operator_span(locator, diagnostic.span.start.line())
         })
         .collect()
 }
@@ -1471,7 +1474,7 @@ fn leading_control_operator_span(locator: Locator<'_>, line_number: usize) -> Op
 
 fn linebreak_before_and_fix(locator: Locator<'_>, span: Span) -> Option<Fix> {
     let source = locator.source();
-    let line_start = line_start_offset(locator, span.start.line)?;
+    let line_start = line_start_offset(locator, span.start.line())?;
     let insert_offset = line_start.checked_sub(1)?;
     if source.as_bytes().get(insert_offset) != Some(&b'\n') {
         return None;
@@ -1481,7 +1484,7 @@ fn linebreak_before_and_fix(locator: Locator<'_>, span: Span) -> Option<Fix> {
     }
 
     let operator = span.slice(source);
-    let rest = source.get(span.end.offset..)?;
+    let rest = source.get(span.end.offset()..)?;
     let trailing_ws_len = rest
         .chars()
         .take_while(|ch| matches!(ch, ' ' | '\t'))
@@ -1489,7 +1492,7 @@ fn linebreak_before_and_fix(locator: Locator<'_>, span: Span) -> Option<Fix> {
         .sum::<usize>();
     Some(Fix::safe_edits([
         Edit::insertion(insert_offset, format!(" {operator}")),
-        Edit::deletion_at(span.start.offset, span.end.offset + trailing_ws_len),
+        Edit::deletion_at(span.start.offset(), span.end.offset() + trailing_ws_len),
     ]))
 }
 
@@ -1520,12 +1523,12 @@ fn until_missing_do_span(
         .iter()
         .find(|diagnostic| {
             is_expected_command_error(&diagnostic.message)
-                && is_done_line(locator, diagnostic.span.start.line)
+                && is_done_line(locator, diagnostic.span.start.line())
                 && {
                     let flags = pending_until_flags
                         .get_or_insert_with(|| compute_pending_until_flags(locator.source()));
                     flags
-                        .get(diagnostic.span.start.line.saturating_sub(1))
+                        .get(diagnostic.span.start.line().saturating_sub(1))
                         .copied()
                         .unwrap_or(false)
                 }
@@ -1561,7 +1564,7 @@ fn if_bracket_glued_span(
         if !is_expected_command_error(&diagnostic.message) {
             return None;
         }
-        if_bracket_glued_span_on_line(locator, diagnostic.span.start.line)
+        if_bracket_glued_span_on_line(locator, diagnostic.span.start.line())
     })
 }
 
@@ -1751,7 +1754,7 @@ fn missing_done_belongs_to_for_loop(
     semantic: &LinterSemanticArtifacts<'_>,
 ) -> bool {
     semantic
-        .missing_done_trailing_loop_is_for(&file.body, file.span.end.offset)
+        .missing_done_trailing_loop_is_for(&file.body, file.span.end.offset())
         .or_else(|| missing_done_loop_kind_from_source(source))
         .unwrap_or(false)
 }
@@ -2240,16 +2243,12 @@ fn c_prototype_fragment_span(diagnostic: &ParseDiagnostic, locator: Locator<'_>)
     {
         return None;
     }
-    let line = diagnostic.span.start.line;
+    let line = diagnostic.span.start.line();
     let line_text = line_text_at(locator, line)?;
     let column = find_attached_background_ampersand_column(line_text)?;
     let line_start_offset = line_start_offset(locator, line)?;
     let offset = line_start_offset + (column - 1);
-    let point = Position {
-        line,
-        column,
-        offset,
-    };
+    let point = Position::at(line, column, offset);
     Some(Span::from_positions(point, point))
 }
 
@@ -2367,8 +2366,8 @@ mod tests {
 
         assert_eq!(diagnostics.len(), 1);
         assert_eq!(diagnostics[0].rule, Rule::MissingFi);
-        assert_eq!(diagnostics[0].span.start.line, 4);
-        assert_eq!(diagnostics[0].span.start.column, 1);
+        assert_eq!(diagnostics[0].span.start.line(), 4);
+        assert_eq!(diagnostics[0].span.start.column(), 1);
         assert_eq!(
             diagnostics[0].fix.as_ref().map(|fix| fix.applicability()),
             Some(Applicability::Unsafe)
@@ -2394,8 +2393,8 @@ mod tests {
 
         assert_eq!(diagnostics.len(), 1);
         assert_eq!(diagnostics[0].rule, Rule::UnterminatedIf);
-        assert_eq!(diagnostics[0].span.start.line, 2);
-        assert_eq!(diagnostics[0].span.start.column, 1);
+        assert_eq!(diagnostics[0].span.start.line(), 2);
+        assert_eq!(diagnostics[0].span.start.column(), 1);
     }
 
     #[test]
@@ -2429,8 +2428,8 @@ mod tests {
 
         assert_eq!(diagnostics.len(), 1);
         assert_eq!(diagnostics[0].rule, Rule::UnterminatedIf);
-        assert_eq!(diagnostics[0].span.start.line, 2);
-        assert_eq!(diagnostics[0].span.start.column, 1);
+        assert_eq!(diagnostics[0].span.start.line(), 2);
+        assert_eq!(diagnostics[0].span.start.column(), 1);
     }
 
     #[test]
@@ -2448,8 +2447,8 @@ mod tests {
 
         assert_eq!(diagnostics.len(), 1);
         assert_eq!(diagnostics[0].rule, Rule::UnterminatedIf);
-        assert_eq!(diagnostics[0].span.start.line, 2);
-        assert_eq!(diagnostics[0].span.start.column, 1);
+        assert_eq!(diagnostics[0].span.start.line(), 2);
+        assert_eq!(diagnostics[0].span.start.column(), 1);
     }
 
     #[test]
@@ -2467,8 +2466,8 @@ mod tests {
 
         assert_eq!(diagnostics.len(), 1);
         assert_eq!(diagnostics[0].rule, Rule::UnterminatedIf);
-        assert_eq!(diagnostics[0].span.start.line, 2);
-        assert_eq!(diagnostics[0].span.start.column, 1);
+        assert_eq!(diagnostics[0].span.start.line(), 2);
+        assert_eq!(diagnostics[0].span.start.column(), 1);
     }
 
     #[test]
@@ -2486,8 +2485,8 @@ mod tests {
 
         assert_eq!(diagnostics.len(), 1);
         assert_eq!(diagnostics[0].rule, Rule::UnterminatedIf);
-        assert_eq!(diagnostics[0].span.start.line, 2);
-        assert_eq!(diagnostics[0].span.start.column, 1);
+        assert_eq!(diagnostics[0].span.start.line(), 2);
+        assert_eq!(diagnostics[0].span.start.column(), 1);
     }
 
     #[test]
@@ -2505,8 +2504,8 @@ mod tests {
 
         assert_eq!(diagnostics.len(), 1);
         assert_eq!(diagnostics[0].rule, Rule::UnterminatedIf);
-        assert_eq!(diagnostics[0].span.start.line, 2);
-        assert_eq!(diagnostics[0].span.start.column, 1);
+        assert_eq!(diagnostics[0].span.start.line(), 2);
+        assert_eq!(diagnostics[0].span.start.column(), 1);
     }
 
     #[test]
@@ -2524,8 +2523,8 @@ mod tests {
 
         assert_eq!(diagnostics.len(), 1);
         assert_eq!(diagnostics[0].rule, Rule::UnterminatedIf);
-        assert_eq!(diagnostics[0].span.start.line, 3);
-        assert_eq!(diagnostics[0].span.start.column, 5);
+        assert_eq!(diagnostics[0].span.start.line(), 3);
+        assert_eq!(diagnostics[0].span.start.column(), 5);
     }
 
     #[test]
@@ -2551,8 +2550,8 @@ EOF
 
         assert_eq!(diagnostics.len(), 1);
         assert_eq!(diagnostics[0].rule, Rule::UnterminatedIf);
-        assert_eq!(diagnostics[0].span.start.line, 2);
-        assert_eq!(diagnostics[0].span.start.column, 1);
+        assert_eq!(diagnostics[0].span.start.line(), 2);
+        assert_eq!(diagnostics[0].span.start.column(), 1);
     }
 
     #[test]
@@ -2577,8 +2576,8 @@ EOF
 
         assert_eq!(diagnostics.len(), 1);
         assert_eq!(diagnostics[0].rule, Rule::UnterminatedIf);
-        assert_eq!(diagnostics[0].span.start.line, 2);
-        assert_eq!(diagnostics[0].span.start.column, 1);
+        assert_eq!(diagnostics[0].span.start.line(), 2);
+        assert_eq!(diagnostics[0].span.start.column(), 1);
     }
 
     #[test]
@@ -2602,8 +2601,8 @@ if outer; then
 
         assert_eq!(diagnostics.len(), 1);
         assert_eq!(diagnostics[0].rule, Rule::UnterminatedIf);
-        assert_eq!(diagnostics[0].span.start.line, 2);
-        assert_eq!(diagnostics[0].span.start.column, 1);
+        assert_eq!(diagnostics[0].span.start.line(), 2);
+        assert_eq!(diagnostics[0].span.start.column(), 1);
     }
 
     #[test]
@@ -2627,8 +2626,8 @@ if outer; then
 
         assert_eq!(diagnostics.len(), 1);
         assert_eq!(diagnostics[0].rule, Rule::UnterminatedIf);
-        assert_eq!(diagnostics[0].span.start.line, 2);
-        assert_eq!(diagnostics[0].span.start.column, 1);
+        assert_eq!(diagnostics[0].span.start.line(), 2);
+        assert_eq!(diagnostics[0].span.start.column(), 1);
     }
 
     #[test]
@@ -2650,8 +2649,8 @@ if true; then
 
         assert_eq!(diagnostics.len(), 1);
         assert_eq!(diagnostics[0].rule, Rule::UnterminatedIf);
-        assert_eq!(diagnostics[0].span.start.line, 2);
-        assert_eq!(diagnostics[0].span.start.column, 1);
+        assert_eq!(diagnostics[0].span.start.line(), 2);
+        assert_eq!(diagnostics[0].span.start.column(), 1);
     }
 
     #[test]
@@ -2675,8 +2674,8 @@ fi + 1
 
         assert_eq!(diagnostics.len(), 1);
         assert_eq!(diagnostics[0].rule, Rule::UnterminatedIf);
-        assert_eq!(diagnostics[0].span.start.line, 2);
-        assert_eq!(diagnostics[0].span.start.column, 1);
+        assert_eq!(diagnostics[0].span.start.line(), 2);
+        assert_eq!(diagnostics[0].span.start.column(), 1);
     }
 
     #[test]
@@ -2752,8 +2751,8 @@ if true; then
 
         assert_eq!(diagnostics.len(), 1);
         assert_eq!(diagnostics[0].rule, Rule::UnterminatedIf);
-        assert_eq!(diagnostics[0].span.start.line, 2);
-        assert_eq!(diagnostics[0].span.start.column, 1);
+        assert_eq!(diagnostics[0].span.start.line(), 2);
+        assert_eq!(diagnostics[0].span.start.column(), 1);
     }
 
     #[test]
@@ -2776,8 +2775,8 @@ if true; then
 
         assert_eq!(diagnostics.len(), 1);
         assert_eq!(diagnostics[0].rule, Rule::UnterminatedIf);
-        assert_eq!(diagnostics[0].span.start.line, 2);
-        assert_eq!(diagnostics[0].span.start.column, 1);
+        assert_eq!(diagnostics[0].span.start.line(), 2);
+        assert_eq!(diagnostics[0].span.start.column(), 1);
     }
 
     #[test]
@@ -2799,8 +2798,8 @@ if true; then
 
         assert_eq!(diagnostics.len(), 1);
         assert_eq!(diagnostics[0].rule, Rule::UnterminatedIf);
-        assert_eq!(diagnostics[0].span.start.line, 2);
-        assert_eq!(diagnostics[0].span.start.column, 1);
+        assert_eq!(diagnostics[0].span.start.line(), 2);
+        assert_eq!(diagnostics[0].span.start.column(), 1);
     }
 
     #[test]
@@ -2824,8 +2823,8 @@ if true; then
 
         assert_eq!(diagnostics.len(), 1);
         assert_eq!(diagnostics[0].rule, Rule::UnterminatedIf);
-        assert_eq!(diagnostics[0].span.start.line, 2);
-        assert_eq!(diagnostics[0].span.start.column, 1);
+        assert_eq!(diagnostics[0].span.start.line(), 2);
+        assert_eq!(diagnostics[0].span.start.column(), 1);
     }
 
     #[test]
@@ -2848,8 +2847,8 @@ fi
 
         assert_eq!(diagnostics.len(), 1);
         assert_eq!(diagnostics[0].rule, Rule::UnterminatedIf);
-        assert_eq!(diagnostics[0].span.start.line, 2);
-        assert_eq!(diagnostics[0].span.start.column, 1);
+        assert_eq!(diagnostics[0].span.start.line(), 2);
+        assert_eq!(diagnostics[0].span.start.column(), 1);
     }
 
     #[test]
@@ -2873,8 +2872,8 @@ if outer; then
 
         assert_eq!(diagnostics.len(), 1);
         assert_eq!(diagnostics[0].rule, Rule::UnterminatedIf);
-        assert_eq!(diagnostics[0].span.start.line, 2);
-        assert_eq!(diagnostics[0].span.start.column, 1);
+        assert_eq!(diagnostics[0].span.start.line(), 2);
+        assert_eq!(diagnostics[0].span.start.column(), 1);
     }
 
     #[test]
@@ -2898,8 +2897,8 @@ if outer; then
 
         assert_eq!(diagnostics.len(), 1);
         assert_eq!(diagnostics[0].rule, Rule::UnterminatedIf);
-        assert_eq!(diagnostics[0].span.start.line, 2);
-        assert_eq!(diagnostics[0].span.start.column, 1);
+        assert_eq!(diagnostics[0].span.start.line(), 2);
+        assert_eq!(diagnostics[0].span.start.column(), 1);
     }
 
     #[test]
@@ -2920,8 +2919,8 @@ if outer; then if inner; then :; fi
 
         assert_eq!(diagnostics.len(), 1);
         assert_eq!(diagnostics[0].rule, Rule::UnterminatedIf);
-        assert_eq!(diagnostics[0].span.start.line, 2);
-        assert_eq!(diagnostics[0].span.start.column, 1);
+        assert_eq!(diagnostics[0].span.start.line(), 2);
+        assert_eq!(diagnostics[0].span.start.column(), 1);
     }
 
     #[test]
@@ -2955,8 +2954,8 @@ f() { if true; then
 
         assert_eq!(diagnostics.len(), 1);
         assert_eq!(diagnostics[0].rule, Rule::UnterminatedIf);
-        assert_eq!(diagnostics[0].span.start.line, 2);
-        assert_eq!(diagnostics[0].span.start.column, 9);
+        assert_eq!(diagnostics[0].span.start.line(), 2);
+        assert_eq!(diagnostics[0].span.start.column(), 9);
     }
 
     #[test]
@@ -2989,8 +2988,8 @@ if outer; then
         );
 
         assert_eq!(diagnostics.len(), 1);
-        assert_eq!(diagnostics[0].span.start.line, 3);
-        assert_eq!(diagnostics[0].span.start.column, 3);
+        assert_eq!(diagnostics[0].span.start.line(), 3);
+        assert_eq!(diagnostics[0].span.start.column(), 3);
     }
 
     #[test]
@@ -3013,8 +3012,8 @@ if outer; then
         );
 
         assert_eq!(diagnostics.len(), 1);
-        assert_eq!(diagnostics[0].span.start.line, 2);
-        assert_eq!(diagnostics[0].span.start.column, 1);
+        assert_eq!(diagnostics[0].span.start.line(), 2);
+        assert_eq!(diagnostics[0].span.start.column(), 1);
     }
 
     #[test]
@@ -3093,8 +3092,8 @@ fi
         assert_eq!(diagnostics.len(), 1);
         assert_eq!(diagnostics[0].rule, Rule::FunctionParamsInSh);
         assert_eq!(diagnostics[0].span.slice(source), "(");
-        assert_eq!(diagnostics[0].span.start.line, 2);
-        assert_eq!(diagnostics[0].span.start.column, 24);
+        assert_eq!(diagnostics[0].span.start.line(), 2);
+        assert_eq!(diagnostics[0].span.start.column(), 24);
     }
 
     #[test]
@@ -3128,8 +3127,8 @@ fi
 
         assert_eq!(diagnostics.len(), 1);
         assert_eq!(diagnostics[0].rule, Rule::LoopWithoutEnd);
-        assert_eq!(diagnostics[0].span.start.line, 4);
-        assert_eq!(diagnostics[0].span.start.column, 1);
+        assert_eq!(diagnostics[0].span.start.line(), 4);
+        assert_eq!(diagnostics[0].span.start.column(), 1);
         assert_eq!(
             diagnostics[0].fix.as_ref().map(|fix| fix.applicability()),
             Some(Applicability::Unsafe)
@@ -3340,8 +3339,8 @@ fi
 
         assert_eq!(diagnostics.len(), 1);
         assert_eq!(diagnostics[0].rule, Rule::IfMissingThen);
-        assert_eq!(diagnostics[0].span.start.line, 2);
-        assert_eq!(diagnostics[0].span.start.column, 1);
+        assert_eq!(diagnostics[0].span.start.line(), 2);
+        assert_eq!(diagnostics[0].span.start.column(), 1);
     }
 
     #[test]
@@ -3807,7 +3806,7 @@ fi
 
         assert_eq!(diagnostics.len(), 1);
         assert_eq!(diagnostics[0].rule, Rule::LinebreakBeforeAnd);
-        assert_eq!(diagnostics[0].span.start.line, 3);
+        assert_eq!(diagnostics[0].span.start.line(), 3);
         assert_eq!(
             apply_fixes(source, &diagnostics, Applicability::Safe).code,
             "#!/bin/bash\ntrue &&\necho x\n"
@@ -3867,8 +3866,8 @@ fi
 
         assert_eq!(diagnostics.len(), 1);
         assert_eq!(diagnostics[0].rule, Rule::CPrototypeFragment);
-        assert_eq!(diagnostics[0].span.start.line, 2);
-        assert_eq!(diagnostics[0].span.start.column, 3);
+        assert_eq!(diagnostics[0].span.start.line(), 2);
+        assert_eq!(diagnostics[0].span.start.column(), 3);
         assert_eq!(
             diagnostics[0].fix.as_ref().map(|fix| fix.applicability()),
             Some(Applicability::Safe)

--- a/crates/shuck-linter/src/rules/correctness/append_to_array_as_string.rs
+++ b/crates/shuck-linter/src/rules/correctness/append_to_array_as_string.rs
@@ -60,8 +60,8 @@ pub fn append_to_array_as_string(checker: &mut Checker) {
             Some((
                 binding.span,
                 Fix::unsafe_edits([
-                    Edit::insertion(value.span.start.offset, "("),
-                    Edit::insertion(value.span.end.offset, ")"),
+                    Edit::insertion(value.span.start.offset(), "("),
+                    Edit::insertion(value.span.end.offset(), ")"),
                 ]),
             ))
         })

--- a/crates/shuck-linter/src/rules/correctness/arithmetic_redirection_target.rs
+++ b/crates/shuck-linter/src/rules/correctness/arithmetic_redirection_target.rs
@@ -63,7 +63,7 @@ echo hi > out.txt
         assert_eq!(
             diagnostics
                 .iter()
-                .map(|diagnostic| diagnostic.span.start.line)
+                .map(|diagnostic| diagnostic.span.start.line())
                 .collect::<Vec<_>>(),
             vec![2, 4]
         );

--- a/crates/shuck-linter/src/rules/correctness/array_slice_in_comparison.rs
+++ b/crates/shuck-linter/src/rules/correctness/array_slice_in_comparison.rs
@@ -121,7 +121,7 @@ fn pattern_span_if_risky(
 }
 
 fn span_contains(outer: Span, inner: Span) -> bool {
-    outer.start.offset <= inner.start.offset && outer.end.offset >= inner.end.offset
+    outer.start.offset() <= inner.start.offset() && outer.end.offset() >= inner.end.offset()
 }
 
 fn intentional_join_fix(expansion_spans: &[Span], source: &str) -> Option<Fix> {

--- a/crates/shuck-linter/src/rules/correctness/array_to_string_conversion.rs
+++ b/crates/shuck-linter/src/rules/correctness/array_to_string_conversion.rs
@@ -26,7 +26,7 @@ pub fn array_to_string_conversion(checker: &mut Checker) {
     let semantic = checker.semantic();
     let mut array_history = HashMap::new();
     let mut bindings = semantic.bindings().iter().collect::<Vec<_>>();
-    bindings.sort_by_key(|binding| (binding.span.start.offset, binding.span.end.offset));
+    bindings.sort_by_key(|binding| (binding.span.start.offset(), binding.span.end.offset()));
     let builtin_history = builtin_array_history(checker);
     let history_events = array_history_events(checker, &bindings, &builtin_history.events);
     let mut next_history_event = 0usize;
@@ -36,7 +36,7 @@ pub fn array_to_string_conversion(checker: &mut Checker) {
         .into_iter()
         .filter_map(|binding| {
             while let Some(event) = history_events.get(next_history_event) {
-                if event.offset > binding.span.start.offset {
+                if event.offset > binding.span.start.offset() {
                     break;
                 }
                 push_array_history(&mut array_history, event.name.clone(), event.state);
@@ -229,7 +229,7 @@ fn zsh_selectorless_subscript_value_resets_scalar_history(
         && !matches!(
             checker
                 .semantic()
-                .shell_behavior_at(binding.span.start.offset)
+                .shell_behavior_at(binding.span.start.offset())
                 .array_reference_policy(),
             ArrayReferencePolicy::RequiresExplicitSelector
         )
@@ -268,7 +268,7 @@ struct BuiltinArrayHistory {
 impl BuiltinArrayHistory {
     fn contains_target(&self, binding: &Binding) -> bool {
         self.target_spans
-            .contains(&(binding.span.start.offset, binding.span.end.offset))
+            .contains(&(binding.span.start.offset(), binding.span.end.offset()))
     }
 }
 
@@ -315,13 +315,13 @@ fn collect_command_array_history(
             }
             history
                 .target_spans
-                .insert((target.span().start.offset, target.span().end.offset));
+                .insert((target.span().start.offset(), target.span().end.offset()));
             history.events.push(ArrayHistoryEvent {
-                offset: target.span().start.offset,
+                offset: target.span().start.offset(),
                 name: Name::from(target.key().as_str()),
                 state: ArrayHistoryState::from_offset(
                     checker,
-                    target.span().start.offset,
+                    target.span().start.offset(),
                     true,
                     false,
                 ),
@@ -345,13 +345,13 @@ fn collect_command_array_history(
             }
             history
                 .target_spans
-                .insert((target.span().start.offset, target.span().end.offset));
+                .insert((target.span().start.offset(), target.span().end.offset()));
             history.events.push(ArrayHistoryEvent {
-                offset: target.span().start.offset,
+                offset: target.span().start.offset(),
                 name: Name::from(target.key().as_str()),
                 state: ArrayHistoryState::from_offset(
                     checker,
-                    target.span().start.offset,
+                    target.span().start.offset(),
                     true,
                     false,
                 ),
@@ -381,7 +381,7 @@ fn presence_test_reset_events(
                 checker,
                 &mut events,
                 &mut seen,
-                fact.command_span().start.offset,
+                fact.command_span().start.offset(),
                 &name,
             );
         }
@@ -390,7 +390,7 @@ fn presence_test_reset_events(
                 checker,
                 &mut events,
                 &mut seen,
-                fact.command_span().start.offset,
+                fact.command_span().start.offset(),
                 &name,
             );
         }
@@ -409,11 +409,11 @@ fn name_only_declaration_history_events(checker: &Checker<'_>) -> Vec<ArrayHisto
             };
             if name_only_declaration_resets_array_history(declaration.builtin, flags) {
                 events.push(ArrayHistoryEvent {
-                    offset: span.start.offset,
+                    offset: span.start.offset(),
                     name: name.clone(),
                     state: ArrayHistoryState::from_offset(
                         checker,
-                        span.start.offset,
+                        span.start.offset(),
                         false,
                         declaration.builtin == DeclarationBuiltin::Local,
                     ),
@@ -504,7 +504,7 @@ fn append_declaration_assignment_name_spans(checker: &Checker<'_>) -> HashSet<(u
         .filter_map(|operand| match operand {
             DeclarationOperand::Assignment {
                 name_span, append, ..
-            } if *append => Some((name_span.start.offset, name_span.end.offset)),
+            } if *append => Some((name_span.start.offset(), name_span.end.offset())),
             DeclarationOperand::Flag { .. }
             | DeclarationOperand::Name { .. }
             | DeclarationOperand::Assignment { .. }
@@ -518,7 +518,7 @@ fn binding_can_trigger_array_to_string_conversion(
     append_declaration_assignments: &HashSet<(usize, usize)>,
 ) -> bool {
     if append_declaration_assignments
-        .contains(&(binding.span.start.offset, binding.span.end.offset))
+        .contains(&(binding.span.start.offset(), binding.span.end.offset()))
     {
         return false;
     }
@@ -635,7 +635,7 @@ fn binding_command<'checker, 'ast>(
     checker
         .facts()
         .command_facts()
-        .innermost_command_at_binding_offset(binding.span.start.offset)
+        .innermost_command_at_binding_offset(binding.span.start.offset())
         .or_else(|| {
             checker
                 .facts()
@@ -727,7 +727,7 @@ fn command_wrapper_is_shadowed_function(
 }
 
 fn contains_span(outer: shuck_ast::Span, inner: shuck_ast::Span) -> bool {
-    outer.start.offset <= inner.start.offset && inner.end.offset <= outer.end.offset
+    outer.start.offset() <= inner.start.offset() && inner.end.offset() <= outer.end.offset()
 }
 
 #[cfg(test)]

--- a/crates/shuck-linter/src/rules/correctness/at_sign_in_string_compare.rs
+++ b/crates/shuck-linter/src/rules/correctness/at_sign_in_string_compare.rs
@@ -50,12 +50,12 @@ fn simple_test_spans(fact: &crate::SimpleTestFact<'_>, source: &str) -> Vec<(Spa
 }
 
 fn at_splat_edit(span: Span) -> Option<Edit> {
-    let start = span.start.offset;
-    let offset = match span.end.offset.saturating_sub(start) {
+    let start = span.start.offset();
+    let offset = match span.end.offset().saturating_sub(start) {
         2 => start + 1,
         _ => start + 2,
     };
-    (offset < span.end.offset).then(|| Edit::replacement_at(offset, offset + 1, "*"))
+    (offset < span.end.offset()).then(|| Edit::replacement_at(offset, offset + 1, "*"))
 }
 
 #[cfg(test)]

--- a/crates/shuck-linter/src/rules/correctness/backslash_before_closing_backtick.rs
+++ b/crates/shuck-linter/src/rules/correctness/backslash_before_closing_backtick.rs
@@ -88,10 +88,10 @@ echo \"$ARCH\"
                 .iter()
                 .map(|diagnostic| {
                     (
-                        diagnostic.span.start.line,
-                        diagnostic.span.start.column,
-                        diagnostic.span.end.line,
-                        diagnostic.span.end.column,
+                        diagnostic.span.start.line(),
+                        diagnostic.span.start.column(),
+                        diagnostic.span.end.line(),
+                        diagnostic.span.end.column(),
                     )
                 })
                 .collect::<Vec<_>>(),

--- a/crates/shuck-linter/src/rules/correctness/bad_redirection_fd_order.rs
+++ b/crates/shuck-linter/src/rules/correctness/bad_redirection_fd_order.rs
@@ -84,7 +84,7 @@ echo ok &>01
         assert_eq!(
             diagnostics
                 .iter()
-                .map(|diagnostic| diagnostic.span.start.line)
+                .map(|diagnostic| diagnostic.span.start.line())
                 .collect::<Vec<_>>(),
             vec![2, 3, 4, 5, 6, 7, 8, 9, 10, 11]
         );

--- a/crates/shuck-linter/src/rules/correctness/bare_done_word.rs
+++ b/crates/shuck-linter/src/rules/correctness/bare_done_word.rs
@@ -45,7 +45,7 @@ trap done EXIT
         assert_eq!(
             diagnostics
                 .iter()
-                .map(|diagnostic| (diagnostic.span.start.line, diagnostic.span.start.column))
+                .map(|diagnostic| (diagnostic.span.start.line(), diagnostic.span.start.column()))
                 .collect::<Vec<_>>(),
             vec![
                 (2, 15),
@@ -84,7 +84,7 @@ select value in do; do :; done
         assert_eq!(
             diagnostics
                 .iter()
-                .map(|diagnostic| (diagnostic.span.start.line, diagnostic.span.start.column))
+                .map(|diagnostic| (diagnostic.span.start.line(), diagnostic.span.start.column()))
                 .collect::<Vec<_>>(),
             vec![(2, 14), (3, 14), (4, 14), (5, 6), (6, 14), (7, 17)]
         );

--- a/crates/shuck-linter/src/rules/correctness/c_prototype_fragment.rs
+++ b/crates/shuck-linter/src/rules/correctness/c_prototype_fragment.rs
@@ -30,10 +30,9 @@ pub fn c_prototype_fragment(checker: &mut Checker) {
         .collect::<Vec<_>>();
 
     for span in spans {
-        checker.report_diagnostic_dedup(
-            crate::Diagnostic::new(CPrototypeFragment, span)
-                .with_fix(Fix::safe_edit(Edit::insertion(span.start.offset + 1, " "))),
-        );
+        checker.report_diagnostic_dedup(crate::Diagnostic::new(CPrototypeFragment, span).with_fix(
+            Fix::safe_edit(Edit::insertion(span.start.offset() + 1, " ")),
+        ));
     }
 }
 
@@ -49,7 +48,7 @@ fn attached_background_ampersand_span(
         return None;
     }
 
-    let next = source[terminator_span.end.offset..].chars().next()?;
+    let next = source[terminator_span.end.offset()..].chars().next()?;
     if !matches!(next, '_' | 'A'..='Z' | 'a'..='z' | '0'..='9') {
         return None;
     }
@@ -72,10 +71,10 @@ mod tests {
         let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::CPrototypeFragment));
 
         assert_eq!(diagnostics.len(), 2);
-        assert_eq!(diagnostics[0].span.start.line, 2);
-        assert_eq!(diagnostics[0].span.start.column, 3);
-        assert_eq!(diagnostics[1].span.start.line, 3);
-        assert_eq!(diagnostics[1].span.start.column, 10);
+        assert_eq!(diagnostics[0].span.start.line(), 2);
+        assert_eq!(diagnostics[0].span.start.column(), 3);
+        assert_eq!(diagnostics[1].span.start.line(), 3);
+        assert_eq!(diagnostics[1].span.start.column(), 10);
     }
 
     #[test]

--- a/crates/shuck-linter/src/rules/correctness/c_style_comment.rs
+++ b/crates/shuck-linter/src/rules/correctness/c_style_comment.rs
@@ -32,7 +32,7 @@ pub fn c_style_comment(checker: &mut Checker) {
                 .starts_with("/*")
                 .then(|| {
                     crate::Diagnostic::new(CStyleComment, name.span).with_fix(Fix::unsafe_edit(
-                        Edit::insertion(name.span.start.offset, "# "),
+                        Edit::insertion(name.span.start.offset(), "# "),
                     ))
                 })
         };

--- a/crates/shuck-linter/src/rules/correctness/case_arm_not_in_getopts.rs
+++ b/crates/shuck-linter/src/rules/correctness/case_arm_not_in_getopts.rs
@@ -73,8 +73,8 @@ fn case_pattern_deletion_fix(
         .iter()
         .find(|item| {
             item.item().patterns.iter().any(|pattern| {
-                pattern.span.start.offset == pattern_span.start.offset
-                    && pattern.span.end.offset == pattern_span.end.offset
+                pattern.span.start.offset() == pattern_span.start.offset()
+                    && pattern.span.end.offset() == pattern_span.end.offset()
             })
         })?;
 
@@ -103,8 +103,8 @@ fn all_item_patterns_reported(checker: &Checker<'_>, item: &CaseItemFact<'_>) ->
 
     item.item().patterns.iter().all(|pattern| {
         reported_spans.iter().any(|span| {
-            span.start.offset == pattern.span.start.offset
-                && span.end.offset == pattern.span.end.offset
+            span.start.offset() == pattern.span.start.offset()
+                && span.end.offset() == pattern.span.end.offset()
         })
     })
 }
@@ -115,22 +115,22 @@ fn pattern_alternative_deletion_span(
     source: &str,
 ) -> Option<Span> {
     let index = patterns.iter().position(|pattern| {
-        pattern.span.start.offset == pattern_span.start.offset
-            && pattern.span.end.offset == pattern_span.end.offset
+        pattern.span.start.offset() == pattern_span.start.offset()
+            && pattern.span.end.offset() == pattern_span.end.offset()
     })?;
 
     if index + 1 < patterns.len() {
-        let next_start = patterns[index + 1].span.start.offset;
-        let pipe = source[pattern_span.end.offset..next_start].find('|')?;
+        let next_start = patterns[index + 1].span.start.offset();
+        let pipe = source[pattern_span.end.offset()..next_start].find('|')?;
         let end = pattern_span
             .end
-            .advanced_by(&source[pattern_span.end.offset..pattern_span.end.offset + pipe + 1]);
+            .advanced_by(&source[pattern_span.end.offset()..pattern_span.end.offset() + pipe + 1]);
         return Some(Span::from_positions(pattern_span.start, end));
     }
 
     if index > 0 {
-        let previous_end = patterns[index - 1].span.end.offset;
-        let pipe = source[previous_end..pattern_span.start.offset].rfind('|')?;
+        let previous_end = patterns[index - 1].span.end.offset();
+        let pipe = source[previous_end..pattern_span.start.offset()].rfind('|')?;
         let start = patterns[index - 1]
             .span
             .end

--- a/crates/shuck-linter/src/rules/correctness/case_default_before_glob.rs
+++ b/crates/shuck-linter/src/rules/correctness/case_default_before_glob.rs
@@ -56,8 +56,8 @@ fn case_pattern_deletion_fix(
         .iter()
         .find(|item| {
             item.item().patterns.iter().any(|pattern| {
-                pattern.span.start.offset == pattern_span.start.offset
-                    && pattern.span.end.offset == pattern_span.end.offset
+                pattern.span.start.offset() == pattern_span.start.offset()
+                    && pattern.span.end.offset() == pattern_span.end.offset()
             })
         })?;
 
@@ -71,8 +71,8 @@ fn case_pattern_deletion_fix(
 
     let all_item_patterns_shadowed = item.item().patterns.iter().all(|pattern| {
         shadowed_spans.iter().any(|span| {
-            span.start.offset == pattern.span.start.offset
-                && span.end.offset == pattern.span.end.offset
+            span.start.offset() == pattern.span.start.offset()
+                && span.end.offset() == pattern.span.end.offset()
         })
     });
 
@@ -91,22 +91,22 @@ fn pattern_alternative_deletion_span(
     source: &str,
 ) -> Option<Span> {
     let index = patterns.iter().position(|pattern| {
-        pattern.span.start.offset == pattern_span.start.offset
-            && pattern.span.end.offset == pattern_span.end.offset
+        pattern.span.start.offset() == pattern_span.start.offset()
+            && pattern.span.end.offset() == pattern_span.end.offset()
     })?;
 
     if index + 1 < patterns.len() {
-        let next_start = patterns[index + 1].span.start.offset;
-        let pipe = source[pattern_span.end.offset..next_start].find('|')?;
+        let next_start = patterns[index + 1].span.start.offset();
+        let pipe = source[pattern_span.end.offset()..next_start].find('|')?;
         let end = pattern_span
             .end
-            .advanced_by(&source[pattern_span.end.offset..pattern_span.end.offset + pipe + 1]);
+            .advanced_by(&source[pattern_span.end.offset()..pattern_span.end.offset() + pipe + 1]);
         return Some(Span::from_positions(pattern_span.start, end));
     }
 
     if index > 0 {
-        let previous_end = patterns[index - 1].span.end.offset;
-        let pipe = source[previous_end..pattern_span.start.offset].rfind('|')?;
+        let previous_end = patterns[index - 1].span.end.offset();
+        let pipe = source[previous_end..pattern_span.start.offset()].rfind('|')?;
         let start = patterns[index - 1]
             .span
             .end

--- a/crates/shuck-linter/src/rules/correctness/case_glob_reachability.rs
+++ b/crates/shuck-linter/src/rules/correctness/case_glob_reachability.rs
@@ -56,8 +56,8 @@ fn case_pattern_deletion_fix(
         .iter()
         .find(|item| {
             item.item().patterns.iter().any(|pattern| {
-                pattern.span.start.offset == pattern_span.start.offset
-                    && pattern.span.end.offset == pattern_span.end.offset
+                pattern.span.start.offset() == pattern_span.start.offset()
+                    && pattern.span.end.offset() == pattern_span.end.offset()
             })
         })?;
 
@@ -71,8 +71,8 @@ fn case_pattern_deletion_fix(
 
     let all_item_patterns_shadow = item.item().patterns.iter().all(|pattern| {
         shadowing_spans.iter().any(|span| {
-            span.start.offset == pattern.span.start.offset
-                && span.end.offset == pattern.span.end.offset
+            span.start.offset() == pattern.span.start.offset()
+                && span.end.offset() == pattern.span.end.offset()
         })
     });
 
@@ -91,22 +91,22 @@ fn pattern_alternative_deletion_span(
     source: &str,
 ) -> Option<Span> {
     let index = patterns.iter().position(|pattern| {
-        pattern.span.start.offset == pattern_span.start.offset
-            && pattern.span.end.offset == pattern_span.end.offset
+        pattern.span.start.offset() == pattern_span.start.offset()
+            && pattern.span.end.offset() == pattern_span.end.offset()
     })?;
 
     if index + 1 < patterns.len() {
-        let next_start = patterns[index + 1].span.start.offset;
-        let pipe = source[pattern_span.end.offset..next_start].find('|')?;
+        let next_start = patterns[index + 1].span.start.offset();
+        let pipe = source[pattern_span.end.offset()..next_start].find('|')?;
         let end = pattern_span
             .end
-            .advanced_by(&source[pattern_span.end.offset..pattern_span.end.offset + pipe + 1]);
+            .advanced_by(&source[pattern_span.end.offset()..pattern_span.end.offset() + pipe + 1]);
         return Some(Span::from_positions(pattern_span.start, end));
     }
 
     if index > 0 {
-        let previous_end = patterns[index - 1].span.end.offset;
-        let pipe = source[previous_end..pattern_span.start.offset].rfind('|')?;
+        let previous_end = patterns[index - 1].span.end.offset();
+        let pipe = source[previous_end..pattern_span.start.offset()].rfind('|')?;
         let start = patterns[index - 1]
             .span
             .end

--- a/crates/shuck-linter/src/rules/correctness/case_item_delete.rs
+++ b/crates/shuck-linter/src/rules/correctness/case_item_delete.rs
@@ -3,7 +3,7 @@ use shuck_ast::{Position, Span};
 pub(super) fn case_item_deletion_span(item: &shuck_ast::CaseItem, source: &str) -> Option<Span> {
     let first = item.patterns.first()?.span;
     let end = item.terminator_span.unwrap_or(item.body.span).end;
-    let mut start_offset = first.start.offset;
+    let mut start_offset = first.start.offset();
     while start_offset > 0 {
         let previous = source.as_bytes()[start_offset - 1];
         if previous == b'\n' {
@@ -15,7 +15,7 @@ pub(super) fn case_item_deletion_span(item: &shuck_ast::CaseItem, source: &str) 
         start_offset -= 1;
     }
 
-    let mut trailing_offset = end.offset;
+    let mut trailing_offset = end.offset();
     let end_offset = loop {
         if trailing_offset >= source.len() {
             break trailing_offset;
@@ -25,20 +25,20 @@ pub(super) fn case_item_deletion_span(item: &shuck_ast::CaseItem, source: &str) 
             break trailing_offset + 1;
         }
         if !byte.is_ascii_whitespace() {
-            break end.offset;
+            break end.offset();
         }
         trailing_offset += 1;
     };
 
     Some(Span::from_positions(
-        Position {
-            offset: start_offset,
-            line: first.start.line,
-            column: first
+        Position::at(
+            first.start.line(),
+            first
                 .start
-                .column
-                .saturating_sub(first.start.offset.saturating_sub(start_offset)),
-        },
-        end.advanced_by(&source[end.offset..end_offset]),
+                .column()
+                .saturating_sub(first.start.offset().saturating_sub(start_offset)),
+            start_offset,
+        ),
+        end.advanced_by(&source[end.offset()..end_offset]),
     ))
 }

--- a/crates/shuck-linter/src/rules/correctness/chained_test_branches.rs
+++ b/crates/shuck-linter/src/rules/correctness/chained_test_branches.rs
@@ -26,8 +26,8 @@ pub fn chained_test_branches(checker: &mut Checker) {
 
     lists.sort_by_key(|list| {
         (
-            list.span().start.offset,
-            Reverse(list.span().end.offset - list.span().start.offset),
+            list.span().start.offset(),
+            Reverse(list.span().end.offset() - list.span().start.offset()),
         )
     });
 
@@ -52,9 +52,9 @@ pub fn chained_test_branches(checker: &mut Checker) {
 }
 
 fn span_strictly_contains(outer: shuck_ast::Span, inner: shuck_ast::Span) -> bool {
-    outer.start.offset <= inner.start.offset
-        && inner.end.offset <= outer.end.offset
-        && (outer.start.offset < inner.start.offset || inner.end.offset < outer.end.offset)
+    outer.start.offset() <= inner.start.offset()
+        && inner.end.offset() <= outer.end.offset()
+        && (outer.start.offset() < inner.start.offset() || inner.end.offset() < outer.end.offset())
 }
 
 fn matches_mixed_short_circuit(checker: &Checker<'_>, list: &ListFact<'_>) -> bool {
@@ -383,7 +383,7 @@ check && {
             test_snippet(source, &LinterSettings::for_rule(Rule::ChainedTestBranches));
 
         assert_eq!(diagnostics.len(), 1);
-        assert_eq!(diagnostics[0].span.start.line, 1);
+        assert_eq!(diagnostics[0].span.start.line(), 1);
         assert_eq!(diagnostics[0].span.slice(source), "&&");
     }
 }

--- a/crates/shuck-linter/src/rules/correctness/commented_continuation_line.rs
+++ b/crates/shuck-linter/src/rules/correctness/commented_continuation_line.rs
@@ -28,12 +28,12 @@ pub fn commented_continuation_line(checker: &mut Checker) {
         {
             let backslash_offset = span
                 .start
-                .offset
+                .offset()
                 .checked_sub(1)
                 .expect("commented continuation anchors should follow a trailing backslash");
             report(
                 Diagnostic::new(CommentedContinuationLine, span).with_fix(Fix::unsafe_edit(
-                    Edit::deletion_at(backslash_offset, span.start.offset),
+                    Edit::deletion_at(backslash_offset, span.start.offset()),
                 )),
             );
         }
@@ -56,11 +56,11 @@ mod tests {
         );
 
         assert_eq!(diagnostics.len(), 1);
-        assert_eq!(diagnostics[0].span.start.line, 3);
-        assert_eq!(diagnostics[0].span.start.column, 11);
+        assert_eq!(diagnostics[0].span.start.line(), 3);
+        assert_eq!(diagnostics[0].span.start.column(), 11);
         assert_eq!(diagnostics[0].span.start, diagnostics[0].span.end);
         assert_eq!(
-            &source[diagnostics[0].span.start.offset - 1..diagnostics[0].span.start.offset],
+            &source[diagnostics[0].span.start.offset() - 1..diagnostics[0].span.start.offset()],
             "\\"
         );
     }

--- a/crates/shuck-linter/src/rules/correctness/constant_comparison_test.rs
+++ b/crates/shuck-linter/src/rules/correctness/constant_comparison_test.rs
@@ -299,7 +299,7 @@ fi
         );
 
         assert_eq!(diagnostics.len(), 1);
-        assert_eq!(diagnostics[0].span.start.line, 2);
+        assert_eq!(diagnostics[0].span.start.line(), 2);
         assert_eq!(diagnostics[0].span.slice(source), "=");
     }
 

--- a/crates/shuck-linter/src/rules/correctness/diff_marker_line.rs
+++ b/crates/shuck-linter/src/rules/correctness/diff_marker_line.rs
@@ -93,17 +93,17 @@ fn command_satisfies_pending_operator(checker: &Checker<'_>, command_id: Command
 fn diagnostic_for_dash_command(source: &str, span: Span, can_fix_in_context: bool) -> Diagnostic {
     let diagnostic = Diagnostic::new(DiffMarkerLine, span);
     if can_fix_in_context && span_starts_physical_line(source, span) {
-        diagnostic.with_fix(Fix::unsafe_edit(Edit::insertion(span.start.offset, "# ")))
+        diagnostic.with_fix(Fix::unsafe_edit(Edit::insertion(span.start.offset(), "# ")))
     } else {
         diagnostic
     }
 }
 
 fn span_starts_physical_line(source: &str, span: Span) -> bool {
-    let line_start = source[..span.start.offset]
+    let line_start = source[..span.start.offset()]
         .rfind('\n')
         .map_or(0, |offset| offset + 1);
-    source[line_start..span.start.offset]
+    source[line_start..span.start.offset()]
         .chars()
         .all(|ch| matches!(ch, ' ' | '\t'))
 }

--- a/crates/shuck-linter/src/rules/correctness/double_paren_grouping.rs
+++ b/crates/shuck-linter/src/rules/correctness/double_paren_grouping.rs
@@ -23,7 +23,7 @@ pub fn double_paren_grouping(checker: &mut Checker) {
         for span in facts.words().double_paren_grouping_spans().iter().copied() {
             report(
                 Diagnostic::new(DoubleParenGrouping, span).with_fix(Fix::unsafe_edit(
-                    Edit::insertion(span.start.offset + 1, " "),
+                    Edit::insertion(span.start.offset() + 1, " "),
                 )),
             );
         }
@@ -47,8 +47,8 @@ mod tests {
             test_snippet(source, &LinterSettings::for_rule(Rule::DoubleParenGrouping));
 
         assert_eq!(diagnostics.len(), 1);
-        assert_eq!(diagnostics[0].span.start.line, 2);
-        assert_eq!(diagnostics[0].span.start.column, 1);
+        assert_eq!(diagnostics[0].span.start.line(), 2);
+        assert_eq!(diagnostics[0].span.start.column(), 1);
     }
 
     #[test]

--- a/crates/shuck-linter/src/rules/correctness/duplicate_redirect.rs
+++ b/crates/shuck-linter/src/rules/correctness/duplicate_redirect.rs
@@ -103,7 +103,7 @@ exec {fd}>a {fd}>b
 
         assert_eq!(diagnostics.len(), 1);
         assert_eq!(
-            diagnostics[0].span.start.offset,
+            diagnostics[0].span.start.offset(),
             source.find('>').expect("first redirect")
         );
     }

--- a/crates/shuck-linter/src/rules/correctness/else_if.rs
+++ b/crates/shuck-linter/src/rules/correctness/else_if.rs
@@ -37,21 +37,17 @@ pub fn else_if(checker: &mut Checker) {
 }
 
 fn else_if_span(nested_if_start: Position, source: &str) -> Option<Span> {
-    let line_start_offset = source[..nested_if_start.offset]
+    let line_start_offset = source[..nested_if_start.offset()]
         .rfind('\n')
         .map_or(0, |offset| offset + 1);
-    let line_prefix = &source[line_start_offset..nested_if_start.offset];
+    let line_prefix = &source[line_start_offset..nested_if_start.offset()];
     let trimmed = line_prefix.trim_end_matches([' ', '\t']);
     if !trimmed.ends_with("else") {
         return None;
     }
 
     let else_start_in_line = trimmed.len().saturating_sub("else".len());
-    let line_start = Position {
-        line: nested_if_start.line,
-        column: 1,
-        offset: line_start_offset,
-    };
+    let line_start = Position::at(nested_if_start.line(), 1, line_start_offset);
     let else_start = line_start.advanced_by(&line_prefix[..else_start_in_line]);
     Some(Span::at(else_start))
 }
@@ -67,8 +63,8 @@ mod tests {
         let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::ElseIf));
 
         assert_eq!(diagnostics.len(), 1);
-        assert_eq!(diagnostics[0].span.start.line, 4);
-        assert_eq!(diagnostics[0].span.start.column, 1);
+        assert_eq!(diagnostics[0].span.start.line(), 4);
+        assert_eq!(diagnostics[0].span.start.column(), 1);
         assert_eq!(diagnostics[0].span.start, diagnostics[0].span.end);
     }
 

--- a/crates/shuck-linter/src/rules/correctness/env_prefix_expansion_only.rs
+++ b/crates/shuck-linter/src/rules/correctness/env_prefix_expansion_only.rs
@@ -43,7 +43,7 @@ pub fn env_prefix_expansion_only(checker: &mut Checker) {
 }
 
 fn env_prefix_expansion_fix(fact: &EnvPrefixExpansionFixFact, source: &str) -> Option<Fix> {
-    let indent = line_indent_before_offset(source, fact.delete_span().start.offset)?;
+    let indent = line_indent_before_offset(source, fact.delete_span().start.offset())?;
     let mut replacement = String::new();
     for assignment_span in fact.assignment_spans() {
         if !replacement.is_empty() {

--- a/crates/shuck-linter/src/rules/correctness/find_or_without_grouping.rs
+++ b/crates/shuck-linter/src/rules/correctness/find_or_without_grouping.rs
@@ -44,8 +44,8 @@ pub fn find_or_without_grouping(checker: &mut Checker) {
         let diagnostic = Diagnostic::new(FindOrWithoutGrouping, span);
         if let Some(fix_span) = fix_span {
             checker.report_diagnostic_dedup(diagnostic.with_fix(Fix::safe_edits([
-                Edit::insertion(fix_span.branch_start.start.offset, "\\( "),
-                Edit::insertion(fix_span.action_span.end.offset, " \\)"),
+                Edit::insertion(fix_span.branch_start.start.offset(), "\\( "),
+                Edit::insertion(fix_span.action_span.end.offset(), " \\)"),
             ])));
         } else {
             checker.report_diagnostic_dedup(diagnostic);

--- a/crates/shuck-linter/src/rules/correctness/find_output_to_xargs.rs
+++ b/crates/shuck-linter/src/rules/correctness/find_output_to_xargs.rs
@@ -117,16 +117,21 @@ fn find_print0_insertion_offset(command: CommandFactRef<'_, '_>) -> usize {
     command
         .redirect_facts()
         .first()
-        .map(|redirect| redirect.redirect().span.start.offset)
-        .or_else(|| command.body_args().last().map(|word| word.span.end.offset))
-        .or_else(|| command.body_name_word().map(|word| word.span.end.offset))
+        .map(|redirect| redirect.redirect().span.start.offset())
+        .or_else(|| {
+            command
+                .body_args()
+                .last()
+                .map(|word| word.span.end.offset())
+        })
+        .or_else(|| command.body_name_word().map(|word| word.span.end.offset()))
         .expect("find command diagnostics should have a body insertion point")
 }
 
 fn xargs_null_input_insertion_offset(command: CommandFactRef<'_, '_>) -> usize {
     command
         .body_name_word()
-        .map(|word| word.span.end.offset)
+        .map(|word| word.span.end.offset())
         .expect("xargs command diagnostics should have a body name word")
 }
 
@@ -196,7 +201,7 @@ command find . -type f | xargs rm
         let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::FindOutputToXargs));
 
         assert_eq!(diagnostics.len(), 1);
-        assert_eq!(diagnostics[0].span.start.line, 2);
+        assert_eq!(diagnostics[0].span.start.line(), 2);
         assert_eq!(diagnostics[0].span.slice(source), "find . -type f");
     }
 
@@ -250,7 +255,7 @@ find \"$pkg\" -print0 | xargs rm
         let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::FindOutputToXargs));
 
         assert_eq!(diagnostics.len(), 1);
-        assert_eq!(diagnostics[0].span.start.line, 2);
+        assert_eq!(diagnostics[0].span.start.line(), 2);
         assert_eq!(diagnostics[0].span.slice(source), "find \"$pkg\" -print0");
     }
 

--- a/crates/shuck-linter/src/rules/correctness/function_called_before_defined.rs
+++ b/crates/shuck-linter/src/rules/correctness/function_called_before_defined.rs
@@ -51,8 +51,8 @@ pub fn function_called_before_defined(checker: &mut Checker) {
             }
 
             let key = CallKey {
-                start: call.name_span.start.offset,
-                end: call.name_span.end.offset,
+                start: call.name_span.start.offset(),
+                end: call.name_span.end.offset(),
             };
             if reported.insert(key) {
                 violations.push((call.name_span, call.callee.as_str().into()));
@@ -60,7 +60,7 @@ pub fn function_called_before_defined(checker: &mut Checker) {
         }
     }
 
-    violations.sort_unstable_by_key(|(span, _)| span.start.offset);
+    violations.sort_unstable_by_key(|(span, _)| span.start.offset());
     for (span, name) in violations {
         checker.report(FunctionCalledBeforeDefined { name }, span);
     }
@@ -71,7 +71,7 @@ fn call_is_reportable_for_function(
     call: &CallSite,
     function: &Binding,
 ) -> bool {
-    if call.name_span.start.offset >= function.span.start.offset {
+    if call.name_span.start.offset() >= function.span.start.offset() {
         return false;
     }
     let call_runtime_scope = checker.semantic().enclosing_function_scope(call.scope);
@@ -103,7 +103,7 @@ fn call_is_reportable_for_function(
         .visible_function_binding_defined_before(
             &call.callee,
             call.scope,
-            call.name_span.start.offset,
+            call.name_span.start.offset(),
         );
     if prior_visible_definition
         .is_some_and(|prior| prior_visible_definition_guaranteed_before_call(checker, prior, call))
@@ -144,7 +144,7 @@ fn prior_visible_definition_guaranteed_before_call(
     }
 
     let entry = analysis
-        .flow_entry_block_for_binding_scopes(&[definition.scope], call.name_span.start.offset);
+        .flow_entry_block_for_binding_scopes(&[definition.scope], call.name_span.start.offset());
     call_blocks
         .iter()
         .copied()
@@ -213,7 +213,7 @@ fn function_scope_callers_can_run_before_definition(
                 .call_sites_for(&caller.name)
                 .iter()
                 .any(|site| {
-                    if site.span.start.offset >= function.span.start.offset
+                    if site.span.start.offset() >= function.span.start.offset()
                         || !call_site_resolves_to_binding(checker, site, function_binding)
                         || !span_can_run(checker, site.span)
                     {
@@ -272,9 +272,9 @@ fn has_prior_source_ref(checker: &Checker<'_>, call: &CallSite) -> bool {
 
         let source_runtime_scope = checker
             .semantic()
-            .enclosing_function_scope(checker.semantic().scope_at(source_ref.span.start.offset));
+            .enclosing_function_scope(checker.semantic().scope_at(source_ref.span.start.offset()));
         if source_runtime_scope == call_runtime_scope {
-            return source_ref.span.start.offset < call.name_span.start.offset
+            return source_ref.span.start.offset() < call.name_span.start.offset()
                 && span_can_run_before_call(checker, source_ref.span, call_blocks);
         }
 
@@ -317,15 +317,15 @@ fn has_source_ref_before_later_definition(
     checker.semantic().source_refs().iter().any(|source_ref| {
         if matches!(source_ref.kind, SourceRefKind::DirectiveDevNull)
             || !source_ref_has_runtime_source_command(checker, source_ref)
-            || source_ref.span.start.offset <= call.name_span.start.offset
-            || source_ref.span.start.offset >= function.span.start.offset
+            || source_ref.span.start.offset() <= call.name_span.start.offset()
+            || source_ref.span.start.offset() >= function.span.start.offset()
         {
             return false;
         }
 
         let source_runtime_scope = checker
             .semantic()
-            .enclosing_function_scope(checker.semantic().scope_at(source_ref.span.start.offset));
+            .enclosing_function_scope(checker.semantic().scope_at(source_ref.span.start.offset()));
         source_runtime_scope == call_runtime_scope
             && span_can_run_before_definition(checker, source_ref.span, function)
     })
@@ -349,14 +349,14 @@ fn has_branch_local_loader_source_after_definition(
     checker.semantic().source_refs().iter().any(|source_ref| {
         if matches!(source_ref.kind, SourceRefKind::DirectiveDevNull)
             || !source_ref_has_runtime_source_command(checker, source_ref)
-            || source_ref.span.start.offset <= function.span.start.offset
+            || source_ref.span.start.offset() <= function.span.start.offset()
         {
             return false;
         }
 
         let source_runtime_scope = checker
             .semantic()
-            .enclosing_function_scope(checker.semantic().scope_at(source_ref.span.start.offset));
+            .enclosing_function_scope(checker.semantic().scope_at(source_ref.span.start.offset()));
         source_runtime_scope == definition_runtime_scope
             && definition_can_run_before_source_ref(checker, function, source_ref.span)
     })
@@ -372,7 +372,7 @@ fn definition_can_run_before_source_ref(
         .blocks_containing_binding(function.id);
     let source_blocks = checker.semantic_analysis().block_ids_for_span(source_span);
     if definition_blocks.is_empty() || source_blocks.is_empty() {
-        return function.span.start.offset < source_span.start.offset;
+        return function.span.start.offset() < source_span.start.offset();
     }
 
     let reachable_definition_blocks = definition_blocks
@@ -394,7 +394,7 @@ fn definition_can_run_before_source_ref(
 fn source_ref_has_runtime_source_command(checker: &Checker<'_>, source_ref: &SourceRef) -> bool {
     checker.facts().commands().iter().any(|fact| {
         (fact.effective_name_is("source") || fact.effective_name_is("."))
-            && fact.span().start.offset == source_ref.span.start.offset
+            && fact.span().start.offset() == source_ref.span.start.offset()
     })
 }
 
@@ -499,7 +499,7 @@ fn span_in_scope_can_run_before_scope(
     active_target_scopes: &mut FxHashSet<ScopeId>,
 ) -> bool {
     if source_runtime_scope == target.runtime_scope {
-        return source_span.start.offset < target.span.start.offset
+        return source_span.start.offset() < target.span.start.offset()
             && span_can_run_before_blocks(checker, source_span, target.blocks);
     }
 
@@ -554,7 +554,7 @@ fn span_in_scope_can_run_before_span(
     active_source_scopes: &mut FxHashSet<ScopeId>,
 ) -> bool {
     if source_runtime_scope == target.runtime_scope {
-        return source_span.start.offset < target.span.start.offset
+        return source_span.start.offset() < target.span.start.offset()
             && span_can_run_before_blocks(checker, source_span, target.blocks);
     }
 
@@ -619,7 +619,7 @@ fn call_site_resolves_to_binding(
                 .visible_function_binding_defined_before(
                     &function.name,
                     site.scope,
-                    site.name_span.start.offset,
+                    site.name_span.start.offset(),
                 )
         })
         == Some(function_binding)
@@ -650,7 +650,7 @@ fn span_can_run_before_definition(
         .semantic_analysis()
         .blocks_containing_binding(function.id);
     if function_blocks.is_empty() {
-        return source_span.start.offset < function.span.start.offset;
+        return source_span.start.offset() < function.span.start.offset();
     }
 
     span_can_run_before_blocks(checker, source_span, function_blocks)
@@ -683,7 +683,7 @@ fn span_can_run_before_blocks(
 }
 
 fn span_contains(outer: Span, inner: Span) -> bool {
-    outer.start.offset <= inner.start.offset && outer.end.offset >= inner.end.offset
+    outer.start.offset() <= inner.start.offset() && outer.end.offset() >= inner.end.offset()
 }
 
 fn call_is_unreachable(checker: &Checker<'_>, call: &CallSite) -> bool {
@@ -714,7 +714,7 @@ fn call_path_terminates_before_function(
     if function_blocks.is_empty()
         && let Some(command_id) = checker
             .semantic()
-            .innermost_command_id_at(function.span.start.offset)
+            .innermost_command_id_at(function.span.start.offset())
     {
         function_blocks.extend(
             checker
@@ -746,7 +746,7 @@ fn innermost_block_for_span(checker: &Checker<'_>, span: Span) -> Option<shuck_s
         .or_else(|| {
             checker
                 .semantic()
-                .innermost_command_id_at(span.start.offset)
+                .innermost_command_id_at(span.start.offset())
                 .and_then(|command_id| {
                     checker
                         .semantic_analysis()
@@ -773,8 +773,8 @@ fn terminator_blocks_between_call_and_function(
         })
         .filter(|fact| fact.enclosing_function_scope() == call_runtime_scope)
         .filter(|fact| {
-            fact.body_span().start.offset > call.name_span.start.offset
-                && fact.body_span().start.offset < function.span.start.offset
+            fact.body_span().start.offset() > call.name_span.start.offset()
+                && fact.body_span().start.offset() < function.span.start.offset()
         })
         .flat_map(|fact| {
             let blocks = checker.semantic_analysis().block_ids_for_span(fact.span());
@@ -811,7 +811,7 @@ fn exit_command_terminates_runtime_scope(
         .visible_function_binding_defined_before(
             &Name::from("exit"),
             fact.scope(),
-            fact.body_span().start.offset,
+            fact.body_span().start.offset(),
         )
         .is_none()
 }
@@ -841,7 +841,7 @@ fn function_definition_is_branch_local(checker: &Checker<'_>, function: &Binding
 fn call_is_in_condition_context(checker: &Checker<'_>, call: &CallSite) -> bool {
     checker
         .semantic()
-        .innermost_command_id_at(call.name_span.start.offset)
+        .innermost_command_id_at(call.name_span.start.offset())
         .and_then(|id| checker.semantic().command_condition_role(id))
         .is_some()
 }

--- a/crates/shuck-linter/src/rules/correctness/function_references_unset_param.rs
+++ b/crates/shuck-linter/src/rules/correctness/function_references_unset_param.rs
@@ -98,7 +98,7 @@ greet
 
         assert_eq!(diagnostics.len(), 1);
         assert_eq!(diagnostics[0].span.slice(source), "greet");
-        assert_eq!(diagnostics[0].span.start.line, 3);
+        assert_eq!(diagnostics[0].span.start.line(), 3);
     }
 
     #[test]
@@ -116,9 +116,9 @@ greet
 
         assert_eq!(diagnostics.len(), 2);
         assert_eq!(diagnostics[0].span.slice(source), "greet");
-        assert_eq!(diagnostics[0].span.start.line, 3);
+        assert_eq!(diagnostics[0].span.start.line(), 3);
         assert_eq!(diagnostics[1].span.slice(source), "greet");
-        assert_eq!(diagnostics[1].span.start.line, 4);
+        assert_eq!(diagnostics[1].span.start.line(), 4);
     }
 
     #[test]
@@ -166,7 +166,7 @@ usage
 
         assert_eq!(diagnostics.len(), 1);
         assert_eq!(diagnostics[0].span.slice(source), "usage");
-        assert_eq!(diagnostics[0].span.start.line, 3);
+        assert_eq!(diagnostics[0].span.start.line(), 3);
     }
 
     #[test]
@@ -248,7 +248,7 @@ requires_name
 
         assert_eq!(diagnostics.len(), 1);
         assert_eq!(diagnostics[0].span.slice(source), "requires_name");
-        assert_eq!(diagnostics[0].span.start.line, 8);
+        assert_eq!(diagnostics[0].span.start.line(), 8);
     }
 
     #[test]
@@ -298,7 +298,7 @@ greet
 
         assert_eq!(diagnostics.len(), 1);
         assert_eq!(diagnostics[0].span.slice(source), "greet");
-        assert_eq!(diagnostics[0].span.start.line, 3);
+        assert_eq!(diagnostics[0].span.start.line(), 3);
     }
 
     #[test]
@@ -321,9 +321,9 @@ removed_chpwd
 
         assert_eq!(diagnostics.len(), 2);
         assert_eq!(diagnostics[0].span.slice(source), "removed_precmd");
-        assert_eq!(diagnostics[0].span.start.line, 7);
+        assert_eq!(diagnostics[0].span.start.line(), 7);
         assert_eq!(diagnostics[1].span.slice(source), "removed_chpwd");
-        assert_eq!(diagnostics[1].span.start.line, 8);
+        assert_eq!(diagnostics[1].span.start.line(), 8);
     }
 
     #[test]
@@ -349,7 +349,7 @@ cb_keep
 
         assert_eq!(diagnostics.len(), 1);
         assert_eq!(diagnostics[0].span.slice(source), "cb_two");
-        assert_eq!(diagnostics[0].span.start.line, 10);
+        assert_eq!(diagnostics[0].span.start.line(), 10);
     }
 
     #[test]
@@ -386,13 +386,13 @@ cb_keep
 
         assert_eq!(diagnostics.len(), 4);
         assert_eq!(diagnostics[0].span.slice(source), "cb_1");
-        assert_eq!(diagnostics[0].span.start.line, 17);
+        assert_eq!(diagnostics[0].span.start.line(), 17);
         assert_eq!(diagnostics[1].span.slice(source), "cb_2");
-        assert_eq!(diagnostics[1].span.start.line, 18);
+        assert_eq!(diagnostics[1].span.start.line(), 18);
         assert_eq!(diagnostics[2].span.slice(source), "cb_10");
-        assert_eq!(diagnostics[2].span.start.line, 19);
+        assert_eq!(diagnostics[2].span.start.line(), 19);
         assert_eq!(diagnostics[3].span.slice(source), "cb_a");
-        assert_eq!(diagnostics[3].span.start.line, 20);
+        assert_eq!(diagnostics[3].span.start.line(), 20);
     }
 
     #[test]
@@ -412,7 +412,7 @@ removed_widget
 
         assert_eq!(diagnostics.len(), 1);
         assert_eq!(diagnostics[0].span.slice(source), "removed_widget");
-        assert_eq!(diagnostics[0].span.start.line, 5);
+        assert_eq!(diagnostics[0].span.start.line(), 5);
     }
 
     #[test]
@@ -474,9 +474,9 @@ latent_hook
 
         assert_eq!(diagnostics.len(), 2);
         assert_eq!(diagnostics[0].span.slice(source), "latent_widget");
-        assert_eq!(diagnostics[0].span.start.line, 6);
+        assert_eq!(diagnostics[0].span.start.line(), 6);
         assert_eq!(diagnostics[1].span.slice(source), "latent_hook");
-        assert_eq!(diagnostics[1].span.start.line, 7);
+        assert_eq!(diagnostics[1].span.start.line(), 7);
     }
 
     #[test]
@@ -495,7 +495,7 @@ dynamic_widget
 
         assert_eq!(diagnostics.len(), 1);
         assert_eq!(diagnostics[0].span.slice(source), "dynamic_widget");
-        assert_eq!(diagnostics[0].span.start.line, 4);
+        assert_eq!(diagnostics[0].span.start.line(), 4);
     }
 
     #[test]
@@ -594,7 +594,7 @@ greet
 
         assert_eq!(diagnostics.len(), 1);
         assert_eq!(diagnostics[0].span.slice(source), "greet");
-        assert_eq!(diagnostics[0].span.start.line, 5);
+        assert_eq!(diagnostics[0].span.start.line(), 5);
     }
 
     #[test]
@@ -615,7 +615,7 @@ wrapper
 
         assert_eq!(diagnostics.len(), 1);
         assert_eq!(diagnostics[0].span.slice(source), "foo");
-        assert_eq!(diagnostics[0].span.start.line, 4);
+        assert_eq!(diagnostics[0].span.start.line(), 4);
     }
 
     #[test]
@@ -689,7 +689,7 @@ greet
 
         assert_eq!(diagnostics.len(), 1);
         assert_eq!(diagnostics[0].span.slice(source), "greet");
-        assert_eq!(diagnostics[0].span.start.line, 7);
+        assert_eq!(diagnostics[0].span.start.line(), 7);
     }
 
     #[test]
@@ -716,7 +716,7 @@ outer_with_args
 
         assert_eq!(diagnostics.len(), 1);
         assert_eq!(diagnostics[0].span.slice(source), "inner");
-        assert_eq!(diagnostics[0].span.start.line, 4);
+        assert_eq!(diagnostics[0].span.start.line(), 4);
     }
 
     #[test]
@@ -735,7 +735,7 @@ greet
 
         assert_eq!(diagnostics.len(), 1);
         assert_eq!(diagnostics[0].span.slice(source), "greet");
-        assert_eq!(diagnostics[0].span.start.line, 6);
+        assert_eq!(diagnostics[0].span.start.line(), 6);
     }
 
     #[test]
@@ -785,7 +785,7 @@ greet
 
         assert_eq!(diagnostics.len(), 1);
         assert_eq!(diagnostics[0].span.slice(source), "greet");
-        assert_eq!(diagnostics[0].span.start.line, 4);
+        assert_eq!(diagnostics[0].span.start.line(), 4);
     }
 
     #[test]
@@ -841,7 +841,7 @@ greet
 
         assert_eq!(diagnostics.len(), 1);
         assert_eq!(diagnostics[0].span.slice(source), "greet");
-        assert_eq!(diagnostics[0].span.start.line, 6);
+        assert_eq!(diagnostics[0].span.start.line(), 6);
     }
 
     #[test]
@@ -883,7 +883,7 @@ greet
 
         assert_eq!(diagnostics.len(), 1);
         assert_eq!(diagnostics[0].span.slice(source), "greet");
-        assert_eq!(diagnostics[0].span.start.line, 9);
+        assert_eq!(diagnostics[0].span.start.line(), 9);
     }
 
     #[test]

--- a/crates/shuck-linter/src/rules/correctness/getopts_option_not_in_case.rs
+++ b/crates/shuck-linter/src/rules/correctness/getopts_option_not_in_case.rs
@@ -58,7 +58,7 @@ done
         assert!(
             diagnostics
                 .iter()
-                .all(|diagnostic| diagnostic.span.start.line == 2)
+                .all(|diagnostic| diagnostic.span.start.line() == 2)
         );
         assert_eq!(
             diagnostics
@@ -111,7 +111,7 @@ done
             diagnostics[0].message,
             "getopts option -b is not handled by this case statement"
         );
-        assert_eq!(diagnostics[0].span.start.line, 2);
+        assert_eq!(diagnostics[0].span.start.line(), 2);
     }
 
     #[test]

--- a/crates/shuck-linter/src/rules/correctness/glob_with_expansion_in_loop.rs
+++ b/crates/shuck-linter/src/rules/correctness/glob_with_expansion_in_loop.rs
@@ -39,8 +39,8 @@ pub fn glob_with_expansion_in_loop(checker: &mut Checker) {
     for span in spans {
         checker.report_diagnostic_dedup(Diagnostic::new(GlobWithExpansionInLoop, span).with_fix(
             Fix::unsafe_edits([
-                Edit::insertion(span.start.offset, "\""),
-                Edit::insertion(span.end.offset, "\""),
+                Edit::insertion(span.start.offset(), "\""),
+                Edit::insertion(span.end.offset(), "\""),
             ]),
         ));
     }

--- a/crates/shuck-linter/src/rules/correctness/greater_than_in_test.rs
+++ b/crates/shuck-linter/src/rules/correctness/greater_than_in_test.rs
@@ -109,24 +109,25 @@ fn numeric_comparison_redirect_diagnostic(
         return None;
     }
 
-    if redirect_data.span.start.offset < opening_bracket_span.end.offset
-        || redirect_data.span.start.offset >= closing_bracket_span.start.offset
+    if redirect_data.span.start.offset() < opening_bracket_span.end.offset()
+        || redirect_data.span.start.offset() >= closing_bracket_span.start.offset()
     {
         return None;
     }
 
     let operator_span = redirect.operator_span();
-    if operator_span.start.offset != redirect_data.span.start.offset {
+    if operator_span.start.offset() != redirect_data.span.start.offset() {
         return None;
     }
 
-    let gap = source.get(operator_span.end.offset..target.span.start.offset)?;
+    let gap = source.get(operator_span.end.offset()..target.span.start.offset())?;
     if !is_shell_token_gap(gap) {
         return None;
     }
 
     let fix_span = Span::from_positions(operator_span.start, target.span.start);
-    let leading_separator = if has_trailing_token_boundary(&source[..operator_span.start.offset]) {
+    let leading_separator = if has_trailing_token_boundary(&source[..operator_span.start.offset()])
+    {
         ""
     } else {
         " "

--- a/crates/shuck-linter/src/rules/correctness/heredoc_closer_not_alone.rs
+++ b/crates/shuck-linter/src/rules/correctness/heredoc_closer_not_alone.rs
@@ -67,7 +67,7 @@ x EOF
         );
 
         assert_eq!(diagnostics.len(), 1);
-        assert_eq!(diagnostics[0].span.start.line, 3);
+        assert_eq!(diagnostics[0].span.start.line(), 3);
         assert_eq!(diagnostics[0].span.slice(source), "EOF");
     }
 
@@ -84,7 +84,7 @@ cat <<-EOF
         );
 
         assert_eq!(diagnostics.len(), 1);
-        assert_eq!(diagnostics[0].span.start.line, 3);
+        assert_eq!(diagnostics[0].span.start.line(), 3);
         assert_eq!(diagnostics[0].span.slice(source), "EOF");
     }
 

--- a/crates/shuck-linter/src/rules/correctness/heredoc_missing_end.rs
+++ b/crates/shuck-linter/src/rules/correctness/heredoc_missing_end.rs
@@ -86,7 +86,7 @@ line
         let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::HeredocMissingEnd));
 
         assert_eq!(diagnostics.len(), 1);
-        assert_eq!(diagnostics[0].span.start.line, 2);
+        assert_eq!(diagnostics[0].span.start.line(), 2);
         assert_eq!(diagnostics[0].span.slice(source), "<<MARK");
     }
 
@@ -114,7 +114,7 @@ line
         let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::HeredocMissingEnd));
 
         assert_eq!(diagnostics.len(), 1);
-        assert_eq!(diagnostics[0].span.start.line, 2);
+        assert_eq!(diagnostics[0].span.start.line(), 2);
         assert_eq!(diagnostics[0].span.slice(source), "<<''");
     }
 

--- a/crates/shuck-linter/src/rules/correctness/if_dollar_command.rs
+++ b/crates/shuck-linter/src/rules/correctness/if_dollar_command.rs
@@ -45,7 +45,7 @@ fn if_dollar_command_fix(span: Span, source: &str) -> Option<(Span, Fix)> {
     Some((
         span,
         Fix::unsafe_edit(Edit::replacement_at(
-            span.start.offset,
+            span.start.offset(),
             close_cleanup.end,
             close_cleanup.replacement_body(body),
         )),
@@ -67,15 +67,15 @@ impl CloseCleanup<'_> {
 }
 
 fn command_substitution_close_cleanup<'a>(span: Span, source: &'a str) -> CloseCleanup<'a> {
-    let close_start = span.end.offset.saturating_sub(1);
+    let close_start = span.end.offset().saturating_sub(1);
     if !offset_is_indented_line_start(source, close_start) {
         return CloseCleanup {
-            end: span.end.offset,
+            end: span.end.offset(),
             list_operator: None,
         };
     }
 
-    let mut end = span.end.offset;
+    let mut end = span.end.offset();
     while source
         .as_bytes()
         .get(end)
@@ -85,7 +85,7 @@ fn command_substitution_close_cleanup<'a>(span: Span, source: &'a str) -> CloseC
     }
     let Some((operator, operator_len)) = close_cleanup_operator(source, end) else {
         return CloseCleanup {
-            end: span.end.offset,
+            end: span.end.offset(),
             list_operator: None,
         };
     };

--- a/crates/shuck-linter/src/rules/correctness/if_missing_then.rs
+++ b/crates/shuck-linter/src/rules/correctness/if_missing_then.rs
@@ -46,7 +46,7 @@ fi
 
         assert_eq!(diagnostics.len(), 1);
         assert_eq!(diagnostics[0].code(), "C064");
-        assert_eq!(diagnostics[0].span.start.line, 2);
-        assert_eq!(diagnostics[0].span.start.column, 1);
+        assert_eq!(diagnostics[0].span.start.line(), 2);
+        assert_eq!(diagnostics[0].span.start.column(), 1);
     }
 }

--- a/crates/shuck-linter/src/rules/correctness/implicit_global_in_function.rs
+++ b/crates/shuck-linter/src/rules/correctness/implicit_global_in_function.rs
@@ -52,7 +52,7 @@ pub fn implicit_global_in_function(checker: &mut Checker) {
                 .is_some_and(|offsets| {
                     offsets
                         .iter()
-                        .any(|offset| *offset <= binding.span.start.offset)
+                        .any(|offset| *offset <= binding.span.start.offset())
                 });
             (!has_local_declaration).then(|| {
                 Diagnostic::new(
@@ -235,7 +235,7 @@ fn binding_is_file_scoped(binding: &Binding, semantic: &shuck_semantic::Semantic
         semantic.scope_kind(binding.scope),
         shuck_semantic::ScopeKind::File
     ) && matches!(
-        semantic.scope_kind(semantic.scope_at(binding.span.start.offset)),
+        semantic.scope_kind(semantic.scope_at(binding.span.start.offset())),
         shuck_semantic::ScopeKind::File
     )
 }
@@ -248,7 +248,7 @@ fn reference_is_top_level(
         semantic.scope_kind(reference.scope),
         shuck_semantic::ScopeKind::File
     ) && matches!(
-        semantic.scope_kind(semantic.scope_at(reference.span.start.offset)),
+        semantic.scope_kind(semantic.scope_at(reference.span.start.offset())),
         shuck_semantic::ScopeKind::File
     )
 }
@@ -284,7 +284,7 @@ fn function_local_declarations(
             declarations
                 .entry((function_scope, binding.name.clone()))
                 .or_default()
-                .push(binding.span.start.offset);
+                .push(binding.span.start.offset());
         }
     }
 
@@ -293,7 +293,7 @@ fn function_local_declarations(
             continue;
         }
 
-        let declaration_scope = semantic.scope_at(declaration.span.start.offset);
+        let declaration_scope = semantic.scope_at(declaration.span.start.offset());
         let Some(function_scope) = semantic.enclosing_function_scope(declaration_scope) else {
             continue;
         };
@@ -326,10 +326,10 @@ fn declaration_operand_names(
         .operands
         .iter()
         .filter_map(|operand| match operand {
-            DeclarationOperand::Name { name, span } => Some((name, span.start.offset)),
+            DeclarationOperand::Name { name, span } => Some((name, span.start.offset())),
             DeclarationOperand::Assignment {
                 name, name_span, ..
-            } => Some((name, name_span.start.offset)),
+            } => Some((name, name_span.start.offset())),
             DeclarationOperand::Flag { .. } | DeclarationOperand::DynamicWord { .. } => None,
         })
 }
@@ -519,7 +519,7 @@ work() {
 
         assert_eq!(diagnostics.len(), 1);
         assert_eq!(diagnostics[0].span.slice(source), "SHARED");
-        assert_eq!(diagnostics[0].span.start.line, 5);
+        assert_eq!(diagnostics[0].span.start.line(), 5);
     }
 
     #[test]
@@ -541,7 +541,7 @@ work() {
 
         assert_eq!(diagnostics.len(), 1);
         assert_eq!(diagnostics[0].span.slice(source), "SHARED");
-        assert_eq!(diagnostics[0].span.start.line, 7);
+        assert_eq!(diagnostics[0].span.start.line(), 7);
     }
 
     #[test]
@@ -564,7 +564,7 @@ work() {
 
         assert_eq!(diagnostics.len(), 1);
         assert_eq!(diagnostics[0].span.slice(source), "SHARED");
-        assert_eq!(diagnostics[0].span.start.line, 8);
+        assert_eq!(diagnostics[0].span.start.line(), 8);
     }
 
     #[test]

--- a/crates/shuck-linter/src/rules/correctness/indented_heredoc_close.rs
+++ b/crates/shuck-linter/src/rules/correctness/indented_heredoc_close.rs
@@ -66,7 +66,7 @@ EOF
         assert_eq!(
             diagnostics
                 .iter()
-                .map(|diagnostic| (diagnostic.span.start.line, diagnostic.span.start.column))
+                .map(|diagnostic| (diagnostic.span.start.line(), diagnostic.span.start.column()))
                 .collect::<Vec<_>>(),
             vec![(4, 1), (5, 1)]
         );
@@ -108,7 +108,7 @@ hi
         );
 
         assert_eq!(diagnostics.len(), 1);
-        assert_eq!(diagnostics[0].span.start.line, 4);
+        assert_eq!(diagnostics[0].span.start.line(), 4);
     }
 
     #[test]
@@ -126,7 +126,7 @@ hi
         );
 
         assert_eq!(diagnostics.len(), 1);
-        assert_eq!(diagnostics[0].span.start.line, 4);
+        assert_eq!(diagnostics[0].span.start.line(), 4);
     }
 
     #[test]

--- a/crates/shuck-linter/src/rules/correctness/indented_shebang.rs
+++ b/crates/shuck-linter/src/rules/correctness/indented_shebang.rs
@@ -46,9 +46,9 @@ mod tests {
         let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::IndentedShebang));
 
         assert_eq!(diagnostics.len(), 1);
-        assert_eq!(diagnostics[0].span.start.line, 1);
-        assert_eq!(diagnostics[0].span.start.column, 1);
-        assert_eq!(diagnostics[0].span.end.column, 1);
+        assert_eq!(diagnostics[0].span.start.line(), 1);
+        assert_eq!(diagnostics[0].span.start.column(), 1);
+        assert_eq!(diagnostics[0].span.end.column(), 1);
     }
 
     #[test]
@@ -57,9 +57,9 @@ mod tests {
         let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::IndentedShebang));
 
         assert_eq!(diagnostics.len(), 1);
-        assert_eq!(diagnostics[0].span.start.line, 2);
-        assert_eq!(diagnostics[0].span.start.column, 1);
-        assert_eq!(diagnostics[0].span.end.column, 1);
+        assert_eq!(diagnostics[0].span.start.line(), 2);
+        assert_eq!(diagnostics[0].span.start.column(), 1);
+        assert_eq!(diagnostics[0].span.end.column(), 1);
     }
 
     #[test]

--- a/crates/shuck-linter/src/rules/correctness/jammed_test_bracket.rs
+++ b/crates/shuck-linter/src/rules/correctness/jammed_test_bracket.rs
@@ -67,9 +67,9 @@ case x in a)[! -r x ];; esac
                 .iter()
                 .map(|diagnostic| {
                     (
-                        diagnostic.span.start.line,
-                        diagnostic.span.start.column,
-                        diagnostic.span.end.column,
+                        diagnostic.span.start.line(),
+                        diagnostic.span.start.column(),
+                        diagnostic.span.end.column(),
                     )
                 })
                 .collect::<Vec<_>>(),

--- a/crates/shuck-linter/src/rules/correctness/leading_glob_argument.rs
+++ b/crates/shuck-linter/src/rules/correctness/leading_glob_argument.rs
@@ -44,7 +44,7 @@ fn reportable_glob_diagnostic(
     }
     let active_globs = fact.active_literal_glob_spans(checker.source());
     let first_glob = active_globs.first().copied()?;
-    if first_glob.start.offset != fact.span().start.offset {
+    if first_glob.start.offset() != fact.span().start.offset() {
         return None;
     }
     let prefix = first_glob.slice(checker.source()).chars().next()?;
@@ -66,7 +66,7 @@ fn reportable_glob_diagnostic(
     let word_span = fact.span();
     Some(
         crate::Diagnostic::new(LeadingGlobArgument, anchor_span(word_span)).with_fix(
-            Fix::unsafe_edit(Edit::insertion(word_span.start.offset, "./")),
+            Fix::unsafe_edit(Edit::insertion(word_span.start.offset(), "./")),
         ),
     )
 }

--- a/crates/shuck-linter/src/rules/correctness/leading_zero_arithmetic.rs
+++ b/crates/shuck-linter/src/rules/correctness/leading_zero_arithmetic.rs
@@ -86,7 +86,7 @@ fn is_adjacent_to_runtime_expansion(
     arithmetic_expansion_spans: &[Span],
     command_substitution_spans: &[Span],
 ) -> bool {
-    let Some(previous_offset) = previous_non_quote_offset(source, span.start.offset) else {
+    let Some(previous_offset) = previous_non_quote_offset(source, span.start.offset()) else {
         return false;
     };
     let Some(previous) = source.as_bytes().get(previous_offset) else {
@@ -102,7 +102,7 @@ fn is_adjacent_to_runtime_expansion(
 fn any_span_end_is_quote_adjacent(source: &str, spans: &[Span], span: Span) -> bool {
     spans
         .iter()
-        .any(|runtime| quote_only_between(source, runtime.end.offset, span.start.offset))
+        .any(|runtime| quote_only_between(source, runtime.end.offset(), span.start.offset()))
 }
 
 fn previous_non_quote_offset(source: &str, end_offset: usize) -> Option<usize> {
@@ -142,7 +142,8 @@ fn is_plain_suppressed_subscript_literal(
 
 fn span_is_within_any(span: Span, containers: &[Span]) -> bool {
     containers.iter().any(|container| {
-        container.start.offset <= span.start.offset && span.end.offset <= container.end.offset
+        container.start.offset() <= span.start.offset()
+            && span.end.offset() <= container.end.offset()
     })
 }
 
@@ -304,7 +305,7 @@ printf '%s\\n' \"))\"
         );
 
         assert_eq!(diagnostics.len(), 1);
-        assert_eq!(diagnostics[0].span.start.line, 4);
+        assert_eq!(diagnostics[0].span.start.line(), 4);
         assert_eq!(diagnostics[0].span.slice(source), "08");
     }
 

--- a/crates/shuck-linter/src/rules/correctness/linebreak_in_test.rs
+++ b/crates/shuck-linter/src/rules/correctness/linebreak_in_test.rs
@@ -51,8 +51,8 @@ mod tests {
         let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::LinebreakInTest));
 
         assert_eq!(diagnostics.len(), 1);
-        assert_eq!(diagnostics[0].span.start.line, 2);
-        assert_eq!(diagnostics[0].span.start.column, 14);
+        assert_eq!(diagnostics[0].span.start.line(), 2);
+        assert_eq!(diagnostics[0].span.start.column(), 14);
         assert_eq!(diagnostics[0].span.start, diagnostics[0].span.end);
     }
 

--- a/crates/shuck-linter/src/rules/correctness/local_cross_reference.rs
+++ b/crates/shuck-linter/src/rules/correctness/local_cross_reference.rs
@@ -121,9 +121,9 @@ fn split_declaration_fix<'a>(source: &str, fact: crate::CommandFactRef<'_, 'a>) 
         return None;
     }
 
-    let indent = line_indent_before_offset(source, declaration.span.start.offset)?;
+    let indent = line_indent_before_offset(source, declaration.span.start.offset())?;
     let head = source
-        .get(declaration.span.start.offset..first_assignment.span.start.offset)?
+        .get(declaration.span.start.offset()..first_assignment.span.start.offset())?
         .trim_end();
     if head.is_empty() {
         return None;
@@ -195,7 +195,7 @@ local a=1 a=2 c=$a
 
         assert_eq!(diagnostics.len(), 1);
         assert_eq!(
-            diagnostics[0].span.start.offset,
+            diagnostics[0].span.start.offset(),
             source.find("a=2").unwrap()
         );
     }

--- a/crates/shuck-linter/src/rules/correctness/loop_control_outside_loop.rs
+++ b/crates/shuck-linter/src/rules/correctness/loop_control_outside_loop.rs
@@ -53,7 +53,7 @@ pub(crate) fn loop_control_violations(
         .filter(|(command_span, _, keyword)| {
             let inside_function = checker
                 .semantic_analysis()
-                .enclosing_function_scope_at(command_span.start.offset)
+                .enclosing_function_scope_at(command_span.start.offset())
                 .is_some();
             let in_subshell = checker
                 .semantic()

--- a/crates/shuck-linter/src/rules/correctness/misquoted_heredoc_close.rs
+++ b/crates/shuck-linter/src/rules/correctness/misquoted_heredoc_close.rs
@@ -88,7 +88,7 @@ x
         );
 
         assert_eq!(diagnostics.len(), 1);
-        assert_eq!(diagnostics[0].span.start.line, 2);
+        assert_eq!(diagnostics[0].span.start.line(), 2);
     }
 
     #[test]

--- a/crates/shuck-linter/src/rules/correctness/missing_bracket_space.rs
+++ b/crates/shuck-linter/src/rules/correctness/missing_bracket_space.rs
@@ -32,7 +32,7 @@ pub fn missing_bracket_space(checker: &mut Checker) {
             let span = fact.glued_closing_bracket_operand_span()?;
             let insert_offset = fact.glued_closing_bracket_insert_offset()?;
             seen_lines
-                .insert(span.start.line)
+                .insert(span.start.line())
                 .then_some((span, insert_offset))
         })
         .map(|(span, insert_offset)| diagnostic_for_glued_closing_bracket(span, insert_offset))
@@ -78,7 +78,7 @@ fi
         assert_eq!(
             diagnostics
                 .iter()
-                .map(|diagnostic| (diagnostic.span.start.line, diagnostic.span.start.column))
+                .map(|diagnostic| (diagnostic.span.start.line(), diagnostic.span.start.column()))
                 .collect::<Vec<_>>(),
             vec![(2, 9), (8, 9), (11, 9)]
         );
@@ -98,8 +98,8 @@ fi
         assert_eq!(diagnostics.len(), 1);
         assert_eq!(
             (
-                diagnostics[0].span.start.line,
-                diagnostics[0].span.start.column
+                diagnostics[0].span.start.line(),
+                diagnostics[0].span.start.column()
             ),
             (2, 11)
         );

--- a/crates/shuck-linter/src/rules/correctness/missing_fi.rs
+++ b/crates/shuck-linter/src/rules/correctness/missing_fi.rs
@@ -32,8 +32,8 @@ mod tests {
 
         assert_eq!(diagnostics.len(), 1);
         assert_eq!(diagnostics[0].code(), "C035");
-        assert_eq!(diagnostics[0].span.start.line, 4);
-        assert_eq!(diagnostics[0].span.start.column, 1);
+        assert_eq!(diagnostics[0].span.start.line(), 4);
+        assert_eq!(diagnostics[0].span.start.column(), 1);
     }
 
     #[test]

--- a/crates/shuck-linter/src/rules/correctness/missing_space_before_bracket_close.rs
+++ b/crates/shuck-linter/src/rules/correctness/missing_space_before_bracket_close.rs
@@ -75,7 +75,7 @@ mod tests {
         assert_eq!(
             diagnostics
                 .iter()
-                .map(|diagnostic| (diagnostic.span.start.line, diagnostic.span.start.column))
+                .map(|diagnostic| (diagnostic.span.start.line(), diagnostic.span.start.column()))
                 .collect::<Vec<_>>(),
             vec![
                 (2, 7),

--- a/crates/shuck-linter/src/rules/correctness/mixed_and_or_in_condition.rs
+++ b/crates/shuck-linter/src/rules/correctness/mixed_and_or_in_condition.rs
@@ -31,8 +31,8 @@ pub fn mixed_and_or_in_condition(checker: &mut Checker) {
                 .iter()
                 .flat_map(|span| {
                     [
-                        Edit::insertion(span.start.offset, "( "),
-                        Edit::insertion(span.end.offset, " )"),
+                        Edit::insertion(span.start.offset(), "( "),
+                        Edit::insertion(span.end.offset(), " )"),
                     ]
                 })
                 .collect::<Vec<_>>();

--- a/crates/shuck-linter/src/rules/correctness/mutable_global.rs
+++ b/crates/shuck-linter/src/rules/correctness/mutable_global.rs
@@ -68,7 +68,7 @@ pub fn mutable_global(checker: &mut Checker) {
     let mut reportable_bindings = Vec::new();
 
     for writes in writes_by_name.values_mut() {
-        writes.sort_unstable_by_key(|write| semantic.binding(write.binding_id).span.start.offset);
+        writes.sort_unstable_by_key(|write| semantic.binding(write.binding_id).span.start.offset());
 
         let Some(first_file_write) = writes
             .iter()
@@ -94,7 +94,7 @@ pub fn mutable_global(checker: &mut Checker) {
     }
 
     reportable_bindings
-        .sort_unstable_by_key(|binding_id| semantic.binding(*binding_id).span.start.offset);
+        .sort_unstable_by_key(|binding_id| semantic.binding(*binding_id).span.start.offset());
 
     for binding_id in reportable_bindings {
         let binding = semantic.binding(binding_id);
@@ -145,7 +145,7 @@ fn has_prior_function_declaration(
         .any(|id| {
             let candidate = semantic.binding(id);
             candidate.scope == function_scope
-                && candidate.span.start.offset < binding.span.start.offset
+                && candidate.span.start.offset() < binding.span.start.offset()
                 && is_function_local_declaration(candidate)
                 && declaration_runs_before_binding(checker, candidate, binding, function_scope)
         })
@@ -346,7 +346,7 @@ update() {
 
         assert_eq!(diagnostics.len(), 1);
         assert_eq!(diagnostics[0].span.slice(source), "value");
-        assert_eq!(diagnostics[0].span.start.line, 7);
+        assert_eq!(diagnostics[0].span.start.line(), 7);
     }
 
     #[test]
@@ -366,7 +366,7 @@ update() {
 
         assert_eq!(diagnostics.len(), 1);
         assert_eq!(diagnostics[0].span.slice(source), "value");
-        assert_eq!(diagnostics[0].span.start.line, 8);
+        assert_eq!(diagnostics[0].span.start.line(), 8);
     }
 
     #[test]
@@ -449,7 +449,7 @@ mode=${mode:-prod}$((mode + 1))
 
         assert_eq!(diagnostics.len(), 1);
         assert_eq!(diagnostics[0].span.slice(source), "mode");
-        assert_eq!(diagnostics[0].span.start.line, 3);
+        assert_eq!(diagnostics[0].span.start.line(), 3);
     }
 
     #[test]
@@ -463,7 +463,7 @@ mode=${mode:-prod}$(mode=$mode; printf x)
 
         assert_eq!(diagnostics.len(), 1);
         assert_eq!(diagnostics[0].span.slice(source), "mode");
-        assert_eq!(diagnostics[0].span.start.line, 3);
+        assert_eq!(diagnostics[0].span.start.line(), 3);
     }
 
     #[test]
@@ -477,7 +477,7 @@ mode=${mode#dev} # ${mode:-prod}
 
         assert_eq!(diagnostics.len(), 1);
         assert_eq!(diagnostics[0].span.slice(source), "mode");
-        assert_eq!(diagnostics[0].span.start.line, 3);
+        assert_eq!(diagnostics[0].span.start.line(), 3);
     }
 
     #[test]
@@ -505,7 +505,7 @@ mode=${mode#dev}; echo ${mode:-prod}
 
         assert_eq!(diagnostics.len(), 1);
         assert_eq!(diagnostics[0].span.slice(source), "mode");
-        assert_eq!(diagnostics[0].span.start.line, 3);
+        assert_eq!(diagnostics[0].span.start.line(), 3);
     }
 
     #[test]
@@ -535,7 +535,7 @@ mode=prod
 
         assert_eq!(diagnostics.len(), 1);
         assert_eq!(diagnostics[0].span.slice(source), "mode");
-        assert_eq!(diagnostics[0].span.start.line, 3);
+        assert_eq!(diagnostics[0].span.start.line(), 3);
     }
 
     #[test]

--- a/crates/shuck-linter/src/rules/correctness/nested_parameter_expansion.rs
+++ b/crates/shuck-linter/src/rules/correctness/nested_parameter_expansion.rs
@@ -41,7 +41,7 @@ x=\"${${FALLBACK:-default}:-value}\"
         );
 
         assert_eq!(diagnostics.len(), 1);
-        assert_eq!(diagnostics[0].span.start.line, 2);
+        assert_eq!(diagnostics[0].span.start.line(), 2);
     }
 
     #[test]

--- a/crates/shuck-linter/src/rules/correctness/non_absolute_shebang.rs
+++ b/crates/shuck-linter/src/rules/correctness/non_absolute_shebang.rs
@@ -71,7 +71,7 @@ mod tests {
         let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::NonAbsoluteShebang));
 
         assert_eq!(diagnostics.len(), 1);
-        assert_eq!(diagnostics[0].span.start.line, 1);
+        assert_eq!(diagnostics[0].span.start.line(), 1);
         assert_eq!(diagnostics[0].span.slice(source), "#!bin/sh");
     }
 

--- a/crates/shuck-linter/src/rules/correctness/open_double_quote.rs
+++ b/crates/shuck-linter/src/rules/correctness/open_double_quote.rs
@@ -52,8 +52,8 @@ mod tests {
         let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::OpenDoubleQuote));
 
         assert_eq!(diagnostics.len(), 1);
-        assert_eq!(diagnostics[0].span.start.line, 2);
-        assert_eq!(diagnostics[0].span.start.column, 6);
+        assert_eq!(diagnostics[0].span.start.line(), 2);
+        assert_eq!(diagnostics[0].span.start.column(), 6);
         assert_eq!(diagnostics[0].span.start, diagnostics[0].span.end);
     }
 
@@ -89,8 +89,8 @@ line two\"$suffix
         let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::OpenDoubleQuote));
 
         assert_eq!(diagnostics.len(), 1);
-        assert_eq!(diagnostics[0].span.start.line, 2);
-        assert_eq!(diagnostics[0].span.start.column, 6);
+        assert_eq!(diagnostics[0].span.start.line(), 2);
+        assert_eq!(diagnostics[0].span.start.column(), 6);
         assert_eq!(diagnostics[0].span.start, diagnostics[0].span.end);
     }
 
@@ -104,8 +104,8 @@ line two''tail'
         let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::OpenDoubleQuote));
 
         assert_eq!(diagnostics.len(), 1);
-        assert_eq!(diagnostics[0].span.start.line, 2);
-        assert_eq!(diagnostics[0].span.start.column, 6);
+        assert_eq!(diagnostics[0].span.start.line(), 2);
+        assert_eq!(diagnostics[0].span.start.column(), 6);
         assert_eq!(diagnostics[0].span.start, diagnostics[0].span.end);
     }
 
@@ -120,10 +120,10 @@ echo \"alpha
         let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::OpenDoubleQuote));
 
         assert_eq!(diagnostics.len(), 2);
-        assert_eq!(diagnostics[0].span.start.line, 2);
-        assert_eq!(diagnostics[0].span.start.column, 6);
-        assert_eq!(diagnostics[1].span.start.line, 3);
-        assert_eq!(diagnostics[1].span.start.column, 6);
+        assert_eq!(diagnostics[0].span.start.line(), 2);
+        assert_eq!(diagnostics[0].span.start.column(), 6);
+        assert_eq!(diagnostics[1].span.start.line(), 3);
+        assert_eq!(diagnostics[1].span.start.column(), 6);
     }
 
     #[test]
@@ -137,10 +137,10 @@ echo \"a
         let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::OpenDoubleQuote));
 
         assert_eq!(diagnostics.len(), 2);
-        assert_eq!(diagnostics[0].span.start.line, 2);
-        assert_eq!(diagnostics[0].span.start.column, 6);
-        assert_eq!(diagnostics[1].span.start.line, 3);
-        assert_eq!(diagnostics[1].span.start.column, 8);
+        assert_eq!(diagnostics[0].span.start.line(), 2);
+        assert_eq!(diagnostics[0].span.start.column(), 6);
+        assert_eq!(diagnostics[1].span.start.line(), 3);
+        assert_eq!(diagnostics[1].span.start.column(), 8);
     }
 
     #[test]
@@ -154,10 +154,10 @@ echo \"a
         let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::OpenDoubleQuote));
 
         assert_eq!(diagnostics.len(), 2);
-        assert_eq!(diagnostics[0].span.start.line, 2);
-        assert_eq!(diagnostics[0].span.start.column, 6);
-        assert_eq!(diagnostics[1].span.start.line, 3);
-        assert_eq!(diagnostics[1].span.start.column, 11);
+        assert_eq!(diagnostics[0].span.start.line(), 2);
+        assert_eq!(diagnostics[0].span.start.column(), 6);
+        assert_eq!(diagnostics[1].span.start.line(), 3);
+        assert_eq!(diagnostics[1].span.start.column(), 11);
     }
 
     #[test]
@@ -279,8 +279,8 @@ echo \"GEM_PATH: \\$GEM_PATH\"
         let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::OpenDoubleQuote));
 
         assert_eq!(diagnostics.len(), 1);
-        assert_eq!(diagnostics[0].span.start.line, 2);
-        assert_eq!(diagnostics[0].span.start.column, 8);
+        assert_eq!(diagnostics[0].span.start.line(), 2);
+        assert_eq!(diagnostics[0].span.start.column(), 8);
         assert_eq!(diagnostics[0].span.start, diagnostics[0].span.end);
     }
 }

--- a/crates/shuck-linter/src/rules/correctness/overwritten_function.rs
+++ b/crates/shuck-linter/src/rules/correctness/overwritten_function.rs
@@ -95,7 +95,7 @@ pub fn overwritten_function(checker: &mut Checker) {
             if has_direct_call_to_binding_before_offset(
                 &mut reach,
                 overwritten.first,
-                second.span.start.offset,
+                second.span.start.offset(),
             ) {
                 continue;
             }
@@ -226,7 +226,7 @@ fn build_compat_structural_facts(checker: &Checker<'_>) -> CompatStructuralFacts
     let mut break_offsets = Vec::new();
 
     for fact in checker.facts().command_facts().structural_commands() {
-        let offset = fact.body_span().start.offset;
+        let offset = fact.body_span().start.offset();
         scopes_by_offset.entry(offset).or_insert(fact.scope());
         let is_function = matches!(fact.command(), shuck_ast::Command::Function(_));
         if is_function {
@@ -270,7 +270,7 @@ fn build_compat_structural_facts(checker: &Checker<'_>) -> CompatStructuralFacts
             .assignments()
             .function_unset_commands_for_name(&binding.name)
         {
-            let offset = fact.body_span().start.offset;
+            let offset = fact.body_span().start.offset();
             if !command_offset_is_under_dominance_barrier(checker, offset)
                 && !command_offset_is_unreachable(checker, offset)
             {
@@ -289,8 +289,8 @@ fn build_compat_structural_facts(checker: &Checker<'_>) -> CompatStructuralFacts
         .into_iter()
         .filter(|candidate| {
             !break_offsets.iter().any(|break_offset| {
-                *break_offset >= candidate.body_span.start.offset
-                    && *break_offset <= candidate.body_span.end.offset
+                *break_offset >= candidate.body_span.start.offset()
+                    && *break_offset <= candidate.body_span.end.offset()
             })
         })
         .map(|candidate| candidate.offset)
@@ -467,7 +467,7 @@ fn build_compat_script_terminator_facts(
         .filter(|block_id| !unreachable.contains(block_id))
         .flat_map(|block_id| cfg.block(*block_id).commands.iter())
         .filter_map(|span| {
-            let offset = span.start.offset;
+            let offset = span.start.offset();
             let scope = structural_facts
                 .scopes_by_offset
                 .get(&offset)
@@ -554,12 +554,12 @@ fn build_compat_unset_facts(
                     .filter(|site| {
                         !command_offset_is_under_dominance_barrier(
                             checker,
-                            site.name_span.start.offset,
+                            site.name_span.start.offset(),
                         )
                     })
                     .map(|site| CompatUnsetCutoffFact {
                         scope: site.scope,
-                        offset: site.name_span.start.offset,
+                        offset: site.name_span.start.offset(),
                     }),
             );
         }
@@ -620,12 +620,12 @@ fn report_transient_shadowed_file_scope_definitions(
             let first_shadow_offset = offsets
                 .iter()
                 .copied()
-                .find(|offset| *offset > binding.span.start.offset)?;
+                .find(|offset| *offset > binding.span.start.offset())?;
             if !checker.semantic_analysis().cfg().script_always_terminates() {
                 return None;
             }
             let terminator_offset =
-                last_script_terminator_offset_after(checker, scan, binding.span.start.offset)?;
+                last_script_terminator_offset_after(checker, scan, binding.span.start.offset())?;
 
             if has_direct_call_to_binding_before_offset(reach, binding.id, first_shadow_offset)
                 || has_non_transient_direct_call_to_binding_between_offsets(
@@ -662,7 +662,7 @@ fn transient_function_shadow_offsets_by_name(checker: &Checker<'_>) -> FxHashMap
         offsets_by_name
             .entry(name.clone())
             .or_default()
-            .push(span.start.offset);
+            .push(span.start.offset());
     }
     for offsets in offsets_by_name.values_mut() {
         offsets.sort_unstable();
@@ -677,7 +677,7 @@ fn first_compat_cutoff_after_binding(
     cutoffs: &CompatCutoffIndex,
 ) -> Option<FunctionCutoff> {
     let binding = checker.semantic().binding(binding_id);
-    let binding_offset = binding.span.start.offset;
+    let binding_offset = binding.span.start.offset();
 
     let unset_cutoff = first_unset_function_cutoff_offset(
         binding.name.as_str(),
@@ -779,7 +779,7 @@ fn command_offset_is_unreachable(checker: &Checker<'_>, offset: usize) -> bool {
         cfg.block(*block_id)
             .commands
             .iter()
-            .any(|span| span.start.offset == offset)
+            .any(|span| span.start.offset() == offset)
     })
 }
 
@@ -922,13 +922,13 @@ fn trim_trailing_function_separator(span: shuck_ast::Span, source: &str) -> shuc
     // the original end instead of re-walking the whole definition body.
     let removed = &original[trimmed.len()..];
     let removed_newlines = removed.bytes().filter(|byte| *byte == b'\n').count();
-    let end_offset = span.start.offset + trimmed.len();
+    let end_offset = span.start.offset() + trimmed.len();
     let end = if removed_newlines == 0 {
-        shuck_ast::Position {
-            line: span.end.line,
-            column: span.end.column - removed.len(),
-            offset: end_offset,
-        }
+        shuck_ast::Position::at(
+            span.end.line(),
+            span.end.column() - removed.len(),
+            end_offset,
+        )
     } else {
         let last_line_start = trimmed.rfind('\n').map(|index| index + 1);
         let tail = &trimmed[last_line_start.unwrap_or(0)..];
@@ -937,14 +937,14 @@ fn trim_trailing_function_separator(span: shuck_ast::Span, source: &str) -> shuc
         } else {
             tail.chars().count()
         };
-        shuck_ast::Position {
-            line: span.end.line - removed_newlines,
-            column: match last_line_start {
+        shuck_ast::Position::at(
+            span.end.line() - removed_newlines,
+            match last_line_start {
                 Some(_) => tail_chars + 1,
-                None => span.start.column + tail_chars,
+                None => span.start.column() + tail_chars,
             },
-            offset: end_offset,
-        }
+            end_offset,
+        )
     };
     shuck_ast::Span::from_positions(span.start, end)
 }
@@ -996,7 +996,7 @@ fn should_suppress_unreached(
         .report_unreached_nested_definitions;
     matches!(binding.kind, BindingKind::Imported)
         || (matches!(unreached.reason, UnreachedFunctionReason::ScriptTerminates)
-            && last_script_terminator_offset_after(checker, scan, binding.span.start.offset)
+            && last_script_terminator_offset_after(checker, scan, binding.span.start.offset())
                 .is_some_and(|terminator_offset| {
                     has_direct_call_to_binding_before_offset(
                         reach,
@@ -1010,13 +1010,13 @@ fn should_suppress_unreached(
         ) && !has_file_scope_termination_barrier_before(
             checker,
             scan,
-            binding.span.start.offset,
+            binding.span.start.offset(),
         ) && has_direct_call_to_binding_before_offset(reach, unreached.binding, usize::MAX))
         || (matches!(unreached.reason, UnreachedFunctionReason::ScriptTerminates)
-            && has_apparent_infinite_loop_after(checker, scan, binding.span.start.offset))
+            && has_apparent_infinite_loop_after(checker, scan, binding.span.start.offset()))
         || (compat_mode
             && matches!(unreached.reason, UnreachedFunctionReason::ScriptTerminates)
-            && has_top_level_return_after(checker, scan, binding.span.start.offset))
+            && has_top_level_return_after(checker, scan, binding.span.start.offset()))
         || (matches!(
             unreached.reason,
             UnreachedFunctionReason::EnclosingFunctionUnreached
@@ -1054,7 +1054,7 @@ fn last_script_terminator_offset_after(
             .filter(|block_id| !unreachable.contains(block_id))
             .flat_map(|block_id| cfg.block(*block_id).commands.iter())
             .filter_map(|span| {
-                let offset = span.start.offset;
+                let offset = span.start.offset();
                 let scope = checker.semantic().scope_at(offset);
                 (!scope_has_transient_ancestor(checker, scope)).then_some(offset)
             })
@@ -1082,7 +1082,7 @@ fn has_file_scope_script_terminator_before(
             .filter(|block_id| !unreachable.contains(block_id))
             .flat_map(|block_id| cfg.block(*block_id).commands.iter())
             .filter_map(|span| {
-                let offset = span.start.offset;
+                let offset = span.start.offset();
                 checker
                     .facts()
                     .command_facts()
@@ -1122,7 +1122,7 @@ fn has_file_scope_return_before(
             .command_facts()
             .structural_commands()
             .filter_map(|fact| {
-                let offset = fact.body_span().start.offset;
+                let offset = fact.body_span().start.offset();
                 (fact.effective_name_is("return")
                     && scope_is_file_scope(checker, fact.scope())
                     && !command_offset_is_under_dominance_barrier(checker, offset)
@@ -1152,9 +1152,9 @@ fn has_top_level_return_after(
                 (fact.effective_name_is("return")
                     && scope_is_file_scope(
                         checker,
-                        checker.semantic().scope_at(fact.body_span().start.offset),
+                        checker.semantic().scope_at(fact.body_span().start.offset()),
                     ))
-                .then_some(fact.body_span().start.offset)
+                .then_some(fact.body_span().start.offset())
             })
             .collect::<Vec<_>>();
         offsets.sort_unstable();
@@ -1187,7 +1187,7 @@ fn has_direct_call_inside_enclosing_function(
 
     reach.binding_has_reachable_direct_call(
         binding_id,
-        DirectFunctionCallWindow::between_offsets(binding.span.start.offset, usize::MAX)
+        DirectFunctionCallWindow::between_offsets(binding.span.start.offset(), usize::MAX)
             .within_scope(enclosing_scope),
     )
 }
@@ -1205,9 +1205,9 @@ fn has_apparent_infinite_loop_after(
             .filter_map(|fact| {
                 (scope_is_file_scope(
                     checker,
-                    checker.semantic().scope_at(fact.body_span().start.offset),
+                    checker.semantic().scope_at(fact.body_span().start.offset()),
                 ) && command_is_apparent_infinite_loop(checker, fact.command()))
-                .then_some(fact.body_span().start.offset)
+                .then_some(fact.body_span().start.offset())
             })
             .collect::<Vec<_>>();
         offsets.sort_unstable();
@@ -1258,8 +1258,8 @@ fn loop_body_contains_break(checker: &Checker<'_>, body_span: shuck_ast::Span) -
         .command_facts()
         .structural_commands()
         .any(|fact| {
-            fact.body_span().start.offset >= body_span.start.offset
-                && fact.body_span().end.offset <= body_span.end.offset
+            fact.body_span().start.offset() >= body_span.start.offset()
+                && fact.body_span().end.offset() <= body_span.end.offset()
                 && matches!(
                     fact.command(),
                     shuck_ast::Command::Builtin(shuck_ast::BuiltinCommand::Break(_))
@@ -1366,7 +1366,7 @@ parse() { :; }
 
         assert_eq!(diagnostics.len(), 1, "diagnostics: {diagnostics:?}");
         assert_eq!(diagnostics[0].rule, Rule::OverwrittenFunction);
-        assert_eq!(diagnostics[0].span.start.line, 1);
+        assert_eq!(diagnostics[0].span.start.line(), 1);
     }
 
     #[test]
@@ -1460,7 +1460,7 @@ exit 0
 
         assert_eq!(diagnostics.len(), 1);
         assert_eq!(diagnostics[0].rule, Rule::OverwrittenFunction);
-        assert_eq!(diagnostics[0].span.start.line, 1);
+        assert_eq!(diagnostics[0].span.start.line(), 1);
     }
 
     #[test]
@@ -1487,7 +1487,7 @@ exit 0
 
         let nested = diagnostics
             .iter()
-            .find(|diagnostic| diagnostic.span.start.column == 10)
+            .find(|diagnostic| diagnostic.span.start.column() == 10)
             .expect("expected nested function diagnostic");
         assert_eq!(nested.span.slice(source), "trans() { echo trans; }");
     }
@@ -1524,7 +1524,7 @@ outer() {
 
         assert_eq!(diagnostics.len(), 1);
         assert_eq!(diagnostics[0].rule, Rule::OverwrittenFunction);
-        assert_eq!(diagnostics[0].span.start.line, 2);
+        assert_eq!(diagnostics[0].span.start.line(), 2);
         assert_eq!(
             diagnostics[0].fix.as_ref().map(|fix| fix.applicability()),
             Some(Applicability::Unsafe)
@@ -1557,7 +1557,7 @@ End
 
         assert_eq!(diagnostics.len(), 1, "diagnostics: {diagnostics:?}");
         assert_eq!(diagnostics[0].rule, Rule::OverwrittenFunction);
-        assert_eq!(diagnostics[0].span.start.line, 5);
+        assert_eq!(diagnostics[0].span.start.line(), 5);
     }
 
     #[test]
@@ -1579,7 +1579,7 @@ End
 
         assert_eq!(diagnostics.len(), 1, "diagnostics: {diagnostics:?}");
         assert_eq!(diagnostics[0].rule, Rule::OverwrittenFunction);
-        assert_eq!(diagnostics[0].span.start.line, 2);
+        assert_eq!(diagnostics[0].span.start.line(), 2);
     }
 
     #[test]
@@ -1599,7 +1599,7 @@ outer() {
         );
 
         assert_eq!(diagnostics.len(), 1, "diagnostics: {diagnostics:?}");
-        assert_eq!(diagnostics[0].span.start.line, 2);
+        assert_eq!(diagnostics[0].span.start.line(), 2);
     }
 
     #[test]
@@ -1618,7 +1618,7 @@ exit 0
         );
 
         assert_eq!(diagnostics.len(), 1, "diagnostics: {diagnostics:?}");
-        assert_eq!(diagnostics[0].span.start.line, 1);
+        assert_eq!(diagnostics[0].span.start.line(), 1);
     }
 
     #[test]
@@ -1638,7 +1638,7 @@ outer() { :; }
         );
 
         assert_eq!(diagnostics.len(), 1, "diagnostics: {diagnostics:?}");
-        assert_eq!(diagnostics[0].span.start.line, 1);
+        assert_eq!(diagnostics[0].span.start.line(), 1);
     }
 
     #[test]
@@ -1659,7 +1659,7 @@ cleanup 0
 
         assert_eq!(diagnostics.len(), 1);
         assert_eq!(diagnostics[0].rule, Rule::OverwrittenFunction);
-        assert_eq!(diagnostics[0].span.start.line, 1);
+        assert_eq!(diagnostics[0].span.start.line(), 1);
     }
 
     #[test]
@@ -1678,7 +1678,7 @@ value=$(outer)
         );
 
         assert_eq!(diagnostics.len(), 1);
-        assert_eq!(diagnostics[0].span.start.line, 2);
+        assert_eq!(diagnostics[0].span.start.line(), 2);
     }
 
     #[test]
@@ -1722,7 +1722,7 @@ fi
         );
 
         assert_eq!(diagnostics.len(), 1);
-        assert_eq!(diagnostics[0].span.start.line, 2);
+        assert_eq!(diagnostics[0].span.start.line(), 2);
     }
 
     #[test]
@@ -1769,7 +1769,7 @@ exit 0
         );
 
         assert_eq!(diagnostics.len(), 1, "diagnostics: {diagnostics:?}");
-        assert_eq!(diagnostics[0].span.start.line, 3);
+        assert_eq!(diagnostics[0].span.start.line(), 3);
     }
 
     #[test]
@@ -1795,7 +1795,7 @@ main
         );
 
         assert_eq!(diagnostics.len(), 1, "diagnostics: {diagnostics:?}");
-        assert_eq!(diagnostics[0].span.start.line, 3);
+        assert_eq!(diagnostics[0].span.start.line(), 3);
     }
 
     #[test]
@@ -1914,7 +1914,7 @@ outer() {
         );
         let lines = diagnostics
             .iter()
-            .map(|diagnostic| diagnostic.span.start.line)
+            .map(|diagnostic| diagnostic.span.start.line())
             .collect::<Vec<_>>();
 
         assert_eq!(lines, [2, 3], "diagnostics: {diagnostics:?}");
@@ -1936,7 +1936,7 @@ outer() {
         );
 
         assert_eq!(diagnostics.len(), 1, "diagnostics: {diagnostics:?}");
-        assert_eq!(diagnostics[0].span.start.line, 3);
+        assert_eq!(diagnostics[0].span.start.line(), 3);
     }
 
     #[test]
@@ -1956,7 +1956,7 @@ exit 0
         );
 
         assert_eq!(diagnostics.len(), 1, "diagnostics: {diagnostics:?}");
-        assert_eq!(diagnostics[0].span.start.line, 1);
+        assert_eq!(diagnostics[0].span.start.line(), 1);
     }
 
     #[test]
@@ -2041,7 +2041,7 @@ exit 0
         );
 
         assert_eq!(diagnostics.len(), 1, "diagnostics: {diagnostics:?}");
-        assert_eq!(diagnostics[0].span.start.line, 1);
+        assert_eq!(diagnostics[0].span.start.line(), 1);
     }
 
     #[test]
@@ -2149,7 +2149,7 @@ exit 0
         );
         let lines = diagnostics
             .iter()
-            .map(|diagnostic| diagnostic.span.start.line)
+            .map(|diagnostic| diagnostic.span.start.line())
             .collect::<Vec<_>>();
 
         assert_eq!(lines, [1, 6], "diagnostics: {diagnostics:?}");
@@ -2170,7 +2170,7 @@ helper
         );
 
         assert_eq!(diagnostics.len(), 1);
-        assert_eq!(diagnostics[0].span.start.line, 1);
+        assert_eq!(diagnostics[0].span.start.line(), 1);
     }
 
     #[test]
@@ -2340,7 +2340,7 @@ exit 0
 
         assert_eq!(diagnostics.len(), 1, "diagnostics: {diagnostics:?}");
         assert_eq!(diagnostics[0].rule, Rule::OverwrittenFunction);
-        assert_eq!(diagnostics[0].span.start.line, 1);
+        assert_eq!(diagnostics[0].span.start.line(), 1);
     }
 
     #[test]
@@ -2364,7 +2364,7 @@ main
 
         assert_eq!(diagnostics.len(), 1, "diagnostics: {diagnostics:?}");
         assert_eq!(diagnostics[0].rule, Rule::OverwrittenFunction);
-        assert_eq!(diagnostics[0].span.start.line, 1);
+        assert_eq!(diagnostics[0].span.start.line(), 1);
     }
 
     #[test]
@@ -2628,13 +2628,13 @@ exit
         assert!(
             diagnostics
                 .iter()
-                .any(|diagnostic| diagnostic.span.start.line == 1),
+                .any(|diagnostic| diagnostic.span.start.line() == 1),
             "diagnostics: {diagnostics:?}"
         );
         assert!(
             diagnostics
                 .iter()
-                .any(|diagnostic| diagnostic.span.start.line == 5),
+                .any(|diagnostic| diagnostic.span.start.line() == 5),
             "diagnostics: {diagnostics:?}"
         );
     }
@@ -2664,7 +2664,7 @@ exit
         assert!(
             diagnostics
                 .iter()
-                .any(|diagnostic| diagnostic.span.start.line == 1),
+                .any(|diagnostic| diagnostic.span.start.line() == 1),
             "diagnostics: {diagnostics:?}"
         );
     }
@@ -2696,7 +2696,7 @@ exit
         assert!(
             diagnostics
                 .iter()
-                .any(|diagnostic| diagnostic.span.start.line == 1),
+                .any(|diagnostic| diagnostic.span.start.line() == 1),
             "diagnostics: {diagnostics:?}"
         );
     }
@@ -2731,7 +2731,7 @@ myfunc() { echo hi; }
 
         assert_eq!(diagnostics.len(), 1);
         assert_eq!(diagnostics[0].rule, Rule::OverwrittenFunction);
-        assert_eq!(diagnostics[0].span.start.line, 2);
+        assert_eq!(diagnostics[0].span.start.line(), 2);
     }
 
     #[test]
@@ -2751,7 +2751,7 @@ driver
         assert!(
             diagnostics
                 .iter()
-                .any(|diagnostic| diagnostic.span.start.line == 2),
+                .any(|diagnostic| diagnostic.span.start.line() == 2),
             "diagnostics: {diagnostics:?}"
         );
     }
@@ -2773,7 +2773,7 @@ driver
         assert!(
             diagnostics
                 .iter()
-                .any(|diagnostic| diagnostic.span.start.line == 2),
+                .any(|diagnostic| diagnostic.span.start.line() == 2),
             "diagnostics: {diagnostics:?}"
         );
     }

--- a/crates/shuck-linter/src/rules/correctness/pattern_with_variable.rs
+++ b/crates/shuck-linter/src/rules/correctness/pattern_with_variable.rs
@@ -83,9 +83,9 @@ pub fn pattern_with_variable(checker: &mut Checker) {
 }
 
 fn span_is_within_any(span: Span, hosts: &[Span]) -> bool {
-    hosts
-        .iter()
-        .any(|host| host.start.offset <= span.start.offset && span.end.offset <= host.end.offset)
+    hosts.iter().any(|host| {
+        host.start.offset() <= span.start.offset() && span.end.offset() <= host.end.offset()
+    })
 }
 
 fn span_is_zsh_numeric_glob_tail_group(span: Span, source: &str) -> bool {
@@ -93,7 +93,7 @@ fn span_is_zsh_numeric_glob_tail_group(span: Span, source: &str) -> bool {
         return false;
     }
 
-    let Some(prefix) = source.get(..span.start.offset) else {
+    let Some(prefix) = source.get(..span.start.offset()) else {
         return false;
     };
 

--- a/crates/shuck-linter/src/rules/correctness/pipe_to_kill.rs
+++ b/crates/shuck-linter/src/rules/correctness/pipe_to_kill.rs
@@ -47,7 +47,7 @@ printf '%s\\n' $$ | cat
         assert_eq!(
             diagnostics
                 .iter()
-                .map(|diagnostic| diagnostic.span.start.line)
+                .map(|diagnostic| diagnostic.span.start.line())
                 .collect::<Vec<_>>(),
             vec![1, 2, 3]
         );

--- a/crates/shuck-linter/src/rules/correctness/positional_param_as_operator.rs
+++ b/crates/shuck-linter/src/rules/correctness/positional_param_as_operator.rs
@@ -36,8 +36,8 @@ echo \"$(( x $1 y ))\"
         );
 
         assert_eq!(diagnostics.len(), 1);
-        assert_eq!(diagnostics[0].span.start.line, 2);
-        assert_eq!(diagnostics[0].span.start.column, 7);
+        assert_eq!(diagnostics[0].span.start.line(), 2);
+        assert_eq!(diagnostics[0].span.start.column(), 7);
         assert_eq!(diagnostics[0].span.end, diagnostics[0].span.start);
     }
 
@@ -69,8 +69,8 @@ echo \"$(( value + prefix$1 ))\"
         );
 
         assert_eq!(diagnostics.len(), 1);
-        assert_eq!(diagnostics[0].span.start.line, 2);
-        assert_eq!(diagnostics[0].span.start.column, 7);
+        assert_eq!(diagnostics[0].span.start.line(), 2);
+        assert_eq!(diagnostics[0].span.start.column(), 7);
         assert_eq!(diagnostics[0].span.end, diagnostics[0].span.start);
     }
 

--- a/crates/shuck-linter/src/rules/correctness/possible_variable_misspelling.rs
+++ b/crates/shuck-linter/src/rules/correctness/possible_variable_misspelling.rs
@@ -62,7 +62,7 @@ pub fn possible_variable_misspelling(checker: &mut Checker) {
             offsets
                 .entry(reference.name.clone())
                 .or_insert_with(Vec::new)
-                .push(reference.span.start.offset);
+                .push(reference.span.start.offset());
             offsets
         });
 
@@ -156,7 +156,7 @@ pub fn possible_variable_misspelling(checker: &mut Checker) {
         ));
     }
 
-    findings.sort_by_key(|(span, _, _)| (span.start.offset, span.end.offset));
+    findings.sort_by_key(|(span, _, _)| (span.start.offset(), span.end.offset()));
     let mut reported_names = FxHashSet::default();
 
     for (span, reference, candidate) in findings {
@@ -188,7 +188,7 @@ fn heredoc_findings(
                 continue;
             }
             let reference_name = name_use.key().as_str();
-            if !seen.insert((Name::from(reference_name), name_use.span().start.offset)) {
+            if !seen.insert((Name::from(reference_name), name_use.span().start.offset())) {
                 continue;
             }
             if !looks_like_case_mismatch_reference(reference_name) {
@@ -267,7 +267,7 @@ fn scope_compat_findings(
 
     for name_use in index.references() {
         let reference_name = name_use.name.as_str();
-        if !seen.insert((name_use.name.clone(), name_use.span.start.offset)) {
+        if !seen.insert((name_use.name.clone(), name_use.span.start.offset())) {
             continue;
         }
         if !looks_like_case_mismatch_reference(reference_name) {
@@ -384,8 +384,8 @@ fn insert_earliest_candidate(
     candidates
         .entry(key)
         .and_modify(|current| {
-            if (span.start.offset, span.end.offset)
-                < (current.span.start.offset, current.span.end.offset)
+            if (span.start.offset(), span.end.offset())
+                < (current.span.start.offset(), current.span.end.offset())
             {
                 *current = candidate.clone();
             }
@@ -478,7 +478,7 @@ fn best_build_flag_candidate(index: &ScopeCompatIndex, reference_name: &str) -> 
             };
             index.best_candidate_by_name(&candidate_name)
         })
-        .min_by_key(|candidate| (candidate.span.start.offset, candidate.span.end.offset))
+        .min_by_key(|candidate| (candidate.span.start.offset(), candidate.span.end.offset()))
         .map(|candidate| candidate.name.clone())
 }
 
@@ -501,7 +501,7 @@ fn source_may_have_scope_compat_misspelling(source: &str) -> bool {
 fn is_braced_parameter_use(source: &str, span: Span) -> bool {
     source
         .as_bytes()
-        .get(span.start.offset..span.start.offset + 2)
+        .get(span.start.offset()..span.start.offset() + 2)
         .is_some_and(|prefix| prefix == b"${")
 }
 
@@ -512,7 +512,7 @@ fn has_prior_guarded_reference(
 ) -> bool {
     guarded_name_offsets
         .get(name)
-        .is_some_and(|offsets| offsets.iter().any(|offset| *offset < span.start.offset))
+        .is_some_and(|offsets| offsets.iter().any(|offset| *offset < span.start.offset()))
 }
 
 fn has_suppressed_reference_span(
@@ -529,7 +529,7 @@ fn has_suppressed_reference_span(
 }
 
 fn spans_overlap(left: Span, right: Span) -> bool {
-    left.start.offset < right.end.offset && right.start.offset < left.end.offset
+    left.start.offset() < right.end.offset() && right.start.offset() < left.end.offset()
 }
 
 fn is_presence_tested_reference_name(
@@ -544,7 +544,7 @@ fn is_presence_tested_reference_name(
 }
 
 fn parameter_reference_span(locator: Locator<'_>, span: Span) -> Span {
-    let Some(previous_offset) = span.start.offset.checked_sub(1) else {
+    let Some(previous_offset) = span.start.offset().checked_sub(1) else {
         return span;
     };
     if locator.source().as_bytes().get(previous_offset) != Some(&b'$') {
@@ -701,12 +701,12 @@ fn is_parallel_c_and_cxx_flag_use(
     }
 
     let source = checker.source();
-    let current_line = source_line_at(source, reference_span.start.offset);
+    let current_line = source_line_at(source, reference_span.start.offset());
     if text_mentions_shell_name(current_line, "CFLAGS") {
         return true;
     }
 
-    let nearby_lines = source_line_window(source, reference_span.start.offset, 1);
+    let nearby_lines = source_line_window(source, reference_span.start.offset(), 1);
     text_mentions_shell_name(nearby_lines, "CPPFLAGS")
         && text_mentions_shell_name(nearby_lines, "CFLAGS")
         && text_mentions_shell_name(nearby_lines, "CXXFLAGS")
@@ -721,11 +721,11 @@ fn is_hostid_label_echo(
         return false;
     }
 
-    let line_start = source[..reference_span.start.offset]
+    let line_start = source[..reference_span.start.offset()]
         .rfind('\n')
         .map_or(0, |index| index + 1);
-    let line = source_line_at(source, reference_span.start.offset);
-    let reference_column = reference_span.start.offset.saturating_sub(line_start);
+    let line = source_line_at(source, reference_span.start.offset());
+    let reference_column = reference_span.start.offset().saturating_sub(line_start);
     let Some(prefix) = line.get(..reference_column) else {
         return false;
     };
@@ -774,12 +774,12 @@ fn is_literal_numbered_suffix_variant(
         return false;
     }
 
-    source_suffix_matches(source, reference_span.end.offset, suffix)
+    source_suffix_matches(source, reference_span.end.offset(), suffix)
         || source
             .as_bytes()
-            .get(reference_span.end.offset)
+            .get(reference_span.end.offset())
             .is_some_and(|byte| *byte == b'}')
-            && source_suffix_matches(source, reference_span.end.offset + 1, suffix)
+            && source_suffix_matches(source, reference_span.end.offset() + 1, suffix)
 }
 
 fn source_suffix_matches(source: &str, offset: usize, suffix: &str) -> bool {

--- a/crates/shuck-linter/src/rules/correctness/quoted_bash_regex.rs
+++ b/crates/shuck-linter/src/rules/correctness/quoted_bash_regex.rs
@@ -69,8 +69,8 @@ pub fn quoted_bash_regex(checker: &mut Checker) {
 fn quoted_bash_regex_fix(word: &shuck_ast::Word, source: &str) -> Option<Fix> {
     let content_span = word.quoted_content_span_in_source(source)?;
     Some(Fix::unsafe_edits([
-        Edit::deletion_at(word.span.start.offset, content_span.start.offset),
-        Edit::deletion_at(content_span.end.offset, word.span.end.offset),
+        Edit::deletion_at(word.span.start.offset(), content_span.start.offset()),
+        Edit::deletion_at(content_span.end.offset(), word.span.end.offset()),
     ]))
 }
 
@@ -140,7 +140,7 @@ mod tests {
         assert_eq!(
             diagnostics
                 .iter()
-                .map(|diagnostic| diagnostic.span.start.line)
+                .map(|diagnostic| diagnostic.span.start.line())
                 .collect::<Vec<_>>(),
             vec![3, 4]
         );

--- a/crates/shuck-linter/src/rules/correctness/redirect_before_pipe.rs
+++ b/crates/shuck-linter/src/rules/correctness/redirect_before_pipe.rs
@@ -72,8 +72,8 @@ fn move_redirect_after_pipeline_fix(
     let redirect_span = redirect.redirect().span;
     let delete_span = redirect_deletion_span(redirect_span, source);
     let insertion_offset = trim_trailing_whitespace_offset(
-        pipeline.last_segment()?.stmt().span.start.offset,
-        pipeline.last_segment()?.stmt().span.end.offset,
+        pipeline.last_segment()?.stmt().span.start.offset(),
+        pipeline.last_segment()?.stmt().span.end.offset(),
         source,
     );
     let insertion = format!(" {}", redirect_span.slice(source).trim());
@@ -95,7 +95,7 @@ fn trim_trailing_whitespace_offset(start: usize, mut end: usize, source: &str) -
 }
 
 fn redirect_deletion_span(span: Span, source: &str) -> Span {
-    let mut start = span.start.offset;
+    let mut start = span.start.offset();
     while start > 0 {
         let previous = source.as_bytes()[start - 1];
         if !matches!(previous, b' ' | b'\t') {
@@ -105,14 +105,13 @@ fn redirect_deletion_span(span: Span, source: &str) -> Span {
     }
 
     Span::from_positions(
-        Position {
-            offset: start,
-            line: span.start.line,
-            column: span
-                .start
-                .column
-                .saturating_sub(span.start.offset.saturating_sub(start)),
-        },
+        Position::at(
+            span.start.line(),
+            span.start
+                .column()
+                .saturating_sub(span.start.offset().saturating_sub(start)),
+            start,
+        ),
         span.end,
     )
 }
@@ -172,7 +171,7 @@ fn stdout_redirect_span_before_pipe(
 fn redirect_operator_span(redirect: &crate::RedirectFact<'_>, source: &str) -> Option<Span> {
     let target_span = redirect.target_span()?;
     let operator_slice =
-        source.get(redirect.redirect().span.start.offset..target_span.start.offset)?;
+        source.get(redirect.redirect().span.start.offset()..target_span.start.offset())?;
     let operator_start = operator_slice.find('>')?;
     let operator_end = operator_slice.rfind(|ch: char| !ch.is_whitespace())? + 1;
     let operator_start_pos = redirect

--- a/crates/shuck-linter/src/rules/correctness/redirect_to_command_name.rs
+++ b/crates/shuck-linter/src/rules/correctness/redirect_to_command_name.rs
@@ -65,7 +65,7 @@ pub fn redirect_to_command_name(checker: &mut Checker) {
     for span in spans {
         checker.report_diagnostic_dedup(
             crate::Diagnostic::new(RedirectToCommandName, span)
-                .with_fix(Fix::safe_edit(Edit::insertion(span.start.offset, "./"))),
+                .with_fix(Fix::safe_edit(Edit::insertion(span.start.offset(), "./"))),
         );
     }
 }
@@ -194,7 +194,7 @@ cat input &> printf
         assert_eq!(
             diagnostics
                 .iter()
-                .map(|diagnostic| diagnostic.span.start.line)
+                .map(|diagnostic| diagnostic.span.start.line())
                 .collect::<Vec<_>>(),
             vec![2, 3, 4, 5, 6, 7, 8]
         );

--- a/crates/shuck-linter/src/rules/correctness/script_scope_local.rs
+++ b/crates/shuck-linter/src/rules/correctness/script_scope_local.rs
@@ -27,16 +27,16 @@ pub fn local_top_level(checker: &mut Checker) {
         .filter(|declaration| declaration.builtin == DeclarationBuiltin::Local)
         .filter(|declaration| {
             checker.first_parse_error().is_none_or(|(line, column)| {
-                declaration.span.start.line < line
-                    || (declaration.span.start.line == line
-                        && declaration.span.start.column < column)
+                declaration.span.start.line() < line
+                    || (declaration.span.start.line() == line
+                        && declaration.span.start.column() < column)
             })
         })
         .filter_map(|declaration| {
             let binding_offsets = semantic
                 .bindings_in_span(declaration.span)
                 .filter(|binding| local_binding_belongs_to_declaration_kind(binding))
-                .map(|binding| binding.span.start.offset)
+                .map(|binding| binding.span.start.offset())
                 .collect::<Vec<_>>();
 
             if binding_offsets.iter().any(|offset| {
@@ -52,7 +52,7 @@ pub fn local_top_level(checker: &mut Checker) {
             }
 
             let inside_function = semantic_analysis
-                .enclosing_function_scope_at(declaration.span.start.offset)
+                .enclosing_function_scope_at(declaration.span.start.offset())
                 .is_some();
 
             (!inside_function).then_some(declaration.span)

--- a/crates/shuck-linter/src/rules/correctness/set_flags_without_dashes.rs
+++ b/crates/shuck-linter/src/rules/correctness/set_flags_without_dashes.rs
@@ -42,7 +42,7 @@ pub fn set_flags_without_dashes(checker: &mut Checker) {
     for span in spans {
         checker.report_diagnostic_dedup(
             Diagnostic::new(SetFlagsWithoutDashes, span)
-                .with_fix(Fix::safe_edit(Edit::insertion(span.start.offset, "-- "))),
+                .with_fix(Fix::safe_edit(Edit::insertion(span.start.offset(), "-- "))),
         );
     }
 }

--- a/crates/shuck-linter/src/rules/correctness/shebang_not_on_first_line.rs
+++ b/crates/shuck-linter/src/rules/correctness/shebang_not_on_first_line.rs
@@ -70,9 +70,9 @@ mod tests {
         );
 
         assert_eq!(diagnostics.len(), 1);
-        assert_eq!(diagnostics[0].span.start.line, 2);
-        assert_eq!(diagnostics[0].span.start.column, 1);
-        assert_eq!(diagnostics[0].span.end.column, 1);
+        assert_eq!(diagnostics[0].span.start.line(), 2);
+        assert_eq!(diagnostics[0].span.start.column(), 1);
+        assert_eq!(diagnostics[0].span.end.column(), 1);
     }
 
     #[test]
@@ -84,7 +84,7 @@ mod tests {
         );
 
         assert_eq!(diagnostics.len(), 1);
-        assert_eq!(diagnostics[0].span.start.line, 2);
+        assert_eq!(diagnostics[0].span.start.line(), 2);
     }
 
     #[test]
@@ -96,9 +96,9 @@ mod tests {
         );
 
         assert_eq!(diagnostics.len(), 1);
-        assert_eq!(diagnostics[0].span.start.line, 3);
-        assert_eq!(diagnostics[0].span.start.column, 1);
-        assert_eq!(diagnostics[0].span.end.column, 1);
+        assert_eq!(diagnostics[0].span.start.line(), 3);
+        assert_eq!(diagnostics[0].span.start.column(), 1);
+        assert_eq!(diagnostics[0].span.end.column(), 1);
     }
 
     #[test]

--- a/crates/shuck-linter/src/rules/correctness/shell_quoting_reuse.rs
+++ b/crates/shuck-linter/src/rules/correctness/shell_quoting_reuse.rs
@@ -354,11 +354,11 @@ fn bracket_v_name_spans(
                 .copied()
                 .filter(|binding_id| {
                     let binding = checker.semantic().binding(*binding_id);
-                    binding.span.start.offset <= operand.span.start.offset
+                    binding.span.start.offset() <= operand.span.start.offset()
                         && is_test_v_variable_binding(binding)
                 })
                 .max_by_key(|binding_id| {
-                    checker.semantic().binding(*binding_id).span.start.offset
+                    checker.semantic().binding(*binding_id).span.start.offset()
                 })?;
             let roots = root_bindings_for_binding(
                 binding_id,
@@ -492,7 +492,7 @@ fn expansion_span_is_plain_reference(
 }
 
 fn sort_and_dedup_spans(spans: &mut Vec<Span>) {
-    spans.sort_unstable_by_key(|span| (span.start.offset, span.end.offset));
+    spans.sort_unstable_by_key(|span| (span.start.offset(), span.end.offset()));
     spans.dedup();
 }
 

--- a/crates/shuck-linter/src/rules/correctness/single_quoted_literal.rs
+++ b/crates/shuck-linter/src/rules/correctness/single_quoted_literal.rs
@@ -655,8 +655,8 @@ END { if (!set) exit 1 }\n\
     fn corpus_regression_backticks_are_reported() {
         let diagnostics = c005_diagnostics("SHOBJ_ARCHFLAGS='-arch_only `/usr/bin/arch`'\n");
         assert_eq!(diagnostics.len(), 1);
-        assert_eq!(diagnostics[0].span.start.line, 1);
-        assert_eq!(diagnostics[0].span.start.column, 17);
+        assert_eq!(diagnostics[0].span.start.line(), 1);
+        assert_eq!(diagnostics[0].span.start.column(), 17);
     }
 
     #[test]
@@ -666,8 +666,8 @@ END { if (!set) exit 1 }\n\
         );
 
         assert_eq!(diagnostics.len(), 1);
-        assert_eq!(diagnostics[0].span.start.line, 2);
-        assert_eq!(diagnostics[0].span.start.column, 7);
+        assert_eq!(diagnostics[0].span.start.line(), 2);
+        assert_eq!(diagnostics[0].span.start.column(), 7);
     }
 
     #[test]
@@ -770,10 +770,10 @@ END { if (!set) exit 1 }\n\
         let diagnostics = c005_diagnostics("echo '$HOME'\n");
 
         assert_eq!(diagnostics.len(), 1);
-        assert_eq!(diagnostics[0].span.start.line, 1);
-        assert_eq!(diagnostics[0].span.start.column, 6);
-        assert_eq!(diagnostics[0].span.end.line, 1);
-        assert_eq!(diagnostics[0].span.end.column, 13);
+        assert_eq!(diagnostics[0].span.start.line(), 1);
+        assert_eq!(diagnostics[0].span.start.column(), 6);
+        assert_eq!(diagnostics[0].span.end.line(), 1);
+        assert_eq!(diagnostics[0].span.end.column(), 13);
         assert_eq!(
             diagnostics[0].fix.as_ref().map(|fix| fix.applicability()),
             Some(Applicability::Unsafe)
@@ -791,8 +791,8 @@ END { if (!set) exit 1 }\n\
         );
 
         assert_eq!(diagnostics.len(), 1);
-        assert_eq!(diagnostics[0].span.start.line, 1);
-        assert_eq!(diagnostics[0].span.start.column, 10);
+        assert_eq!(diagnostics[0].span.start.line(), 1);
+        assert_eq!(diagnostics[0].span.start.column(), 10);
     }
 
     #[test]
@@ -888,7 +888,7 @@ echo \"\\\"$HOME\\\" and \\\\\\\\path\"
         let diagnostics = c005_diagnostics(source);
 
         assert_eq!(diagnostics.len(), 1);
-        assert_eq!(diagnostics[0].span.start.line, 5);
+        assert_eq!(diagnostics[0].span.start.line(), 5);
         assert_eq!(diagnostics[0].span.slice(source), "'\"${!options[@]}\"'");
     }
 
@@ -918,7 +918,7 @@ subcommand()
         let diagnostics = c005_diagnostics(source);
 
         assert_eq!(diagnostics.len(), 1);
-        assert_eq!(diagnostics[0].span.start.line, 7);
+        assert_eq!(diagnostics[0].span.start.line(), 7);
         assert_eq!(diagnostics[0].span.slice(source), "'\"${!options[@]}\"'");
     }
 
@@ -937,10 +937,10 @@ lt_compile=`echo \"$ac_compile\" | $SED \\\n\
                 .iter()
                 .map(|diagnostic| {
                     (
-                        diagnostic.span.start.line,
-                        diagnostic.span.start.column,
-                        diagnostic.span.end.line,
-                        diagnostic.span.end.column,
+                        diagnostic.span.start.line(),
+                        diagnostic.span.start.column(),
+                        diagnostic.span.end.line(),
+                        diagnostic.span.end.column(),
                     )
                 })
                 .collect::<Vec<_>>(),
@@ -959,7 +959,7 @@ sed -i -e 's/foo/$bar/' \\\n\
         assert_eq!(
             diagnostics
                 .iter()
-                .map(|diagnostic| diagnostic.span.start.line)
+                .map(|diagnostic| diagnostic.span.start.line())
                 .collect::<Vec<_>>(),
             vec![1, 2]
         );
@@ -982,10 +982,10 @@ x=$(printf %s \\\n\
         assert_eq!(diagnostics.len(), 1);
         assert_eq!(
             (
-                diagnostics[0].span.start.line,
-                diagnostics[0].span.start.column,
-                diagnostics[0].span.end.line,
-                diagnostics[0].span.end.column,
+                diagnostics[0].span.start.line(),
+                diagnostics[0].span.start.column(),
+                diagnostics[0].span.end.line(),
+                diagnostics[0].span.end.column(),
             ),
             (2, 1, 2, 8)
         );
@@ -1000,10 +1000,10 @@ relink_command=`$ECHO \"$compile_var$compile_command$compile_rpath\" | $SED 's%@
         assert_eq!(diagnostics.len(), 1);
         assert_eq!(
             (
-                diagnostics[0].span.start.line,
-                diagnostics[0].span.start.column,
-                diagnostics[0].span.end.line,
-                diagnostics[0].span.end.column,
+                diagnostics[0].span.start.line(),
+                diagnostics[0].span.start.column(),
+                diagnostics[0].span.end.line(),
+                diagnostics[0].span.end.column(),
             ),
             (1, 75, 1, 104)
         );

--- a/crates/shuck-linter/src/rules/correctness/space_after_hash_bang.rs
+++ b/crates/shuck-linter/src/rules/correctness/space_after_hash_bang.rs
@@ -51,9 +51,9 @@ mod tests {
         let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::SpaceAfterHashBang));
 
         assert_eq!(diagnostics.len(), 1);
-        assert_eq!(diagnostics[0].span.start.line, 1);
-        assert_eq!(diagnostics[0].span.start.column, 2);
-        assert_eq!(diagnostics[0].span.end.column, 2);
+        assert_eq!(diagnostics[0].span.start.line(), 1);
+        assert_eq!(diagnostics[0].span.start.column(), 2);
+        assert_eq!(diagnostics[0].span.end.column(), 2);
     }
 
     #[test]
@@ -76,8 +76,8 @@ mod tests {
         let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::SpaceAfterHashBang));
 
         assert_eq!(diagnostics.len(), 1);
-        assert_eq!(diagnostics[0].span.start.column, 2);
-        assert_eq!(diagnostics[0].span.end.column, 2);
+        assert_eq!(diagnostics[0].span.start.column(), 2);
+        assert_eq!(diagnostics[0].span.end.column(), 2);
     }
 
     #[test]
@@ -86,9 +86,9 @@ mod tests {
         let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::SpaceAfterHashBang));
 
         assert_eq!(diagnostics.len(), 1);
-        assert_eq!(diagnostics[0].span.start.line, 2);
-        assert_eq!(diagnostics[0].span.start.column, 2);
-        assert_eq!(diagnostics[0].span.end.column, 2);
+        assert_eq!(diagnostics[0].span.start.line(), 2);
+        assert_eq!(diagnostics[0].span.start.column(), 2);
+        assert_eq!(diagnostics[0].span.end.column(), 2);
     }
 
     #[test]

--- a/crates/shuck-linter/src/rules/correctness/spaced_assignment.rs
+++ b/crates/shuck-linter/src/rules/correctness/spaced_assignment.rs
@@ -46,13 +46,16 @@ fn spaced_assignment_diagnostics(operands: &[DeclOperand], source: &str) -> Vec<
         }
 
         let mut edits = vec![Edit::deletion_at(
-            name.span.end.offset,
-            word.span.start.offset,
+            name.span.end.offset(),
+            word.span.start.offset(),
         )];
         if word.span.slice(source) == "="
             && let Some(next) = operands.get(index + 2).and_then(decl_operand_span)
         {
-            edits.push(Edit::deletion_at(word.span.end.offset, next.start.offset));
+            edits.push(Edit::deletion_at(
+                word.span.end.offset(),
+                next.start.offset(),
+            ));
         }
         diagnostics
             .push(Diagnostic::new(SpacedAssignment, word.span).with_fix(Fix::unsafe_edits(edits)));

--- a/crates/shuck-linter/src/rules/correctness/stderr_before_stdout_redirect.rs
+++ b/crates/shuck-linter/src/rules/correctness/stderr_before_stdout_redirect.rs
@@ -122,9 +122,9 @@ fn reordered_redirect_segment(
     for index in stderr_index + 1..=stdout_index {
         let span = redirects[index].redirect().span;
         let gap = if index == stderr_index + 1 {
-            strip_leading_shell_trivia(&source[moved_span.end.offset..span.start.offset])
+            strip_leading_shell_trivia(&source[moved_span.end.offset()..span.start.offset()])
         } else {
-            &source[redirects[index - 1].redirect().span.end.offset..span.start.offset]
+            &source[redirects[index - 1].redirect().span.end.offset()..span.start.offset()]
         };
         replacement.push_str(gap);
         replacement.push_str(span.slice(source));
@@ -211,7 +211,7 @@ out=$(bar 2>&1 >/dev/null)
         );
 
         assert_eq!(diagnostics.len(), 1);
-        assert_eq!(diagnostics[0].span.start.line, 2);
+        assert_eq!(diagnostics[0].span.start.line(), 2);
     }
 
     #[test]
@@ -415,6 +415,6 @@ echo ok | foo 2>&1 >/dev/null
         );
 
         assert_eq!(diagnostics.len(), 1);
-        assert_eq!(diagnostics[0].span.start.line, 3);
+        assert_eq!(diagnostics[0].span.start.line(), 3);
     }
 }

--- a/crates/shuck-linter/src/rules/correctness/string_compared_with_eq.rs
+++ b/crates/shuck-linter/src/rules/correctness/string_compared_with_eq.rs
@@ -156,8 +156,8 @@ fn string_eq_fix(binary: ConditionalBinaryFact<'_>, operands: &[StringOperand]) 
         .iter()
         .filter(|operand| operand.quote == Some(WordQuote::Unquoted))
     {
-        edits.push(Edit::insertion(operand.span.start.offset, "\""));
-        edits.push(Edit::insertion(operand.span.end.offset, "\""));
+        edits.push(Edit::insertion(operand.span.start.offset(), "\""));
+        edits.push(Edit::insertion(operand.span.end.offset(), "\""));
     }
 
     Some(Fix::unsafe_edits(edits))
@@ -197,7 +197,7 @@ fn looks_like_defined_variable_name(checker: &Checker<'_>, text: &str, span: Spa
         .copied()
         .any(|binding_id| {
             let binding = checker.semantic().binding(binding_id);
-            binding.span.start.offset != span.start.offset
+            binding.span.start.offset() != span.start.offset()
                 && binding_defines_variable_name_at(checker, binding, span)
         })
 }

--- a/crates/shuck-linter/src/rules/correctness/subshell_local_assignment.rs
+++ b/crates/shuck-linter/src/rules/correctness/subshell_local_assignment.rs
@@ -1529,7 +1529,7 @@ echo \"$x\"
         );
 
         assert_eq!(diagnostics.len(), 1);
-        assert_eq!(diagnostics[0].span.start.line, 4);
+        assert_eq!(diagnostics[0].span.start.line(), 4);
         assert_eq!(diagnostics[0].span.slice(source), "x");
     }
 
@@ -1548,7 +1548,7 @@ echo \"$x\"
         );
 
         assert_eq!(diagnostics.len(), 1);
-        assert_eq!(diagnostics[0].span.start.line, 4);
+        assert_eq!(diagnostics[0].span.start.line(), 4);
         assert_eq!(diagnostics[0].span.slice(source), "x");
     }
 }

--- a/crates/shuck-linter/src/rules/correctness/subst_with_redirect_err.rs
+++ b/crates/shuck-linter/src/rules/correctness/subst_with_redirect_err.rs
@@ -89,7 +89,7 @@ fi
         assert_eq!(
             diagnostics
                 .iter()
-                .map(|diagnostic| diagnostic.span.start.line)
+                .map(|diagnostic| diagnostic.span.start.line())
                 .collect::<Vec<_>>(),
             vec![8, 9, 11, 12, 14, 15]
         );

--- a/crates/shuck-linter/src/rules/correctness/template_brace_in_command.rs
+++ b/crates/shuck-linter/src/rules/correctness/template_brace_in_command.rs
@@ -57,7 +57,7 @@ mod tests {
         assert_eq!(
             diagnostics
                 .iter()
-                .map(|diagnostic| diagnostic.span.start.line)
+                .map(|diagnostic| diagnostic.span.start.line())
                 .collect::<Vec<_>>(),
             vec![2]
         );

--- a/crates/shuck-linter/src/rules/correctness/truthy_literal_test.rs
+++ b/crates/shuck-linter/src/rules/correctness/truthy_literal_test.rs
@@ -154,7 +154,7 @@ test *.sh
         assert_eq!(
             diagnostics
                 .iter()
-                .map(|diagnostic| diagnostic.span.start.line)
+                .map(|diagnostic| diagnostic.span.start.line())
                 .collect::<Vec<_>>(),
             vec![8]
         );
@@ -174,7 +174,7 @@ test foo
         assert_eq!(
             diagnostics
                 .iter()
-                .map(|diagnostic| diagnostic.span.start.line)
+                .map(|diagnostic| diagnostic.span.start.line())
                 .collect::<Vec<_>>(),
             vec![2, 3, 4]
         );
@@ -277,7 +277,7 @@ esac
             diagnostics
                 .iter()
                 .map(|diagnostic| (
-                    diagnostic.span.start.line,
+                    diagnostic.span.start.line(),
                     diagnostic.span.slice(source).to_owned(),
                 ))
                 .collect::<Vec<_>>()
@@ -300,7 +300,7 @@ test x
         assert_eq!(
             diagnostics
                 .iter()
-                .map(|diagnostic| diagnostic.span.start.line)
+                .map(|diagnostic| diagnostic.span.start.line())
                 .collect::<Vec<_>>(),
             vec![2, 4, 5, 6]
         );

--- a/crates/shuck-linter/src/rules/correctness/unchecked_directory_change.rs
+++ b/crates/shuck-linter/src/rules/correctness/unchecked_directory_change.rs
@@ -38,7 +38,7 @@ pub(crate) fn unchecked_directory_change_spans(checker: &mut Checker) -> Vec<(&'
         .commands()
         .iter()
         .filter_map(|fact| {
-            let scope = semantic.scope_at(fact.stmt().span.start.offset);
+            let scope = semantic.scope_at(fact.stmt().span.start.offset());
             if fact.is_nested_word_command()
                 && !matches!(semantic.scope_kind(scope), ScopeKind::CommandSubstitution)
             {
@@ -72,7 +72,7 @@ pub(crate) fn report_span(fact: crate::facts::CommandFactRef<'_, '_>, source: &s
                 .map(|word| word.span.end)
                 .into_iter()
                 .chain(fact.redirects().iter().map(|redirect| redirect.span.end))
-                .max_by_key(|position| position.offset)
+                .max_by_key(|position| position.offset())
                 .unwrap_or(command.name.span.end);
             Span::from_positions(start, end)
         }

--- a/crates/shuck-linter/src/rules/correctness/unchecked_directory_change_in_function.rs
+++ b/crates/shuck-linter/src/rules/correctness/unchecked_directory_change_in_function.rs
@@ -39,7 +39,7 @@ pub fn unchecked_directory_change_in_function(checker: &mut Checker) {
     let mut reports = Vec::new();
 
     for fact in checker.facts().commands() {
-        let scope = semantic.scope_at(fact.stmt().span.start.offset);
+        let scope = semantic.scope_at(fact.stmt().span.start.offset());
         let barrier = nearest_dominance_barrier(checker.facts(), fact.id());
         if fact.is_nested_word_command()
             && !matches!(semantic.scope_kind(scope), ScopeKind::CommandSubstitution)

--- a/crates/shuck-linter/src/rules/correctness/undefined_variable.rs
+++ b/crates/shuck-linter/src/rules/correctness/undefined_variable.rs
@@ -40,7 +40,7 @@ pub fn undefined_variable(checker: &mut Checker) {
         .to_vec();
     uninitialized_references.sort_by_key(|uninitialized| {
         let reference = checker.semantic().reference(uninitialized.reference);
-        (reference.span.start.offset, reference.span.end.offset)
+        (reference.span.start.offset(), reference.span.end.offset())
     });
 
     let mut reported_names = FxHashSet::default();
@@ -100,7 +100,7 @@ fn is_zsh_completion_context_reference(checker: &Checker<'_>, reference: &Refere
         && is_zsh_completion_context_name(reference.name.as_str())
         && checker
             .semantic_analysis()
-            .enclosing_function_scope_at(reference.span.start.offset)
+            .enclosing_function_scope_at(reference.span.start.offset())
             .is_some_and(|scope| {
                 checker
                     .facts()

--- a/crates/shuck-linter/src/rules/correctness/unicode_single_quote_in_single_quotes.rs
+++ b/crates/shuck-linter/src/rules/correctness/unicode_single_quote_in_single_quotes.rs
@@ -35,8 +35,8 @@ pub fn unicode_single_quote_in_single_quotes(checker: &mut Checker) {
                 let start = fragment.span().start.advanced_by(&text[..offset]);
                 let span = shuck_ast::Span::from_positions(start, start);
                 let fix = Fix::unsafe_edit(Edit::replacement_at(
-                    start.offset,
-                    start.offset + char.len_utf8(),
+                    start.offset(),
+                    start.offset() + char.len_utf8(),
                     "'\\''",
                 ));
                 Some(Diagnostic::new(UnicodeSingleQuoteInSingleQuotes, span).with_fix(fix))
@@ -73,11 +73,11 @@ echo \"hello ‘world’\"
                 .iter()
                 .map(|diagnostic| {
                     (
-                        diagnostic.span.start.line,
-                        diagnostic.span.start.column,
-                        diagnostic.span.end.line,
-                        diagnostic.span.end.column,
-                        source[diagnostic.span.start.offset..]
+                        diagnostic.span.start.line(),
+                        diagnostic.span.start.column(),
+                        diagnostic.span.end.line(),
+                        diagnostic.span.end.column(),
+                        source[diagnostic.span.start.offset()..]
                             .chars()
                             .next()
                             .unwrap(),

--- a/crates/shuck-linter/src/rules/correctness/unreachable_after_exit.rs
+++ b/crates/shuck-linter/src/rules/correctness/unreachable_after_exit.rs
@@ -99,7 +99,7 @@ fn unreached_function_definition_spans(checker: &Checker<'_>) -> Vec<Span> {
         spans.extend(statically_unreached_function_definition_spans(checker));
     }
 
-    spans.sort_by_key(|span| (span.start.offset, span.end.offset));
+    spans.sort_by_key(|span| (span.start.offset(), span.end.offset()));
     spans.dedup();
     spans
 }
@@ -164,9 +164,9 @@ fn statically_reachable_function_bindings(
                 checker,
                 call.callee,
                 call.name_span,
-                call.name_span.start.offset,
+                call.name_span.start.offset(),
             )
-            .then_some((call.callee, call.name_span.start.offset))
+            .then_some((call.callee, call.name_span.start.offset()))
         })
         .collect::<Vec<_>>();
 
@@ -204,11 +204,11 @@ fn static_call_can_resolve_at_entry(
     entry_offset: usize,
 ) -> bool {
     let callee_binding = checker.semantic().binding(callee);
-    name_span.start.offset >= callee_binding.span.start.offset
+    name_span.start.offset() >= callee_binding.span.start.offset()
         || (matches!(
             checker.semantic().scope(callee_binding.scope).kind,
             ScopeKind::File
-        ) && entry_offset >= callee_binding.span.start.offset)
+        ) && entry_offset >= callee_binding.span.start.offset())
 }
 
 fn function_bindings_by_scope(checker: &Checker<'_>) -> FxHashMap<ScopeId, BindingId> {
@@ -226,7 +226,7 @@ fn enclosing_function_binding(
     scope_bindings: &FxHashMap<ScopeId, BindingId>,
     span: Span,
 ) -> Option<BindingId> {
-    let scope = checker.semantic().scope_at(span.start.offset);
+    let scope = checker.semantic().scope_at(span.start.offset());
     checker
         .semantic()
         .ancestor_scopes(scope)
@@ -286,7 +286,7 @@ fn file_has_top_level_exit_command(checker: &Checker<'_>) -> bool {
 
 fn span_is_inside_unreached_function(span: Span, function_spans: &[Span]) -> bool {
     function_spans.iter().any(|function| {
-        function.start.offset < span.start.offset && span.end.offset <= function.end.offset
+        function.start.offset() < span.start.offset() && span.end.offset() <= function.end.offset()
     })
 }
 
@@ -388,9 +388,9 @@ fn wrapper_name_resolves_to_function(
 fn outermost_unreachable_spans(mut spans: Vec<shuck_ast::Span>) -> Vec<shuck_ast::Span> {
     spans.sort_by(|left, right| {
         left.start
-            .offset
-            .cmp(&right.start.offset)
-            .then_with(|| right.end.offset.cmp(&left.end.offset))
+            .offset()
+            .cmp(&right.start.offset())
+            .then_with(|| right.end.offset().cmp(&left.end.offset()))
     });
 
     let mut outermost = Vec::new();
@@ -410,7 +410,7 @@ fn outermost_unreachable_spans(mut spans: Vec<shuck_ast::Span>) -> Vec<shuck_ast
 }
 
 fn span_contained_by(inner: shuck_ast::Span, outer: shuck_ast::Span) -> bool {
-    outer.start.offset <= inner.start.offset && inner.end.offset <= outer.end.offset
+    outer.start.offset() <= inner.start.offset() && inner.end.offset() <= outer.end.offset()
 }
 
 fn trim_trailing_terminator(span: Span, source: &str) -> Span {

--- a/crates/shuck-linter/src/rules/correctness/unused_assignment.rs
+++ b/crates/shuck-linter/src/rules/correctness/unused_assignment.rs
@@ -91,7 +91,7 @@ pub fn unused_assignment(checker: &mut Checker) {
             suppressed_binding_offsets_by_family
                 .entry(family.clone())
                 .or_default()
-                .push(report_span.start.offset);
+                .push(report_span.start.offset());
         }
 
         if binding.attributes.contains(BindingAttributes::EXPORTED) {
@@ -126,10 +126,10 @@ pub fn unused_assignment(checker: &mut Checker) {
             .and_modify(|current_binding_id| {
                 let current = semantic.binding(*current_binding_id);
                 if binding_follows_in_source(
-                    current.span.start.offset,
-                    current.span.end.offset,
-                    binding.span.start.offset,
-                    binding.span.end.offset,
+                    current.span.start.offset(),
+                    current.span.end.offset(),
+                    binding.span.start.offset(),
+                    binding.span.end.offset(),
                 ) {
                     *current_binding_id = *binding_id;
                 }
@@ -145,7 +145,7 @@ pub fn unused_assignment(checker: &mut Checker) {
 
         if let Some(binding_id) = last_unused_binding_by_family.get(family).copied() {
             let binding = semantic.binding(binding_id);
-            let report_offset = report_span_for_binding(checker, binding).start.offset;
+            let report_offset = report_span_for_binding(checker, binding).start.offset();
             if suppressed_binding_offsets_by_family
                 .get(family)
                 .is_some_and(|offsets| offsets.iter().any(|offset| *offset >= report_offset))
@@ -156,7 +156,7 @@ pub fn unused_assignment(checker: &mut Checker) {
         }
     }
     reportable_bindings
-        .sort_unstable_by_key(|binding_id| semantic.binding(*binding_id).span.start.offset);
+        .sort_unstable_by_key(|binding_id| semantic.binding(*binding_id).span.start.offset());
 
     for binding_id in reportable_bindings {
         let binding = semantic.binding(binding_id);
@@ -500,7 +500,7 @@ done
         let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::UnusedAssignment));
 
         assert_eq!(diagnostics.len(), 1);
-        assert_eq!(diagnostics[0].span.start.line, 3);
+        assert_eq!(diagnostics[0].span.start.line(), 3);
         assert_eq!(diagnostics[0].span.slice(source), "foo");
     }
 
@@ -947,7 +947,7 @@ printf '%s\\n' \"$field\"
 
         assert_eq!(diagnostics.len(), 1);
         assert_eq!(diagnostics[0].span.slice(source), "rest");
-        assert_eq!(diagnostics[0].span.start.line, 2);
+        assert_eq!(diagnostics[0].span.start.line(), 2);
     }
 
     #[test]
@@ -993,7 +993,7 @@ fi
         let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::UnusedAssignment));
 
         assert_eq!(diagnostics.len(), 1);
-        assert_eq!(diagnostics[0].span.start.line, 7);
+        assert_eq!(diagnostics[0].span.start.line(), 7);
         assert_eq!(diagnostics[0].span.slice(source), "LIBDIRSUFFIX");
     }
 
@@ -1010,7 +1010,7 @@ fi
         let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::UnusedAssignment));
 
         assert_eq!(diagnostics.len(), 1);
-        assert_eq!(diagnostics[0].span.start.line, 5);
+        assert_eq!(diagnostics[0].span.start.line(), 5);
         assert_eq!(diagnostics[0].span.slice(source), "foo");
     }
 
@@ -1020,7 +1020,7 @@ fi
         let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::UnusedAssignment));
 
         assert_eq!(diagnostics.len(), 1);
-        assert_eq!(diagnostics[0].span.start.line, 4);
+        assert_eq!(diagnostics[0].span.start.line(), 4);
         assert_eq!(diagnostics[0].span.slice(source), "emoji[smile]");
     }
 
@@ -1044,7 +1044,7 @@ map[dead]=2
         let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::UnusedAssignment));
 
         assert_eq!(diagnostics.len(), 1);
-        assert_eq!(diagnostics[0].span.start.line, 3);
+        assert_eq!(diagnostics[0].span.start.line(), 3);
     }
 
     #[test]
@@ -1053,7 +1053,7 @@ map[dead]=2
         let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::UnusedAssignment));
 
         assert_eq!(diagnostics.len(), 1);
-        assert_eq!(diagnostics[0].span.start.line, 3);
+        assert_eq!(diagnostics[0].span.start.line(), 3);
     }
 
     #[test]
@@ -1062,7 +1062,7 @@ map[dead]=2
         let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::UnusedAssignment));
 
         assert_eq!(diagnostics.len(), 1);
-        assert_eq!(diagnostics[0].span.start.line, 3);
+        assert_eq!(diagnostics[0].span.start.line(), 3);
     }
 
     #[test]
@@ -1077,9 +1077,9 @@ done
         let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::UnusedAssignment));
 
         assert_eq!(diagnostics.len(), 2);
-        assert_eq!(diagnostics[0].span.start.line, 2);
+        assert_eq!(diagnostics[0].span.start.line(), 2);
         assert_eq!(diagnostics[0].span.slice(source), "unused");
-        assert_eq!(diagnostics[1].span.start.line, 3);
+        assert_eq!(diagnostics[1].span.start.line(), 3);
         assert_eq!(diagnostics[1].span.slice(source), "for");
     }
 
@@ -1125,7 +1125,7 @@ done
         let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::UnusedAssignment));
 
         assert_eq!(diagnostics.len(), 1);
-        assert_eq!(diagnostics[0].span.start.line, 3);
+        assert_eq!(diagnostics[0].span.start.line(), 3);
     }
 
     #[test]
@@ -1879,7 +1879,7 @@ ordinary=1
         let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::UnusedAssignment));
 
         assert_eq!(diagnostics.len(), 1);
-        assert_eq!(diagnostics[0].span.start.line, 6);
+        assert_eq!(diagnostics[0].span.start.line(), 6);
         assert_eq!(diagnostics[0].span.slice(source), "foo");
     }
 
@@ -1897,7 +1897,7 @@ ordinary=1
         let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::UnusedAssignment));
 
         assert_eq!(diagnostics.len(), 1);
-        assert_eq!(diagnostics[0].span.start.line, 5);
+        assert_eq!(diagnostics[0].span.start.line(), 5);
     }
 
     #[test]
@@ -1923,7 +1923,7 @@ f
         let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::UnusedAssignment));
 
         assert_eq!(diagnostics.len(), 1);
-        assert_eq!(diagnostics[0].span.start.line, 3);
+        assert_eq!(diagnostics[0].span.start.line(), 3);
     }
 
     #[test]
@@ -1932,7 +1932,7 @@ f
         let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::UnusedAssignment));
 
         assert_eq!(diagnostics.len(), 1);
-        assert_eq!(diagnostics[0].span.start.line, 3);
+        assert_eq!(diagnostics[0].span.start.line(), 3);
     }
 
     #[test]
@@ -1957,7 +1957,7 @@ f
         let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::UnusedAssignment));
 
         assert_eq!(diagnostics.len(), 1);
-        assert_eq!(diagnostics[0].span.start.line, 2);
+        assert_eq!(diagnostics[0].span.start.line(), 2);
         assert_eq!(diagnostics[0].span.slice(source), "foo");
     }
 

--- a/crates/shuck-linter/src/rules/correctness/unused_heredoc.rs
+++ b/crates/shuck-linter/src/rules/correctness/unused_heredoc.rs
@@ -43,30 +43,30 @@ fn unused_heredoc_fix(locator: Locator<'_>, span: Span) -> Option<Fix> {
         return None;
     }
 
-    let line_range = locator.line_range(span.start.line)?;
+    let line_range = locator.line_range(span.start.line())?;
     let line_start = usize::from(line_range.start());
     let raw_line_end = usize::from(line_range.end());
     let line_end = trim_cr_end(source, raw_line_end);
-    let header_delete_start = preceding_space_start(source, span.start.offset, line_start);
+    let header_delete_start = preceding_space_start(source, span.start.offset(), line_start);
     let body_start = locator
         .line_index()
-        .line_start(span.start.line + 1)
+        .line_start(span.start.line() + 1)
         .map(usize::from)
         .unwrap_or(source.len());
-    let body_end = heredoc_body_end(locator, span.start.line + 1, &marker)?;
+    let body_end = heredoc_body_end(locator, span.start.line() + 1, &marker)?;
 
     let prefix_is_blank = source
         .get(line_start..header_delete_start)
         .is_some_and(|prefix| prefix.trim().is_empty());
     let suffix_is_blank = source
-        .get(span.end.offset..line_end)
+        .get(span.end.offset()..line_end)
         .is_some_and(|suffix| suffix.trim().is_empty());
     if prefix_is_blank && suffix_is_blank {
         return Some(Fix::unsafe_edit(Edit::deletion_at(line_start, body_end)));
     }
 
     Some(Fix::unsafe_edits([
-        Edit::deletion_at(header_delete_start, span.end.offset),
+        Edit::deletion_at(header_delete_start, span.end.offset()),
         Edit::deletion_at(body_start, body_end),
     ]))
 }
@@ -161,7 +161,7 @@ EOF
         assert_eq!(
             diagnostics
                 .iter()
-                .map(|diagnostic| diagnostic.span.start.line)
+                .map(|diagnostic| diagnostic.span.start.line())
                 .collect::<Vec<_>>(),
             vec![2, 6, 10]
         );

--- a/crates/shuck-linter/src/rules/correctness/variable_reference_common.rs
+++ b/crates/shuck-linter/src/rules/correctness/variable_reference_common.rs
@@ -87,10 +87,10 @@ pub(super) fn has_visible_function_name_binding(
     at: Span,
 ) -> bool {
     let semantic = checker.semantic();
-    let scope = semantic.scope_at(at.start.offset);
+    let scope = semantic.scope_at(at.start.offset());
     if checker
         .semantic_analysis()
-        .visible_function_binding_defined_before(name, scope, at.start.offset)
+        .visible_function_binding_defined_before(name, scope, at.start.offset())
         .is_some()
     {
         return true;

--- a/crates/shuck-linter/src/rules/performance/grep_count_pipeline.rs
+++ b/crates/shuck-linter/src/rules/performance/grep_count_pipeline.rs
@@ -101,10 +101,10 @@ fn grep_count_pipeline_fix(
 ) -> Option<Fix> {
     let grep_name = grep.body_name_word()?;
     let wc_span = wc.span_in_source(source);
-    let delete_start = pipeline_delete_start(source, operator_span.start.offset);
+    let delete_start = pipeline_delete_start(source, operator_span.start.offset());
     Some(Fix::unsafe_edits([
-        Edit::insertion(grep_name.span.end.offset, " -c"),
-        Edit::deletion_at(delete_start, wc_span.end.offset),
+        Edit::insertion(grep_name.span.end.offset(), " -c"),
+        Edit::deletion_at(delete_start, wc_span.end.offset()),
     ]))
 }
 
@@ -113,14 +113,14 @@ fn command_body_span(fact: CommandFactRef<'_, '_>) -> Option<Span> {
     let mut end = body_name.span.end;
 
     for word in fact.body_args() {
-        if word.span.end.offset > end.offset {
+        if word.span.end.offset() > end.offset() {
             end = word.span.end;
         }
     }
 
     for redirect in fact.redirect_facts() {
         let redirect_end = redirect.redirect().span.end;
-        if redirect_end.offset > end.offset {
+        if redirect_end.offset() > end.offset() {
             end = redirect_end;
         }
     }

--- a/crates/shuck-linter/src/rules/performance/single_test_subshell.rs
+++ b/crates/shuck-linter/src/rules/performance/single_test_subshell.rs
@@ -36,11 +36,11 @@ pub fn single_test_subshell(checker: &mut Checker) {
 }
 
 fn remove_outer_parens_fix(source: &str, span: Span) -> Fix {
-    let close_start = span.end.offset.saturating_sub(1);
+    let close_start = span.end.offset().saturating_sub(1);
     Fix::unsafe_edits([
         Edit::deletion_at(
-            opening_paren_delete_start(source, span.start.offset),
-            span.start.offset + 1,
+            opening_paren_delete_start(source, span.start.offset()),
+            span.start.offset() + 1,
         ),
         closing_paren_edit(source, close_start),
     ])

--- a/crates/shuck-linter/src/rules/performance/subshell_test_group.rs
+++ b/crates/shuck-linter/src/rules/performance/subshell_test_group.rs
@@ -39,7 +39,7 @@ pub fn subshell_test_group(checker: &mut Checker) {
 }
 
 fn brace_group_fix(source: &str, span: Span) -> Fix {
-    let close_start = span.end.offset.saturating_sub(1);
+    let close_start = span.end.offset().saturating_sub(1);
     let close_replacement = if offset_is_indented_line_start(source, close_start) {
         "}"
     } else {
@@ -47,8 +47,8 @@ fn brace_group_fix(source: &str, span: Span) -> Fix {
     };
 
     Fix::unsafe_edits([
-        Edit::replacement_at(span.start.offset, span.start.offset + 1, "{"),
-        Edit::replacement_at(close_start, span.end.offset, close_replacement),
+        Edit::replacement_at(span.start.offset(), span.start.offset() + 1, "{"),
+        Edit::replacement_at(close_start, span.end.offset(), close_replacement),
     ])
 }
 

--- a/crates/shuck-linter/src/rules/portability/ampersand_redirect_in_sh.rs
+++ b/crates/shuck-linter/src/rules/portability/ampersand_redirect_in_sh.rs
@@ -63,8 +63,8 @@ fn combined_ampersand_redirect_span(redirect: &RedirectFact<'_>, source: &str) -
         return None;
     }
 
-    let redirect_start = redirect_data.span.start.offset;
-    let target_start = target.span.start.offset;
+    let redirect_start = redirect_data.span.start.offset();
+    let target_start = target.span.start.offset();
     if redirect_start > target_start || target_start > source.len() {
         return None;
     }

--- a/crates/shuck-linter/src/rules/portability/ampersand_redirection.rs
+++ b/crates/shuck-linter/src/rules/portability/ampersand_redirection.rs
@@ -59,7 +59,7 @@ fn ampersand_redirection_fix(redirect: &RedirectFact<'_>, source: &str) -> Optio
     }
 
     let operator_span = redirect.operator_span();
-    if has_standalone_fd_prefix(source, operator_span.start.offset) {
+    if has_standalone_fd_prefix(source, operator_span.start.offset()) {
         return None;
     }
 
@@ -67,7 +67,7 @@ fn ampersand_redirection_fix(redirect: &RedirectFact<'_>, source: &str) -> Optio
 
     Some(Fix::safe_edits([
         Edit::replacement(">", operator_span),
-        Edit::insertion(target_span.end.offset, " 2>&1"),
+        Edit::insertion(target_span.end.offset(), " 2>&1"),
     ]))
 }
 

--- a/crates/shuck-linter/src/rules/portability/ansi_c_quoting.rs
+++ b/crates/shuck-linter/src/rules/portability/ansi_c_quoting.rs
@@ -45,7 +45,7 @@ pub fn ansi_c_quoting(checker: &mut Checker) {
 }
 
 fn span_contains(outer: shuck_ast::Span, inner: shuck_ast::Span) -> bool {
-    outer.start.offset <= inner.start.offset && outer.end.offset >= inner.end.offset
+    outer.start.offset() <= inner.start.offset() && outer.end.offset() >= inner.end.offset()
 }
 
 fn is_well_formed_ansi_c_quote(span: shuck_ast::Span, source: &str) -> bool {

--- a/crates/shuck-linter/src/rules/portability/bash_case_fallthrough.rs
+++ b/crates/shuck-linter/src/rules/portability/bash_case_fallthrough.rs
@@ -74,9 +74,9 @@ mod tests {
             test_snippet(source, &LinterSettings::for_rule(Rule::BashCaseFallthrough));
 
         assert_eq!(diagnostics.len(), 1);
-        assert_eq!(diagnostics[0].span.start.line, 2);
-        assert_eq!(diagnostics[0].span.start.column, 1);
-        assert_eq!(diagnostics[0].span.end.line, 6);
-        assert_eq!(diagnostics[0].span.end.column, 5);
+        assert_eq!(diagnostics[0].span.start.line(), 2);
+        assert_eq!(diagnostics[0].span.start.column(), 1);
+        assert_eq!(diagnostics[0].span.end.line(), 6);
+        assert_eq!(diagnostics[0].span.end.column(), 5);
     }
 }

--- a/crates/shuck-linter/src/rules/portability/c_style_for_in_sh.rs
+++ b/crates/shuck-linter/src/rules/portability/c_style_for_in_sh.rs
@@ -80,7 +80,7 @@ fn c_style_for_fix(
         return None;
     }
 
-    let indent = line_indent_before(source, replacement_span.start.offset);
+    let indent = line_indent_before(source, replacement_span.start.offset());
     let child_indent = format!("{indent}  ");
     let mut replacement = String::new();
     if let Some(init) = init.filter(|init| !init.is_empty()) {

--- a/crates/shuck-linter/src/rules/portability/conditional_portability.rs
+++ b/crates/shuck-linter/src/rules/portability/conditional_portability.rs
@@ -328,7 +328,7 @@ pub fn caret_negation_in_bracket(checker: &mut Checker) {
 }
 
 fn caret_negation_fix(span: Span) -> Edit {
-    Edit::replacement_at(span.start.offset + 1, span.start.offset + 2, "!")
+    Edit::replacement_at(span.start.offset() + 1, span.start.offset() + 2, "!")
 }
 
 pub fn a_test_in_sh(checker: &mut Checker) {

--- a/crates/shuck-linter/src/rules/portability/declare_command.rs
+++ b/crates/shuck-linter/src/rules/portability/declare_command.rs
@@ -119,7 +119,7 @@ fn declaration_anchor_end(
     source: &str,
 ) -> shuck_ast::Position {
     for redirect in fact.redirects() {
-        if redirect.span.end.offset > end.offset {
+        if redirect.span.end.offset() > end.offset() {
             end = redirect.span.end;
         }
     }
@@ -141,7 +141,7 @@ fn clip_terminator(
     _source: &str,
 ) -> shuck_ast::Position {
     if let Some(terminator_span) = fact.stmt().terminator_span
-        && terminator_span.start.offset < end.offset
+        && terminator_span.start.offset() < end.offset()
     {
         end = terminator_span.start;
     }

--- a/crates/shuck-linter/src/rules/portability/dollar_string_in_sh.rs
+++ b/crates/shuck-linter/src/rules/portability/dollar_string_in_sh.rs
@@ -44,8 +44,8 @@ pub fn dollar_string_in_sh(checker: &mut Checker) {
 
 fn dollar_string_in_sh_fix(span: Span) -> Fix {
     Fix::unsafe_edit(Edit::deletion_at(
-        span.start.offset,
-        span.start.offset + "$".len(),
+        span.start.offset(),
+        span.start.offset() + "$".len(),
     ))
 }
 

--- a/crates/shuck-linter/src/rules/portability/errexit_trap_in_sh.rs
+++ b/crates/shuck-linter/src/rules/portability/errexit_trap_in_sh.rs
@@ -88,8 +88,14 @@ fn command_is_empty_set_after_removing_span(
     span: shuck_ast::Span,
 ) -> bool {
     let command = command_span.slice(source);
-    let remove_start = span.start.offset.saturating_sub(command_span.start.offset);
-    let remove_end = span.end.offset.saturating_sub(command_span.start.offset);
+    let remove_start = span
+        .start
+        .offset()
+        .saturating_sub(command_span.start.offset());
+    let remove_end = span
+        .end
+        .offset()
+        .saturating_sub(command_span.start.offset());
     let mut remaining = String::with_capacity(command.len());
     remaining.push_str(&command[..remove_start]);
     remaining.push_str(&command[remove_end..]);

--- a/crates/shuck-linter/src/rules/portability/function_keyword_in_sh.rs
+++ b/crates/shuck-linter/src/rules/portability/function_keyword_in_sh.rs
@@ -51,8 +51,8 @@ fn function_keyword_in_sh_fix(header: &FunctionHeaderFact<'_>) -> Option<Fix> {
     let (_, name_span) = header.static_name_entry()?;
 
     Some(Fix::safe_edit(Edit::deletion_at(
-        keyword_span.start.offset,
-        name_span.start.offset,
+        keyword_span.start.offset(),
+        name_span.start.offset(),
     )))
 }
 

--- a/crates/shuck-linter/src/rules/portability/function_params_in_sh.rs
+++ b/crates/shuck-linter/src/rules/portability/function_params_in_sh.rs
@@ -156,8 +156,8 @@ coproc pycoproc (python3 \"$pywrapper\")
         let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::FunctionParamsInSh));
 
         assert_eq!(diagnostics.len(), 1);
-        assert_eq!(diagnostics[0].span.start.line, 2);
-        assert_eq!(diagnostics[0].span.start.column, 18);
+        assert_eq!(diagnostics[0].span.start.line(), 2);
+        assert_eq!(diagnostics[0].span.start.column(), 18);
         assert_eq!(diagnostics[0].span.start, diagnostics[0].span.end);
     }
 }

--- a/crates/shuck-linter/src/rules/portability/pipe_stderr_in_sh.rs
+++ b/crates/shuck-linter/src/rules/portability/pipe_stderr_in_sh.rs
@@ -45,14 +45,14 @@ pub fn pipe_stderr_in_sh(checker: &mut Checker) {
 }
 
 fn pipe_all_replacement(source: &str, span: shuck_ast::Span) -> String {
-    let leading = span.start.offset > 0
+    let leading = span.start.offset() > 0
         && source
             .as_bytes()
-            .get(span.start.offset - 1)
+            .get(span.start.offset() - 1)
             .is_some_and(|byte| !byte.is_ascii_whitespace());
     let trailing = source
         .as_bytes()
-        .get(span.end.offset)
+        .get(span.end.offset())
         .is_some_and(|byte| !byte.is_ascii_whitespace());
 
     format!(

--- a/crates/shuck-linter/src/rules/portability/source_inside_function_in_sh.rs
+++ b/crates/shuck-linter/src/rules/portability/source_inside_function_in_sh.rs
@@ -68,13 +68,13 @@ fn source_command_for_ref<'checker, 'ast>(
 }
 
 fn same_start(left: Span, right: Span) -> bool {
-    left.start.offset == right.start.offset
+    left.start.offset() == right.start.offset()
 }
 
 fn inside_function(checker: &Checker<'_>, span: Span) -> bool {
     checker
         .semantic_analysis()
-        .enclosing_function_scope_at(span.start.offset)
+        .enclosing_function_scope_at(span.start.offset())
         .is_some()
 }
 

--- a/crates/shuck-linter/src/rules/security/eval_on_array.rs
+++ b/crates/shuck-linter/src/rules/security/eval_on_array.rs
@@ -78,8 +78,8 @@ eval \\
 
         assert_eq!(diagnostics.len(), 1, "{diagnostics:#?}");
         assert_eq!(diagnostics[0].span.slice(source), "${shims[@]}");
-        assert_eq!(diagnostics[0].span.start.line, 6);
-        assert_eq!(diagnostics[0].span.start.column, 5);
+        assert_eq!(diagnostics[0].span.start.line(), 6);
+        assert_eq!(diagnostics[0].span.start.column(), 5);
     }
 
     #[test]

--- a/crates/shuck-linter/src/rules/style/ampersand_semicolon.rs
+++ b/crates/shuck-linter/src/rules/style/ampersand_semicolon.rs
@@ -48,9 +48,9 @@ mod tests {
 
         assert_eq!(diagnostics.len(), 2);
         assert_eq!(diagnostics[0].span.slice(source), ";");
-        assert_eq!(diagnostics[0].span.start.line, 2);
+        assert_eq!(diagnostics[0].span.start.line(), 2);
         assert_eq!(diagnostics[1].span.slice(source), ";");
-        assert_eq!(diagnostics[1].span.start.line, 3);
+        assert_eq!(diagnostics[1].span.start.line(), 3);
     }
 
     #[test]

--- a/crates/shuck-linter/src/rules/style/avoid_let_builtin.rs
+++ b/crates/shuck-linter/src/rules/style/avoid_let_builtin.rs
@@ -85,7 +85,7 @@ fn let_command_span(source: &str, fact: crate::facts::CommandFactRef<'_, '_>) ->
         .last()
         .map_or(name.span.end, |word| let_argument_end(source, word));
 
-    let tail = source.get(end.offset..)?;
+    let tail = source.get(end.offset()..)?;
     let mut padding_end = end;
     for ch in tail.chars() {
         match ch {
@@ -125,9 +125,9 @@ mod tests {
         let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::AvoidLetBuiltin));
 
         assert_eq!(diagnostics.len(), 1);
-        assert_eq!(diagnostics[0].span.start.line, 2);
-        assert_eq!(diagnostics[0].span.start.column, 1);
-        assert_eq!(diagnostics[0].span.end.column, 7);
+        assert_eq!(diagnostics[0].span.start.line(), 2);
+        assert_eq!(diagnostics[0].span.start.column(), 1);
+        assert_eq!(diagnostics[0].span.end.column(), 7);
     }
 
     #[test]
@@ -136,9 +136,9 @@ mod tests {
         let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::AvoidLetBuiltin));
 
         assert_eq!(diagnostics.len(), 1);
-        assert_eq!(diagnostics[0].span.start.line, 2);
-        assert_eq!(diagnostics[0].span.start.column, 1);
-        assert_eq!(diagnostics[0].span.end.column, 21);
+        assert_eq!(diagnostics[0].span.start.line(), 2);
+        assert_eq!(diagnostics[0].span.start.column(), 1);
+        assert_eq!(diagnostics[0].span.end.column(), 21);
     }
 
     #[test]

--- a/crates/shuck-linter/src/rules/style/bare_command_name_assignment.rs
+++ b/crates/shuck-linter/src/rules/style/bare_command_name_assignment.rs
@@ -41,11 +41,11 @@ pub fn bare_command_name_assignment(checker: &mut Checker) {
 
 fn quote_assignment_value_fix(span: Span, source: &str) -> Option<Fix> {
     let line = source
-        .get(span.start.offset..)?
+        .get(span.start.offset()..)?
         .split_inclusive('\n')
         .next()?;
     let eq_relative = line.find('=')?;
-    let value_start = span.start.offset + eq_relative + 1;
+    let value_start = span.start.offset() + eq_relative + 1;
     let value_text = source.get(value_start..)?;
     let value_len = value_text
         .chars()

--- a/crates/shuck-linter/src/rules/style/brace_variable_before_bracket.rs
+++ b/crates/shuck-linter/src/rules/style/brace_variable_before_bracket.rs
@@ -47,7 +47,7 @@ pub fn brace_variable_before_bracket(checker: &mut Checker) {
 }
 
 fn brace_variable_fix(span: Span, source: &str) -> Option<Fix> {
-    let offset = span.start.offset;
+    let offset = span.start.offset();
     let tail = source.get(offset..)?;
     let rest = tail.strip_prefix('$')?;
     let mut chars = rest.char_indices();
@@ -96,7 +96,7 @@ $cmd[0] arg
         assert_eq!(
             diagnostics
                 .iter()
-                .map(|diagnostic| (diagnostic.span.start.line, diagnostic.span.start.column))
+                .map(|diagnostic| (diagnostic.span.start.line(), diagnostic.span.start.column()))
                 .collect::<Vec<_>>(),
             vec![(2, 7), (3, 7), (4, 10), (5, 7), (6, 1)]
         );
@@ -146,7 +146,7 @@ sed_var() {
         assert_eq!(
             diagnostics
                 .iter()
-                .map(|diagnostic| (diagnostic.span.start.line, diagnostic.span.start.column))
+                .map(|diagnostic| (diagnostic.span.start.line(), diagnostic.span.start.column()))
                 .collect::<Vec<_>>(),
             vec![(4, 33), (7, 14)]
         );

--- a/crates/shuck-linter/src/rules/style/combine_appends.rs
+++ b/crates/shuck-linter/src/rules/style/combine_appends.rs
@@ -45,7 +45,7 @@ pub fn combine_appends(checker: &mut Checker) {
 }
 
 fn append_run_spans_in_body(checker: &Checker<'_>, statements: &mut [StatementFact]) -> Vec<Span> {
-    statements.sort_by_key(|fact| fact.stmt_span().start.offset);
+    statements.sort_by_key(|fact| fact.stmt_span().start.offset());
 
     let mut spans = Vec::new();
     let mut current_key: Option<ComparablePathKey> = None;
@@ -123,17 +123,17 @@ fn append_target_for_statement(
                     .redirect_facts()
                     .iter()
                     .map(|redirect| redirect.redirect().span.end)
-                    .max_by_key(|position| position.offset)
+                    .max_by_key(|position| position.offset())
                     .unwrap_or(command_end);
                 anchor_start = Some(command.body_span().start);
-                anchor_end = Some(if redirect_end.offset > command_end.offset {
+                anchor_end = Some(if redirect_end.offset() > command_end.offset() {
                     redirect_end
                 } else {
                     command_end
                 });
             }
             if let Some(current_end) = &mut anchor_end
-                && comparable.span().end.offset > current_end.offset
+                && comparable.span().end.offset() > current_end.offset()
             {
                 *current_end = comparable.span().end;
             }

--- a/crates/shuck-linter/src/rules/style/double_quote_nesting.rs
+++ b/crates/shuck-linter/src/rules/style/double_quote_nesting.rs
@@ -19,10 +19,10 @@ impl Violation for DoubleQuoteNesting {
 }
 
 fn span_is_strictly_inside(span: &shuck_ast::Span, host: &shuck_ast::Span) -> bool {
-    host.start.offset <= span.start.offset
-        && span.end.offset <= host.end.offset
-        && span.start.offset != host.start.offset
-        && span.end.offset != host.end.offset
+    host.start.offset() <= span.start.offset()
+        && span.end.offset() <= host.end.offset()
+        && span.start.offset() != host.start.offset()
+        && span.end.offset() != host.end.offset()
 }
 
 pub fn double_quote_nesting(checker: &mut Checker) {

--- a/crates/shuck-linter/src/rules/style/duplicate_shebang_flag.rs
+++ b/crates/shuck-linter/src/rules/style/duplicate_shebang_flag.rs
@@ -36,7 +36,7 @@ mod tests {
             );
 
             assert_eq!(diagnostics.len(), 1);
-            assert_eq!(diagnostics[0].span.start.line, 1);
+            assert_eq!(diagnostics[0].span.start.line(), 1);
         }
     }
 

--- a/crates/shuck-linter/src/rules/style/echo_here_doc.rs
+++ b/crates/shuck-linter/src/rules/style/echo_here_doc.rs
@@ -40,24 +40,24 @@ fn echo_here_doc_fix(locator: Locator<'_>, span: Span) -> Option<Fix> {
     let source = locator.source();
     let span_text = span.slice(source);
     let operator_offset = span_text.find("<<")?;
-    let redirect_start = span.start.offset + operator_offset;
+    let redirect_start = span.start.offset() + operator_offset;
     let marker = heredoc_marker_from_redirect_text(&span_text[operator_offset..])?;
     if marker.name.is_empty() {
         return None;
     }
 
-    let line_range = locator.line_range(span.start.line)?;
+    let line_range = locator.line_range(span.start.line())?;
     let line_start = usize::from(line_range.start());
     let header_delete_start = preceding_space_start(source, redirect_start, line_start);
     let body_start = locator
         .line_index()
-        .line_start(span.start.line + 1)
+        .line_start(span.start.line() + 1)
         .map(usize::from)
         .unwrap_or(source.len());
-    let body_end = heredoc_body_end(locator, span.start.line + 1, &marker)?;
+    let body_end = heredoc_body_end(locator, span.start.line() + 1, &marker)?;
 
     Some(Fix::unsafe_edits([
-        Edit::deletion_at(header_delete_start, span.end.offset),
+        Edit::deletion_at(header_delete_start, span.end.offset()),
         Edit::deletion_at(body_start, body_end),
     ]))
 }
@@ -140,7 +140,7 @@ EOF
         let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::EchoHereDoc));
 
         assert_eq!(diagnostics.len(), 1);
-        assert_eq!(diagnostics[0].span.start.line, 2);
+        assert_eq!(diagnostics[0].span.start.line(), 2);
         assert_eq!(diagnostics[0].span.slice(source), "echo <<EOF");
     }
 
@@ -155,7 +155,7 @@ echo <<-EOF
         let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::EchoHereDoc));
 
         assert_eq!(diagnostics.len(), 1);
-        assert_eq!(diagnostics[0].span.start.line, 2);
+        assert_eq!(diagnostics[0].span.start.line(), 2);
         assert_eq!(diagnostics[0].span.slice(source), "echo <<-EOF");
     }
 

--- a/crates/shuck-linter/src/rules/style/echo_to_sed_substitution.rs
+++ b/crates/shuck-linter/src/rules/style/echo_to_sed_substitution.rs
@@ -41,9 +41,9 @@ EC2_REGION=\"`echo \\\"$EC2_AVAIL_ZONE\\\" | sed -e 's:\\([0-9][0-9]*\\)[a-z]*\\
             &LinterSettings::for_rule(Rule::EchoToSedSubstitution),
         );
         assert_eq!(diagnostics.len(), 1);
-        assert_eq!(diagnostics[0].span.start.line, 2);
-        assert_eq!(diagnostics[0].span.start.column, 14);
-        assert_eq!(diagnostics[0].span.end.line, 2);
-        assert_eq!(diagnostics[0].span.end.column, 76);
+        assert_eq!(diagnostics[0].span.start.line(), 2);
+        assert_eq!(diagnostics[0].span.start.column(), 14);
+        assert_eq!(diagnostics[0].span.end.line(), 2);
+        assert_eq!(diagnostics[0].span.end.column(), 76);
     }
 }

--- a/crates/shuck-linter/src/rules/style/echoed_command_substitution.rs
+++ b/crates/shuck-linter/src/rules/style/echoed_command_substitution.rs
@@ -122,7 +122,7 @@ mod tests {
         assert_eq!(
             diagnostics
                 .iter()
-                .map(|diagnostic| diagnostic.span.start.line)
+                .map(|diagnostic| diagnostic.span.start.line())
                 .collect::<Vec<_>>(),
             vec![1]
         );

--- a/crates/shuck-linter/src/rules/style/escaped_underscore.rs
+++ b/crates/shuck-linter/src/rules/style/escaped_underscore.rs
@@ -62,7 +62,7 @@ pub fn escaped_underscore(checker: &mut Checker) {
     let non_fixable_spans = escapes
         .iter()
         .filter(|escape| escape.source_kind() == EscapeScanSourceKind::PatternCharClass)
-        .map(|escape| (escape.span().start.offset, escape.span().end.offset))
+        .map(|escape| (escape.span().start.offset(), escape.span().end.offset()))
         .collect::<FxHashSet<_>>();
     let diagnostics = escapes
         .into_iter()
@@ -72,7 +72,9 @@ pub fn escaped_underscore(checker: &mut Checker) {
                 escape.span().start.advanced_by("\\"),
             );
             let diagnostic = Diagnostic::new(EscapedUnderscore, escape.span());
-            if non_fixable_spans.contains(&(escape.span().start.offset, escape.span().end.offset)) {
+            if non_fixable_spans
+                .contains(&(escape.span().start.offset(), escape.span().end.offset()))
+            {
                 diagnostic
             } else {
                 diagnostic.with_fix(Fix::unsafe_edit(Edit::deletion(backslash_span)))

--- a/crates/shuck-linter/src/rules/style/export_command_substitution.rs
+++ b/crates/shuck-linter/src/rules/style/export_command_substitution.rs
@@ -71,7 +71,7 @@ fn should_report_s010_declaration(
 
     let inside_function = checker
         .semantic_analysis()
-        .enclosing_function_scope_at(span.start.offset)
+        .enclosing_function_scope_at(span.start.offset())
         .is_some();
 
     !inside_function

--- a/crates/shuck-linter/src/rules/style/function_body_without_braces.rs
+++ b/crates/shuck-linter/src/rules/style/function_body_without_braces.rs
@@ -49,14 +49,14 @@ pub fn function_body_without_braces(checker: &mut Checker) {
 fn wrap_function_body_fix(span: Span, source: &str) -> Fix {
     let insert_end = trim_trailing_whitespace_offset(span, source);
     Fix::safe_edits([
-        Edit::insertion(span.start.offset, "{ "),
+        Edit::insertion(span.start.offset(), "{ "),
         Edit::insertion(insert_end, "; }"),
     ])
 }
 
 fn trim_trailing_whitespace_offset(span: Span, source: &str) -> usize {
-    let mut offset = span.end.offset;
-    while offset > span.start.offset {
+    let mut offset = span.end.offset();
+    while offset > span.start.offset() {
         let Some(ch) = source[..offset].chars().next_back() else {
             break;
         };

--- a/crates/shuck-linter/src/rules/style/getopts_invalid_flag_handler.rs
+++ b/crates/shuck-linter/src/rules/style/getopts_invalid_flag_handler.rs
@@ -69,7 +69,7 @@ done
         );
 
         assert_eq!(diagnostics.len(), 1);
-        assert_eq!(diagnostics[0].span.start.line, 2);
+        assert_eq!(diagnostics[0].span.start.line(), 2);
     }
 
     #[test]
@@ -126,7 +126,7 @@ done
         assert_eq!(
             diagnostics
                 .iter()
-                .map(|diagnostic| diagnostic.span.start.line)
+                .map(|diagnostic| diagnostic.span.start.line())
                 .collect::<Vec<_>>(),
             vec![2, 8]
         );
@@ -197,7 +197,7 @@ done
         );
 
         assert_eq!(diagnostics.len(), 1);
-        assert_eq!(diagnostics[0].span.start.line, 3);
+        assert_eq!(diagnostics[0].span.start.line(), 3);
     }
 
     #[test]
@@ -215,6 +215,6 @@ done
         );
 
         assert_eq!(diagnostics.len(), 1);
-        assert_eq!(diagnostics[0].span.start.line, 2);
+        assert_eq!(diagnostics[0].span.start.line(), 2);
     }
 }

--- a/crates/shuck-linter/src/rules/style/grep_output_in_test.rs
+++ b/crates/shuck-linter/src/rules/style/grep_output_in_test.rs
@@ -211,7 +211,7 @@ fn collect_conditional_spans(
 
 fn shellcheck_truthy_test_span(source: &str, span: Span) -> Span {
     let Some(next) = source
-        .get(span.end.offset..)
+        .get(span.end.offset()..)
         .and_then(|tail| tail.chars().next())
     else {
         return span;
@@ -220,8 +220,8 @@ fn shellcheck_truthy_test_span(source: &str, span: Span) -> Span {
         return span;
     }
 
-    let end_offset = span.end.offset + next.len_utf8();
-    let separator = &source[span.end.offset..end_offset];
+    let end_offset = span.end.offset() + next.len_utf8();
+    let separator = &source[span.end.offset()..end_offset];
     Span::from_positions(span.start, span.end.advanced_by(separator))
 }
 
@@ -266,7 +266,7 @@ fn word_has_top_level_grep_substitution(
 }
 
 fn span_contains(outer: Span, inner: Span) -> bool {
-    outer.start.offset <= inner.start.offset && outer.end.offset >= inner.end.offset
+    outer.start.offset() <= inner.start.offset() && outer.end.offset() >= inner.end.offset()
 }
 
 #[cfg(test)]

--- a/crates/shuck-linter/src/rules/style/heredoc_end_space.rs
+++ b/crates/shuck-linter/src/rules/style/heredoc_end_space.rs
@@ -38,7 +38,7 @@ pub fn heredoc_end_space(checker: &mut Checker) {
 }
 
 fn heredoc_end_space_fix(span: Span, source: &str) -> Option<(Span, Fix)> {
-    let start = span.start.offset;
+    let start = span.start.offset();
     let rest = source.get(start..)?;
     let len = rest
         .chars()
@@ -69,10 +69,10 @@ EOF
         let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::HeredocEndSpace));
 
         assert_eq!(diagnostics.len(), 1);
-        assert_eq!(diagnostics[0].span.start.line, 4);
-        assert_eq!(diagnostics[0].span.start.column, 4);
-        assert_eq!(diagnostics[0].span.end.line, 4);
-        assert_eq!(diagnostics[0].span.end.column, 4);
+        assert_eq!(diagnostics[0].span.start.line(), 4);
+        assert_eq!(diagnostics[0].span.start.column(), 4);
+        assert_eq!(diagnostics[0].span.end.line(), 4);
+        assert_eq!(diagnostics[0].span.end.column(), 4);
         assert_eq!(diagnostics[0].span.slice(source), "");
     }
 
@@ -82,9 +82,9 @@ EOF
         let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::HeredocEndSpace));
 
         assert_eq!(diagnostics.len(), 1);
-        assert_eq!(diagnostics[0].span.start.line, 4);
-        assert_eq!(diagnostics[0].span.start.column, 4);
-        assert_eq!(diagnostics[0].span.end.column, 4);
+        assert_eq!(diagnostics[0].span.start.line(), 4);
+        assert_eq!(diagnostics[0].span.start.column(), 4);
+        assert_eq!(diagnostics[0].span.end.column(), 4);
         assert_eq!(diagnostics[0].span.slice(source), "");
     }
 
@@ -99,9 +99,9 @@ cat <<-EOF
         let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::HeredocEndSpace));
 
         assert_eq!(diagnostics.len(), 1);
-        assert_eq!(diagnostics[0].span.start.line, 4);
-        assert_eq!(diagnostics[0].span.start.column, 5);
-        assert_eq!(diagnostics[0].span.end.column, 5);
+        assert_eq!(diagnostics[0].span.start.line(), 4);
+        assert_eq!(diagnostics[0].span.start.column(), 5);
+        assert_eq!(diagnostics[0].span.end.column(), 5);
         assert_eq!(diagnostics[0].span.slice(source), "");
     }
 
@@ -111,10 +111,10 @@ cat <<-EOF
         let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::HeredocEndSpace));
 
         assert_eq!(diagnostics.len(), 1);
-        assert_eq!(diagnostics[0].span.start.line, 4);
-        assert_eq!(diagnostics[0].span.start.column, 4);
-        assert_eq!(diagnostics[0].span.end.line, 4);
-        assert_eq!(diagnostics[0].span.end.column, 4);
+        assert_eq!(diagnostics[0].span.start.line(), 4);
+        assert_eq!(diagnostics[0].span.start.column(), 4);
+        assert_eq!(diagnostics[0].span.end.line(), 4);
+        assert_eq!(diagnostics[0].span.end.column(), 4);
         assert_eq!(diagnostics[0].span.slice(source), "");
     }
 
@@ -158,9 +158,9 @@ EOF
         let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::HeredocEndSpace));
 
         assert_eq!(diagnostics.len(), 1);
-        assert_eq!(diagnostics[0].span.start.line, 4);
-        assert_eq!(diagnostics[0].span.start.column, 4);
-        assert_eq!(diagnostics[0].span.end.column, 4);
+        assert_eq!(diagnostics[0].span.start.line(), 4);
+        assert_eq!(diagnostics[0].span.start.column(), 4);
+        assert_eq!(diagnostics[0].span.end.column(), 4);
         assert_eq!(diagnostics[0].span.slice(source), "");
     }
 }

--- a/crates/shuck-linter/src/rules/style/ifs_equals_ambiguity.rs
+++ b/crates/shuck-linter/src/rules/style/ifs_equals_ambiguity.rs
@@ -32,8 +32,8 @@ pub fn ifs_equals_ambiguity(checker: &mut Checker) {
     for span in spans {
         checker.report_diagnostic_dedup(Diagnostic::new(IfsEqualsAmbiguity, span).with_fix(
             Fix::safe_edit(Edit::replacement_at(
-                span.start.offset,
-                span.start.offset + 1,
+                span.start.offset(),
+                span.start.offset() + 1,
                 "'='",
             )),
         ));
@@ -98,7 +98,7 @@ done < /dev/null
         assert_eq!(
             diagnostics
                 .iter()
-                .map(|diagnostic| (diagnostic.span.start.line, diagnostic.span.start.column))
+                .map(|diagnostic| (diagnostic.span.start.line(), diagnostic.span.start.column()))
                 .collect::<Vec<_>>(),
             vec![(2, 5), (3, 11)]
         );

--- a/crates/shuck-linter/src/rules/style/linebreak_before_and.rs
+++ b/crates/shuck-linter/src/rules/style/linebreak_before_and.rs
@@ -29,8 +29,8 @@ mod tests {
         let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::LinebreakBeforeAnd));
 
         assert_eq!(diagnostics.len(), 1);
-        assert_eq!(diagnostics[0].span.start.line, 3);
-        assert_eq!(diagnostics[0].span.start.column, 1);
+        assert_eq!(diagnostics[0].span.start.line(), 3);
+        assert_eq!(diagnostics[0].span.start.column(), 1);
         assert_eq!(diagnostics[0].span.slice(source), "&&");
     }
 

--- a/crates/shuck-linter/src/rules/style/literal_backslash.rs
+++ b/crates/shuck-linter/src/rules/style/literal_backslash.rs
@@ -33,8 +33,8 @@ pub fn literal_backslash(checker: &mut Checker) {
         .filter_map(|fact| fact.standalone_literal_backslash_span(source))
         .map(|span| {
             Diagnostic::new(LiteralBackslash, span).with_fix(Fix::safe_edit(Edit::deletion_at(
-                span.start.offset,
-                span.start.offset + 1,
+                span.start.offset(),
+                span.start.offset() + 1,
             )))
         })
         .collect::<Vec<_>>();

--- a/crates/shuck-linter/src/rules/style/literal_backslash_in_single_quotes.rs
+++ b/crates/shuck-linter/src/rules/style/literal_backslash_in_single_quotes.rs
@@ -86,7 +86,7 @@ printf '%s\\n' '\\\\n'foo
         assert_eq!(
             diagnostics
                 .iter()
-                .map(|diagnostic| (diagnostic.span.start.line, diagnostic.span.start.column))
+                .map(|diagnostic| (diagnostic.span.start.line(), diagnostic.span.start.column()))
                 .collect::<Vec<_>>(),
             vec![(2, 15), (3, 18), (4, 20), (5, 19)]
         );

--- a/crates/shuck-linter/src/rules/style/literal_braces.rs
+++ b/crates/shuck-linter/src/rules/style/literal_braces.rs
@@ -23,7 +23,7 @@ pub fn literal_braces(checker: &mut Checker) {
         for span in facts.words().literal_brace_spans().iter().copied() {
             report(
                 Diagnostic::new(LiteralBraces, span)
-                    .with_fix(Fix::safe_edit(Edit::insertion(span.start.offset, "\\"))),
+                    .with_fix(Fix::safe_edit(Edit::insertion(span.start.offset(), "\\"))),
             );
         }
     });
@@ -40,8 +40,8 @@ mod tests {
         let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::LiteralBraces));
 
         assert_eq!(diagnostics.len(), 2);
-        assert_eq!(diagnostics[0].span.start.column, 11);
-        assert_eq!(diagnostics[1].span.start.column, 13);
+        assert_eq!(diagnostics[0].span.start.column(), 11);
+        assert_eq!(diagnostics[1].span.start.column(), 13);
     }
 
     #[test]
@@ -189,8 +189,8 @@ xargs printf -I{x}
         let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::LiteralBraces));
 
         assert_eq!(diagnostics.len(), 2);
-        assert_eq!(diagnostics[0].span.start.column, 16);
-        assert_eq!(diagnostics[1].span.start.column, 18);
+        assert_eq!(diagnostics[0].span.start.column(), 16);
+        assert_eq!(diagnostics[1].span.start.column(), 18);
     }
 
     #[test]
@@ -240,7 +240,7 @@ value=$(cut -d} -f1)
         let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::LiteralBraces));
 
         assert_eq!(diagnostics.len(), 1);
-        assert_eq!(diagnostics[0].span.start.column, 15);
+        assert_eq!(diagnostics[0].span.start.column(), 15);
     }
 
     #[test]
@@ -273,8 +273,8 @@ value=$(
         let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::LiteralBraces));
 
         assert_eq!(diagnostics.len(), 1);
-        assert_eq!(diagnostics[0].span.start.line, 4);
-        assert_eq!(diagnostics[0].span.start.column, 11);
+        assert_eq!(diagnostics[0].span.start.line(), 4);
+        assert_eq!(diagnostics[0].span.start.column(), 11);
     }
 
     #[test]
@@ -297,10 +297,10 @@ go list -f {{.Dir}} \"$path\"
         let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::LiteralBraces));
 
         assert_eq!(diagnostics.len(), 4);
-        assert_eq!(diagnostics[0].span.start.column, 12);
-        assert_eq!(diagnostics[1].span.start.column, 13);
-        assert_eq!(diagnostics[2].span.start.column, 18);
-        assert_eq!(diagnostics[3].span.start.column, 19);
+        assert_eq!(diagnostics[0].span.start.column(), 12);
+        assert_eq!(diagnostics[1].span.start.column(), 13);
+        assert_eq!(diagnostics[2].span.start.column(), 18);
+        assert_eq!(diagnostics[3].span.start.column(), 19);
     }
 
     #[test]
@@ -313,12 +313,12 @@ cut -d} -f1
         let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::LiteralBraces));
 
         assert_eq!(diagnostics.len(), 3);
-        assert_eq!(diagnostics[0].span.start.line, 2);
-        assert_eq!(diagnostics[0].span.start.column, 36);
-        assert_eq!(diagnostics[1].span.start.line, 2);
-        assert_eq!(diagnostics[1].span.start.column, 74);
-        assert_eq!(diagnostics[2].span.start.line, 3);
-        assert_eq!(diagnostics[2].span.start.column, 7);
+        assert_eq!(diagnostics[0].span.start.line(), 2);
+        assert_eq!(diagnostics[0].span.start.column(), 36);
+        assert_eq!(diagnostics[1].span.start.line(), 2);
+        assert_eq!(diagnostics[1].span.start.column(), 74);
+        assert_eq!(diagnostics[2].span.start.line(), 3);
+        assert_eq!(diagnostics[2].span.start.column(), 7);
     }
 
     #[test]
@@ -402,7 +402,7 @@ exec {IPC_FIFO_FD}>&-
         let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::LiteralBraces));
         let positions = diagnostics
             .iter()
-            .map(|diagnostic| (diagnostic.span.start.line, diagnostic.span.start.column))
+            .map(|diagnostic| (diagnostic.span.start.line(), diagnostic.span.start.column()))
             .collect::<Vec<_>>();
 
         assert_eq!(positions, vec![(3, 29), (3, 43), (4, 11), (4, 44)]);
@@ -444,7 +444,7 @@ fi
         let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::LiteralBraces));
         let positions = diagnostics
             .iter()
-            .map(|diagnostic| (diagnostic.span.start.line, diagnostic.span.start.column))
+            .map(|diagnostic| (diagnostic.span.start.line(), diagnostic.span.start.column()))
             .collect::<Vec<_>>();
 
         assert_eq!(positions, vec![(2, 24), (2, 36)]);
@@ -459,7 +459,7 @@ echo \\${${name}}/\\${fallback}
         let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::LiteralBraces));
         let positions = diagnostics
             .iter()
-            .map(|diagnostic| (diagnostic.span.start.line, diagnostic.span.start.column))
+            .map(|diagnostic| (diagnostic.span.start.line(), diagnostic.span.start.column()))
             .collect::<Vec<_>>();
 
         assert_eq!(positions, vec![(2, 8), (2, 16), (2, 20), (2, 29)]);
@@ -478,7 +478,7 @@ nft add chain inet fw4 input { type filter hook input priority filter \\; } 2>/d
         let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::LiteralBraces));
         let positions = diagnostics
             .iter()
-            .map(|diagnostic| (diagnostic.span.start.line, diagnostic.span.start.column))
+            .map(|diagnostic| (diagnostic.span.start.line(), diagnostic.span.start.column()))
             .collect::<Vec<_>>();
 
         assert_eq!(

--- a/crates/shuck-linter/src/rules/style/local_declare_combined.rs
+++ b/crates/shuck-linter/src/rules/style/local_declare_combined.rs
@@ -70,30 +70,29 @@ fn declaration_combination_span(fact: crate::CommandFactRef<'_, '_>) -> Option<s
 
 fn operand_deletion_span(span: shuck_ast::Span, source: &str) -> shuck_ast::Span {
     let bytes = source.as_bytes();
-    let mut end_offset = span.end.offset;
+    let mut end_offset = span.end.offset();
     while end_offset < bytes.len() && matches!(bytes[end_offset], b' ' | b'\t') {
         end_offset += 1;
     }
-    if end_offset > span.end.offset {
+    if end_offset > span.end.offset() {
         return shuck_ast::Span::from_positions(
             span.start,
-            span.end.advanced_by(&source[span.end.offset..end_offset]),
+            span.end.advanced_by(&source[span.end.offset()..end_offset]),
         );
     }
 
-    let mut start_offset = span.start.offset;
+    let mut start_offset = span.start.offset();
     while start_offset > 0 && matches!(bytes[start_offset - 1], b' ' | b'\t') {
         start_offset -= 1;
     }
     shuck_ast::Span::from_positions(
-        shuck_ast::Position {
-            offset: start_offset,
-            line: span.start.line,
-            column: span
-                .start
-                .column
-                .saturating_sub(span.start.offset.saturating_sub(start_offset)),
-        },
+        shuck_ast::Position::at(
+            span.start.line(),
+            span.start
+                .column()
+                .saturating_sub(span.start.offset().saturating_sub(start_offset)),
+            start_offset,
+        ),
         span.end,
     )
 }

--- a/crates/shuck-linter/src/rules/style/ls_in_substitution.rs
+++ b/crates/shuck-linter/src/rules/style/ls_in_substitution.rs
@@ -94,7 +94,7 @@ fn pipeline_ls_command_span(
 }
 
 fn span_contains(outer: Span, inner: Span) -> bool {
-    outer.start.offset <= inner.start.offset && inner.end.offset <= outer.end.offset
+    outer.start.offset() <= inner.start.offset() && inner.end.offset() <= outer.end.offset()
 }
 
 fn trim_trailing_whitespace(span: Span, source: &str) -> Span {

--- a/crates/shuck-linter/src/rules/style/missing_main_entrypoint.rs
+++ b/crates/shuck-linter/src/rules/style/missing_main_entrypoint.rs
@@ -41,7 +41,7 @@ pub fn missing_main_entrypoint(checker: &mut Checker) {
                 .is_none()
                 .then_some(statement.body_span())
         })
-        .max_by_key(|span| span.end.offset.saturating_sub(span.start.offset))
+        .max_by_key(|span| span.end.offset().saturating_sub(span.start.offset()))
     else {
         return;
     };
@@ -50,7 +50,7 @@ pub fn missing_main_entrypoint(checker: &mut Checker) {
         .statement_facts()
         .iter()
         .filter(|statement| statement.body_span() == top_level_body_span)
-        .max_by_key(|statement| statement.stmt_span().end.offset)
+        .max_by_key(|statement| statement.stmt_span().end.offset())
     else {
         return;
     };

--- a/crates/shuck-linter/src/rules/style/missing_shebang_line.rs
+++ b/crates/shuck-linter/src/rules/style/missing_shebang_line.rs
@@ -33,7 +33,7 @@ mod tests {
         let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::MissingShebangLine));
 
         assert_eq!(diagnostics.len(), 1);
-        assert_eq!(diagnostics[0].span.start.line, 1);
+        assert_eq!(diagnostics[0].span.start.line(), 1);
         assert_eq!(
             diagnostics[0].span.slice(source),
             "# /etc/config/myapp.conf"

--- a/crates/shuck-linter/src/rules/style/printf_format_variable.rs
+++ b/crates/shuck-linter/src/rules/style/printf_format_variable.rs
@@ -55,7 +55,7 @@ mod tests {
         assert_eq!(
             diagnostics
                 .iter()
-                .map(|diagnostic| diagnostic.span.start.line)
+                .map(|diagnostic| diagnostic.span.start.line())
                 .collect::<Vec<_>>(),
             vec![2, 3, 4, 5]
         );
@@ -111,7 +111,7 @@ mod tests {
         assert_eq!(
             diagnostics
                 .iter()
-                .map(|diagnostic| diagnostic.span.start.line)
+                .map(|diagnostic| diagnostic.span.start.line())
                 .collect::<Vec<_>>(),
             vec![1, 2, 3]
         );

--- a/crates/shuck-linter/src/rules/style/ps_grep_pipeline.rs
+++ b/crates/shuck-linter/src/rules/style/ps_grep_pipeline.rs
@@ -58,14 +58,14 @@ fn command_body_span(fact: CommandFactRef<'_, '_>) -> Option<Span> {
     let mut end = body_name.span.end;
 
     for word in fact.body_args() {
-        if word.span.end.offset > end.offset {
+        if word.span.end.offset() > end.offset() {
             end = word.span.end;
         }
     }
 
     for redirect in fact.redirect_facts() {
         let redirect_end = redirect.redirect().span.end;
-        if redirect_end.offset > end.offset {
+        if redirect_end.offset() > end.offset() {
             end = redirect_end;
         }
     }

--- a/crates/shuck-linter/src/rules/style/quoted_dollar_star_loop.rs
+++ b/crates/shuck-linter/src/rules/style/quoted_dollar_star_loop.rs
@@ -56,14 +56,14 @@ pub fn quoted_dollar_star_loop(checker: &mut Checker) {
 }
 
 fn quoted_loop_word_fix(span: Span) -> Option<(Span, Fix)> {
-    if span.end.offset < span.start.offset + 2 {
+    if span.end.offset() < span.start.offset() + 2 {
         return None;
     }
     Some((
         span,
         Fix::unsafe_edits([
-            Edit::deletion_at(span.start.offset, span.start.offset + 1),
-            Edit::deletion_at(span.end.offset - 1, span.end.offset),
+            Edit::deletion_at(span.start.offset(), span.start.offset() + 1),
+            Edit::deletion_at(span.end.offset() - 1, span.end.offset()),
         ]),
     ))
 }

--- a/crates/shuck-linter/src/rules/style/read_without_raw.rs
+++ b/crates/shuck-linter/src/rules/style/read_without_raw.rs
@@ -32,7 +32,7 @@ pub fn read_without_raw(checker: &mut Checker) {
         .filter_map(|fact| fact.body_name_word().map(|word| word.span))
         .map(|span| {
             Diagnostic::new(ReadWithoutRaw, span)
-                .with_fix(Fix::unsafe_edit(Edit::insertion(span.end.offset, " -r")))
+                .with_fix(Fix::unsafe_edit(Edit::insertion(span.end.offset(), " -r")))
         })
         .collect::<Vec<_>>();
 

--- a/crates/shuck-linter/src/rules/style/single_quote_backslash.rs
+++ b/crates/shuck-linter/src/rules/style/single_quote_backslash.rs
@@ -30,7 +30,7 @@ pub fn single_quote_backslash(checker: &mut Checker) {
         .filter_map(|fragment| single_quoted_fragment_backslash_span(fragment.span(), source))
         .map(|span| {
             Diagnostic::new(SingleQuoteBackslash, span).with_fix(Fix::safe_edit(
-                Edit::replacement_at(span.start.offset, span.start.offset + 2, "'\\\\"),
+                Edit::replacement_at(span.start.offset(), span.start.offset() + 2, "'\\\\"),
             ))
         })
         .collect::<Vec<_>>();

--- a/crates/shuck-linter/src/rules/style/spaced_tabstrip_close.rs
+++ b/crates/shuck-linter/src/rules/style/spaced_tabstrip_close.rs
@@ -38,7 +38,7 @@ pub fn spaced_tabstrip_close(checker: &mut Checker) {
 }
 
 fn spaced_tabstrip_close_fix(span: Span, source: &str) -> Option<(Span, Fix)> {
-    let start = span.start.offset;
+    let start = span.start.offset();
     let line = source.get(start..)?.split_inclusive('\n').next()?;
     let mut edits = Vec::new();
     let mut offset = start;
@@ -71,8 +71,8 @@ END
             test_snippet(source, &LinterSettings::for_rule(Rule::SpacedTabstripClose));
 
         assert_eq!(diagnostics.len(), 1);
-        assert_eq!(diagnostics[0].span.start.line, 4);
-        assert_eq!(diagnostics[0].span.start.column, 1);
+        assert_eq!(diagnostics[0].span.start.line(), 4);
+        assert_eq!(diagnostics[0].span.start.column(), 1);
     }
 
     #[test]
@@ -88,8 +88,8 @@ END
             test_snippet(source, &LinterSettings::for_rule(Rule::SpacedTabstripClose));
 
         assert_eq!(diagnostics.len(), 1);
-        assert_eq!(diagnostics[0].span.start.line, 4);
-        assert_eq!(diagnostics[0].span.start.column, 1);
+        assert_eq!(diagnostics[0].span.start.line(), 4);
+        assert_eq!(diagnostics[0].span.start.column(), 1);
     }
 
     #[test]
@@ -149,7 +149,7 @@ END
             test_snippet(source, &LinterSettings::for_rule(Rule::SpacedTabstripClose));
 
         assert_eq!(diagnostics.len(), 2);
-        assert_eq!(diagnostics[0].span.start.line, 4);
-        assert_eq!(diagnostics[1].span.start.line, 5);
+        assert_eq!(diagnostics[0].span.start.line(), 4);
+        assert_eq!(diagnostics[1].span.start.line(), 5);
     }
 }

--- a/crates/shuck-linter/src/rules/style/suspect_closing_quote.rs
+++ b/crates/shuck-linter/src/rules/style/suspect_closing_quote.rs
@@ -48,8 +48,8 @@ mod tests {
             test_snippet(source, &LinterSettings::for_rule(Rule::SuspectClosingQuote));
 
         assert_eq!(diagnostics.len(), 1);
-        assert_eq!(diagnostics[0].span.start.line, 3);
-        assert_eq!(diagnostics[0].span.start.column, 7);
+        assert_eq!(diagnostics[0].span.start.line(), 3);
+        assert_eq!(diagnostics[0].span.start.column(), 7);
         assert_eq!(diagnostics[0].span.start, diagnostics[0].span.end);
     }
 
@@ -94,11 +94,11 @@ echo \"alpha
             test_snippet(source, &LinterSettings::for_rule(Rule::SuspectClosingQuote));
 
         assert_eq!(diagnostics.len(), 2);
-        assert_eq!(diagnostics[0].span.start.line, 3);
-        assert_eq!(diagnostics[0].span.start.column, 1);
+        assert_eq!(diagnostics[0].span.start.line(), 3);
+        assert_eq!(diagnostics[0].span.start.column(), 1);
         assert_eq!(diagnostics[0].span.start, diagnostics[0].span.end);
-        assert_eq!(diagnostics[1].span.start.line, 4);
-        assert_eq!(diagnostics[1].span.start.column, 1);
+        assert_eq!(diagnostics[1].span.start.line(), 4);
+        assert_eq!(diagnostics[1].span.start.column(), 1);
         assert_eq!(diagnostics[1].span.start, diagnostics[1].span.end);
     }
 
@@ -127,11 +127,11 @@ echo \"alpha
             test_snippet(source, &LinterSettings::for_rule(Rule::SuspectClosingQuote));
 
         assert_eq!(diagnostics.len(), 2);
-        assert_eq!(diagnostics[0].span.start.line, 3);
-        assert_eq!(diagnostics[0].span.start.column, 1);
+        assert_eq!(diagnostics[0].span.start.line(), 3);
+        assert_eq!(diagnostics[0].span.start.column(), 1);
         assert_eq!(diagnostics[0].span.start, diagnostics[0].span.end);
-        assert_eq!(diagnostics[1].span.start.line, 4);
-        assert_eq!(diagnostics[1].span.start.column, 1);
+        assert_eq!(diagnostics[1].span.start.line(), 4);
+        assert_eq!(diagnostics[1].span.start.column(), 1);
         assert_eq!(diagnostics[1].span.start, diagnostics[1].span.end);
     }
 
@@ -148,8 +148,8 @@ echo \"GEM_PATH: \\$GEM_PATH\"
             test_snippet(source, &LinterSettings::for_rule(Rule::SuspectClosingQuote));
 
         assert_eq!(diagnostics.len(), 1);
-        assert_eq!(diagnostics[0].span.start.line, 3);
-        assert_eq!(diagnostics[0].span.start.column, 6);
+        assert_eq!(diagnostics[0].span.start.line(), 3);
+        assert_eq!(diagnostics[0].span.start.column(), 6);
         assert_eq!(diagnostics[0].span.start, diagnostics[0].span.end);
     }
 
@@ -164,8 +164,8 @@ cat \"alpha
             test_snippet(source, &LinterSettings::for_rule(Rule::SuspectClosingQuote));
 
         assert_eq!(diagnostics.len(), 1);
-        assert_eq!(diagnostics[0].span.start.line, 3);
-        assert_eq!(diagnostics[0].span.start.column, 1);
+        assert_eq!(diagnostics[0].span.start.line(), 3);
+        assert_eq!(diagnostics[0].span.start.column(), 1);
         assert_eq!(diagnostics[0].span.start, diagnostics[0].span.end);
     }
 }

--- a/crates/shuck-linter/src/rules/style/todo_format.rs
+++ b/crates/shuck-linter/src/rules/style/todo_format.rs
@@ -195,7 +195,7 @@ mod tests {
         let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::TodoFormat));
 
         assert_eq!(diagnostics.len(), 1);
-        assert_eq!(diagnostics[0].span.start.line, 2);
+        assert_eq!(diagnostics[0].span.start.line(), 2);
         assert_eq!(diagnostics[0].span.slice(source), "TODO");
     }
 }

--- a/crates/shuck-linter/src/rules/style/trailing_directive.rs
+++ b/crates/shuck-linter/src/rules/style/trailing_directive.rs
@@ -36,14 +36,14 @@ pub fn trailing_directive(checker: &mut Checker) {
 
 fn trailing_directive_fix(locator: Locator<'_>, span: shuck_ast::Span) -> Option<Fix> {
     let source = locator.source();
-    let line_range = locator.line_range(span.start.line)?;
+    let line_range = locator.line_range(span.start.line())?;
     let line_start = usize::from(line_range.start());
     let raw_line_end = usize::from(line_range.end());
     let line_end = source
         .get(..raw_line_end)
         .filter(|_| raw_line_end > 0 && source.as_bytes()[raw_line_end - 1] == b'\r')
         .map_or(raw_line_end, |_| raw_line_end - 1);
-    let comment_start = span.start.offset;
+    let comment_start = span.start.offset();
     if comment_start < line_start || comment_start >= line_end {
         return None;
     }
@@ -85,8 +85,8 @@ mod tests {
         let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::TrailingDirective));
 
         assert_eq!(diagnostics.len(), 1);
-        assert_eq!(diagnostics[0].span.start.line, 2);
-        assert_eq!(diagnostics[0].span.start.column, 3);
+        assert_eq!(diagnostics[0].span.start.line(), 2);
+        assert_eq!(diagnostics[0].span.start.column(), 3);
         assert_eq!(diagnostics[0].span.slice(source), "#");
     }
 
@@ -96,8 +96,8 @@ mod tests {
         let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::TrailingDirective));
 
         assert_eq!(diagnostics.len(), 1);
-        assert_eq!(diagnostics[0].span.start.line, 2);
-        assert_eq!(diagnostics[0].span.start.column, 3);
+        assert_eq!(diagnostics[0].span.start.line(), 2);
+        assert_eq!(diagnostics[0].span.start.column(), 3);
         assert_eq!(diagnostics[0].span.slice(source), "#");
     }
 
@@ -205,7 +205,7 @@ mod tests {
         let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::TrailingDirective));
 
         assert_eq!(diagnostics.len(), 1);
-        assert_eq!(diagnostics[0].span.start.line, 2);
+        assert_eq!(diagnostics[0].span.start.line(), 2);
     }
 
     #[test]
@@ -214,7 +214,7 @@ mod tests {
         let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::TrailingDirective));
 
         assert_eq!(diagnostics.len(), 1);
-        assert_eq!(diagnostics[0].span.start.line, 2);
+        assert_eq!(diagnostics[0].span.start.line(), 2);
     }
 
     #[test]
@@ -224,7 +224,7 @@ mod tests {
         let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::TrailingDirective));
 
         assert_eq!(diagnostics.len(), 1);
-        assert_eq!(diagnostics[0].span.start.line, 2);
+        assert_eq!(diagnostics[0].span.start.line(), 2);
     }
 
     #[test]

--- a/crates/shuck-linter/src/rules/style/unquoted_array_split.rs
+++ b/crates/shuck-linter/src/rules/style/unquoted_array_split.rs
@@ -61,7 +61,7 @@ pub fn unquoted_array_split(checker: &mut Checker) {
 }
 
 fn span_contains(outer: Span, inner: Span) -> bool {
-    outer.start.offset <= inner.start.offset && outer.end.offset >= inner.end.offset
+    outer.start.offset() <= inner.start.offset() && outer.end.offset() >= inner.end.offset()
 }
 
 fn is_excluded_special_parameter_span(span: Span, source: &str) -> bool {

--- a/crates/shuck-linter/src/rules/style/unquoted_command_substitution.rs
+++ b/crates/shuck-linter/src/rules/style/unquoted_command_substitution.rs
@@ -460,9 +460,9 @@ docker inspect -f '{{ if ne \"true\" (index .Config.Labels \"com.dokku.devcontai
                 .collect::<Vec<_>>(),
             vec!["$(docker ps -q)"]
         );
-        assert_eq!(diagnostics[0].span.start.line, 2);
-        assert_eq!(diagnostics[0].span.start.column, 105);
-        assert_eq!(diagnostics[0].span.end.column, 120);
+        assert_eq!(diagnostics[0].span.start.line(), 2);
+        assert_eq!(diagnostics[0].span.start.column(), 105);
+        assert_eq!(diagnostics[0].span.end.column(), 120);
     }
 
     #[test]
@@ -544,8 +544,8 @@ fi
                 .collect::<Vec<_>>(),
             vec!["$(echo cfgtest_${name})"]
         );
-        assert_eq!(diagnostics[0].span.start.line, 9);
-        assert_eq!(diagnostics[0].span.start.column, 22);
-        assert_eq!(diagnostics[0].span.end.column, 45);
+        assert_eq!(diagnostics[0].span.start.line(), 9);
+        assert_eq!(diagnostics[0].span.start.column(), 22);
+        assert_eq!(diagnostics[0].span.end.column(), 45);
     }
 }

--- a/crates/shuck-linter/src/rules/style/unquoted_expansion.rs
+++ b/crates/shuck-linter/src/rules/style/unquoted_expansion.rs
@@ -196,7 +196,7 @@ fn collect_numeric_test_operand_spans(checker: &Checker, source: &str) -> Vec<Sp
                 .map(|word| word.span)
         })
         .collect::<Vec<_>>();
-    spans.sort_by_key(|span| (span.start.offset, span.end.offset));
+    spans.sort_by_key(|span| (span.start.offset(), span.end.offset()));
     spans.dedup_by_key(|span| FactSpan::new(*span));
     spans
 }
@@ -232,7 +232,7 @@ fn collect_array_assignment_split_candidate_spans(checker: &Checker) -> Vec<Span
                 })
         })
         .collect::<Vec<_>>();
-    spans.sort_by_key(|span| (span.start.offset, span.end.offset));
+    spans.sort_by_key(|span| (span.start.offset(), span.end.offset()));
     spans.dedup();
     spans
 }
@@ -308,7 +308,7 @@ fn should_check_context(context: ExpansionContext, shell: ShellDialect) -> bool 
 }
 
 fn span_contains(outer: Span, inner: Span) -> bool {
-    outer.start.offset <= inner.start.offset && outer.end.offset >= inner.end.offset
+    outer.start.offset() <= inner.start.offset() && outer.end.offset() >= inner.end.offset()
 }
 
 fn arithmetic_word_follows_command_substitution(
@@ -317,10 +317,10 @@ fn arithmetic_word_follows_command_substitution(
     command_substitution_spans: &[Span],
 ) -> bool {
     command_substitution_spans.iter().copied().any(|span| {
-        if span.end.offset > word_span.start.offset {
+        if span.end.offset() > word_span.start.offset() {
             return false;
         }
-        let Some(between) = source.get(span.end.offset..word_span.start.offset) else {
+        let Some(between) = source.get(span.end.offset()..word_span.start.offset()) else {
             return false;
         };
         !between.contains('\n') && between.chars().all(char::is_whitespace)
@@ -939,10 +939,10 @@ mkdir_umask=`expr $umask + 22 \\
                 .iter()
                 .map(|diagnostic| {
                     (
-                        diagnostic.span.start.line,
-                        diagnostic.span.start.column,
-                        diagnostic.span.end.line,
-                        diagnostic.span.end.column,
+                        diagnostic.span.start.line(),
+                        diagnostic.span.start.column(),
+                        diagnostic.span.end.line(),
+                        diagnostic.span.end.column(),
                     )
                 })
                 .collect::<Vec<_>>(),
@@ -972,10 +972,10 @@ mkdir_umask=`expr $umask + 22 \\
                 .iter()
                 .map(|diagnostic| {
                     (
-                        diagnostic.span.start.line,
-                        diagnostic.span.start.column,
-                        diagnostic.span.end.line,
-                        diagnostic.span.end.column,
+                        diagnostic.span.start.line(),
+                        diagnostic.span.start.column(),
+                        diagnostic.span.end.line(),
+                        diagnostic.span.end.column(),
                     )
                 })
                 .collect::<Vec<_>>(),
@@ -999,10 +999,10 @@ mkdir_umask=`expr $umask + 22 \\
                 .iter()
                 .map(|diagnostic| {
                     (
-                        diagnostic.span.start.line,
-                        diagnostic.span.start.column,
-                        diagnostic.span.end.line,
-                        diagnostic.span.end.column,
+                        diagnostic.span.start.line(),
+                        diagnostic.span.start.column(),
+                        diagnostic.span.end.line(),
+                        diagnostic.span.end.column(),
                     )
                 })
                 .collect::<Vec<_>>(),
@@ -1816,7 +1816,7 @@ printf '%s\\n' ${z:=fallback}
         assert_eq!(
             diagnostics
                 .iter()
-                .map(|diagnostic| (diagnostic.span.start.line, diagnostic.span.slice(source)))
+                .map(|diagnostic| (diagnostic.span.start.line(), diagnostic.span.slice(source)))
                 .collect::<Vec<_>>(),
             vec![(2, "$other"), (3, "${z:=fallback}")]
         );
@@ -2148,10 +2148,10 @@ printf '%s\\n' `echo \\$1 \\$HOME \\$SAFE \\$PPID`
                 .iter()
                 .map(|diagnostic| {
                     (
-                        diagnostic.span.start.line,
-                        diagnostic.span.start.column,
-                        diagnostic.span.end.line,
-                        diagnostic.span.end.column,
+                        diagnostic.span.start.line(),
+                        diagnostic.span.start.column(),
+                        diagnostic.span.end.line(),
+                        diagnostic.span.end.column(),
                     )
                 })
                 .collect::<Vec<_>>(),
@@ -2177,10 +2177,10 @@ EOF
                 .iter()
                 .map(|diagnostic| {
                     (
-                        diagnostic.span.start.line,
-                        diagnostic.span.start.column,
-                        diagnostic.span.end.line,
-                        diagnostic.span.end.column,
+                        diagnostic.span.start.line(),
+                        diagnostic.span.start.column(),
+                        diagnostic.span.end.line(),
+                        diagnostic.span.end.column(),
                     )
                 })
                 .collect::<Vec<_>>(),
@@ -2202,10 +2202,10 @@ depfile=${depfile-`echo \"$object\" |
                 .iter()
                 .map(|diagnostic| {
                     (
-                        diagnostic.span.start.line,
-                        diagnostic.span.start.column,
-                        diagnostic.span.end.line,
-                        diagnostic.span.end.column,
+                        diagnostic.span.start.line(),
+                        diagnostic.span.start.column(),
+                        diagnostic.span.end.line(),
+                        diagnostic.span.end.column(),
                     )
                 })
                 .collect::<Vec<_>>(),
@@ -2229,10 +2229,10 @@ printf '%s\\n' `echo \\$value`
                 .iter()
                 .map(|diagnostic| {
                     (
-                        diagnostic.span.start.line,
-                        diagnostic.span.start.column,
-                        diagnostic.span.end.line,
-                        diagnostic.span.end.column,
+                        diagnostic.span.start.line(),
+                        diagnostic.span.start.column(),
+                        diagnostic.span.end.line(),
+                        diagnostic.span.end.column(),
                     )
                 })
                 .collect::<Vec<_>>(),
@@ -2253,10 +2253,10 @@ printf '%s\\n' `echo \\${SAFE:-$fallback} \\${SAFE:+$fallback}`
                 .iter()
                 .map(|diagnostic| {
                     (
-                        diagnostic.span.start.line,
-                        diagnostic.span.start.column,
-                        diagnostic.span.end.line,
-                        diagnostic.span.end.column,
+                        diagnostic.span.start.line(),
+                        diagnostic.span.start.column(),
+                        diagnostic.span.end.line(),
+                        diagnostic.span.end.column(),
                     )
                 })
                 .collect::<Vec<_>>(),
@@ -2509,10 +2509,10 @@ echo \"script
             diagnostics
                 .iter()
                 .map(|diagnostic| (
-                    diagnostic.span.start.line,
-                    diagnostic.span.start.column,
-                    diagnostic.span.end.line,
-                    diagnostic.span.end.column,
+                    diagnostic.span.start.line(),
+                    diagnostic.span.start.column(),
+                    diagnostic.span.end.line(),
+                    diagnostic.span.end.column(),
                     diagnostic.span.slice(source),
                 ))
                 .collect::<Vec<_>>(),
@@ -4032,10 +4032,10 @@ exit $RETVAL
                 .iter()
                 .map(|diagnostic| {
                     (
-                        diagnostic.span.start.line,
-                        diagnostic.span.start.column,
-                        diagnostic.span.end.line,
-                        diagnostic.span.end.column,
+                        diagnostic.span.start.line(),
+                        diagnostic.span.start.column(),
+                        diagnostic.span.end.line(),
+                        diagnostic.span.end.column(),
                     )
                 })
                 .collect::<Vec<_>>(),

--- a/crates/shuck-linter/src/rules/style/unquoted_expansion/safe_value.rs
+++ b/crates/shuck-linter/src/rules/style/unquoted_expansion/safe_value.rs
@@ -129,7 +129,7 @@ impl<'a> SafeValueIndex<'a> {
                     TerminalFlowKind::Exit | TerminalFlowKind::Stop
                 )
             })
-            .map(|command| (command.span().end.offset, command.id()))
+            .map(|command| (command.span().end.offset(), command.id()))
             .collect::<Vec<_>>();
         terminal_inline_commands
             .sort_unstable_by_key(|(end_offset, command_id)| (*end_offset, command_id.index()));
@@ -442,7 +442,7 @@ impl<'a> SafeValueIndex<'a> {
             .copied()
             .any(|binding_id| {
                 let binding = self.semantic.binding(binding_id);
-                if binding.span.start.offset > span.start.offset {
+                if binding.span.start.offset() > span.start.offset() {
                     return false;
                 }
                 let Some(word) = self
@@ -500,7 +500,7 @@ impl<'a> SafeValueIndex<'a> {
         let mut setup_bindings = Vec::new();
         for binding_id in self.semantic.bindings_for(&name).iter().copied() {
             let binding = self.semantic.binding(binding_id);
-            if binding.span.start.offset >= span.start.offset {
+            if binding.span.start.offset() >= span.start.offset() {
                 continue;
             }
             if binding.attributes.contains(BindingAttributes::LOCAL) {
@@ -529,7 +529,7 @@ impl<'a> SafeValueIndex<'a> {
             && (self.bindings_cover_all_paths_to_reference(&setup_bindings, &name, span)
                 || setup_bindings.iter().copied().any(|binding_id| {
                     let binding = self.semantic.binding(binding_id);
-                    binding.span.end.offset <= span.start.offset
+                    binding.span.end.offset() <= span.start.offset()
                         && self.binding_dominates_reference(binding_id, &name, span)
                 }))
     }
@@ -562,11 +562,11 @@ impl<'a> SafeValueIndex<'a> {
         let mut current = self
             .facts
             .command_facts()
-            .innermost_command_id_at(span.start.offset)
+            .innermost_command_id_at(span.start.offset())
             .or_else(|| {
                 self.facts
                     .command_facts()
-                    .innermost_command_id_containing_offset(span.start.offset)
+                    .innermost_command_id_containing_offset(span.start.offset())
             });
         while let Some(command_id) = current {
             if matches!(
@@ -593,11 +593,11 @@ impl<'a> SafeValueIndex<'a> {
         let mut current = self
             .facts
             .command_facts()
-            .innermost_command_id_at(span.start.offset)
+            .innermost_command_id_at(span.start.offset())
             .or_else(|| {
                 self.facts
                     .command_facts()
-                    .innermost_command_id_containing_offset(span.start.offset)
+                    .innermost_command_id_containing_offset(span.start.offset())
             });
         while let Some(command_id) = current {
             if let Command::Compound(CompoundCommand::If(command)) =
@@ -667,7 +667,7 @@ impl<'a> SafeValueIndex<'a> {
         let behavior = self
             .facts
             .command_facts()
-            .expansion_behavior_at(word.span.start.offset);
+            .expansion_behavior_at(word.span.start.offset());
         let runtime = analyze_literal_runtime(word, self.source, context, Some(&behavior));
         if !runtime.is_runtime_sensitive() {
             return false;
@@ -723,7 +723,7 @@ impl<'a> SafeValueIndex<'a> {
         }
         let case_cli_scope = query
             .is_field_context()
-            .then(|| self.case_cli_dispatch_scope_at(at.start.offset))
+            .then(|| self.case_cli_dispatch_scope_at(at.start.offset()))
             .flatten();
         if bindings.is_empty()
             && self.status_capture_declaration_probe_covers_reference(
@@ -800,7 +800,7 @@ impl<'a> SafeValueIndex<'a> {
             && !direct_bindings.is_empty()
             && self.bindings_cover_all_paths_to_reference(&direct_bindings, name, at);
         let unsafe_helper_binding_writes_visible_local = self
-            .enclosing_function_scope_at(at.start.offset)
+            .enclosing_function_scope_at(at.start.offset())
             .is_some_and(|scope| {
                 helper_bindings.iter().copied().any(|binding_id| {
                     self.binding_writes_visible_local_in_scope_before(binding_id, scope, at)
@@ -811,7 +811,9 @@ impl<'a> SafeValueIndex<'a> {
             return false;
         }
         if direct_bindings_cover_all_paths
-            && self.enclosing_function_scope_at(at.start.offset).is_some()
+            && self
+                .enclosing_function_scope_at(at.start.offset())
+                .is_some()
             && !self.span_is_exit_or_return_argument(at)
             && self.covering_direct_field_safe_bindings_can_stay_safe(&direct_bindings, query)
         {
@@ -865,8 +867,9 @@ impl<'a> SafeValueIndex<'a> {
         }
         let outer_bindings_cover_callers = !needs_arg_path_coverage
             || self.helper_outer_bindings_cover_all_caller_paths(name, at, &bindings);
-        let reference_is_inside_function =
-            self.enclosing_function_scope_at(at.start.offset).is_some();
+        let reference_is_inside_function = self
+            .enclosing_function_scope_at(at.start.offset())
+            .is_some();
         if helper_bindings.is_empty()
             && needs_arg_path_coverage
             && !bindings_cover_all_paths
@@ -949,8 +952,9 @@ impl<'a> SafeValueIndex<'a> {
             if !dispatch_bindings.is_empty() {
                 let mut combined = bindings.clone();
                 combined.extend(dispatch_bindings);
-                combined
-                    .sort_by_key(|binding_id| self.semantic.binding(*binding_id).span.start.offset);
+                combined.sort_by_key(|binding_id| {
+                    self.semantic.binding(*binding_id).span.start.offset()
+                });
                 combined.dedup();
                 if let Some(exposure) =
                     self.s001_field_safe_binding_group_exposure(&combined, at, query)
@@ -993,7 +997,7 @@ impl<'a> SafeValueIndex<'a> {
         if !query.is_field_context() || self.span_is_within_command_name(at) {
             return false;
         }
-        let Some(scope) = self.case_cli_reachable_function_scope_at(at.start.offset) else {
+        let Some(scope) = self.case_cli_reachable_function_scope_at(at.start.offset()) else {
             return false;
         };
 
@@ -1062,11 +1066,11 @@ impl<'a> SafeValueIndex<'a> {
     fn span_is_exit_or_return_argument(&self, at: Span) -> bool {
         self.facts
             .command_facts()
-            .innermost_command_id_at(at.start.offset)
+            .innermost_command_id_at(at.start.offset())
             .or_else(|| {
                 self.facts
                     .command_facts()
-                    .innermost_command_id_containing_offset(at.start.offset)
+                    .innermost_command_id_containing_offset(at.start.offset())
             })
             .is_some_and(|command_id| {
                 let command = self.facts.command_facts().command(command_id);
@@ -1105,11 +1109,11 @@ impl<'a> SafeValueIndex<'a> {
     fn span_is_return_argument(&self, at: Span) -> bool {
         self.facts
             .command_facts()
-            .innermost_command_id_at(at.start.offset)
+            .innermost_command_id_at(at.start.offset())
             .or_else(|| {
                 self.facts
                     .command_facts()
-                    .innermost_command_id_containing_offset(at.start.offset)
+                    .innermost_command_id_containing_offset(at.start.offset())
             })
             .is_some_and(|command_id| {
                 let command = self.facts.command_facts().command(command_id);
@@ -1170,9 +1174,10 @@ impl<'a> SafeValueIndex<'a> {
                                     self.definition_command_resolves_at_call(
                                         header.command_id(),
                                         call_span,
-                                    ) && call_span.end.offset <= at.start.offset
-                                        && (call_span.start.offset >= binding.span.end.offset
-                                            || call_span.end.offset <= binding.span.start.offset)
+                                    ) && call_span.end.offset() <= at.start.offset()
+                                        && (call_span.start.offset() >= binding.span.end.offset()
+                                            || call_span.end.offset()
+                                                <= binding.span.start.offset())
                                 }
                         })
             })
@@ -1180,7 +1185,7 @@ impl<'a> SafeValueIndex<'a> {
 
     fn span_is_after_unconditional_inline_terminator(&self, at: Span) -> bool {
         for (end_offset, command_id) in &self.terminal_inline_commands {
-            if *end_offset > at.start.offset {
+            if *end_offset > at.start.offset() {
                 break;
             }
             if self.command_runs_in_unconditional_flow(*command_id, at) {
@@ -1197,8 +1202,8 @@ impl<'a> SafeValueIndex<'a> {
         call_span: Span,
     ) -> bool {
         let command = self.facts.command_facts().command(command_id);
-        let command_scope = self.enclosing_function_scope_at(command.span().start.offset);
-        let call_scope = self.enclosing_function_scope_at(call_span.start.offset);
+        let command_scope = self.enclosing_function_scope_at(command.span().start.offset());
+        let call_scope = self.enclosing_function_scope_at(call_span.start.offset());
         if command_scope.is_some() && command_scope != call_scope {
             return false;
         }
@@ -1226,14 +1231,14 @@ impl<'a> SafeValueIndex<'a> {
         }
 
         let command = self.facts.command_facts().command(command_id);
-        let definition_scope = self.enclosing_function_scope_at(command.span().start.offset);
-        let call_scope = self.enclosing_function_scope_at(call_span.start.offset);
+        let definition_scope = self.enclosing_function_scope_at(command.span().start.offset());
+        let call_scope = self.enclosing_function_scope_at(call_span.start.offset());
 
         if definition_scope.is_none() && call_scope.is_some() {
             return true;
         }
 
-        command.span_in_source(self.source).end.offset <= call_span.start.offset
+        command.span_in_source(self.source).end.offset() <= call_span.start.offset()
     }
 
     fn command_for_name_word_span(
@@ -1267,7 +1272,7 @@ impl<'a> SafeValueIndex<'a> {
     }
 
     fn s001_reference_function_unset_before_first_call(&mut self, at: Span) -> bool {
-        let Some(scope) = self.enclosing_function_scope_at(at.start.offset) else {
+        let Some(scope) = self.enclosing_function_scope_at(at.start.offset()) else {
             return false;
         };
         if let Some(result) = self.s001_unset_before_call_memo.get(&scope) {
@@ -1283,7 +1288,7 @@ impl<'a> SafeValueIndex<'a> {
         let Some(definition_command) = self.function_definition_command_for_scope(scope) else {
             return false;
         };
-        let after_offset = definition_command.span_in_source(self.source).end.offset;
+        let after_offset = definition_command.span_in_source(self.source).end.offset();
         let Some(first_unset) = self.s001_first_function_unset_event_after(scope, after_offset)
         else {
             return false;
@@ -1333,20 +1338,20 @@ impl<'a> SafeValueIndex<'a> {
                     {
                         continue;
                     }
-                    match self.enclosing_function_scope_at(call_span.start.offset) {
+                    match self.enclosing_function_scope_at(call_span.start.offset()) {
                         Some(caller_scope) => {
                             for mut event_key in self.s001_function_call_event_keys_after_inner(
                                 caller_scope,
                                 after_offset,
                                 seen_scopes,
                             ) {
-                                event_key.push(call_span.start.offset);
+                                event_key.push(call_span.start.offset());
                                 event_keys.push(event_key);
                             }
                         }
                         None => {
-                            if call_span.start.offset > after_offset {
-                                event_keys.push(vec![call_span.start.offset]);
+                            if call_span.start.offset() > after_offset {
+                                event_keys.push(vec![call_span.start.offset()]);
                             }
                         }
                     }
@@ -1386,20 +1391,20 @@ impl<'a> SafeValueIndex<'a> {
             }
 
             let command_span = command.span_in_source(self.source);
-            let event_key = match self.enclosing_function_scope_at(command_span.start.offset) {
+            let event_key = match self.enclosing_function_scope_at(command_span.start.offset()) {
                 Some(unsetter_scope) => {
                     if unsetter_scope == target_scope {
                         None
                     } else {
                         self.s001_first_function_call_event_after(unsetter_scope, after_offset)
                             .map(|mut event_key| {
-                                event_key.push(command_span.start.offset);
+                                event_key.push(command_span.start.offset());
                                 event_key
                             })
                     }
                 }
-                None => (command_span.start.offset > after_offset)
-                    .then(|| vec![command_span.start.offset]),
+                None => (command_span.start.offset() > after_offset)
+                    .then(|| vec![command_span.start.offset()]),
             };
 
             if let Some(event_key) = event_key {
@@ -1430,8 +1435,8 @@ impl<'a> SafeValueIndex<'a> {
         reference_at: Span,
     ) -> bool {
         let command = self.facts.command_facts().command(command_id);
-        if self.enclosing_function_scope_at(command.span().start.offset)
-            != self.enclosing_function_scope_at(reference_at.start.offset)
+        if self.enclosing_function_scope_at(command.span().start.offset())
+            != self.enclosing_function_scope_at(reference_at.start.offset())
         {
             return false;
         }
@@ -1583,7 +1588,7 @@ impl<'a> SafeValueIndex<'a> {
         if !query.is_field_context()
             || bindings.is_empty()
             || bindings.iter().copied().any(|binding_id| {
-                self.semantic.binding(binding_id).span.end.offset > at.start.offset
+                self.semantic.binding(binding_id).span.end.offset() > at.start.offset()
             })
             || !self.bindings_cover_all_paths_to_reference(bindings, name, at)
         {
@@ -1614,20 +1619,20 @@ impl<'a> SafeValueIndex<'a> {
         if !query.is_field_context() || bindings.is_empty() {
             return false;
         }
-        let Some(function_scope) = self.enclosing_function_scope_at(at.start.offset) else {
+        let Some(function_scope) = self.enclosing_function_scope_at(at.start.offset()) else {
             return false;
         };
 
         let mut saw_conditional_literal = false;
-        let mut first_binding_start = at.start.offset;
+        let mut first_binding_start = at.start.offset();
         for binding_id in bindings.iter().copied() {
             let binding = self.semantic.binding(binding_id);
-            if binding.span.end.offset > at.start.offset
+            if binding.span.end.offset() > at.start.offset()
                 || !self.binding_is_in_scope_or_descendant(binding_id, function_scope)
             {
                 return false;
             }
-            first_binding_start = first_binding_start.min(binding.span.start.offset);
+            first_binding_start = first_binding_start.min(binding.span.start.offset());
 
             let Some(value) = self.facts.assignments().binding_value(binding_id) else {
                 return false;
@@ -1655,7 +1660,7 @@ impl<'a> SafeValueIndex<'a> {
                 .copied()
                 .any(|binding_id| {
                     let binding = self.semantic.binding(binding_id);
-                    binding.span.end.offset <= first_binding_start
+                    binding.span.end.offset() <= first_binding_start
                         && self.semantic.binding_visible_at(binding_id, at)
                         && self.binding_is_in_scope_or_descendant(binding_id, function_scope)
                         && self.binding_is_name_only_declaration(binding_id)
@@ -1827,7 +1832,7 @@ impl<'a> SafeValueIndex<'a> {
             if candidate_id == binding_id
                 || candidate.scope != binding.scope
                 || candidate.name != binding.name
-                || candidate.span.start.offset <= binding.span.start.offset
+                || candidate.span.start.offset() <= binding.span.start.offset()
             {
                 continue;
             }
@@ -2120,7 +2125,7 @@ impl<'a> SafeValueIndex<'a> {
             prior_bindings.push(previous.id);
         }
         prior_bindings
-            .sort_by_key(|binding_id| self.semantic.binding(*binding_id).span.start.offset);
+            .sort_by_key(|binding_id| self.semantic.binding(*binding_id).span.start.offset());
         prior_bindings.dedup();
 
         self.bindings_are_all_plain_empty_static_literals(&prior_bindings)
@@ -2191,7 +2196,7 @@ impl<'a> SafeValueIndex<'a> {
             .iter()
             .copied()
             .filter(|binding_id| {
-                self.semantic.binding(*binding_id).span.end.offset <= at.start.offset
+                self.semantic.binding(*binding_id).span.end.offset() <= at.start.offset()
             })
             .filter(|binding_id| {
                 self.binding_is_standalone_status_capture(*binding_id, at, case_cli_scope)
@@ -2203,20 +2208,20 @@ impl<'a> SafeValueIndex<'a> {
             return false;
         }
 
-        let Some(reference_scope) = self.enclosing_function_scope_at(at.start.offset) else {
+        let Some(reference_scope) = self.enclosing_function_scope_at(at.start.offset()) else {
             return true;
         };
         let first_status_offset = status_bindings
             .iter()
-            .map(|binding_id| self.semantic.binding(*binding_id).span.start.offset)
+            .map(|binding_id| self.semantic.binding(*binding_id).span.start.offset())
             .min()
-            .unwrap_or(at.start.offset);
+            .unwrap_or(at.start.offset());
 
         !bindings.iter().copied().any(|binding_id| {
             let binding = self.semantic.binding(binding_id);
             binding.scope == reference_scope
-                && binding.span.start.offset > first_status_offset
-                && binding.span.start.offset < at.start.offset
+                && binding.span.start.offset() > first_status_offset
+                && binding.span.start.offset() < at.start.offset()
                 && !self.binding_is_standalone_status_capture(binding_id, at, case_cli_scope)
         })
     }
@@ -2288,7 +2293,7 @@ impl<'a> SafeValueIndex<'a> {
         if !self.status_capture_binding_is_in_short_circuit_branch(binding.span) {
             return false;
         }
-        let Some(binding_scope) = self.enclosing_function_scope_at(binding.span.start.offset)
+        let Some(binding_scope) = self.enclosing_function_scope_at(binding.span.start.offset())
         else {
             return false;
         };
@@ -2302,7 +2307,7 @@ impl<'a> SafeValueIndex<'a> {
             return false;
         }
 
-        let at_scope = self.semantic.scope_at(at.start.offset);
+        let at_scope = self.semantic.scope_at(at.start.offset());
         let reference_is_in_binding_scope = self
             .semantic
             .scope_is_in_scope_or_descendant(at_scope, binding_scope);
@@ -2318,7 +2323,7 @@ impl<'a> SafeValueIndex<'a> {
         !relevant_call_sites.is_empty()
             && relevant_call_sites.into_iter().all(|(scope, span)| {
                 let caller_scope = self
-                    .enclosing_function_scope_at(span.start.offset)
+                    .enclosing_function_scope_at(span.start.offset())
                     .unwrap_or(scope);
                 self.scope_has_visible_initialized_local_binding_before(
                     &binding.name,
@@ -2352,10 +2357,10 @@ impl<'a> SafeValueIndex<'a> {
             .command_facts()
             .structural_commands()
             .any(|command| {
-                command.span().end.offset <= at.start.offset
+                command.span().end.offset() <= at.start.offset()
                     && self.command_blocks_cover_all_paths_to_reference(command, name, at)
                     && !case_cli_scope.is_some_and(|scope| {
-                        self.offset_is_in_scope_or_descendant(command.span().start.offset, scope)
+                        self.offset_is_in_scope_or_descendant(command.span().start.offset(), scope)
                     })
                     && command
                         .declaration_assignment_probes()
@@ -2392,8 +2397,8 @@ impl<'a> SafeValueIndex<'a> {
         name: &Name,
         at: Span,
     ) -> bool {
-        if self.enclosing_function_scope_at(command.span().start.offset)
-            != self.enclosing_function_scope_at(at.start.offset)
+        if self.enclosing_function_scope_at(command.span().start.offset())
+            != self.enclosing_function_scope_at(at.start.offset())
         {
             return false;
         }
@@ -2417,7 +2422,7 @@ impl<'a> SafeValueIndex<'a> {
         }
 
         let entry = self
-            .enclosing_function_scope_at(at.start.offset)
+            .enclosing_function_scope_at(at.start.offset())
             .and_then(|scope| self.analysis.cfg().scope_entry(scope))
             .unwrap_or_else(|| self.analysis.cfg().entry());
         let cover_blocks = cover_blocks.iter().copied().collect::<FxHashSet<_>>();
@@ -2430,7 +2435,7 @@ impl<'a> SafeValueIndex<'a> {
             .assignments()
             .unset_commands_for_name(name)
             .any(|command| {
-                command.span().end.offset <= at.start.offset
+                command.span().end.offset() <= at.start.offset()
                     && self.command_runs_in_persistent_shell_context(command.id())
                     && self.command_runs_in_unconditional_flow(command.id(), at)
                     && self.command_blocks_cover_all_paths_to_reference(command, name, at)
@@ -2448,8 +2453,8 @@ impl<'a> SafeValueIndex<'a> {
             .assignments()
             .unset_commands_for_name(name)
             .any(|command| {
-                command.span().start.offset >= binding.span.end.offset
-                    && command.span().end.offset <= at.start.offset
+                command.span().start.offset() >= binding.span.end.offset()
+                    && command.span().end.offset() <= at.start.offset()
                     && self.command_runs_in_persistent_shell_context(command.id())
                     && !self.command_is_in_background_context(command.id())
                     && self.command_blocks_cover_all_paths_to_reference(command, name, at)
@@ -2515,7 +2520,7 @@ impl<'a> SafeValueIndex<'a> {
         {
             prior_bindings.push(previous.id);
         }
-        prior_bindings.sort_by_key(|prior_id| self.semantic.binding(*prior_id).span.start.offset);
+        prior_bindings.sort_by_key(|prior_id| self.semantic.binding(*prior_id).span.start.offset());
         prior_bindings.dedup();
 
         if prior_bindings.is_empty() {
@@ -2565,7 +2570,7 @@ impl<'a> SafeValueIndex<'a> {
         definition_span: Span,
         at: Span,
     ) -> bool {
-        let Some(helper_scope) = self.enclosing_function_scope_at(at.start.offset) else {
+        let Some(helper_scope) = self.enclosing_function_scope_at(at.start.offset()) else {
             return false;
         };
         self.loop_variable_scope_callers_stay_within_body(
@@ -2592,7 +2597,7 @@ impl<'a> SafeValueIndex<'a> {
                     return true;
                 }
 
-                let caller_scope = self.semantic.scope_at(call_span.start.offset);
+                let caller_scope = self.semantic.scope_at(call_span.start.offset());
                 let mut caller_seen = seen_scopes.clone();
                 self.loop_variable_scope_callers_stay_within_body(
                     definition_span,
@@ -2621,13 +2626,13 @@ impl<'a> SafeValueIndex<'a> {
         helper_bindings.extend(self.top_level_transitive_helper_bindings_before(name, at));
         self.retain_value_bindings(&mut helper_bindings);
         helper_bindings
-            .sort_by_key(|binding_id| self.semantic.binding(*binding_id).span.start.offset);
+            .sort_by_key(|binding_id| self.semantic.binding(*binding_id).span.start.offset());
         helper_bindings.dedup();
         let mut caller_bindings = self.caller_bindings_covering_all_static_call_sites(name, at);
         self.retain_value_bindings(&mut caller_bindings);
         let mut uncalled_function_bindings = self.uncalled_function_outer_bindings_at_end(name, at);
         self.retain_value_bindings(&mut uncalled_function_bindings);
-        let function_scope = self.enclosing_function_scope_at(at.start.offset);
+        let function_scope = self.enclosing_function_scope_at(at.start.offset());
         let function_local_binding = function_scope.is_some_and(|scope| {
             bindings
                 .iter()
@@ -2645,7 +2650,8 @@ impl<'a> SafeValueIndex<'a> {
         {
             bindings = caller_bindings;
             bindings.extend(helper_bindings);
-            bindings.sort_by_key(|binding_id| self.semantic.binding(*binding_id).span.start.offset);
+            bindings
+                .sort_by_key(|binding_id| self.semantic.binding(*binding_id).span.start.offset());
             bindings.dedup();
         } else if !caller_bindings.is_empty()
             && function_scope.is_some()
@@ -2654,16 +2660,19 @@ impl<'a> SafeValueIndex<'a> {
         {
             bindings = caller_bindings;
             bindings.extend(helper_bindings);
-            bindings.sort_by_key(|binding_id| self.semantic.binding(*binding_id).span.start.offset);
+            bindings
+                .sort_by_key(|binding_id| self.semantic.binding(*binding_id).span.start.offset());
             bindings.dedup();
         } else if bindings.is_empty() {
             bindings = caller_bindings;
             bindings.extend(helper_bindings);
-            bindings.sort_by_key(|binding_id| self.semantic.binding(*binding_id).span.start.offset);
+            bindings
+                .sort_by_key(|binding_id| self.semantic.binding(*binding_id).span.start.offset());
             bindings.dedup();
         } else if !helper_bindings.is_empty() {
             bindings.extend(helper_bindings);
-            bindings.sort_by_key(|binding_id| self.semantic.binding(*binding_id).span.start.offset);
+            bindings
+                .sort_by_key(|binding_id| self.semantic.binding(*binding_id).span.start.offset());
             bindings.dedup();
         }
         if let Some(scope) = function_scope
@@ -2680,9 +2689,9 @@ impl<'a> SafeValueIndex<'a> {
                 !self.binding_writes_visible_local_in_scope_before(*binding_id, scope, at)
             });
         }
-        let reference_scope = self.semantic.scope_at(at.start.offset);
+        let reference_scope = self.semantic.scope_at(at.start.offset());
         bindings.retain(|binding_id| {
-            self.semantic.binding(*binding_id).span.start.offset <= at.start.offset
+            self.semantic.binding(*binding_id).span.start.offset() <= at.start.offset()
                 || !self.binding_is_in_scope_or_descendant(*binding_id, reference_scope)
                 || self.future_binding_can_reach_reference(*binding_id, name, at)
         });
@@ -2711,7 +2720,7 @@ impl<'a> SafeValueIndex<'a> {
     }
 
     fn uncalled_function_outer_bindings_at_end(&mut self, name: &Name, at: Span) -> Vec<BindingId> {
-        let Some(helper_scope) = self.enclosing_function_scope_at(at.start.offset) else {
+        let Some(helper_scope) = self.enclosing_function_scope_at(at.start.offset()) else {
             return Vec::new();
         };
         if self
@@ -2742,17 +2751,18 @@ impl<'a> SafeValueIndex<'a> {
             .iter()
             .copied()
             .filter(|binding_id| !self.binding_is_guarded_before_reference(*binding_id, eof_span))
-            .max_by_key(|binding_id| self.semantic.binding(*binding_id).span.start.offset);
+            .max_by_key(|binding_id| self.semantic.binding(*binding_id).span.start.offset());
         let Some(latest_unguarded) = latest_unguarded else {
             return Vec::new();
         };
-        let latest_unguarded_offset = self.semantic.binding(latest_unguarded).span.start.offset;
+        let latest_unguarded_offset = self.semantic.binding(latest_unguarded).span.start.offset();
         bindings.retain(|binding_id| {
             *binding_id == latest_unguarded
-                || (self.semantic.binding(*binding_id).span.start.offset > latest_unguarded_offset
+                || (self.semantic.binding(*binding_id).span.start.offset()
+                    > latest_unguarded_offset
                     && self.binding_is_guarded_before_reference(*binding_id, eof_span))
         });
-        bindings.sort_by_key(|binding_id| self.semantic.binding(*binding_id).span.start.offset);
+        bindings.sort_by_key(|binding_id| self.semantic.binding(*binding_id).span.start.offset());
         bindings.dedup();
         bindings
     }
@@ -2762,7 +2772,7 @@ impl<'a> SafeValueIndex<'a> {
         name: &Name,
         at: Span,
     ) -> Vec<BindingId> {
-        let Some(helper_scope) = self.enclosing_function_scope_at(at.start.offset) else {
+        let Some(helper_scope) = self.enclosing_function_scope_at(at.start.offset()) else {
             return Vec::new();
         };
         self.caller_bindings_covering_static_scope_call_sites(
@@ -2791,7 +2801,7 @@ impl<'a> SafeValueIndex<'a> {
         let mut bindings = Vec::new();
         for (scope, span) in caller_sites {
             let caller_scope = self
-                .enclosing_function_scope_at(span.start.offset)
+                .enclosing_function_scope_at(span.start.offset())
                 .unwrap_or(scope);
             let mut branch = self.caller_branch_bindings_before(name, caller_scope, span);
             self.drop_declarations_shadowed_by_covering_loop_bindings(&mut branch, span);
@@ -2829,7 +2839,7 @@ impl<'a> SafeValueIndex<'a> {
             bindings.extend(transitive);
         }
 
-        bindings.sort_by_key(|binding_id| self.semantic.binding(*binding_id).span.start.offset);
+        bindings.sort_by_key(|binding_id| self.semantic.binding(*binding_id).span.start.offset());
         bindings.dedup();
         Some(bindings)
     }
@@ -2888,7 +2898,8 @@ impl<'a> SafeValueIndex<'a> {
                 }
             }
             bindings.retain(|binding_id| *binding_id != current_binding);
-            bindings.sort_by_key(|binding_id| self.semantic.binding(*binding_id).span.start.offset);
+            bindings
+                .sort_by_key(|binding_id| self.semantic.binding(*binding_id).span.start.offset());
             bindings.dedup();
             return bindings;
         }
@@ -2899,8 +2910,9 @@ impl<'a> SafeValueIndex<'a> {
                     .reaching_value_bindings_bypassing(name, bindings[0], at);
             if !expanded.is_empty() {
                 expanded.push(bindings[0]);
-                expanded
-                    .sort_by_key(|binding_id| self.semantic.binding(*binding_id).span.start.offset);
+                expanded.sort_by_key(|binding_id| {
+                    self.semantic.binding(*binding_id).span.start.offset()
+                });
                 expanded.dedup();
                 bindings = expanded;
             }
@@ -2982,7 +2994,7 @@ impl<'a> SafeValueIndex<'a> {
                 (self.loop_variable_reference_stays_within_body(*definition_span, at)
                     || self
                         .loop_variable_reference_stays_within_static_callers(*definition_span, at))
-                .then_some((binding.scope, definition_span.start.offset))
+                .then_some((binding.scope, definition_span.start.offset()))
             })
             .collect::<FxHashSet<_>>();
         if covering_loop_bindings.is_empty() {
@@ -2996,7 +3008,7 @@ impl<'a> SafeValueIndex<'a> {
             }
 
             !covering_loop_bindings.iter().any(|(scope, loop_start)| {
-                binding.scope == *scope && binding.span.start.offset <= *loop_start
+                binding.scope == *scope && binding.span.start.offset() <= *loop_start
             })
         });
     }
@@ -3064,20 +3076,23 @@ impl<'a> SafeValueIndex<'a> {
         name: &Name,
         at: Span,
     ) -> Vec<BindingId> {
-        if self.enclosing_function_scope_at(at.start.offset).is_some() {
+        if self
+            .enclosing_function_scope_at(at.start.offset())
+            .is_some()
+        {
             return Vec::new();
         }
 
         let mut bindings = Vec::new();
-        let scope = self.semantic.scope_at(at.start.offset);
+        let scope = self.semantic.scope_at(at.start.offset());
         let dispatcher_scopes = self
             .value_flow
             .borrow()
-            .called_function_scopes_before(scope, at.start.offset);
+            .called_function_scopes_before(scope, at.start.offset());
         for dispatcher_scope in dispatcher_scopes {
             bindings.extend(self.s001_branch_helper_bindings_in_scope(name, dispatcher_scope));
         }
-        bindings.sort_by_key(|binding_id| self.semantic.binding(*binding_id).span.start.offset);
+        bindings.sort_by_key(|binding_id| self.semantic.binding(*binding_id).span.start.offset());
         bindings.dedup();
         bindings
     }
@@ -3106,9 +3121,9 @@ impl<'a> SafeValueIndex<'a> {
                 }
             }
         }
-        call_sites.sort_by_key(|(_, span)| (span.start.offset, span.end.offset));
+        call_sites.sort_by_key(|(_, span)| (span.start.offset(), span.end.offset()));
         call_sites.dedup_by_key(|(callee_scope, span)| {
-            (*callee_scope, span.start.offset, span.end.offset)
+            (*callee_scope, span.start.offset(), span.end.offset())
         });
         if call_sites.len() < 2 {
             return Vec::new();
@@ -3129,7 +3144,10 @@ impl<'a> SafeValueIndex<'a> {
     }
 
     fn top_level_transitive_helper_bindings_before(&self, name: &Name, at: Span) -> Vec<BindingId> {
-        if self.enclosing_function_scope_at(at.start.offset).is_some() {
+        if self
+            .enclosing_function_scope_at(at.start.offset())
+            .is_some()
+        {
             return Vec::new();
         }
 
@@ -3153,7 +3171,7 @@ impl<'a> SafeValueIndex<'a> {
         at: Span,
         bindings: &[BindingId],
     ) -> bool {
-        let Some(helper_scope) = self.enclosing_function_scope_at(at.start.offset) else {
+        let Some(helper_scope) = self.enclosing_function_scope_at(at.start.offset()) else {
             return true;
         };
         if !bindings
@@ -3171,7 +3189,7 @@ impl<'a> SafeValueIndex<'a> {
 
         caller_sites.into_iter().all(|(scope, span)| {
             let caller_scope = self
-                .enclosing_function_scope_at(span.start.offset)
+                .enclosing_function_scope_at(span.start.offset())
                 .unwrap_or(scope);
             let mut branch = self.caller_branch_bindings_before(name, caller_scope, span);
             self.drop_declarations_shadowed_by_covering_loop_bindings(&mut branch, span);
@@ -3243,7 +3261,7 @@ impl<'a> SafeValueIndex<'a> {
         if self.scope_has_visible_local_binding_before(name, scope, at) {
             branch.retain(|binding_id| self.semantic.binding(*binding_id).scope == scope);
         }
-        branch.sort_by_key(|binding_id| self.semantic.binding(*binding_id).span.start.offset);
+        branch.sort_by_key(|binding_id| self.semantic.binding(*binding_id).span.start.offset());
         branch.dedup();
         branch
     }
@@ -3255,7 +3273,7 @@ impl<'a> SafeValueIndex<'a> {
         let Some(mut command_id) = self
             .facts
             .command_facts()
-            .innermost_command_id_at(call_span.start.offset)
+            .innermost_command_id_at(call_span.start.offset())
         else {
             return false;
         };
@@ -3269,8 +3287,8 @@ impl<'a> SafeValueIndex<'a> {
         let mut current = self.facts.command_facts().command_parent_id(command_id);
         while let Some(command_id) = current {
             let command = self.facts.command_facts().command(command_id);
-            if command.span().start.offset < call_span.start.offset
-                && call_span.end.offset <= command.span().end.offset
+            if command.span().start.offset() < call_span.start.offset()
+                && call_span.end.offset() <= command.span().end.offset()
                 && self
                     .facts
                     .command_facts()
@@ -3328,7 +3346,7 @@ impl<'a> SafeValueIndex<'a> {
             .any(|binding_id| {
                 let binding = self.semantic.binding(binding_id);
                 binding.scope == scope
-                    && binding.span.end.offset <= at.start.offset
+                    && binding.span.end.offset() <= at.start.offset()
                     && binding.attributes.contains(BindingAttributes::LOCAL)
             })
     }
@@ -3347,10 +3365,10 @@ impl<'a> SafeValueIndex<'a> {
             .filter(|binding_id| {
                 let binding = self.semantic.binding(*binding_id);
                 binding.scope == scope
-                    && binding.span.end.offset <= at.start.offset
+                    && binding.span.end.offset() <= at.start.offset()
                     && binding.attributes.contains(BindingAttributes::LOCAL)
             })
-            .map(|binding_id| self.semantic.binding(binding_id).span.start.offset)
+            .map(|binding_id| self.semantic.binding(binding_id).span.start.offset())
             .max();
         let Some(latest_local_start) = latest_local_start else {
             return false;
@@ -3378,8 +3396,8 @@ impl<'a> SafeValueIndex<'a> {
                     }
                 };
                 binding.scope == scope
-                    && binding.span.end.offset <= at.start.offset
-                    && binding.span.start.offset >= latest_local_start
+                    && binding.span.end.offset() <= at.start.offset()
+                    && binding.span.start.offset() >= latest_local_start
                     && initializes_local_value
             })
     }
@@ -3422,7 +3440,7 @@ impl<'a> SafeValueIndex<'a> {
 
     fn call_site_dominates_use(&self, call_span: Span, name: &Name, at: Span) -> bool {
         let _ = name;
-        self.call_site_dominates_offset(call_span, at.start.offset)
+        self.call_site_dominates_offset(call_span, at.start.offset())
     }
 
     fn function_scope_end_span(&self, scope: ScopeId) -> Option<Span> {
@@ -3440,15 +3458,15 @@ impl<'a> SafeValueIndex<'a> {
         at: Span,
         relaxed: bool,
     ) -> Vec<BindingId> {
-        let scope = self.semantic.scope_at(at.start.offset);
+        let scope = self.semantic.scope_at(at.start.offset());
         let callee_scopes = if relaxed {
             self.value_flow
                 .borrow()
-                .transitively_called_function_scopes_before_relaxed(scope, at.start.offset)
+                .transitively_called_function_scopes_before_relaxed(scope, at.start.offset())
         } else {
             self.value_flow
                 .borrow()
-                .transitively_called_function_scopes_before(scope, at.start.offset)
+                .transitively_called_function_scopes_before(scope, at.start.offset())
         };
         let mut bindings = callee_scopes
             .into_iter()
@@ -3464,20 +3482,20 @@ impl<'a> SafeValueIndex<'a> {
                     })
             })
             .collect::<Vec<_>>();
-        bindings.sort_by_key(|binding_id| self.semantic.binding(*binding_id).span.start.offset);
+        bindings.sort_by_key(|binding_id| self.semantic.binding(*binding_id).span.start.offset());
         bindings.dedup();
         bindings
     }
 
     fn call_site_dominates_offset(&self, call_span: Span, limit_offset: usize) -> bool {
-        if call_span.start.offset >= limit_offset {
+        if call_span.start.offset() >= limit_offset {
             return false;
         }
 
         let Some(mut command_id) = self
             .facts
             .command_facts()
-            .innermost_command_id_at(call_span.start.offset)
+            .innermost_command_id_at(call_span.start.offset())
         else {
             return true;
         };
@@ -3491,10 +3509,10 @@ impl<'a> SafeValueIndex<'a> {
         let mut current = self.facts.command_facts().command_parent_id(command_id);
         while let Some(command_id) = current {
             let command = self.facts.command_facts().command(command_id);
-            if command.span().end.offset > limit_offset {
+            if command.span().end.offset() > limit_offset {
                 break;
             }
-            if command.span().start.offset < call_span.start.offset
+            if command.span().start.offset() < call_span.start.offset()
                 && self
                     .facts
                     .command_facts()
@@ -3513,7 +3531,7 @@ impl<'a> SafeValueIndex<'a> {
         let Some(mut current) = self
             .facts
             .command_facts()
-            .innermost_command_id_at(binding.span.start.offset)
+            .innermost_command_id_at(binding.span.start.offset())
             .and_then(|id| self.facts.command_facts().command_parent_id(id))
         else {
             return false;
@@ -3525,7 +3543,7 @@ impl<'a> SafeValueIndex<'a> {
                 .facts
                 .command_facts()
                 .command_is_dominance_barrier(current)
-                && command.span().end.offset <= at.start.offset
+                && command.span().end.offset() <= at.start.offset()
             {
                 return true;
             }
@@ -3679,7 +3697,7 @@ impl<'a> SafeValueIndex<'a> {
             .collect::<Vec<_>>();
         let entry = self
             .analysis
-            .flow_entry_block_for_binding_scopes(&binding_scopes, at.start.offset);
+            .flow_entry_block_for_binding_scopes(&binding_scopes, at.start.offset());
         self.analysis
             .blocks_cover_all_paths_to_block(entry, reference_block, &cover_blocks)
     }
@@ -3693,9 +3711,9 @@ impl<'a> SafeValueIndex<'a> {
             .assignments()
             .unset_commands_for_name(name)
             .filter(|command| {
-                command.span().end.offset <= at.start.offset
-                    && self.enclosing_function_scope_at(command.span().start.offset)
-                        == self.enclosing_function_scope_at(at.start.offset)
+                command.span().end.offset() <= at.start.offset()
+                    && self.enclosing_function_scope_at(command.span().start.offset())
+                        == self.enclosing_function_scope_at(at.start.offset())
                     && self.command_runs_in_persistent_shell_context(command.id())
                     && !self.command_is_in_background_context(command.id())
                     && !self.command_is_in_boolean_list(command.id())
@@ -3764,11 +3782,11 @@ impl<'a> SafeValueIndex<'a> {
         let command_id = self
             .facts
             .command_facts()
-            .innermost_command_id_at(at.start.offset)
+            .innermost_command_id_at(at.start.offset())
             .or_else(|| {
                 self.facts
                     .command_facts()
-                    .innermost_command_id_containing_offset(at.start.offset)
+                    .innermost_command_id_containing_offset(at.start.offset())
             })?;
         self.analysis
             .block_ids_for_span(self.facts.command_facts().command(command_id).span())
@@ -4068,7 +4086,7 @@ impl<'a> SafeValueIndex<'a> {
         name: &Name,
         at: Span,
     ) -> bool {
-        let Some(function_scope) = self.enclosing_function_scope_at(at.start.offset) else {
+        let Some(function_scope) = self.enclosing_function_scope_at(at.start.offset()) else {
             return false;
         };
         if self
@@ -4087,7 +4105,7 @@ impl<'a> SafeValueIndex<'a> {
 
         let Some(file_scope) = self
             .semantic
-            .ancestor_scopes(self.semantic.scope_at(at.start.offset))
+            .ancestor_scopes(self.semantic.scope_at(at.start.offset()))
             .find(|scope| matches!(self.semantic.scope(*scope).kind, ScopeKind::File))
         else {
             return false;
@@ -4132,7 +4150,7 @@ impl<'a> SafeValueIndex<'a> {
         );
         self.retain_value_bindings(&mut transitive_helper_bindings);
         bindings.extend(transitive_helper_bindings.iter().copied());
-        bindings.sort_by_key(|binding_id| self.semantic.binding(*binding_id).span.start.offset);
+        bindings.sort_by_key(|binding_id| self.semantic.binding(*binding_id).span.start.offset());
         bindings.dedup();
         if bindings.is_empty() {
             return false;
@@ -4159,7 +4177,7 @@ impl<'a> SafeValueIndex<'a> {
         let has_covering_binding = self.bindings_cover_all_paths_to_reference(&bindings, name, at)
             || bindings.iter().copied().any(|binding_id| {
                 let binding = self.semantic.binding(binding_id);
-                binding.span.end.offset <= at.start.offset
+                binding.span.end.offset() <= at.start.offset()
                     && self.binding_dominates_reference(binding_id, name, at)
             });
         has_covering_binding
@@ -4223,7 +4241,7 @@ impl<'a> SafeValueIndex<'a> {
         let has_covering_binding = self.bindings_cover_all_paths_to_reference(&bindings, name, at)
             || bindings.iter().copied().any(|binding_id| {
                 let binding = self.semantic.binding(binding_id);
-                binding.span.end.offset <= at.start.offset
+                binding.span.end.offset() <= at.start.offset()
                     && self.binding_dominates_reference(binding_id, name, at)
             });
         has_covering_binding
@@ -4265,7 +4283,7 @@ impl<'a> SafeValueIndex<'a> {
                 | Command::Function(_)
                 | Command::AnonymousFunction(_) => None,
             })
-            .min_by_key(|span| span.end.offset - span.start.offset)
+            .min_by_key(|span| span.end.offset() - span.start.offset())
     }
 
     fn binding_assigns_numeric_operand_value(&mut self, binding_id: BindingId, at: Span) -> bool {
@@ -4371,7 +4389,7 @@ fn plain_scalar_reference_name_from_part(part: &WordPart) -> Option<Name> {
 }
 
 fn span_contains(container: Span, inner: Span) -> bool {
-    container.start.offset <= inner.start.offset && inner.end.offset <= container.end.offset
+    container.start.offset() <= inner.start.offset() && inner.end.offset() <= container.end.offset()
 }
 
 fn shell_name_is_uppercase_setup_value(text: &str) -> bool {
@@ -5444,7 +5462,7 @@ done
             .find(|fact| {
                 fact.expansion_context() == Some(ExpansionContext::CommandArgument)
                     && fact.span().slice(source) == "$i"
-                    && fact.span().start.line == 5
+                    && fact.span().start.line() == 5
             })
             .expect("expected post-loop $i word fact");
         let binding_id = safe_values
@@ -5895,7 +5913,7 @@ exit $?
             .next()
             .expect("expected reaching status binding");
         let case_cli_scope =
-            safe_values.case_cli_dispatch_scope_at(dispatched_use.span().start.offset);
+            safe_values.case_cli_dispatch_scope_at(dispatched_use.span().start.offset());
 
         assert_eq!(
             case_cli_scope,
@@ -6321,7 +6339,8 @@ done
             .word_facts()
             .iter()
             .filter(|fact| {
-                fact.span().slice(source).contains("$i") && matches!(fact.span().start.line, 5 | 8)
+                fact.span().slice(source).contains("$i")
+                    && matches!(fact.span().start.line(), 5 | 8)
             })
             .collect::<Vec<_>>();
 
@@ -6637,7 +6656,7 @@ render() {
             })
             .expect("expected local argument fact");
         let render_scope = analysis
-            .enclosing_function_scope_at(word_fact.span().start.offset)
+            .enclosing_function_scope_at(word_fact.span().start.offset())
             .expect("expected render scope");
         let outer_helper_binding = semantic
             .semantic()

--- a/crates/shuck-linter/src/suppression/directive.rs
+++ b/crates/shuck-linter/src/suppression/directive.rs
@@ -333,10 +333,10 @@ fn directive_can_apply_to_following_command(
     visits.iter().any(|visit| match visit.command {
         Command::Compound(CompoundCommand::If(command)) => {
             let if_header = command.condition.first().is_some_and(|stmt| {
-                next_command_starts_after_comment_line(stmt.span.start.offset, &context)
+                next_command_starts_after_comment_line(stmt.span.start.offset(), &context)
                     && command_start_segment_matches(
                         source,
-                        visit.stmt.span.start.offset,
+                        visit.stmt.span.start.offset(),
                         context.comment_start,
                         "if",
                     )
@@ -344,24 +344,24 @@ fn directive_can_apply_to_following_command(
 
             let then_header = body_header_matches(
                 source,
-                command.condition.span.end.offset,
+                command.condition.span.end.offset(),
                 &command.then_branch,
                 &context,
                 "then",
             ) || body_opener_matches(
                 source,
-                command.condition.span.end.offset,
+                command.condition.span.end.offset(),
                 &command.then_branch,
                 &context,
                 '{',
             );
 
-            let mut previous_branch_end = command.then_branch.span.end.offset;
+            let mut previous_branch_end = command.then_branch.span.end.offset();
             let mut elif_header = false;
             let mut elif_body_header = false;
             for (condition, branch) in &command.elif_branches {
                 elif_header |= condition.first().is_some_and(|stmt| {
-                    next_command_starts_after_comment_line(stmt.span.start.offset, &context)
+                    next_command_starts_after_comment_line(stmt.span.start.offset(), &context)
                         && gap_segment_ends_with_keyword(
                             source,
                             previous_branch_end,
@@ -371,23 +371,23 @@ fn directive_can_apply_to_following_command(
                 });
                 elif_body_header |= body_header_matches(
                     source,
-                    condition.span.end.offset,
+                    condition.span.end.offset(),
                     branch,
                     &context,
                     "then",
                 ) || body_opener_matches(
                     source,
-                    condition.span.end.offset,
+                    condition.span.end.offset(),
                     branch,
                     &context,
                     '{',
                 );
-                previous_branch_end = branch.span.end.offset;
+                previous_branch_end = branch.span.end.offset();
             }
 
             let else_header = command.else_branch.as_ref().is_some_and(|branch| {
                 branch.first().is_some_and(|stmt| {
-                    next_command_starts_after_comment_line(stmt.span.start.offset, &context)
+                    next_command_starts_after_comment_line(stmt.span.start.offset(), &context)
                         && (gap_segment_ends_with_keyword(
                             source,
                             previous_branch_end,
@@ -407,13 +407,13 @@ fn directive_can_apply_to_following_command(
         Command::Compound(CompoundCommand::For(command)) => {
             body_header_matches(
                 source,
-                visit.stmt.span.start.offset,
+                visit.stmt.span.start.offset(),
                 &command.body,
                 &context,
                 "do",
             ) || body_opener_matches(
                 source,
-                visit.stmt.span.start.offset,
+                visit.stmt.span.start.offset(),
                 &command.body,
                 &context,
                 '{',
@@ -422,13 +422,13 @@ fn directive_can_apply_to_following_command(
         Command::Compound(CompoundCommand::Repeat(command)) => {
             body_header_matches(
                 source,
-                visit.stmt.span.start.offset,
+                visit.stmt.span.start.offset(),
                 &command.body,
                 &context,
                 "do",
             ) || body_opener_matches(
                 source,
-                visit.stmt.span.start.offset,
+                visit.stmt.span.start.offset(),
                 &command.body,
                 &context,
                 '{',
@@ -437,13 +437,13 @@ fn directive_can_apply_to_following_command(
         Command::Compound(CompoundCommand::Foreach(command)) => {
             body_header_matches(
                 source,
-                visit.stmt.span.start.offset,
+                visit.stmt.span.start.offset(),
                 &command.body,
                 &context,
                 "do",
             ) || body_opener_matches(
                 source,
-                visit.stmt.span.start.offset,
+                visit.stmt.span.start.offset(),
                 &command.body,
                 &context,
                 '{',
@@ -452,13 +452,13 @@ fn directive_can_apply_to_following_command(
         Command::Compound(CompoundCommand::ArithmeticFor(command)) => {
             body_header_matches(
                 source,
-                visit.stmt.span.start.offset,
+                visit.stmt.span.start.offset(),
                 &command.body,
                 &context,
                 "do",
             ) || body_opener_matches(
                 source,
-                visit.stmt.span.start.offset,
+                visit.stmt.span.start.offset(),
                 &command.body,
                 &context,
                 '{',
@@ -467,19 +467,19 @@ fn directive_can_apply_to_following_command(
         Command::Compound(CompoundCommand::While(command)) => {
             loop_header_matches(
                 source,
-                visit.stmt.span.start.offset,
+                visit.stmt.span.start.offset(),
                 &command.condition,
                 context,
                 "while",
             ) || body_header_matches(
                 source,
-                command.condition.span.end.offset,
+                command.condition.span.end.offset(),
                 &command.body,
                 &context,
                 "do",
             ) || body_opener_matches(
                 source,
-                command.condition.span.end.offset,
+                command.condition.span.end.offset(),
                 &command.body,
                 &context,
                 '{',
@@ -488,19 +488,19 @@ fn directive_can_apply_to_following_command(
         Command::Compound(CompoundCommand::Until(command)) => {
             loop_header_matches(
                 source,
-                visit.stmt.span.start.offset,
+                visit.stmt.span.start.offset(),
                 &command.condition,
                 context,
                 "until",
             ) || body_header_matches(
                 source,
-                command.condition.span.end.offset,
+                command.condition.span.end.offset(),
                 &command.body,
                 &context,
                 "do",
             ) || body_opener_matches(
                 source,
-                command.condition.span.end.offset,
+                command.condition.span.end.offset(),
                 &command.body,
                 &context,
                 '{',
@@ -509,24 +509,24 @@ fn directive_can_apply_to_following_command(
         Command::Compound(CompoundCommand::Select(command)) => {
             body_header_matches(
                 source,
-                visit.stmt.span.start.offset,
+                visit.stmt.span.start.offset(),
                 &command.body,
                 &context,
                 "do",
             ) || body_opener_matches(
                 source,
-                visit.stmt.span.start.offset,
+                visit.stmt.span.start.offset(),
                 &command.body,
                 &context,
                 '{',
             )
         }
         Command::Compound(CompoundCommand::Subshell(body)) => body.first().is_some_and(|stmt| {
-            next_command_starts_after_comment_line(stmt.span.start.offset, &context)
+            next_command_starts_after_comment_line(stmt.span.start.offset(), &context)
                 && context.prefix.trim_end().ends_with('(')
         }),
         Command::Compound(CompoundCommand::BraceGroup(body)) => body.first().is_some_and(|stmt| {
-            next_command_starts_after_comment_line(stmt.span.start.offset, &context)
+            next_command_starts_after_comment_line(stmt.span.start.offset(), &context)
                 && context.prefix.trim_end().ends_with('{')
         }),
         _ => false,
@@ -554,17 +554,18 @@ fn case_label_directive(case: &CaseItem, comment: &NormalizedComment<'_>) -> boo
         return false;
     };
 
-    let Some(pattern_line) = u32::try_from(pattern.span.end.line).ok() else {
+    let Some(pattern_line) = u32::try_from(pattern.span.end.line()).ok() else {
         return false;
     };
-    if pattern_line != comment.line || usize::from(comment.range.start()) <= pattern.span.end.offset
+    if pattern_line != comment.line
+        || usize::from(comment.range.start()) <= pattern.span.end.offset()
     {
         return false;
     }
 
     case.body
         .first()
-        .is_none_or(|stmt| u32::try_from(stmt.span.start.line).ok() != Some(comment.line))
+        .is_none_or(|stmt| u32::try_from(stmt.span.start.line()).ok() != Some(comment.line))
 }
 
 fn strip_comment_prefix(text: &str) -> &str {
@@ -680,7 +681,7 @@ fn loop_header_matches(
     keyword: &str,
 ) -> bool {
     condition.first().is_some_and(|stmt| {
-        next_command_starts_after_comment_line(stmt.span.start.offset, &context)
+        next_command_starts_after_comment_line(stmt.span.start.offset(), &context)
             && command_start_segment_matches(source, command_start, context.comment_start, keyword)
     })
 }
@@ -693,7 +694,7 @@ fn body_header_matches(
     keyword: &str,
 ) -> bool {
     body.first().is_some_and(|stmt| {
-        next_command_starts_after_comment_line(stmt.span.start.offset, context)
+        next_command_starts_after_comment_line(stmt.span.start.offset(), context)
             && gap_segment_ends_with_keyword(source, header_end, context.comment_start, keyword)
     })
 }
@@ -706,7 +707,7 @@ fn body_opener_matches(
     opener: char,
 ) -> bool {
     body.first().is_some_and(|stmt| {
-        next_command_starts_after_comment_line(stmt.span.start.offset, context)
+        next_command_starts_after_comment_line(stmt.span.start.offset(), context)
             && gap_segment_ends_with_char(source, header_end, context.comment_start, opener)
     })
 }

--- a/crates/shuck-linter/src/suppression/index.rs
+++ b/crates/shuck-linter/src/suppression/index.rs
@@ -79,7 +79,7 @@ impl SuppressionIndex {
 pub(crate) fn first_statement_line(file: &File) -> Option<u32> {
     file.body
         .iter()
-        .filter_map(|command| u32::try_from(command.span.start.line).ok())
+        .filter_map(|command| u32::try_from(command.span.start.line()).ok())
         .min()
 }
 
@@ -146,22 +146,22 @@ pub(crate) fn sort_command_spans_for_lookup(spans: &mut [Span]) {
     // children during `next_command_range_after`.
     spans.sort_by(|left, right| {
         left.start
-            .offset
-            .cmp(&right.start.offset)
-            .then_with(|| right.end.offset.cmp(&left.end.offset))
+            .offset()
+            .cmp(&right.start.offset())
+            .then_with(|| right.end.offset().cmp(&left.end.offset()))
     });
 }
 
 fn next_command_range_after(spans: &[Span], offset: TextSize) -> Option<LineRange> {
     let offset = offset.to_u32() as usize;
-    let idx = spans.partition_point(|span| span.start.offset <= offset);
+    let idx = spans.partition_point(|span| span.start.offset() <= offset);
     spans.get(idx).copied().and_then(line_range)
 }
 
 fn line_range(span: Span) -> Option<LineRange> {
-    let start_line = u32::try_from(span.start.line).ok()?;
-    let mut end_line = u32::try_from(span.end.line).ok()?;
-    if span.end.offset > span.start.offset && span.end.column == 1 {
+    let start_line = u32::try_from(span.start.line()).ok()?;
+    let mut end_line = u32::try_from(span.end.line()).ok()?;
+    if span.end.offset() > span.start.offset() && span.end.column() == 1 {
         end_line = end_line.saturating_sub(1);
     }
 
@@ -235,13 +235,13 @@ fn extend_span_with_heredoc_body(span: &mut Span, parts: &[HeredocBodyPartNode])
 }
 
 fn extend_span(span: &mut Span, extension: Span) {
-    if extension.start.line == 0 || extension.end.line == 0 {
+    if extension.start.line() == 0 || extension.end.line() == 0 {
         return;
     }
-    if span.start.line == 0 || extension.start.offset < span.start.offset {
+    if span.start.line() == 0 || extension.start.offset() < span.start.offset() {
         span.start = extension.start;
     }
-    if span.end.line == 0 || extension.end.offset > span.end.offset {
+    if span.end.line() == 0 || extension.end.offset() > span.end.offset() {
         span.end = extension.end;
     }
 }

--- a/crates/shuck-linter/src/suppression/rewrite.rs
+++ b/crates/shuck-linter/src/suppression/rewrite.rs
@@ -65,7 +65,7 @@ pub fn add_ignores_to_path_with_resolvers(
     let target_lines = analysis
         .diagnostics
         .iter()
-        .map(|diagnostic| diagnostic.span.start.line)
+        .map(|diagnostic| diagnostic.span.start.line())
         .collect::<BTreeSet<_>>();
 
     for line in target_lines {
@@ -80,7 +80,7 @@ pub fn add_ignores_to_path_with_resolvers(
         let line_diagnostics = analysis
             .diagnostics
             .iter()
-            .filter(|diagnostic| diagnostic.span.start.line == line)
+            .filter(|diagnostic| diagnostic.span.start.line() == line)
             .cloned()
             .collect::<Vec<_>>();
         if line_diagnostics.is_empty() {
@@ -140,7 +140,7 @@ pub fn build_ignore_edit_for_line(
     let line_diagnostics = analysis
         .diagnostics
         .iter()
-        .filter(|diagnostic| diagnostic.span.start.line == line)
+        .filter(|diagnostic| diagnostic.span.start.line() == line)
         .cloned()
         .collect::<Vec<_>>();
     if line_diagnostics.is_empty() {
@@ -406,7 +406,7 @@ fn edit_is_valid(
     }
 
     if candidate.diagnostics.iter().any(|diagnostic| {
-        diagnostic.span.start.line == usize::try_from(line).unwrap_or_default()
+        diagnostic.span.start.line() == usize::try_from(line).unwrap_or_default()
             && target_rules.contains(&diagnostic.rule)
     }) {
         return false;
@@ -463,10 +463,10 @@ impl DiagnosticKey {
     fn new(diagnostic: &Diagnostic) -> Self {
         Self {
             rule: diagnostic.rule,
-            start_line: diagnostic.span.start.line,
-            start_column: diagnostic.span.start.column,
-            end_line: diagnostic.span.end.line,
-            end_column: diagnostic.span.end.column,
+            start_line: diagnostic.span.start.line(),
+            start_column: diagnostic.span.start.column(),
+            end_line: diagnostic.span.end.line(),
+            end_column: diagnostic.span.end.column(),
             message: diagnostic.message.clone(),
         }
     }
@@ -823,7 +823,7 @@ mod tests {
         let line_diagnostics = current
             .diagnostics
             .iter()
-            .filter(|diagnostic| diagnostic.span.start.line == 2)
+            .filter(|diagnostic| diagnostic.span.start.line() == 2)
             .cloned()
             .collect::<Vec<_>>();
 
@@ -860,7 +860,7 @@ mod tests {
         let line_diagnostics = current
             .diagnostics
             .iter()
-            .filter(|diagnostic| diagnostic.span.start.line == 2)
+            .filter(|diagnostic| diagnostic.span.start.line() == 2)
             .cloned()
             .collect::<Vec<_>>();
 

--- a/crates/shuck-linter/src/test.rs
+++ b/crates/shuck-linter/src/test.rs
@@ -181,8 +181,8 @@ pub fn print_diagnostics(diagnostics: &[Diagnostic], source: &str) -> String {
             output.push('\n');
         }
 
-        let line = diagnostic.span.start.line;
-        let col = diagnostic.span.start.column;
+        let line = diagnostic.span.start.line();
+        let col = diagnostic.span.start.column();
         let line_width = line.to_string().len();
 
         // Rule code + message

--- a/crates/shuck-parser/examples/dump_tokens.rs
+++ b/crates/shuck-parser/examples/dump_tokens.rs
@@ -25,10 +25,13 @@ fn main() {
 
     let mut lexer = Lexer::new(&input);
     while let Some(token) = lexer.next_lexed_token() {
-        if token.span.start.line >= start_line && token.span.start.line <= end_line {
+        if token.span.start.line() >= start_line && token.span.start.line() <= end_line {
             println!(
                 "{:>6}:{:<4} {:<30?} {:?}",
-                token.span.start.line, token.span.start.column, token.span, token
+                token.span.start.line(),
+                token.span.start.column(),
+                token.span,
+                token
             );
         }
     }

--- a/crates/shuck-parser/src/parser/arithmetic.rs
+++ b/crates/shuck-parser/src/parser/arithmetic.rs
@@ -1293,7 +1293,7 @@ impl<'a> ArithmeticParser<'a> {
     }
 
     fn error_at(&self, pos: Position, message: impl Into<String>) -> Error {
-        Error::parse_at(message, pos.line, pos.column)
+        Error::parse_at(message, pos.line(), pos.column())
     }
 
     fn tick(&mut self) -> Result<()> {

--- a/crates/shuck-parser/src/parser/brace_syntax.rs
+++ b/crates/shuck-parser/src/parser/brace_syntax.rs
@@ -17,11 +17,11 @@ impl<'a> Parser<'a> {
             brace_ccl_enabled,
             &mut brace_syntax,
         );
-        brace_syntax.sort_by_key(|brace| (brace.span.start.offset, brace.span.end.offset));
+        brace_syntax.sort_by_key(|brace| (brace.span.start.offset(), brace.span.end.offset()));
         brace_syntax.dedup_by_key(|brace| {
             (
-                brace.span.start.offset,
-                brace.span.end.offset,
+                brace.span.start.offset(),
+                brace.span.end.offset(),
                 brace.quote_context,
                 brace.kind,
             )
@@ -97,12 +97,12 @@ impl<'a> Parser<'a> {
             return false;
         }
 
-        let mut cursor = parts[0].span.start.offset;
+        let mut cursor = parts[0].span.start.offset();
         for part in parts {
-            if part.span.start.offset > cursor
+            if part.span.start.offset() > cursor
                 && self
                     .input
-                    .get(cursor..part.span.start.offset)
+                    .get(cursor..part.span.start.offset())
                     .is_some_and(|raw| raw.contains(['{', '}']))
             {
                 return true;
@@ -116,7 +116,7 @@ impl<'a> Parser<'a> {
                 | WordPart::DoubleQuoted { .. }
                 | WordPart::ZshQualifiedGlob(_) => self
                     .input
-                    .get(part.span.start.offset..part.span.end.offset)
+                    .get(part.span.start.offset()..part.span.end.offset())
                     .is_some_and(|raw| raw.contains(['{', '}'])),
                 WordPart::Variable(_)
                 | WordPart::CommandSubstitution { .. }
@@ -138,7 +138,7 @@ impl<'a> Parser<'a> {
                 return true;
             }
 
-            cursor = part.span.end.offset;
+            cursor = part.span.end.offset();
         }
 
         false
@@ -159,7 +159,9 @@ impl<'a> Parser<'a> {
                     );
                 }
                 WordPart::SingleQuoted { .. } => {
-                    if let Some(raw) = self.input.get(part.span.start.offset..part.span.end.offset)
+                    if let Some(raw) = self
+                        .input
+                        .get(part.span.start.offset()..part.span.end.offset())
                     {
                         Self::push_brace_scan_text(raw, part.span.start, out);
                     }
@@ -195,12 +197,12 @@ impl<'a> Parser<'a> {
         parts: &[WordPartNode],
         out: &mut Vec<(char, Position)>,
     ) {
-        let mut cursor_offset = span.start.offset;
+        let mut cursor_offset = span.start.offset();
         let mut cursor_position = span.start;
 
         for part in parts {
-            if part.span.start.offset > cursor_offset
-                && let Some(raw) = self.input.get(cursor_offset..part.span.start.offset)
+            if part.span.start.offset() > cursor_offset
+                && let Some(raw) = self.input.get(cursor_offset..part.span.start.offset())
             {
                 Self::push_brace_scan_text(raw, cursor_position, out);
             }
@@ -214,7 +216,9 @@ impl<'a> Parser<'a> {
                     );
                 }
                 WordPart::SingleQuoted { .. } => {
-                    if let Some(raw) = self.input.get(part.span.start.offset..part.span.end.offset)
+                    if let Some(raw) = self
+                        .input
+                        .get(part.span.start.offset()..part.span.end.offset())
                     {
                         Self::push_brace_scan_text(raw, part.span.start, out);
                     }
@@ -242,12 +246,12 @@ impl<'a> Parser<'a> {
                 }
             }
 
-            cursor_offset = part.span.end.offset;
+            cursor_offset = part.span.end.offset();
             cursor_position = part.span.end;
         }
 
-        if cursor_offset < span.end.offset
-            && let Some(raw) = self.input.get(cursor_offset..span.end.offset)
+        if cursor_offset < span.end.offset()
+            && let Some(raw) = self.input.get(cursor_offset..span.end.offset())
         {
             Self::push_brace_scan_text(raw, cursor_position, out);
         }
@@ -960,8 +964,8 @@ impl<'a> Parser<'a> {
         span: Span,
         source_backed: bool,
     ) -> Option<Word> {
-        let features = self.zsh_glob_parse_features_at(span.start.offset);
-        if !self.zsh_glob_word_parsing_enabled_at(span.start.offset)
+        let features = self.zsh_glob_parse_features_at(span.start.offset());
+        if !self.zsh_glob_word_parsing_enabled_at(span.start.offset())
             || text.is_empty()
             || text.contains('=')
             || text.contains(['\x00', '\\', '\'', '"', '$', '`'])

--- a/crates/shuck-parser/src/parser/commands/case.rs
+++ b/crates/shuck-parser/src/parser/commands/case.rs
@@ -82,12 +82,12 @@ impl<'a> Parser<'a> {
 
     pub(super) fn record_zsh_case_group_parts_from_current_case_header(&mut self) {
         let start = self.current_span.start;
-        let mut split_features = self.zsh_glob_parse_features_at(start.offset);
+        let mut split_features = self.zsh_glob_parse_features_at(start.offset());
         if self.dialect != ShellDialect::Zsh {
             split_features.bare_groups = true;
         }
 
-        let Some((pattern_spans, _)) = (if self.input[start.offset..].starts_with('(')
+        let Some((pattern_spans, _)) = (if self.input[start.offset()..].starts_with('(')
             && let Some(wrapper_close) = self.scan_zsh_case_group_close(start)
             && self.case_wrapper_close_is_arm_delimiter(wrapper_close)
         {
@@ -106,7 +106,7 @@ impl<'a> Parser<'a> {
         };
 
         for span in pattern_spans {
-            let mut features = self.zsh_glob_parse_features_at(span.start.offset);
+            let mut features = self.zsh_glob_parse_features_at(span.start.offset());
             if self.dialect != ShellDialect::Zsh {
                 features.bare_groups = true;
             }
@@ -166,7 +166,7 @@ impl<'a> Parser<'a> {
             .collect::<Vec<_>>();
 
         while self.current_token.is_some()
-            && self.current_span.start.offset < delimiter_span.end.offset
+            && self.current_span.start.offset() < delimiter_span.end.offset()
         {
             self.advance();
         }
@@ -189,7 +189,7 @@ impl<'a> Parser<'a> {
         &self,
         start: Position,
     ) -> Option<(Vec<Span>, Span)> {
-        if self.input[start.offset..].starts_with('(')
+        if self.input[start.offset()..].starts_with('(')
             && let Some(wrapper_close) = self.scan_zsh_case_group_close(start)
             && self.case_wrapper_close_is_arm_delimiter(wrapper_close)
         {
@@ -206,7 +206,7 @@ impl<'a> Parser<'a> {
     }
 
     pub(super) fn case_wrapper_close_is_arm_delimiter(&self, close_span: Span) -> bool {
-        self.input[close_span.end.offset..]
+        self.input[close_span.end.offset()..]
             .chars()
             .next()
             .is_none_or(char::is_whitespace)
@@ -215,7 +215,7 @@ impl<'a> Parser<'a> {
     pub(super) fn split_zsh_case_pattern_alternatives(&self, span: Span) -> Option<Vec<Span>> {
         self.split_zsh_case_pattern_alternatives_with_features(
             span,
-            self.zsh_glob_parse_features_at(span.start.offset),
+            self.zsh_glob_parse_features_at(span.start.offset()),
         )
     }
 
@@ -225,7 +225,7 @@ impl<'a> Parser<'a> {
         features: ZshGlobParseFeatures,
     ) -> Option<Vec<Span>> {
         let mut state = ZshCaseScanState::new(span.start);
-        let mut chars = self.input[span.start.offset..span.end.offset]
+        let mut chars = self.input[span.start.offset()..span.end.offset()]
             .chars()
             .peekable();
         let mut part_start = span.start;
@@ -353,7 +353,7 @@ impl<'a> Parser<'a> {
 
     pub(super) fn scan_zsh_case_group_close(&self, start: Position) -> Option<Span> {
         let mut state = ZshCaseScanState::new(start);
-        let mut chars = self.input[start.offset..].chars().peekable();
+        let mut chars = self.input[start.offset()..].chars().peekable();
 
         if Self::next_word_char_unwrap(&mut chars, &mut state.position) != '(' {
             return None;
@@ -443,7 +443,7 @@ impl<'a> Parser<'a> {
 
     pub(super) fn scan_zsh_case_arm_delimiter(&self, start: Position) -> Option<Span> {
         let mut state = ZshCaseScanState::new(start);
-        let mut chars = self.input[start.offset..].chars().peekable();
+        let mut chars = self.input[start.offset()..].chars().peekable();
 
         while let Some(ch) = chars.peek().copied() {
             let ch_start = state.position;

--- a/crates/shuck-parser/src/parser/commands/compound.rs
+++ b/crates/shuck-parser/src/parser/commands/compound.rs
@@ -440,9 +440,9 @@ impl<'a> Parser<'a> {
             return Error::parse(message);
         }
 
-        let rebased_line = base.line + line.saturating_sub(1);
+        let rebased_line = base.line() + line.saturating_sub(1);
         let rebased_column = if line == 1 {
-            base.column + column.saturating_sub(1)
+            base.column() + column.saturating_sub(1)
         } else {
             column
         };

--- a/crates/shuck-parser/src/parser/commands/conditionals.rs
+++ b/crates/shuck-parser/src/parser/commands/conditionals.rs
@@ -131,7 +131,7 @@ impl<'a> Parser<'a> {
                     let span = left_paren_span.merge(right_paren_span);
                     let text = span.slice(self.input).to_string();
                     while self.current_token.is_some()
-                        && self.current_span.start.offset < right_paren_span.end.offset
+                        && self.current_span.start.offset() < right_paren_span.end.offset()
                     {
                         self.advance();
                     }
@@ -271,7 +271,7 @@ impl<'a> Parser<'a> {
         stop_at_right_paren: bool,
         starts_with_paren: bool,
     ) -> Option<(String, Position)> {
-        if start.offset >= self.input.len() {
+        if start.offset() >= self.input.len() {
             return None;
         }
 
@@ -286,8 +286,8 @@ impl<'a> Parser<'a> {
         let mut escaped = false;
         let mut prev_char = None;
 
-        while cursor.offset < self.input.len() {
-            let rest = &self.input[cursor.offset..];
+        while cursor.offset() < self.input.len() {
+            let rest = &self.input[cursor.offset()..];
             if !in_single
                 && !in_double
                 && !in_backtick
@@ -311,7 +311,7 @@ impl<'a> Parser<'a> {
                 }
             }
 
-            let ch = self.input[cursor.offset..].chars().next()?;
+            let ch = self.input[cursor.offset()..].chars().next()?;
             cursor.advance(ch);
             text.push(ch);
 
@@ -351,8 +351,8 @@ impl<'a> Parser<'a> {
         stop_at_right_paren: bool,
     ) -> Option<(TokenKind, Span)> {
         let mut cursor = end;
-        while cursor.offset < self.input.len() {
-            let rest = &self.input[cursor.offset..];
+        while cursor.offset() < self.input.len() {
+            let rest = &self.input[cursor.offset()..];
             let ch = rest.chars().next()?;
             if matches!(ch, ' ' | '\t') {
                 cursor.advance(ch);
@@ -361,7 +361,7 @@ impl<'a> Parser<'a> {
             break;
         }
 
-        let rest = self.input.get(cursor.offset..)?;
+        let rest = self.input.get(cursor.offset()..)?;
         let (kind, text) = if rest.starts_with("]]") {
             (TokenKind::DoubleRightBracket, "]]")
         } else if rest.starts_with("&&") {
@@ -506,7 +506,7 @@ impl<'a> Parser<'a> {
             }
 
             if let Some(prev_end) = previous_end
-                && prev_end.offset < self.current_span.start.offset
+                && prev_end.offset() < self.current_span.start.offset()
             {
                 let gap_span = Span::from_positions(prev_end, self.current_span.start);
                 let gap_text = gap_span.slice(self.input);
@@ -681,7 +681,7 @@ impl<'a> Parser<'a> {
                 | Some(TokenKind::RedirectOut)
                 | Some(TokenKind::RedirectReadWrite) => {
                     let literal = self.input
-                        [self.current_span.start.offset..self.current_span.end.offset]
+                        [self.current_span.start.offset()..self.current_span.end.offset()]
                         .to_string();
                     if start.is_none() {
                         start = Some(self.current_span.start);
@@ -705,7 +705,7 @@ impl<'a> Parser<'a> {
                 }
                 _ => {
                     let literal = self.input
-                        [self.current_span.start.offset..self.current_span.end.offset]
+                        [self.current_span.start.offset()..self.current_span.end.offset()]
                         .to_string();
                     if literal.is_empty() {
                         break;
@@ -754,7 +754,7 @@ impl<'a> Parser<'a> {
             ));
         };
         while self.current_token.is_some()
-            && self.current_span.start.offset < right_paren_span.end.offset
+            && self.current_span.start.offset() < right_paren_span.end.offset()
         {
             self.advance();
         }
@@ -781,8 +781,8 @@ impl<'a> Parser<'a> {
         let mut in_backtick = false;
         let mut escaped = false;
 
-        while cursor.offset < self.input.len() {
-            let rest = &self.input[cursor.offset..];
+        while cursor.offset() < self.input.len() {
+            let rest = &self.input[cursor.offset()..];
 
             if !in_single && !in_double && !in_backtick {
                 if rest.starts_with("((") {

--- a/crates/shuck-parser/src/parser/commands/if_clause.rs
+++ b/crates/shuck-parser/src/parser/commands/if_clause.rs
@@ -114,8 +114,8 @@ impl<'a> Parser<'a> {
                 if elif_body.is_empty() {
                     if self.dialect == ShellDialect::Zsh
                         && self.has_recorded_comment_between(
-                            elif_body_region_start.offset,
-                            self.current_span.start.offset,
+                            elif_body_region_start.offset(),
+                            self.current_span.start.offset(),
                         )
                     {
                         Self::stmt_seq_with_span(
@@ -164,8 +164,8 @@ impl<'a> Parser<'a> {
                 if branch.is_empty() {
                     if self.dialect == ShellDialect::Zsh
                         && self.has_recorded_comment_between(
-                            else_region_start.offset,
-                            self.current_span.start.offset,
+                            else_region_start.offset(),
+                            self.current_span.start.offset(),
                         )
                     {
                         Some(Self::stmt_seq_with_span(

--- a/crates/shuck-parser/src/parser/commands/simple.rs
+++ b/crates/shuck-parser/src/parser/commands/simple.rs
@@ -325,8 +325,8 @@ impl<'a> Parser<'a> {
     }
 
     pub(super) fn word_is_attached_to_current_token(&self, word: &Word) -> bool {
-        let start = word.span.end.offset;
-        let end = self.current_span.start.offset;
+        let start = word.span.end.offset();
+        let end = self.current_span.start.offset();
         let input_len = self.input.len();
         start <= end
             && end <= input_len

--- a/crates/shuck-parser/src/parser/comments.rs
+++ b/crates/shuck-parser/src/parser/comments.rs
@@ -7,11 +7,11 @@ impl<'a> Parser<'a> {
 
     pub(super) fn is_inline_comment(source: &str, stmt: &Stmt, comment: Comment) -> bool {
         let comment_start = Self::comment_start(comment);
-        if comment_start < stmt.span.end.offset {
+        if comment_start < stmt.span.end.offset() {
             return false;
         }
         source
-            .get(stmt.span.end.offset..comment_start)
+            .get(stmt.span.end.offset()..comment_start)
             .is_some_and(|gap| !gap.contains('\n'))
     }
 
@@ -48,20 +48,20 @@ impl<'a> Parser<'a> {
                 .trailing_comments
                 .extend(Self::take_comments_before(
                     comments,
-                    sequence.span.end.offset,
+                    sequence.span.end.offset(),
                 ));
             return;
         }
 
         for (index, stmt) in sequence.stmts.iter_mut().enumerate() {
-            let leading = Self::take_comments_before(comments, stmt.span.start.offset);
+            let leading = Self::take_comments_before(comments, stmt.span.start.offset());
             if index == 0 {
                 sequence.leading_comments.extend(leading);
             } else {
                 stmt.leading_comments.extend(leading);
             }
 
-            let mut nested = Self::take_comments_before(comments, stmt.span.end.offset);
+            let mut nested = Self::take_comments_before(comments, stmt.span.end.offset());
             Self::attach_comments_to_stmt_with_source(source, stmt, &mut nested);
             if !nested.is_empty() {
                 stmt.leading_comments.extend(nested);
@@ -80,7 +80,7 @@ impl<'a> Parser<'a> {
             .trailing_comments
             .extend(Self::take_comments_before(
                 comments,
-                sequence.span.end.offset,
+                sequence.span.end.offset(),
             ));
     }
 
@@ -92,7 +92,7 @@ impl<'a> Parser<'a> {
         match &mut stmt.command {
             AstCommand::Binary(binary) => {
                 let mut left_comments =
-                    Self::take_comments_before(comments, binary.left.span.end.offset);
+                    Self::take_comments_before(comments, binary.left.span.end.offset());
                 Self::attach_comments_to_stmt_with_source(
                     source,
                     binary.left.as_mut(),
@@ -149,7 +149,7 @@ impl<'a> Parser<'a> {
         match command {
             CompoundCommand::If(command) => {
                 let mut condition =
-                    Self::take_comments_before(comments, command.condition.span.end.offset);
+                    Self::take_comments_before(comments, command.condition.span.end.offset());
                 Self::attach_comments_to_stmt_seq_with_source(
                     source,
                     &mut command.condition,
@@ -158,7 +158,7 @@ impl<'a> Parser<'a> {
                 command.condition.trailing_comments.extend(condition);
 
                 let mut then_branch =
-                    Self::take_comments_before(comments, command.then_branch.span.end.offset);
+                    Self::take_comments_before(comments, command.then_branch.span.end.offset());
                 Self::attach_comments_to_stmt_seq_with_source(
                     source,
                     &mut command.then_branch,
@@ -168,7 +168,7 @@ impl<'a> Parser<'a> {
 
                 for (condition_seq, body_seq) in &mut command.elif_branches {
                     let mut elif_condition =
-                        Self::take_comments_before(comments, condition_seq.span.end.offset);
+                        Self::take_comments_before(comments, condition_seq.span.end.offset());
                     Self::attach_comments_to_stmt_seq_with_source(
                         source,
                         condition_seq,
@@ -177,7 +177,7 @@ impl<'a> Parser<'a> {
                     condition_seq.trailing_comments.extend(elif_condition);
 
                     let mut elif_body =
-                        Self::take_comments_before(comments, body_seq.span.end.offset);
+                        Self::take_comments_before(comments, body_seq.span.end.offset());
                     Self::attach_comments_to_stmt_seq_with_source(source, body_seq, &mut elif_body);
                     body_seq.trailing_comments.extend(elif_body);
                 }
@@ -230,7 +230,7 @@ impl<'a> Parser<'a> {
             }
             CompoundCommand::While(command) => {
                 let mut condition =
-                    Self::take_comments_before(comments, command.condition.span.end.offset);
+                    Self::take_comments_before(comments, command.condition.span.end.offset());
                 Self::attach_comments_to_stmt_seq_with_source(
                     source,
                     &mut command.condition,
@@ -248,7 +248,7 @@ impl<'a> Parser<'a> {
             }
             CompoundCommand::Until(command) => {
                 let mut condition =
-                    Self::take_comments_before(comments, command.condition.span.end.offset);
+                    Self::take_comments_before(comments, command.condition.span.end.offset());
                 Self::attach_comments_to_stmt_seq_with_source(
                     source,
                     &mut command.condition,
@@ -267,7 +267,7 @@ impl<'a> Parser<'a> {
             CompoundCommand::Case(command) => {
                 for case in &mut command.cases {
                     let mut body_comments =
-                        Self::take_comments_before(comments, case.body.span.end.offset);
+                        Self::take_comments_before(comments, case.body.span.end.offset());
                     Self::attach_comments_to_stmt_seq_with_source(
                         source,
                         &mut case.body,
@@ -292,7 +292,7 @@ impl<'a> Parser<'a> {
             }
             CompoundCommand::Always(command) => {
                 let mut body_comments =
-                    Self::take_comments_before(comments, command.body.span.end.offset);
+                    Self::take_comments_before(comments, command.body.span.end.offset());
                 Self::attach_comments_to_stmt_seq_with_source(
                     source,
                     &mut command.body,

--- a/crates/shuck-parser/src/parser/cursor.rs
+++ b/crates/shuck-parser/src/parser/cursor.rs
@@ -169,7 +169,7 @@ impl<'a> Parser<'a> {
             return false;
         }
 
-        let Some(tail) = self.input.get(self.current_span.end.offset..) else {
+        let Some(tail) = self.input.get(self.current_span.end.offset()..) else {
             return false;
         };
         let tail = tail.trim_start_matches([' ', '\t']);

--- a/crates/shuck-parser/src/parser/diagnostics.rs
+++ b/crates/shuck-parser/src/parser/diagnostics.rs
@@ -5,8 +5,8 @@ impl<'a> Parser<'a> {
     pub(super) fn error(&self, message: impl Into<String>) -> Error {
         Error::parse_at(
             message,
-            self.current_span.start.line,
-            self.current_span.start.column,
+            self.current_span.start.line(),
+            self.current_span.start.column(),
         )
     }
 

--- a/crates/shuck-parser/src/parser/entry.rs
+++ b/crates/shuck-parser/src/parser/entry.rs
@@ -235,7 +235,7 @@ impl<'a> Parser<'a> {
         shell_profile: ShellProfile,
     ) -> Word {
         let mut parser = Parser::with_limits_and_profile(text, max_depth, max_fuel, shell_profile);
-        let source_backed = span.end.offset <= source.len() && span.slice(source) == text;
+        let source_backed = span.end.offset() <= source.len() && span.slice(source) == text;
         let start = Position::new();
         let fragment_span = Span::from_positions(start, start.advanced_by(text));
         let mut word = parser.parse_word_with_context(text, fragment_span, start, source_backed);

--- a/crates/shuck-parser/src/parser/lexer/cursor.rs
+++ b/crates/shuck-parser/src/parser/lexer/cursor.rs
@@ -214,7 +214,7 @@ impl<'a> Lexer<'a> {
         end: Position,
     ) {
         if capture.is_none() {
-            *capture = Some(self.input[start.offset..end.offset].to_string());
+            *capture = Some(self.input[start.offset()..end.offset()].to_string());
         }
     }
 
@@ -297,7 +297,7 @@ impl<'a> Lexer<'a> {
     ) -> &'b str {
         capture
             .as_deref()
-            .unwrap_or(&self.input[start.offset..self.offset])
+            .unwrap_or(&self.input[start.offset()..self.offset])
     }
 
     pub(in crate::parser) fn current_word_surface_is_single_char(

--- a/crates/shuck-parser/src/parser/lexer/heredoc.rs
+++ b/crates/shuck-parser/src/parser/lexer/heredoc.rs
@@ -173,7 +173,7 @@ impl<'a> Lexer<'a> {
         // parser. Always replay a terminating newline so parsing stops before
         // tokens that originally lived on later source lines, like `}` or `do`.
         let post_heredoc_offset = self.offset;
-        self.offset = rest_of_line_start.offset;
+        self.offset = rest_of_line_start.offset();
         for ch in rest_of_line.chars() {
             self.reinject_buf.push_back(ch);
         }

--- a/crates/shuck-parser/src/parser/lexer/mod.rs
+++ b/crates/shuck-parser/src/parser/lexer/mod.rs
@@ -68,12 +68,12 @@ impl TokenText<'_> {
     fn into_shared<'a>(self, source: &Arc<str>, span: Option<Span>) -> TokenText<'a> {
         match self {
             Self::Borrowed(text) => span
-                .filter(|span| span.end.offset <= source.len())
+                .filter(|span| span.end.offset() <= source.len())
                 .map_or_else(
                     || TokenText::Owned(text.to_string()),
                     |span| TokenText::Shared {
                         source: Arc::clone(source),
-                        range: span.start.offset..span.end.offset,
+                        range: span.start.offset()..span.end.offset(),
                     },
                 ),
             Self::Shared { source, range } => TokenText::Shared { source, range },
@@ -532,8 +532,9 @@ impl<'a> LexedToken<'a> {
             return None;
         }
 
-        (self.span.start.offset <= self.span.end.offset && self.span.end.offset <= source.len())
-            .then(|| &source[self.span.start.offset..self.span.end.offset])
+        (self.span.start.offset() <= self.span.end.offset()
+            && self.span.end.offset() <= source.len())
+        .then(|| &source[self.span.start.offset()..self.span.end.offset()])
     }
 
     /// Return the file-descriptor payload for redirection tokens that carry one.
@@ -669,12 +670,12 @@ impl<'a> PositionMap<'a> {
     }
 
     fn position(&mut self, offset: usize) -> Position {
-        if offset == self.cached.offset {
+        if offset == self.cached.offset() {
             return self.cached;
         }
 
-        let position = if offset > self.cached.offset && offset <= self.source.len() {
-            Self::advance_from(self.cached, &self.source[self.cached.offset..offset])
+        let position = if offset > self.cached.offset() && offset <= self.source.len() {
+            Self::advance_from(self.cached, &self.source[self.cached.offset()..offset])
         } else {
             self.position_uncached(offset)
         };
@@ -696,36 +697,33 @@ impl<'a> PositionMap<'a> {
             line_text.chars().count() + 1
         };
 
-        Position {
-            line: line_index + 1,
-            column,
-            offset,
-        }
+        Position::at(line_index + 1, column, offset)
     }
 
-    fn advance_from(mut position: Position, text: &str) -> Position {
-        position.offset += text.len();
+    fn advance_from(position: Position, text: &str) -> Position {
+        let offset = position.offset() + text.len();
         let newline_count = memchr_iter(b'\n', text.as_bytes()).count();
         if newline_count == 0 {
-            position.column += if text.is_ascii() {
-                text.len()
-            } else {
-                text.chars().count()
-            };
-            return position;
+            let column = position.column()
+                + if text.is_ascii() {
+                    text.len()
+                } else {
+                    text.chars().count()
+                };
+            return Position::at(position.line(), column, offset);
         }
 
-        position.line += newline_count;
+        let line = position.line() + newline_count;
         let tail_start = memrchr(b'\n', text.as_bytes())
             .map(|index| index + 1)
             .unwrap_or_default();
         let tail = &text[tail_start..];
-        position.column = if tail.is_ascii() {
+        let column = if tail.is_ascii() {
             tail.len() + 1
         } else {
             tail.chars().count() + 1
         };
-        position
+        Position::at(line, column, offset)
     }
 }
 

--- a/crates/shuck-parser/src/parser/lexer/quotes.rs
+++ b/crates/shuck-parser/src/parser/lexer/quotes.rs
@@ -73,7 +73,7 @@ impl<'a> Lexer<'a> {
         if can_borrow {
             Ok(LexedWordSegment::borrowed_with_spans(
                 LexedWordSegmentKind::SingleQuoted,
-                &self.input[content_start.offset..content_end.offset],
+                &self.input[content_start.offset()..content_end.offset()],
                 content_span,
                 wrapper_span,
             ))
@@ -480,7 +480,7 @@ impl<'a> Lexer<'a> {
                 } else {
                     LexedWordSegmentKind::DoubleQuoted
                 },
-                &self.input[content_start.offset..content_end.offset],
+                &self.input[content_start.offset()..content_end.offset()],
                 content_span,
                 wrapper_span,
             ))

--- a/crates/shuck-parser/src/parser/lexer/tests/heredoc.rs
+++ b/crates/shuck-parser/src/parser/lexer/tests/heredoc.rs
@@ -273,8 +273,8 @@ fn test_heredoc_span_does_not_leak() {
     assert_next_token(&mut lexer, TokenKind::Word, Some("EOF"));
 
     let heredoc = lexer.read_heredoc("EOF", false);
-    let start = heredoc.content_span.start.offset;
-    let end = heredoc.content_span.end.offset;
+    let start = heredoc.content_span.start.offset();
+    let end = heredoc.content_span.end.offset();
     assert!(
         end <= source.len(),
         "heredoc span end ({end}) exceeds source length ({})",
@@ -397,8 +397,8 @@ fn test_heredoc_with_unicode_content() {
 
     let heredoc = lexer.read_heredoc("EOF", false);
     assert_eq!(heredoc.content, "# 你好\ncafé\n");
-    let start = heredoc.content_span.start.offset;
-    let end = heredoc.content_span.end.offset;
+    let start = heredoc.content_span.start.offset();
+    let end = heredoc.content_span.end.offset();
     assert!(
         source.is_char_boundary(start),
         "heredoc span start ({start}) not on char boundary"

--- a/crates/shuck-parser/src/parser/lexer/tests/mod.rs
+++ b/crates/shuck-parser/src/parser/lexer/tests/mod.rs
@@ -41,7 +41,8 @@ fn assert_non_newline_tokens_stay_on_one_line(input: &str) {
         }
 
         assert_eq!(
-            token.span.start.line, token.span.end.line,
+            token.span.start.line(),
+            token.span.end.line(),
             "token should stay on one line: {:?}",
             token
         );

--- a/crates/shuck-parser/src/parser/lexer/tests/quotes.rs
+++ b/crates/shuck-parser/src/parser/lexer/tests/quotes.rs
@@ -28,10 +28,10 @@ fn test_unterminated_segmented_quote_error_span_starts_at_quote() {
 
     assert_eq!(token.kind, TokenKind::Error);
     assert_eq!(token.error_kind(), Some(LexerErrorKind::DoubleQuote));
-    assert_eq!(token.span.start.line, 1);
-    assert_eq!(token.span.start.column, 10);
-    assert_eq!(token.span.start.offset, 9);
-    assert_eq!(token.span.end.offset, source.len());
+    assert_eq!(token.span.start.line(), 1);
+    assert_eq!(token.span.start.column(), 10);
+    assert_eq!(token.span.start.offset(), 9);
+    assert_eq!(token.span.end.offset(), source.len());
 }
 
 #[test]

--- a/crates/shuck-parser/src/parser/lexer/tests/tokens.rs
+++ b/crates/shuck-parser/src/parser/lexer/tests/tokens.rs
@@ -90,10 +90,10 @@ fn test_comment_token_with_span() {
     let comment = lexer.next_lexed_token_with_comments().unwrap();
     assert_eq!(comment.kind, TokenKind::Comment);
     assert_eq!(token_text(&comment, lexer.input).as_deref(), Some(" lead"));
-    assert_eq!(comment.span.start.line, 1);
-    assert_eq!(comment.span.start.column, 1);
-    assert_eq!(comment.span.end.line, 1);
-    assert_eq!(comment.span.end.column, 7);
+    assert_eq!(comment.span.start.line(), 1);
+    assert_eq!(comment.span.start.column(), 1);
+    assert_eq!(comment.span.end.line(), 1);
+    assert_eq!(comment.span.end.column(), 7);
 
     assert_next_token(&mut lexer, TokenKind::Newline, None);
     assert_next_token(&mut lexer, TokenKind::Word, Some("echo"));
@@ -102,8 +102,8 @@ fn test_comment_token_with_span() {
     let inline = lexer.next_lexed_token_with_comments().unwrap();
     assert_eq!(inline.kind, TokenKind::Comment);
     assert_eq!(token_text(&inline, lexer.input).as_deref(), Some(" tail"));
-    assert_eq!(inline.span.start.line, 2);
-    assert_eq!(inline.span.start.column, 9);
+    assert_eq!(inline.span.start.line(), 2);
+    assert_eq!(inline.span.start.column(), 9);
 }
 
 #[test]
@@ -153,8 +153,8 @@ fn test_comment_with_unicode() {
         Some(" café résumé")
     );
     // Span should cover exactly the comment bytes (including #)
-    let start = comment.span.start.offset;
-    let end = comment.span.end.offset;
+    let start = comment.span.start.offset();
+    let end = comment.span.end.offset();
     assert_eq!(start, 0);
     assert_eq!(&source[start..end], "# café résumé");
     assert!(source.is_char_boundary(start));
@@ -176,8 +176,8 @@ fn test_comment_with_cjk_characters() {
         token_text(&comment, lexer.input).as_deref(),
         Some(" 你好世界")
     );
-    let start = comment.span.start.offset;
-    let end = comment.span.end.offset;
+    let start = comment.span.start.offset();
+    let end = comment.span.end.offset();
     assert_eq!(&source[start..end], "# 你好世界");
     assert!(source.is_char_boundary(start));
     assert!(source.is_char_boundary(end));

--- a/crates/shuck-parser/src/parser/lexer/word.rs
+++ b/crates/shuck-parser/src/parser/lexer/word.rs
@@ -119,7 +119,7 @@ impl<'a> Lexer<'a> {
                     .is_none_or(|byte| byte.is_ascii())
             {
                 self.consume_source_bytes(ascii_len);
-                &self.input[start.offset..self.offset]
+                &self.input[start.offset()..self.offset]
             } else {
                 let chunk = self.cursor.eat_while(Self::is_plain_word_char);
                 self.advance_scanned_source_bytes(chunk.len());
@@ -147,7 +147,7 @@ impl<'a> Lexer<'a> {
                     let end = self.current_position();
                     return Some(LexedToken::borrowed_word(
                         TokenKind::Word,
-                        &self.input[start.offset..self.offset],
+                        &self.input[start.offset()..self.offset],
                         Some(Span::from_positions(start, end)),
                     ));
                 }
@@ -164,7 +164,7 @@ impl<'a> Lexer<'a> {
                 let end = self.current_position();
                 return self.finish_segmented_word(LexedWord::borrowed(
                     LexedWordSegmentKind::Plain,
-                    &self.input[start.offset..self.offset],
+                    &self.input[start.offset()..self.offset],
                     Some(Span::from_positions(start, end)),
                 ));
             }
@@ -219,7 +219,7 @@ impl<'a> Lexer<'a> {
             } else if ch == '$' {
                 let expansion_start = self.current_position();
                 if matches!(self.second_char(), Some('\'') | Some('"'))
-                    && (self.current_position().offset > start.offset
+                    && (self.current_position().offset() > start.offset()
                         || word.as_ref().is_some_and(|word| !word.is_empty()))
                 {
                     break;
@@ -488,7 +488,7 @@ impl<'a> Lexer<'a> {
             let end = self.current_position();
             Ok(LexedWordSegment::borrowed(
                 LexedWordSegmentKind::Plain,
-                &self.input[start.offset..self.offset],
+                &self.input[start.offset()..self.offset],
                 Some(Span::from_positions(start, end)),
             ))
         }
@@ -509,7 +509,7 @@ impl<'a> Lexer<'a> {
                     .is_none_or(|byte| byte.is_ascii())
             {
                 self.consume_source_bytes(ascii_len);
-                &self.input[start.offset..self.offset]
+                &self.input[start.offset()..self.offset]
             } else {
                 let chunk = self.cursor.eat_while(Self::is_plain_word_char);
                 self.advance_scanned_source_bytes(chunk.len());
@@ -522,7 +522,7 @@ impl<'a> Lexer<'a> {
             let end = self.current_position();
             return Some(LexedWordSegment::borrowed(
                 LexedWordSegmentKind::Plain,
-                &self.input[start.offset..self.offset],
+                &self.input[start.offset()..self.offset],
                 Some(Span::from_positions(start, end)),
             ));
         }
@@ -644,7 +644,7 @@ impl<'a> Lexer<'a> {
         } else {
             Some(LexedWordSegment::borrowed_with_spans(
                 LexedWordSegmentKind::Plain,
-                &self.input[start.offset..end.offset],
+                &self.input[start.offset()..end.offset()],
                 span,
                 span,
             ))

--- a/crates/shuck-parser/src/parser/recovery.rs
+++ b/crates/shuck-parser/src/parser/recovery.rs
@@ -39,7 +39,7 @@ impl<'a> Parser<'a> {
                 break;
             }
 
-            let before_offset = self.current_span.start.offset;
+            let before_offset = self.current_span.start.offset();
             self.advance();
             advanced = true;
 
@@ -47,8 +47,8 @@ impl<'a> Parser<'a> {
                 break;
             }
 
-            if self.current_span.start.offset > failed_offset
-                && before_offset != self.current_span.start.offset
+            if self.current_span.start.offset() > failed_offset
+                && before_offset != self.current_span.start.offset()
             {
                 continue;
             }
@@ -65,7 +65,7 @@ impl<'a> Parser<'a> {
         let mut terminal_error = None;
 
         while self.current_token.is_some() {
-            let checkpoint = self.current_span.start.offset;
+            let checkpoint = self.current_span.start.offset();
 
             if let Err(error) = self.tick() {
                 diagnostics.push(self.parse_diagnostic_from_error(error.clone()));
@@ -82,7 +82,7 @@ impl<'a> Parser<'a> {
                 let recovered = self.recover_to_command_boundary(checkpoint);
                 if recovered
                     || (self.current_token.is_some()
-                        && self.current_span.start.offset < self.input.len())
+                        && self.current_span.start.offset() < self.input.len())
                 {
                     terminal_error.get_or_insert(error);
                 }
@@ -95,7 +95,7 @@ impl<'a> Parser<'a> {
                 break;
             }
 
-            let command_start = self.current_span.start.offset;
+            let command_start = self.current_span.start.offset();
             match self.parse_command_list_required() {
                 Ok(command_stmts) => {
                     self.apply_stmt_list_effects(&command_stmts);
@@ -106,7 +106,7 @@ impl<'a> Parser<'a> {
                     let recovered = self.recover_to_command_boundary(command_start);
                     if recovered
                         || (self.current_token.is_some()
-                            && self.current_span.start.offset < self.input.len())
+                            && self.current_span.start.offset() < self.input.len())
                     {
                         terminal_error.get_or_insert(error);
                     }

--- a/crates/shuck-parser/src/parser/redirects.rs
+++ b/crates/shuck-parser/src/parser/redirects.rs
@@ -377,10 +377,10 @@ impl<'a> Parser<'a> {
         let mut redirects = SmallVec::<[Redirect; 1]>::new();
         let mut pending_fd_var = None;
         loop {
-            let current_end = self.current_span.end.offset;
+            let current_end = self.current_span.end.offset();
             let next_token = self
                 .peek_next()
-                .map(|token| (token.kind, token.span.start.offset));
+                .map(|token| (token.kind, token.span.start.offset()));
             let input_len = self.input.len();
             if pending_fd_var.is_none()
                 && let Some((fd_var, fd_var_span)) = self.current_fd_var()

--- a/crates/shuck-parser/src/parser/result.rs
+++ b/crates/shuck-parser/src/parser/result.rs
@@ -96,8 +96,8 @@ impl ParseResult {
             };
             Error::parse_at(
                 diagnostic.message.clone(),
-                diagnostic.span.start.line,
-                diagnostic.span.start.column,
+                diagnostic.span.start.line(),
+                diagnostic.span.start.column(),
             )
         })
     }

--- a/crates/shuck-parser/src/parser/source_tree.rs
+++ b/crates/shuck-parser/src/parser/source_tree.rs
@@ -30,7 +30,7 @@ impl<'a> Parser<'a> {
         start: Position,
         end: Position,
     ) -> StmtSeq {
-        if start.offset > end.offset || end.offset > self.input.len() {
+        if start.offset() > end.offset() || end.offset() > self.input.len() {
             return StmtSeq {
                 leading_comments: Vec::new(),
                 stmts: Vec::new(),
@@ -38,7 +38,7 @@ impl<'a> Parser<'a> {
                 span: Span::from_positions(start, start),
             };
         }
-        let source = &self.input[start.offset..end.offset];
+        let source = &self.input[start.offset()..end.offset()];
         self.nested_stmt_seq_from_source(source, start)
     }
 
@@ -55,7 +55,7 @@ impl<'a> Parser<'a> {
     }
 
     pub(super) fn optional_span(start: Position, end: Position) -> Option<Span> {
-        (start.offset < end.offset).then(|| Span::from_positions(start, end))
+        (start.offset() < end.offset()).then(|| Span::from_positions(start, end))
     }
 
     pub(super) fn split_nested_arithmetic_close(&mut self, context: &'static str) -> Result<Span> {
@@ -130,7 +130,7 @@ impl<'a> Parser<'a> {
     }
 
     pub(super) fn rebase_comments(comments: &mut [Comment], base: Position) {
-        let base_offset = TextSize::new(base.offset as u32);
+        let base_offset = TextSize::new(base.offset() as u32);
         for comment in comments {
             comment.range = comment.range.offset_by(base_offset);
         }
@@ -150,7 +150,7 @@ impl<'a> Parser<'a> {
         Self::rebase_comments(&mut stmt.leading_comments, base);
         stmt.terminator_span = stmt.terminator_span.map(|span| span.rebased(base));
         if let Some(comment) = &mut stmt.inline_comment {
-            let base_offset = TextSize::new(base.offset as u32);
+            let base_offset = TextSize::new(base.offset() as u32);
             comment.range = comment.range.offset_by(base_offset);
         }
         Self::rebase_redirects(&mut stmt.redirects, base);

--- a/crates/shuck-parser/src/parser/tests/commands/conditionals.rs
+++ b/crates/shuck-parser/src/parser/tests/commands/conditionals.rs
@@ -86,8 +86,8 @@ fn test_parse_conditional_builds_structured_logical_ast() {
     assert_eq!(binary.op, ConditionalBinaryOp::And);
     assert!(matches!(binary.left.as_ref(), ConditionalExpr::Word(_)));
     assert!(matches!(binary.right.as_ref(), ConditionalExpr::Word(_)));
-    assert_eq!(command.left_bracket_span.start.column, 1);
-    assert_eq!(command.right_bracket_span.start.column, 19);
+    assert_eq!(command.left_bracket_span.start.column(), 1);
+    assert_eq!(command.right_bracket_span.start.column(), 19);
 }
 
 #[test]

--- a/crates/shuck-parser/src/parser/tests/commands/recovery.rs
+++ b/crates/shuck-parser/src/parser/tests/commands/recovery.rs
@@ -26,7 +26,7 @@ fn test_parse_recovered_skips_invalid_command_and_continues() {
     assert_eq!(recovered.file.body.len(), 2);
     assert_eq!(recovered.diagnostics.len(), 1);
     assert_eq!(recovered.diagnostics[0].message, "expected word");
-    assert_eq!(recovered.diagnostics[0].span.start.line, 2);
+    assert_eq!(recovered.diagnostics[0].span.start.line(), 2);
 
     let first = expect_simple(&recovered.file.body[0]);
     assert_eq!(first.name.render(input), "echo");

--- a/crates/shuck-parser/src/parser/tests/heredocs.rs
+++ b/crates/shuck-parser/src/parser/tests/heredocs.rs
@@ -322,9 +322,9 @@ EOF
         "$(eval echo \\$$(echo cfgtest_${name}))"
     );
     assert_eq!(inner.span.slice(input), "$(echo cfgtest_${name})");
-    assert_eq!(inner.span.start.line, 4);
-    assert_eq!(inner.span.start.column, 21);
-    assert_eq!(inner.span.end.column, 44);
+    assert_eq!(inner.span.start.line(), 4);
+    assert_eq!(inner.span.start.column(), 21);
+    assert_eq!(inner.span.end.column(), 44);
 }
 
 #[test]

--- a/crates/shuck-parser/src/parser/tests/redirects.rs
+++ b/crates/shuck-parser/src/parser/tests/redirects.rs
@@ -353,16 +353,16 @@ fn test_leaf_spans_track_words_assignments_and_redirects() {
         panic!("expected simple command");
     };
 
-    assert_eq!(command.assignments[0].span.start.line, 1);
-    assert_eq!(command.assignments[0].span.start.column, 1);
-    assert_eq!(command.name.span.start.column, 9);
-    assert_eq!(command.args[0].span.start.column, 14);
-    assert_eq!(script.body[0].redirects[0].span.start.column, 17);
+    assert_eq!(command.assignments[0].span.start.line(), 1);
+    assert_eq!(command.assignments[0].span.start.column(), 1);
+    assert_eq!(command.name.span.start.column(), 9);
+    assert_eq!(command.args[0].span.start.column(), 14);
+    assert_eq!(script.body[0].redirects[0].span.start.column(), 17);
     assert_eq!(
         redirect_word_target(&script.body[0].redirects[0])
             .span
             .start
-            .column,
+            .column(),
         19
     );
 }

--- a/crates/shuck-parser/src/parser/tests/words/expansions.rs
+++ b/crates/shuck-parser/src/parser/tests/words/expansions.rs
@@ -875,8 +875,8 @@ echo \"script
 
     assert_eq!(inner.name.span.slice(input), "basename");
     assert_eq!(inner.args[0].span.slice(input), "$child");
-    assert_eq!(inner.args[0].span.start.line, 3);
-    assert_eq!(inner.args[0].span.start.column, 29);
+    assert_eq!(inner.args[0].span.start.line(), 3);
+    assert_eq!(inner.args[0].span.start.column(), 29);
 }
 
 #[test]
@@ -2001,7 +2001,7 @@ fn test_read_replacement_pattern_stops_before_unescaped_delimiter() {
 
     let pattern = parser.read_replacement_pattern(&mut chars, &mut cursor, true);
     assert_eq!(pattern.slice(input), "\\\\");
-    assert_eq!(cursor.offset, offset + 2);
+    assert_eq!(cursor.offset(), offset + 2);
 }
 
 #[test]
@@ -2189,10 +2189,10 @@ fn test_command_substitution_spans_are_absolute() {
     assert_eq!(*syntax, CommandSubstitutionSyntax::DollarParen);
     let inner = expect_simple(&commands[0]);
 
-    assert_eq!(inner.name.span.start.line, 2);
-    assert_eq!(inner.name.span.start.column, 3);
-    assert_eq!(inner.args[0].span.start.line, 2);
-    assert_eq!(inner.args[1].span.start.column, 17);
+    assert_eq!(inner.name.span.start.line(), 2);
+    assert_eq!(inner.name.span.start.column(), 3);
+    assert_eq!(inner.args[0].span.start.line(), 2);
+    assert_eq!(inner.args[1].span.start.column(), 17);
 }
 
 #[test]

--- a/crates/shuck-parser/src/parser/tests/words/integration.rs
+++ b/crates/shuck-parser/src/parser/tests/words/integration.rs
@@ -25,9 +25,9 @@ fn test_unterminated_double_quote_reports_segment_start() {
     let parsed = Parser::new(&input).parse();
     let diagnostic = parsed.diagnostics.first().unwrap();
 
-    assert_eq!(diagnostic.span.start.line, 27);
-    assert_eq!(diagnostic.span.start.column, 9);
-    assert_eq!(diagnostic.span.start.offset, input.find('"').unwrap());
+    assert_eq!(diagnostic.span.start.line(), 27);
+    assert_eq!(diagnostic.span.start.column(), 9);
+    assert_eq!(diagnostic.span.start.offset(), input.find('"').unwrap());
 
     let Error::Parse { line, column, .. } = parsed.strict_error();
     assert_eq!((line, column), (27, 9));
@@ -44,8 +44,8 @@ fn test_unterminated_multiline_quotes_report_their_opening_tokens() {
         let parsed = Parser::new(input).parse();
         let diagnostic = parsed.diagnostics.first().unwrap();
 
-        assert_eq!(diagnostic.span.start.line, 1, "{input:?}");
-        assert_eq!(diagnostic.span.start.column, expected_column, "{input:?}");
+        assert_eq!(diagnostic.span.start.line(), 1, "{input:?}");
+        assert_eq!(diagnostic.span.start.column(), expected_column, "{input:?}");
     }
 }
 
@@ -98,9 +98,9 @@ fn test_process_substitution_spans_are_absolute() {
     assert!(*is_input);
 
     let inner = expect_simple(&commands[0]);
-    assert_eq!(inner.name.span.start.line, 2);
-    assert_eq!(inner.name.span.start.column, 3);
-    assert_eq!(inner.args[1].span.start.column, 17);
+    assert_eq!(inner.name.span.start.line(), 2);
+    assert_eq!(inner.name.span.start.column(), 3);
+    assert_eq!(inner.args[1].span.start.column(), 17);
 }
 
 #[test]

--- a/crates/shuck-parser/src/parser/token_stream.rs
+++ b/crates/shuck-parser/src/parser/token_stream.rs
@@ -96,17 +96,17 @@ impl<'a> Parser<'a> {
     }
 
     pub(super) fn current_token_has_leading_whitespace(&self) -> bool {
-        self.current_span.start.offset > 0
-            && self.input[..self.current_span.start.offset]
+        self.current_span.start.offset() > 0
+            && self.input[..self.current_span.start.offset()]
                 .chars()
                 .next_back()
                 .is_some_and(|ch| matches!(ch, ' ' | '\t' | '\n'))
     }
 
     pub(super) fn current_token_is_tight_to_next_token(&mut self) -> bool {
-        let current_end = self.current_span.end.offset;
+        let current_end = self.current_span.end.offset();
         self.peek_next()
-            .is_some_and(|token| token.span.start.offset == current_end)
+            .is_some_and(|token| token.span.start.offset() == current_end)
     }
 
     pub(super) fn at_in_set(&self, set: TokenSet) -> bool {

--- a/crates/shuck-parser/src/parser/word/fallback.rs
+++ b/crates/shuck-parser/src/parser/word/fallback.rs
@@ -8,7 +8,7 @@ impl<'a> Parser<'a> {
 
         let span = text.span();
         let nested_profile = self
-            .zsh_options_at_offset(span.start.offset)
+            .zsh_options_at_offset(span.start.offset())
             .cloned()
             .map(|options| ShellProfile::with_zsh_options(self.dialect, options))
             .unwrap_or_else(|| self.shell_profile.clone());
@@ -22,8 +22,8 @@ impl<'a> Parser<'a> {
         let reparse_depth = (remaining_depth - 1).min(SOURCE_TEXT_WORD_REPARSE_MAX_DEPTH);
 
         if !text.is_source_backed()
-            && span.start.offset <= span.end.offset
-            && span.end.offset <= self.input.len()
+            && span.start.offset() <= span.end.offset()
+            && span.end.offset() <= self.input.len()
         {
             let raw = span.slice(self.input);
             if raw.contains("\\\"") {
@@ -65,7 +65,7 @@ impl<'a> Parser<'a> {
 
         if Self::word_text_needs_parse(raw)
             || raw.contains(['\'', '"', '\\'])
-            || self.zsh_glob_word_parsing_enabled_at(span.start.offset)
+            || self.zsh_glob_word_parsing_enabled_at(span.start.offset())
         {
             return None;
         }

--- a/crates/shuck-parser/src/parser/word/heredocs.rs
+++ b/crates/shuck-parser/src/parser/word/heredocs.rs
@@ -71,7 +71,7 @@ impl<'a> Parser<'a> {
         part: WordPart,
         span: Span,
     ) -> HeredocBodyPart {
-        if span.end.offset <= self.input.len() {
+        if span.end.offset() <= self.input.len() {
             return HeredocBodyPart::Literal(LiteralText::source());
         }
 

--- a/crates/shuck-parser/src/parser/word/mod.rs
+++ b/crates/shuck-parser/src/parser/word/mod.rs
@@ -15,7 +15,7 @@ impl<'a> Parser<'a> {
     }
 
     pub(in crate::parser) fn word_with_parts(&self, parts: Vec<WordPartNode>, span: Span) -> Word {
-        let brace_syntax = self.brace_syntax_from_parts(&parts, span.start.offset);
+        let brace_syntax = self.brace_syntax_from_parts(&parts, span.start.offset());
         Word {
             parts,
             span,
@@ -28,7 +28,7 @@ impl<'a> Parser<'a> {
         parts: WordPartBuffer,
         span: Span,
     ) -> Word {
-        let brace_syntax = self.brace_syntax_from_parts(&parts, span.start.offset);
+        let brace_syntax = self.brace_syntax_from_parts(&parts, span.start.offset());
         let parts = if parts.spilled() {
             parts.into_vec()
         } else {

--- a/crates/shuck-parser/src/parser/word/parameters.rs
+++ b/crates/shuck-parser/src/parser/word/parameters.rs
@@ -154,7 +154,7 @@ impl<'a> Parser<'a> {
         span: Span,
         source_backed: bool,
     ) -> SourceText {
-        if source_backed && span.end.offset <= self.input.len() {
+        if source_backed && span.end.offset() <= self.input.len() {
             let syntax = span.slice(self.input);
             if let Some(body) = syntax
                 .strip_prefix("${")

--- a/crates/shuck-parser/src/parser/word/preserve.rs
+++ b/crates/shuck-parser/src/parser/word/preserve.rs
@@ -101,7 +101,7 @@ impl<'a> Parser<'a> {
         ch: char,
     ) -> bool {
         self.input
-            .get(start.offset..end.offset)
+            .get(start.offset()..end.offset())
             .is_some_and(|slice| slice.ends_with(ch))
     }
 
@@ -116,10 +116,10 @@ impl<'a> Parser<'a> {
     }
 
     pub(in crate::parser) fn source_matches(&self, span: Span, text: &str) -> bool {
-        span.start.offset <= span.end.offset
+        span.start.offset() <= span.end.offset()
             && self
                 .input
-                .get(span.start.offset..span.end.offset)
+                .get(span.start.offset()..span.end.offset())
                 .is_some_and(|slice| slice == text)
     }
 }

--- a/crates/shuck-parser/src/parser/word/raw_shell.rs
+++ b/crates/shuck-parser/src/parser/word/raw_shell.rs
@@ -23,7 +23,7 @@ impl<'a> Parser<'a> {
             return None;
         }
         let span = Span::from_positions(start, end);
-        if self.zsh_glob_word_parsing_enabled_at(span.start.offset)
+        if self.zsh_glob_word_parsing_enabled_at(span.start.offset())
             && let Some(word) = self.maybe_parse_zsh_qualified_glob_word(&text, span, true)
         {
             return Some(word);
@@ -33,11 +33,11 @@ impl<'a> Parser<'a> {
     }
 
     pub(in crate::parser) fn source_word_contains_zsh_glob_control(&self, start: Position) -> bool {
-        if start.offset >= self.input.len() {
+        if start.offset() >= self.input.len() {
             return false;
         }
 
-        let source = &self.input[start.offset..];
+        let source = &self.input[start.offset()..];
         let mut chars = source.chars().peekable();
         let mut cursor = start;
         let mut paren_depth = 0_i32;
@@ -92,11 +92,11 @@ impl<'a> Parser<'a> {
         &self,
         start: Position,
     ) -> Option<(String, Position)> {
-        if start.offset >= self.input.len() {
+        if start.offset() >= self.input.len() {
             return None;
         }
 
-        let source = &self.input[start.offset..];
+        let source = &self.input[start.offset()..];
         let mut chars = source.chars().peekable();
         let mut cursor = start;
         let mut text = String::new();
@@ -150,9 +150,11 @@ impl<'a> Parser<'a> {
             .source_slice(self.input)
             .map(Cow::Borrowed)
             .or_else(|| {
-                (token.span.start.offset <= token.span.end.offset
-                    && token.span.end.offset <= self.input.len())
-                .then(|| Cow::Borrowed(&self.input[token.span.start.offset..token.span.end.offset]))
+                (token.span.start.offset() <= token.span.end.offset()
+                    && token.span.end.offset() <= self.input.len())
+                .then(|| {
+                    Cow::Borrowed(&self.input[token.span.start.offset()..token.span.end.offset()])
+                })
             })
             .or_else(|| token.word_string().map(Cow::Owned))
     }

--- a/crates/shuck-parser/src/parser/word/render.rs
+++ b/crates/shuck-parser/src/parser/word/render.rs
@@ -2,7 +2,7 @@ use super::super::*;
 
 impl<'a> Parser<'a> {
     pub(in crate::parser) fn word_syntax_is_source_backed(&self, word: &Word) -> bool {
-        word.span.end.offset <= self.input.len()
+        word.span.end.offset() <= self.input.len()
             && word
                 .parts
                 .first()
@@ -22,7 +22,7 @@ impl<'a> Parser<'a> {
         part: &WordPart,
         span: Span,
     ) -> bool {
-        span.end.offset <= self.input.len()
+        span.end.offset() <= self.input.len()
             && match part {
                 WordPart::Literal(text) => text.is_source_backed(),
                 WordPart::ZshQualifiedGlob(glob) => {
@@ -498,7 +498,7 @@ impl<'a> Parser<'a> {
     }
 
     pub(in crate::parser) fn push_pattern_syntax(&self, out: &mut String, pattern: &Pattern) {
-        if pattern.is_source_backed() && pattern.span.end.offset <= self.input.len() {
+        if pattern.is_source_backed() && pattern.span.end.offset() <= self.input.len() {
             out.push_str(pattern.span.slice(self.input));
             return;
         }

--- a/crates/shuck-parser/src/parser/word_tokens.rs
+++ b/crates/shuck-parser/src/parser/word_tokens.rs
@@ -9,7 +9,7 @@ impl<'a> Parser<'a> {
         let word = token.word()?;
         let source_backed = !token.flags.is_synthetic();
 
-        if self.zsh_glob_word_parsing_enabled_at(span.start.offset)
+        if self.zsh_glob_word_parsing_enabled_at(span.start.offset())
             && let Some(segment) = word.single_segment()
             && segment.kind() == LexedWordSegmentKind::Plain
             && let Some(word) = self.maybe_parse_zsh_qualified_glob_word(
@@ -439,7 +439,8 @@ impl<'a> Parser<'a> {
             .current_token
             .as_ref()
             .is_some_and(|token| token.flags.is_synthetic());
-        while self.current_token.is_some() && self.current_span.start.offset < word.span.end.offset
+        while self.current_token.is_some()
+            && self.current_span.start.offset() < word.span.end.offset()
         {
             self.advance();
             if stop_after_synthetic
@@ -463,7 +464,7 @@ impl<'a> Parser<'a> {
     pub(super) fn current_conditional_literal_word(&self) -> Option<Word> {
         match self.current_token_kind? {
             TokenKind::LeftBrace | TokenKind::RightBrace => Some(Word::literal_with_span(
-                self.input[self.current_span.start.offset..self.current_span.end.offset]
+                self.input[self.current_span.start.offset()..self.current_span.end.offset()]
                     .to_string(),
                 self.current_span,
             )),

--- a/crates/shuck-parser/src/parser/words/array.rs
+++ b/crates/shuck-parser/src/parser/words/array.rs
@@ -104,7 +104,7 @@ impl<'a> Parser<'a> {
                     in_backtick = !in_backtick
                 }
                 ',' if !in_single && !in_ansi_c_single && !in_double && !in_backtick => {
-                    let comma_offset = word.span.start.offset + index;
+                    let comma_offset = word.span.start.offset() + index;
                     if !self.comma_is_brace_separator(word, comma_offset, was_escaped)
                         && !self.comma_is_zsh_word_syntax(word, comma_offset)
                     {
@@ -531,7 +531,7 @@ impl<'a> Parser<'a> {
             .iter()
             .copied()
             .filter(|brace| brace.expands())
-            .any(|brace| brace.span.start.offset <= offset && offset < brace.span.end.offset)
+            .any(|brace| brace.span.start.offset() <= offset && offset < brace.span.end.offset())
     }
 
     pub(in crate::parser) fn comma_is_zsh_word_syntax(
@@ -552,12 +552,12 @@ impl<'a> Parser<'a> {
         word: &Word,
         comma_offset: usize,
     ) -> bool {
-        if comma_offset < word.span.start.offset || word.span.end.offset <= comma_offset {
+        if comma_offset < word.span.start.offset() || word.span.end.offset() <= comma_offset {
             return false;
         }
 
         let text = word.span.slice(self.input);
-        let relative_comma = comma_offset - word.span.start.offset;
+        let relative_comma = comma_offset - word.span.start.offset();
         let Some(group_start) = Self::enclosing_terminal_group_start(text, relative_comma) else {
             return false;
         };
@@ -622,7 +622,7 @@ impl<'a> Parser<'a> {
         let mut brace_depth = 0usize;
 
         for (index, ch) in text.char_indices() {
-            let absolute = word.span.start.offset + index;
+            let absolute = word.span.start.offset() + index;
 
             if absolute == target_offset {
                 return brace_depth > 0;

--- a/crates/shuck-parser/src/parser/words/assignment.rs
+++ b/crates/shuck-parser/src/parser/words/assignment.rs
@@ -14,8 +14,8 @@ impl<'a> Parser<'a> {
         let mut in_backtick = false;
         let mut escaped = false;
 
-        while cursor.offset < self.input.len() {
-            let rest = &self.input[cursor.offset..];
+        while cursor.offset() < self.input.len() {
+            let rest = &self.input[cursor.offset()..];
             let ch = rest.chars().next()?;
             let ch_start = cursor;
             cursor.advance(ch);
@@ -26,13 +26,13 @@ impl<'a> Parser<'a> {
             }
 
             if ch == '$' && !in_single {
-                let next_offset = ch_start.offset + ch.len_utf8();
+                let next_offset = ch_start.offset() + ch.len_utf8();
                 if self.input[next_offset..].starts_with("((")
                     && let Some(consumed) =
                         Self::scan_array_arithmetic_expansion_len(&self.input[next_offset + 2..])
                 {
                     let end = next_offset + 2 + consumed;
-                    cursor = ch_start.advanced_by(&self.input[ch_start.offset..end]);
+                    cursor = ch_start.advanced_by(&self.input[ch_start.offset()..end]);
                     continue;
                 }
 
@@ -41,14 +41,14 @@ impl<'a> Parser<'a> {
                         Self::scan_array_parameter_expansion_len(&self.input[next_offset + 1..])
                 {
                     let end = next_offset + 1 + consumed;
-                    cursor = ch_start.advanced_by(&self.input[ch_start.offset..end]);
+                    cursor = ch_start.advanced_by(&self.input[ch_start.offset()..end]);
                     continue;
                 }
 
                 if let Some(end) =
-                    Self::scan_raw_dollar_paren_substitution_end(self.input, ch_start.offset)
+                    Self::scan_raw_dollar_paren_substitution_end(self.input, ch_start.offset())
                 {
-                    cursor = ch_start.advanced_by(&self.input[ch_start.offset..end]);
+                    cursor = ch_start.advanced_by(&self.input[ch_start.offset()..end]);
                     continue;
                 }
             }
@@ -60,10 +60,10 @@ impl<'a> Parser<'a> {
                     && bracket_depth == 0
                     && brace_depth == 0
                     && paren_depth == 0
-                    && Self::raw_source_hash_starts_comment(self.input, ch_start.offset) =>
+                    && Self::raw_source_hash_starts_comment(self.input, ch_start.offset()) =>
                 {
-                    while cursor.offset < self.input.len() {
-                        let Some(comment_ch) = self.input[cursor.offset..].chars().next() else {
+                    while cursor.offset() < self.input.len() {
+                        let Some(comment_ch) = self.input[cursor.offset()..].chars().next() else {
                             break;
                         };
                         cursor.advance(comment_ch);
@@ -108,9 +108,9 @@ impl<'a> Parser<'a> {
     ) -> (ArrayExpr, Span) {
         if let Some(closing_span) = self.scan_compound_array_close(open_paren_span) {
             let inner =
-                self.input[open_paren_span.end.offset..closing_span.start.offset].to_string();
+                self.input[open_paren_span.end.offset()..closing_span.start.offset()].to_string();
             while self.current_token.is_some()
-                && self.current_span.start.offset < closing_span.end.offset
+                && self.current_span.start.offset() < closing_span.end.offset()
             {
                 self.advance();
             }
@@ -147,10 +147,10 @@ impl<'a> Parser<'a> {
         }
 
         let inner = if closing_span != Span::new()
-            && inner_start.offset <= closing_span.start.offset
-            && closing_span.start.offset <= self.input.len()
+            && inner_start.offset() <= closing_span.start.offset()
+            && closing_span.start.offset() <= self.input.len()
         {
-            self.input[inner_start.offset..closing_span.start.offset].to_string()
+            self.input[inner_start.offset()..closing_span.start.offset()].to_string()
         } else {
             fallback
         };
@@ -170,10 +170,10 @@ impl<'a> Parser<'a> {
         span: Span,
         start: Position,
     ) -> Option<(LiteralText, Span)> {
-        if start.offset <= span.start.offset {
+        if start.offset() <= span.start.offset() {
             return Some((literal, span));
         }
-        if start.offset >= span.end.offset {
+        if start.offset() >= span.end.offset() {
             return None;
         }
 
@@ -181,7 +181,7 @@ impl<'a> Parser<'a> {
         let literal = match literal {
             LiteralText::Source => LiteralText::source(),
             LiteralText::Owned(text) | LiteralText::CookedSource(text) => {
-                let split_at = start.offset.saturating_sub(span.start.offset);
+                let split_at = start.offset().saturating_sub(span.start.offset());
                 LiteralText::owned(text.get(split_at..)?.to_string())
             }
         };
@@ -194,10 +194,10 @@ impl<'a> Parser<'a> {
         span: Span,
         start: Position,
     ) -> Option<(WordPart, Span)> {
-        if start.offset <= span.start.offset {
+        if start.offset() <= span.start.offset() {
             return Some((part, span));
         }
-        if start.offset >= span.end.offset {
+        if start.offset() >= span.end.offset() {
             return None;
         }
 
@@ -278,7 +278,7 @@ impl<'a> Parser<'a> {
         explicit_array_kind: Option<ArrayKind>,
         subscript_interpretation: SubscriptInterpretation,
     ) -> Option<Assignment> {
-        let source_backed = assignment_span.end.offset <= self.input.len()
+        let source_backed = assignment_span.end.offset() <= self.input.len()
             && assignment_span.slice(self.input) == w;
         let word = self.decode_word_text_preserving_quotes_if_needed(
             w,
@@ -583,7 +583,7 @@ impl<'a> Parser<'a> {
 
         let span = Span::from_positions(raw_body_start, *cursor);
         let raw_body = if source_backed
-            && span.end.offset <= self.input.len()
+            && span.end.offset() <= self.input.len()
             && span.slice(self.input) == raw_body_text
         {
             span.slice(self.input).to_owned()
@@ -876,12 +876,12 @@ impl<'a> Parser<'a> {
 
         let open_paren_span = self.current_span;
         if let Some(closing_span) = self.scan_compound_array_close(open_paren_span) {
-            let paren_text = &self.input[open_paren_span.start.offset..closing_span.end.offset];
+            let paren_text = &self.input[open_paren_span.start.offset()..closing_span.end.offset()];
             let mut compound = String::with_capacity(saved_w.len() + paren_text.len());
             compound.push_str(saved_w);
             compound.push_str(paren_text);
             while self.current_token.is_some()
-                && self.current_span.start.offset < closing_span.end.offset
+                && self.current_span.start.offset() < closing_span.end.offset()
             {
                 self.advance();
             }
@@ -921,8 +921,8 @@ impl<'a> Parser<'a> {
             saved_span.merge(closing_span)
         };
 
-        if saved_span.start.offset <= span.end.offset && span.end.offset <= self.input.len() {
-            let source = &self.input[saved_span.start.offset..span.end.offset];
+        if saved_span.start.offset() <= span.end.offset() && span.end.offset() <= self.input.len() {
+            let source = &self.input[saved_span.start.offset()..span.end.offset()];
             return Ok(Some(self.decode_word_text(
                 source,
                 span,

--- a/crates/shuck-parser/src/parser/words/decode.rs
+++ b/crates/shuck-parser/src/parser/words/decode.rs
@@ -171,7 +171,7 @@ impl<'a> Parser<'a> {
                     }
 
                     if c == '$' && source_backed {
-                        let relative_offset = cursor.offset.saturating_sub(base.offset);
+                        let relative_offset = cursor.offset().saturating_sub(base.offset());
                         let remaining = &s[relative_offset..];
 
                         if chars.peek() == Some(&'(')
@@ -1201,8 +1201,9 @@ impl<'a> Parser<'a> {
                                         );
                                         (
                                             replacement,
-                                            cursor.offset > 0
-                                                && self.input_prefix_ends_with(cursor.offset, '}'),
+                                            cursor.offset() > 0
+                                                && self
+                                                    .input_prefix_ends_with(cursor.offset(), '}'),
                                         )
                                     } else {
                                         (self.empty_source_text(cursor), false)
@@ -1211,7 +1212,7 @@ impl<'a> Parser<'a> {
                                     Self::consume_word_char_if(&mut chars, &mut cursor, '}');
                                 }
                                 if !self.input_span_ends_with(part_start, cursor, '}')
-                                    && self.input_suffix_starts_with(cursor.offset, '}')
+                                    && self.input_suffix_starts_with(cursor.offset(), '}')
                                 {
                                     cursor.advance('}');
                                 }
@@ -1490,8 +1491,8 @@ impl<'a> Parser<'a> {
                                     );
                                     (
                                         replacement,
-                                        cursor.offset > 0
-                                            && self.input_prefix_ends_with(cursor.offset, '}'),
+                                        cursor.offset() > 0
+                                            && self.input_prefix_ends_with(cursor.offset(), '}'),
                                     )
                                 } else {
                                     (self.empty_source_text(cursor), false)
@@ -1500,7 +1501,7 @@ impl<'a> Parser<'a> {
                                 Self::consume_word_char_if(&mut chars, &mut cursor, '}');
                             }
                             if !self.input_span_ends_with(part_start, cursor, '}')
-                                && self.input_suffix_starts_with(cursor.offset, '}')
+                                && self.input_suffix_starts_with(cursor.offset(), '}')
                             {
                                 cursor.advance('}');
                             }
@@ -1662,7 +1663,7 @@ impl<'a> Parser<'a> {
                     WordPart::Variable(var_name.into())
                 };
 
-                let part = if cursor.offset > brace_body_start.offset {
+                let part = if cursor.offset() > brace_body_start.offset() {
                     self.parameter_word_part_from_legacy(part, part_start, cursor, source_backed)
                 } else {
                     part

--- a/crates/shuck-parser/src/parser/words/expansion.rs
+++ b/crates/shuck-parser/src/parser/words/expansion.rs
@@ -24,16 +24,16 @@ impl<'a> Parser<'a> {
         let needle_len = "$(".len() + inner_text.len() + ")".len();
         // The approximate start is usually exact, so try it before scanning.
         let subst_start =
-            if substitution_matches_at(self.input, approximate_dollar_start.offset, inner_text) {
-                approximate_dollar_start.offset
+            if substitution_matches_at(self.input, approximate_dollar_start.offset(), inner_text) {
+                approximate_dollar_start.offset()
             } else {
                 let search_start = floor_char_boundary(
                     self.input,
-                    approximate_dollar_start.offset.saturating_sub(512),
+                    approximate_dollar_start.offset().saturating_sub(512),
                 );
                 let search_end = ceil_char_boundary(
                     self.input,
-                    (approximate_dollar_start.offset + needle_len + 4096).min(self.input.len()),
+                    (approximate_dollar_start.offset() + needle_len + 4096).min(self.input.len()),
                 );
                 let haystack = self.input.get(search_start..search_end)?;
                 // Occurrences arrive in ascending order, so the distance to the
@@ -45,7 +45,7 @@ impl<'a> Parser<'a> {
                         continue;
                     }
                     let distance =
-                        (search_start + relative_start).abs_diff(approximate_dollar_start.offset);
+                        (search_start + relative_start).abs_diff(approximate_dollar_start.offset());
                     match best {
                         Some((_, best_distance)) if distance >= best_distance => break,
                         _ => best = Some((relative_start, distance)),
@@ -606,8 +606,8 @@ impl<'a> Parser<'a> {
                             let replacement = self.read_brace_operand(chars, cursor, source_backed);
                             (
                                 replacement,
-                                cursor.offset > 0
-                                    && self.input_prefix_ends_with(cursor.offset, '}'),
+                                cursor.offset() > 0
+                                    && self.input_prefix_ends_with(cursor.offset(), '}'),
                             )
                         } else {
                             (self.empty_source_text(*cursor), false)
@@ -616,7 +616,7 @@ impl<'a> Parser<'a> {
                         Self::consume_word_char_if(chars, cursor, '}');
                     }
                     if !self.input_span_ends_with(part_start, *cursor, '}')
-                        && self.input_suffix_starts_with(cursor.offset, '}')
+                        && self.input_suffix_starts_with(cursor.offset(), '}')
                     {
                         cursor.advance('}');
                     }
@@ -1024,7 +1024,7 @@ impl<'a> Parser<'a> {
         let Some(first) = probe.next() else {
             return true;
         };
-        let Some(source_suffix) = self.input.get(cursor.offset..) else {
+        let Some(source_suffix) = self.input.get(cursor.offset()..) else {
             return false;
         };
         source_suffix.starts_with(first)

--- a/crates/shuck-parser/src/parser/words/mod.rs
+++ b/crates/shuck-parser/src/parser/words/mod.rs
@@ -372,7 +372,11 @@ impl<'a> PatternParser<'a> {
                     }
                 }
                 PatternSegment::Word(part) => {
-                    scanned += part.span.end.offset.saturating_sub(part.span.start.offset);
+                    scanned += part
+                        .span
+                        .end
+                        .offset()
+                        .saturating_sub(part.span.start.offset());
                     if scanned > Self::MAX_ZSH_CASE_GROUP_PRESCAN_BYTES {
                         return true;
                     }
@@ -689,8 +693,8 @@ impl<'a> PatternParser<'a> {
     }
 
     fn source_matches(&self, span: Span, text: &str) -> bool {
-        span.start.offset <= span.end.offset
-            && span.end.offset <= self.input.len()
+        span.start.offset() <= span.end.offset()
+            && span.end.offset() <= self.input.len()
             && span.slice(self.input) == text
     }
 }
@@ -865,7 +869,7 @@ fn var_ref_subscript_contains_offset(reference: &VarRef, offset: usize) -> bool 
 }
 
 fn span_contains_offset(span: Span, offset: usize) -> bool {
-    span.start.offset <= offset && offset < span.end.offset
+    span.start.offset() <= offset && offset < span.end.offset()
 }
 
 #[inline]
@@ -900,14 +904,14 @@ fn try_pure_literal_end_position(
     }
 
     let len = bytes.len();
-    Some(Position {
-        line: base.line + newline_count,
-        column: match last_newline {
+    Some(Position::at(
+        base.line() + newline_count,
+        match last_newline {
             Some(idx) => len - idx,
-            None => base.column + len,
+            None => base.column() + len,
         },
-        offset: base.offset + len,
-    })
+        base.offset() + len,
+    ))
 }
 
 fn source_prefix_ends_inside_double_quotes(prefix: &str) -> bool {

--- a/crates/shuck-parser/src/parser/words/pattern.rs
+++ b/crates/shuck-parser/src/parser/words/pattern.rs
@@ -5,13 +5,13 @@ impl<'a> Parser<'a> {
         PatternParser::new(
             self.input,
             word,
-            self.zsh_glob_parse_features_at(word.span.start.offset),
+            self.zsh_glob_parse_features_at(word.span.start.offset()),
         )
         .parse()
     }
 
     pub(in crate::parser) fn pattern_from_conditional_word(&self, word: &Word) -> Pattern {
-        let features = self.zsh_glob_parse_features_at(word.span.start.offset);
+        let features = self.zsh_glob_parse_features_at(word.span.start.offset());
         let source_backed_word = self
             .conditional_prefixed_bare_group_source_word(word, features)
             .unwrap_or_else(|| word.clone());
@@ -162,7 +162,7 @@ impl<'a> Parser<'a> {
         } else {
             self.decode_word_text(text, span, span.start, true)
         };
-        let features = self.zsh_glob_parse_features_at(span.start.offset);
+        let features = self.zsh_glob_parse_features_at(span.start.offset());
         self.pattern_from_zsh_case_word_with_features(&word, features)
     }
 
@@ -208,7 +208,7 @@ impl<'a> Parser<'a> {
             self.input,
             &parts,
             span,
-            self.zsh_glob_parse_features_at(span.start.offset),
+            self.zsh_glob_parse_features_at(span.start.offset()),
         )
         .parse();
         self.source_text_pattern_depth -= 1;
@@ -405,11 +405,11 @@ impl<'a> Parser<'a> {
         &self,
         start: Position,
     ) -> Option<(String, Position)> {
-        if start.offset >= self.input.len() {
+        if start.offset() >= self.input.len() {
             return None;
         }
 
-        let source = &self.input[start.offset..];
+        let source = &self.input[start.offset()..];
         let mut chars = source.chars().peekable();
         let mut cursor = start;
         let mut text = String::new();
@@ -525,7 +525,7 @@ impl<'a> Parser<'a> {
             SubscriptInterpretation::Contextual,
         )?;
 
-        while self.current_token.is_some() && self.current_span.start.offset < end.offset {
+        while self.current_token.is_some() && self.current_span.start.offset() < end.offset() {
             self.advance();
         }
 

--- a/crates/shuck-parser/src/parser/zsh_features.rs
+++ b/crates/shuck-parser/src/parser/zsh_features.rs
@@ -9,7 +9,7 @@ impl<'a> Parser<'a> {
     }
 
     pub(super) fn current_zsh_options(&self) -> Option<&ZshOptionState> {
-        self.zsh_options_at_offset(self.current_span.start.offset)
+        self.zsh_options_at_offset(self.current_span.start.offset())
     }
 
     pub(super) fn zsh_short_loops_enabled(&self) -> bool {

--- a/crates/shuck-semantic/src/analysis.rs
+++ b/crates/shuck-semantic/src/analysis.rs
@@ -157,8 +157,8 @@ impl<'model> SemanticAnalysis<'model> {
                     let name = Name::from(name.as_str());
                     let Some(binding_id) = self.visible_function_binding_defined_before(
                         &name,
-                        self.model.scope_at(dispatcher_span.start.offset),
-                        dispatcher_span.start.offset,
+                        self.model.scope_at(dispatcher_span.start.offset()),
+                        dispatcher_span.start.offset(),
                     ) else {
                         continue;
                     };
@@ -182,19 +182,19 @@ impl<'model> SemanticAnalysis<'model> {
     ) -> Vec<ScopeId> {
         let dispatcher_offset = dispatches
             .iter()
-            .map(|dispatch| dispatch.dispatcher_span().start.offset)
+            .map(|dispatch| dispatch.dispatcher_span().start.offset())
             .min();
         let top_level_exit_offset = file
             .body
             .iter()
             .find(|stmt| stmt_is_standalone_exit(stmt))
-            .map(|stmt| stmt.span.start.offset);
+            .map(|stmt| stmt.span.start.offset());
         let mut scopes = self
             .function_bindings_by_scope()
             .filter_map(|(scope, bindings)| {
                 let function_start = bindings
                     .iter()
-                    .map(|binding_id| self.model.binding(*binding_id).span.start.offset)
+                    .map(|binding_id| self.model.binding(*binding_id).span.start.offset())
                     .min()?;
                 (self.function_scope_is_nested(scope)
                     || dispatcher_offset.is_some_and(|offset| function_start < offset)
@@ -202,7 +202,7 @@ impl<'model> SemanticAnalysis<'model> {
                 .then_some(scope)
             })
             .collect::<Vec<_>>();
-        scopes.sort_by_key(|scope| self.model.scope(*scope).span.start.offset);
+        scopes.sort_by_key(|scope| self.model.scope(*scope).span.start.offset());
         scopes.dedup();
         scopes
     }
@@ -230,7 +230,7 @@ impl<'model> SemanticAnalysis<'model> {
             .iter()
             .copied()
             .find_map(|scope| {
-                self.latest_function_binding_before(name, scope, site.name_span.start.offset)
+                self.latest_function_binding_before(name, scope, site.name_span.start.offset())
             })
             .or_else(|| {
                 scopes
@@ -251,8 +251,8 @@ impl<'model> SemanticAnalysis<'model> {
             .iter()
             .copied()
             .filter(|candidate| self.model.binding(*candidate).scope == scope)
-            .filter(|candidate| self.model.binding(*candidate).span.start.offset < offset)
-            .max_by_key(|candidate| self.model.binding(*candidate).span.start.offset)
+            .filter(|candidate| self.model.binding(*candidate).span.start.offset() < offset)
+            .max_by_key(|candidate| self.model.binding(*candidate).span.start.offset())
     }
 
     fn earliest_function_binding_in_scope(&self, name: &Name, scope: ScopeId) -> Option<BindingId> {
@@ -261,7 +261,7 @@ impl<'model> SemanticAnalysis<'model> {
             .iter()
             .copied()
             .filter(|candidate| self.model.binding(*candidate).scope == scope)
-            .min_by_key(|candidate| self.model.binding(*candidate).span.start.offset)
+            .min_by_key(|candidate| self.model.binding(*candidate).span.start.offset())
     }
 
     fn visible_function_call_bindings(&self) -> &FxHashMap<SpanKey, BindingId> {
@@ -404,7 +404,7 @@ impl<'model> SemanticAnalysis<'model> {
         }
 
         let binding_scope = self.model.binding(binding_id).scope;
-        let entry = self.flow_entry_block_for_binding_scopes(&[binding_scope], at.start.offset);
+        let entry = self.flow_entry_block_for_binding_scopes(&[binding_scope], at.start.offset());
         self.blocks_cover_all_paths_to_block(
             entry,
             reference_block,

--- a/crates/shuck-semantic/src/array_use.rs
+++ b/crates/shuck-semantic/src/array_use.rs
@@ -49,7 +49,7 @@ impl ArrayUseIndex {
                 continue;
             }
 
-            let scope = model.scope_at(declaration.span.start.offset);
+            let scope = model.scope_at(declaration.span.start.offset());
             let declaration_has_array_flag = declaration.operands.iter().any(|operand| {
                 matches!(
                     operand,
@@ -91,8 +91,8 @@ impl ArrayUseIndex {
                             append_local_declaration_spans.insert((
                                 scope,
                                 name.clone(),
-                                name_span.start.offset,
-                                name_span.end.offset,
+                                name_span.start.offset(),
+                                name_span.end.offset(),
                             ));
                         }
                     }
@@ -110,7 +110,7 @@ impl ArrayUseIndex {
                     .is_some_and(|spans| {
                         spans
                             .iter()
-                            .any(|span| span.end.offset < binding.span.start.offset)
+                            .any(|span| span.end.offset() < binding.span.start.offset())
                     })
             })
             .collect::<Vec<_>>();
@@ -121,8 +121,8 @@ impl ArrayUseIndex {
                 append_local_declaration_spans.contains(&(
                     binding.scope,
                     binding.name.clone(),
-                    binding.span.start.offset,
-                    binding.span.end.offset,
+                    binding.span.start.offset(),
+                    binding.span.end.offset(),
                 ))
             })
             .collect::<Vec<_>>();
@@ -143,7 +143,7 @@ impl ArrayUseIndex {
                 let mut inherited = false;
                 for candidate_id in model.bindings_for(&binding.name).iter().copied().rev() {
                     let candidate = model.binding(candidate_id);
-                    if candidate.span.start.offset >= binding.span.start.offset {
+                    if candidate.span.start.offset() >= binding.span.start.offset() {
                         continue;
                     }
                     if !same_scope_candidate_allowed
@@ -332,7 +332,7 @@ impl SemanticModel {
         }
 
         let latest_barrier = self
-            .ancestor_scopes(self.scope_at(reference.span.start.offset))
+            .ancestor_scopes(self.scope_at(reference.span.start.offset()))
             .flat_map(|scope| {
                 self.array_use_index()
                     .initialized_scalar_local_declarations_by_scope_name
@@ -341,8 +341,8 @@ impl SemanticModel {
                     .flatten()
                     .copied()
             })
-            .filter(|span| span.end.offset < reference.span.start.offset)
-            .max_by_key(|span| span.start.offset);
+            .filter(|span| span.end.offset() < reference.span.start.offset())
+            .max_by_key(|span| span.start.offset());
 
         latest_barrier.is_some_and(|barrier| {
             !self.zsh_array_binding_after_scalar_local_barrier(reference, barrier)
@@ -359,8 +359,8 @@ impl SemanticModel {
             .copied()
             .any(|binding_id| {
                 let binding = self.binding(binding_id);
-                binding.span.start.offset > barrier.start.offset
-                    && binding.span.start.offset < reference.span.start.offset
+                binding.span.start.offset() > barrier.start.offset()
+                    && binding.span.start.offset() < reference.span.start.offset()
                     && self.binding_visible_at(binding_id, reference.span)
                     && self.binding_has_sticky_indexed_array_type(binding_id)
             })
@@ -422,7 +422,7 @@ impl SemanticModel {
         }
 
         Some(
-            self.shell_behavior_at(reference.span.start.offset)
+            self.shell_behavior_at(reference.span.start.offset())
                 .array_reference_policy(),
         )
     }
@@ -437,7 +437,8 @@ fn binding_reset_by_name_only_declaration_before(
         .get(&(binding.scope, binding.name.clone()))
         .is_some_and(|spans| {
             spans.iter().any(|span| {
-                span.start.offset > binding.span.start.offset && span.end.offset < at.start.offset
+                span.start.offset() > binding.span.start.offset()
+                    && span.end.offset() < at.start.offset()
             })
         })
 }

--- a/crates/shuck-semantic/src/builder/arithmetic.rs
+++ b/crates/shuck-semantic/src/builder/arithmetic.rs
@@ -261,7 +261,7 @@ impl<'a, 'idx, 'observer> SemanticModelBuilder<'a, 'idx, 'observer> {
         nested_regions: &mut Vec<IsolatedRegion>,
     ) {
         if self
-            .arithmetic_index_uses_associative_word_semantics(owner_name, index.span.start.offset)
+            .arithmetic_index_uses_associative_word_semantics(owner_name, index.span.start.offset())
         {
             self.visit_associative_arithmetic_key_into(index, flow, nested_regions);
             return;
@@ -420,7 +420,7 @@ impl<'a, 'idx, 'observer> SemanticModelBuilder<'a, 'idx, 'observer> {
                             name: name.clone(),
                             index: index.clone(),
                         },
-                        span.start.offset,
+                        span.start.offset(),
                     ) | BindingAttributes::SELF_REFERENTIAL_READ,
                 );
             }
@@ -443,7 +443,7 @@ impl<'a, 'idx, 'observer> SemanticModelBuilder<'a, 'idx, 'observer> {
         let name_span = arithmetic_name_span(target_span, name);
         let reference_start = self.references.len();
         self.visit_arithmetic_lvalue_indices_into(target, flow, nested_regions);
-        let mut attributes = self.arithmetic_binding_attributes(target, target_span.start.offset);
+        let mut attributes = self.arithmetic_binding_attributes(target, target_span.start.offset());
         if !matches!(op, ArithmeticAssignOp::Assign) {
             self.add_reference(name, self.arithmetic_reference_kind, name_span);
         }

--- a/crates/shuck-semantic/src/builder/bindings.rs
+++ b/crates/shuck-semantic/src/builder/bindings.rs
@@ -48,7 +48,7 @@ impl<'a, 'idx, 'observer> SemanticModelBuilder<'a, 'idx, 'observer> {
             && !explicit_array_declaration
             && self.previous_visible_binding_is_assoc(
                 &assignment.target.name,
-                assignment.target.name_span.start.offset,
+                assignment.target.name_span.start.offset(),
             )
         {
             attributes |= BindingAttributes::ARRAY | BindingAttributes::ASSOC;
@@ -72,7 +72,7 @@ impl<'a, 'idx, 'observer> SemanticModelBuilder<'a, 'idx, 'observer> {
                 .resolve_reference(
                     &assignment.target.name,
                     self.current_scope(),
-                    assignment.target.name_span.start.offset,
+                    assignment.target.name_span.start.offset(),
                 )
                 .map(|binding_id| {
                     self.bindings[binding_id.index()]
@@ -122,7 +122,7 @@ impl<'a, 'idx, 'observer> SemanticModelBuilder<'a, 'idx, 'observer> {
         self.resolve_reference(
             &assignment.target.name,
             self.current_scope(),
-            assignment.target.name_span.start.offset,
+            assignment.target.name_span.start.offset(),
         )
         .is_some_and(|binding_id| {
             !crate::binding::is_array_like_binding(&self.bindings[binding_id.index()])
@@ -202,7 +202,7 @@ impl<'a, 'idx, 'observer> SemanticModelBuilder<'a, 'idx, 'observer> {
     ) -> bool {
         for scope in ancestor_scopes(&self.scopes, lookup_scope) {
             let clear_lower_bound = if scope == binding.scope {
-                binding.span.start.offset
+                binding.span.start.offset()
             } else {
                 0
             };
@@ -238,7 +238,7 @@ impl<'a, 'idx, 'observer> SemanticModelBuilder<'a, 'idx, 'observer> {
             .and_then(|bindings| {
                 bindings.iter().rev().copied().find(|binding_id| {
                     let binding = &self.bindings[binding_id.index()];
-                    binding.span.start.offset <= offset
+                    binding.span.start.offset() <= offset
                         && binding.attributes.contains(BindingAttributes::LOCAL)
                 })
             })
@@ -246,7 +246,7 @@ impl<'a, 'idx, 'observer> SemanticModelBuilder<'a, 'idx, 'observer> {
                 !self.binding_was_cleared_in_scope_between(
                     name,
                     scope,
-                    self.bindings[binding_id.index()].span.start.offset,
+                    self.bindings[binding_id.index()].span.start.offset(),
                     offset,
                 )
             })
@@ -270,7 +270,7 @@ impl<'a, 'idx, 'observer> SemanticModelBuilder<'a, 'idx, 'observer> {
             return attributes;
         };
         if attributes.contains(BindingAttributes::LOCAL)
-            || self.has_uncleared_local_binding_in_scope(name, function_scope, span.start.offset)
+            || self.has_uncleared_local_binding_in_scope(name, function_scope, span.start.offset())
         {
             return attributes;
         }
@@ -340,7 +340,7 @@ fn assignment_source_path_template_for_binding(
         zsh_runtime_vars_enabled,
         |name, span| {
             builder
-                .resolve_reference(name, builder.current_scope(), span.start.offset)
+                .resolve_reference(name, builder.current_scope(), span.start.offset())
                 .and_then(|binding_id| {
                     builder
                         .source_path_templates_by_binding

--- a/crates/shuck-semantic/src/builder/declarations.rs
+++ b/crates/shuck-semantic/src/builder/declarations.rs
@@ -121,14 +121,14 @@ impl<'a, 'idx, 'observer> SemanticModelBuilder<'a, 'idx, 'observer> {
         let (scope, attributes) =
             self.declaration_scope_and_attributes(builtin, flags, global_flag_enabled);
         let local_like = attributes.contains(BindingAttributes::LOCAL);
-        let existing = self.resolve_reference(name, scope, span.start.offset);
+        let existing = self.resolve_reference(name, scope, span.start.offset());
 
         let reuse_existing = existing.is_some_and(|existing| {
             let existing_binding = &self.bindings[existing.index()];
 
             !local_like
                 || (existing_binding.scope == scope
-                    && self.has_uncleared_local_binding_in_scope(name, scope, span.start.offset))
+                    && self.has_uncleared_local_binding_in_scope(name, scope, span.start.offset()))
         });
 
         if reuse_existing {

--- a/crates/shuck-semantic/src/builder/mod.rs
+++ b/crates/shuck-semantic/src/builder/mod.rs
@@ -125,11 +125,11 @@ pub(crate) struct SemanticModelBuilder<'a, 'idx, 'observer> {
 fn semantic_statement_span(stmt: &Stmt) -> Span {
     let mut end = stmt
         .terminator_span
-        .filter(|terminator| terminator.end.offset == stmt.span.end.offset)
+        .filter(|terminator| terminator.end.offset() == stmt.span.end.offset())
         .map_or(stmt.span.end, |terminator| terminator.start);
 
     for redirect in stmt.redirects.iter() {
-        if redirect.span.end.offset > end.offset {
+        if redirect.span.end.offset() > end.offset() {
             end = redirect.span.end;
         }
     }
@@ -1166,7 +1166,7 @@ pub(super) fn escaped_parameter_template_body_starts(
     source: &str,
 ) -> SmallVec<[usize; 2]> {
     let mut starts = SmallVec::new();
-    if word_span.start.offset >= word_span.end.offset {
+    if word_span.start.offset() >= word_span.end.offset() {
         return starts;
     }
     let text = word_span.slice(source);
@@ -1178,7 +1178,7 @@ pub(super) fn escaped_parameter_template_body_starts(
     while index < text.len() {
         if text[index..].starts_with("\\${") {
             let dollar_offset = index + '\\'.len_utf8();
-            if offset_is_backslash_escaped(word_span.start.offset + dollar_offset, source)
+            if offset_is_backslash_escaped(word_span.start.offset() + dollar_offset, source)
                 && let Some(end_offset) = escaped_parameter_template_end(text, dollar_offset)
             {
                 let body_start = dollar_offset + "${".len();
@@ -1189,7 +1189,7 @@ pub(super) fn escaped_parameter_template_body_starts(
                         .next()
                         .is_some_and(is_name_start_character)
                 {
-                    starts.push(word_span.start.offset + body_start);
+                    starts.push(word_span.start.offset() + body_start);
                 }
                 index = end_offset;
                 continue;
@@ -1757,7 +1757,7 @@ fn contiguous_word_groups<'a>(words: &'a [&'a Word]) -> Vec<&'a [&'a Word]> {
     while start < words.len() {
         let mut end = start + 1;
         while let Some(next) = words.get(end).copied() {
-            if words[end - 1].span.end.offset != next.span.start.offset {
+            if words[end - 1].span.end.offset() != next.span.start.offset() {
                 break;
             }
             end += 1;
@@ -1873,10 +1873,10 @@ fn printf_attached_v_target(word: &Word, source: &str, target_text: &str) -> Opt
 fn read_option_attached_target_span(span: Span, source: &str, start: usize, end: usize) -> Span {
     let start_pos = span
         .start
-        .advanced_by(&source[span.start.offset..span.start.offset + start]);
+        .advanced_by(&source[span.start.offset()..span.start.offset() + start]);
     let end_pos = span
         .start
-        .advanced_by(&source[span.start.offset..span.start.offset + end]);
+        .advanced_by(&source[span.start.offset()..span.start.offset() + end]);
     Span::from_positions(start_pos, end_pos)
 }
 
@@ -2249,7 +2249,7 @@ fn assignment_target_span(assignment: &Assignment, source: &str) -> Span {
 
     let subscript_end = subscript.syntax_source_text().span().end;
     if source
-        .get(subscript_end.offset..)
+        .get(subscript_end.offset()..)
         .is_some_and(|rest| rest.starts_with(']'))
     {
         return Span::from_positions(

--- a/crates/shuck-semantic/src/builder/references.rs
+++ b/crates/shuck-semantic/src/builder/references.rs
@@ -25,7 +25,7 @@ impl<'a, 'idx, 'observer> SemanticModelBuilder<'a, 'idx, 'observer> {
         };
         let id = ReferenceId(self.references.len() as u32);
         let scope = self.current_scope();
-        let resolved = self.resolve_reference(name, scope, span.start.offset);
+        let resolved = self.resolve_reference(name, scope, span.start.offset());
         let predefined_runtime = resolved.is_none() && self.runtime.is_preinitialized(name);
 
         self.references.push(Reference {
@@ -74,7 +74,7 @@ impl<'a, 'idx, 'observer> SemanticModelBuilder<'a, 'idx, 'observer> {
         kind: ReferenceKind,
         span: Span,
     ) -> Span {
-        if span.end.offset >= self.source.len() {
+        if span.end.offset() >= self.source.len() {
             return span;
         }
 
@@ -90,18 +90,18 @@ impl<'a, 'idx, 'observer> SemanticModelBuilder<'a, 'idx, 'observer> {
         if let Some(start_rel) = syntax.find('$') {
             let candidate = &syntax[start_rel..];
             if unbraced_parameter_reference_matches(candidate, name.as_str()) {
-                let start_offset = span.start.offset + start_rel;
+                let start_offset = span.start.offset() + start_rel;
                 let end_offset = start_offset + '$'.len_utf8() + name.as_str().len();
                 if let Some(start) = shifted_position_within_line(span.start, syntax, start_rel)
                     && let Some(matched) = self.source.get(start_offset..end_offset)
                     && let Some(end) = shifted_position_within_line(start, matched, matched.len())
-                    && start.offset < end.offset
+                    && start.offset() < end.offset()
                 {
                     return Span::from_positions(start, end);
                 }
                 if let Some((start, end)) =
                     self.source_positions_for_offsets(start_offset, end_offset)
-                    && start.offset < end.offset
+                    && start.offset() < end.offset()
                 {
                     return Span::from_positions(start, end);
                 }
@@ -113,22 +113,18 @@ impl<'a, 'idx, 'observer> SemanticModelBuilder<'a, 'idx, 'observer> {
                 .or_else(|| self.recover_braced_reference_span(name, span))
                 .unwrap_or(span);
         };
-        if self.source.as_bytes().get(span.end.offset) != Some(&b'}') {
+        if self.source.as_bytes().get(span.end.offset()) != Some(&b'}') {
             return self
                 .recover_braced_reference_span(name, span)
                 .unwrap_or(span);
         }
 
-        let start_offset = span.start.offset + start_rel;
-        let end_offset = span.end.offset + '}'.len_utf8();
+        let start_offset = span.start.offset() + start_rel;
+        let end_offset = span.end.offset() + '}'.len_utf8();
         if let Some(start) = shifted_position_within_line(span.start, syntax, start_rel) {
             // The closing brace is a single-column character after the span.
-            let end = Position {
-                line: span.end.line,
-                column: span.end.column + 1,
-                offset: end_offset,
-            };
-            if start.offset < end.offset {
+            let end = Position::at(span.end.line(), span.end.column() + 1, end_offset);
+            if start.offset() < end.offset() {
                 return Span::from_positions(start, end);
             }
             return span;
@@ -136,7 +132,7 @@ impl<'a, 'idx, 'observer> SemanticModelBuilder<'a, 'idx, 'observer> {
         let Some((start, end)) = self.source_positions_for_offsets(start_offset, end_offset) else {
             return span;
         };
-        if start.offset < end.offset {
+        if start.offset() < end.offset() {
             Span::from_positions(start, end)
         } else {
             span
@@ -146,7 +142,7 @@ impl<'a, 'idx, 'observer> SemanticModelBuilder<'a, 'idx, 'observer> {
     fn reference_name_span(&self, name: &Name, span: Span) -> Option<Span> {
         let syntax = span.slice(self.source);
         if syntax == name.as_str() {
-            return (span.start.offset < span.end.offset).then_some(span);
+            return (span.start.offset() < span.end.offset()).then_some(span);
         }
         // `$name` and `${name}` spans dominate; match them directly instead of
         // running a substring search per reference.
@@ -164,42 +160,42 @@ impl<'a, 'idx, 'observer> SemanticModelBuilder<'a, 'idx, 'observer> {
             } else {
                 return None;
             };
-        let start_offset = span.start.offset + relative_start;
+        let start_offset = span.start.offset() + relative_start;
         let end_offset = start_offset + name_len;
         if let Some(start) = shifted_position_within_line(span.start, syntax, relative_start) {
             let matched = &syntax[relative_start..relative_start + name_len];
             if let Some(end) = shifted_position_within_line(start, matched, name_len) {
-                return (start.offset < end.offset).then(|| Span::from_positions(start, end));
+                return (start.offset() < end.offset()).then(|| Span::from_positions(start, end));
             }
         }
         let (start, end) = self.source_positions_for_offsets(start_offset, end_offset)?;
-        (start.offset < end.offset).then(|| Span::from_positions(start, end))
+        (start.offset() < end.offset()).then(|| Span::from_positions(start, end))
     }
 
     pub(super) fn recover_braced_reference_span(&self, name: &Name, span: Span) -> Option<Span> {
-        if name.is_empty() || span.start.offset >= self.source.len() {
+        if name.is_empty() || span.start.offset() >= self.source.len() {
             return None;
         }
 
         let name = name.as_str();
         let search_end = self
             .source
-            .get(span.start.offset..)?
+            .get(span.start.offset()..)?
             .find('\n')
-            .map(|relative| span.start.offset + relative)
+            .map(|relative| span.start.offset() + relative)
             .unwrap_or(self.source.len());
 
-        let search = self.source.get(span.start.offset..search_end)?;
+        let search = self.source.get(span.start.offset()..search_end)?;
         let mut needle = compact_str::CompactString::const_new("${");
         needle.push_str(name);
         for (start_rel, _) in search.match_indices(needle.as_str()) {
-            let start_offset = span.start.offset + start_rel;
+            let start_offset = span.start.offset() + start_rel;
             if braced_parameter_start_matches(self.source, start_offset, name)
                 && let Some(end_offset) =
                     braced_parameter_end_offset(self.source, start_offset, search_end)
                 && let Some((start, end)) =
                     self.source_positions_for_offsets(start_offset, end_offset)
-                && start.offset < end.offset
+                && start.offset() < end.offset()
             {
                 return Some(Span::from_positions(start, end));
             }
@@ -209,11 +205,12 @@ impl<'a, 'idx, 'observer> SemanticModelBuilder<'a, 'idx, 'observer> {
     }
 
     pub(super) fn recover_unbraced_reference_span(&self, name: &Name, span: Span) -> Option<Span> {
-        if name.is_empty() || span.start.offset >= self.source.len() {
+        if name.is_empty() || span.start.offset() >= self.source.len() {
             return None;
         }
 
-        let (line_start_offset, line) = source_line(self.source, self.line_index, span.start.line)?;
+        let (line_start_offset, line) =
+            source_line(self.source, self.line_index, span.start.line())?;
         let name = name.as_str();
         let mut best = None::<(usize, usize, usize)>;
         for (start, _) in line.match_indices('$') {
@@ -222,7 +219,7 @@ impl<'a, 'idx, 'observer> SemanticModelBuilder<'a, 'idx, 'observer> {
             }
             let end = start + '$'.len_utf8() + name.len();
             let column = line.get(..start)?.chars().count() + 1;
-            let distance = column.abs_diff(span.start.column);
+            let distance = column.abs_diff(span.start.column());
             if best
                 .as_ref()
                 .is_none_or(|(_, _, best_distance)| distance < *best_distance)
@@ -235,7 +232,7 @@ impl<'a, 'idx, 'observer> SemanticModelBuilder<'a, 'idx, 'observer> {
         let start_offset = line_start_offset + start;
         let end_offset = line_start_offset + end;
         let (start, end) = self.source_positions_for_offsets(start_offset, end_offset)?;
-        (start.offset < end.offset).then(|| Span::from_positions(start, end))
+        (start.offset() < end.offset()).then(|| Span::from_positions(start, end))
     }
 
     pub(super) fn recover_braced_reference_span_on_line(
@@ -244,7 +241,8 @@ impl<'a, 'idx, 'observer> SemanticModelBuilder<'a, 'idx, 'observer> {
         needle: &str,
         span: Span,
     ) -> Option<Span> {
-        let (line_start_offset, line) = source_line(self.source, self.line_index, span.start.line)?;
+        let (line_start_offset, line) =
+            source_line(self.source, self.line_index, span.start.line())?;
         let mut best = None::<(usize, usize, usize)>;
         for (start, _) in line.match_indices(needle) {
             if !braced_parameter_start_matches(line, start, name) {
@@ -254,7 +252,7 @@ impl<'a, 'idx, 'observer> SemanticModelBuilder<'a, 'idx, 'observer> {
                 continue;
             };
             let column = line.get(..start)?.chars().count() + 1;
-            let distance = column.abs_diff(span.start.column);
+            let distance = column.abs_diff(span.start.column());
             if best
                 .as_ref()
                 .is_none_or(|(_, _, best_distance)| distance < *best_distance)
@@ -267,7 +265,7 @@ impl<'a, 'idx, 'observer> SemanticModelBuilder<'a, 'idx, 'observer> {
         let start_offset = line_start_offset + start;
         let end_offset = line_start_offset + end;
         let (start, end) = self.source_positions_for_offsets(start_offset, end_offset)?;
-        (start.offset < end.offset).then(|| Span::from_positions(start, end))
+        (start.offset() < end.offset()).then(|| Span::from_positions(start, end))
     }
 
     pub(super) fn source_positions_for_offsets(
@@ -296,7 +294,7 @@ impl<'a, 'idx, 'observer> SemanticModelBuilder<'a, 'idx, 'observer> {
                 .resolve_reference(
                     &reference.name,
                     self.current_scope(),
-                    reference.name_span.start.offset,
+                    reference.name_span.start.offset(),
                 )
                 .map(|binding_id| {
                     let binding = &self.bindings[binding_id.index()];
@@ -304,7 +302,7 @@ impl<'a, 'idx, 'observer> SemanticModelBuilder<'a, 'idx, 'observer> {
                         && !self.binding_was_cleared_before_lookup(
                             binding,
                             self.current_scope(),
-                            reference.name_span.start.offset,
+                            reference.name_span.start.offset(),
                         )
                 })
                 .unwrap_or(false)
@@ -327,7 +325,7 @@ impl<'a, 'idx, 'observer> SemanticModelBuilder<'a, 'idx, 'observer> {
 
     pub(super) fn add_reference_if_bound(&mut self, name: &Name, kind: ReferenceKind, span: Span) {
         if self
-            .resolve_reference(name, self.current_scope(), span.start.offset)
+            .resolve_reference(name, self.current_scope(), span.start.offset())
             .is_some()
         {
             self.add_reference(name, kind, span);
@@ -363,7 +361,7 @@ impl<'a, 'idx, 'observer> SemanticModelBuilder<'a, 'idx, 'observer> {
                 }
             } else {
                 for binding in bindings.iter().rev().copied() {
-                    if self.bindings[binding.index()].span.start.offset <= offset {
+                    if self.bindings[binding.index()].span.start.offset() <= offset {
                         return Some(binding);
                     }
                 }
@@ -409,11 +407,11 @@ fn shifted_position_within_line(
     } else {
         prefix.chars().count()
     };
-    Some(Position {
-        line: base.line,
-        column: base.column + chars,
-        offset: base.offset + byte_offset,
-    })
+    Some(Position::at(
+        base.line(),
+        base.column() + chars,
+        base.offset() + byte_offset,
+    ))
 }
 
 fn source_position_at_offset(
@@ -433,11 +431,7 @@ fn source_position_at_offset(
     } else {
         prefix.chars().count()
     } + 1;
-    Some(Position {
-        line,
-        column,
-        offset,
-    })
+    Some(Position::at(line, column, offset))
 }
 
 #[cfg(test)]
@@ -451,37 +445,21 @@ mod tests {
 
         assert_eq!(
             source_position_at_offset(source, &line_index, 0),
-            Some(Position {
-                line: 1,
-                column: 1,
-                offset: 0
-            })
+            Some(Position::at(1, 1, 0))
         );
         let beta_offset = source.find('b').expect("expected second line");
         assert_eq!(
             source_position_at_offset(source, &line_index, beta_offset),
-            Some(Position {
-                line: 2,
-                column: 1,
-                offset: beta_offset
-            })
+            Some(Position::at(2, 1, beta_offset))
         );
         let after_e_acute = beta_offset + "b\u{e9}".len();
         assert_eq!(
             source_position_at_offset(source, &line_index, after_e_acute),
-            Some(Position {
-                line: 2,
-                column: 3,
-                offset: after_e_acute
-            })
+            Some(Position::at(2, 3, after_e_acute))
         );
         assert_eq!(
             source_position_at_offset(source, &line_index, source.len()),
-            Some(Position {
-                line: 3,
-                column: 1,
-                offset: source.len()
-            })
+            Some(Position::at(3, 1, source.len()))
         );
     }
 }

--- a/crates/shuck-semantic/src/builder/special_builtins.rs
+++ b/crates/shuck-semantic/src/builder/special_builtins.rs
@@ -123,14 +123,14 @@ impl<'a, 'idx, 'observer> SemanticModelBuilder<'a, 'idx, 'observer> {
                 if let Some((argument, span, mut attributes)) = zstyle_target(args, self.source) {
                     if attributes.contains(BindingAttributes::ARRAY)
                         && self
-                            .resolve_reference(&argument, self.current_scope(), span.start.offset)
+                            .resolve_reference(&argument, self.current_scope(), span.start.offset())
                             .map(|binding_id| {
                                 let binding = &self.bindings[binding_id.index()];
                                 binding.attributes.contains(BindingAttributes::ASSOC)
                                     && !self.binding_was_cleared_before_lookup(
                                         binding,
                                         self.current_scope(),
-                                        span.start.offset,
+                                        span.start.offset(),
                                     )
                             })
                             .unwrap_or(false)
@@ -517,9 +517,11 @@ impl<'a, 'idx, 'observer> SemanticModelBuilder<'a, 'idx, 'observer> {
 
             if nameref_mode {
                 let name = Name::from(text.as_ref());
-                let Some(binding_id) =
-                    self.resolve_reference(&name, self.current_scope(), argument.span.start.offset)
-                else {
+                let Some(binding_id) = self.resolve_reference(
+                    &name,
+                    self.current_scope(),
+                    argument.span.start.offset(),
+                ) else {
                     continue;
                 };
                 let binding = &self.bindings[binding_id.index()];
@@ -533,7 +535,7 @@ impl<'a, 'idx, 'observer> SemanticModelBuilder<'a, 'idx, 'observer> {
             self.cleared_variables
                 .entry((self.current_scope(), Name::from(text.as_ref())))
                 .or_default()
-                .push(argument.span.start.offset);
+                .push(argument.span.start.offset());
         }
     }
 
@@ -542,7 +544,7 @@ impl<'a, 'idx, 'observer> SemanticModelBuilder<'a, 'idx, 'observer> {
             return DescribeDynamicStart::Unknown;
         };
         let Some(binding_id) =
-            self.resolve_reference(&name, self.current_scope(), word.span.start.offset)
+            self.resolve_reference(&name, self.current_scope(), word.span.start.offset())
         else {
             return DescribeDynamicStart::Unknown;
         };
@@ -812,7 +814,7 @@ fn static_scalar_assignment_value(binding: &Binding, source: &str) -> Option<Str
         return None;
     }
 
-    let rest = source.get(binding.span.end.offset..)?;
+    let rest = source.get(binding.span.end.offset()..)?;
     let rest = rest.strip_prefix('=')?;
     parse_static_assignment_literal(rest)
 }

--- a/crates/shuck-semantic/src/builder/words.rs
+++ b/crates/shuck-semantic/src/builder/words.rs
@@ -197,7 +197,7 @@ impl<'a, 'idx, 'observer> SemanticModelBuilder<'a, 'idx, 'observer> {
         let escaped_template_starts = self.escaped_parameter_template_body_starts_cached(word_span);
         for part in parts {
             if !escaped_template_starts.is_empty()
-                && escaped_template_starts.contains(&part.span.start.offset)
+                && escaped_template_starts.contains(&part.span.start.offset())
             {
                 continue;
             }
@@ -287,7 +287,7 @@ impl<'a, 'idx, 'observer> SemanticModelBuilder<'a, 'idx, 'observer> {
             subscript.interpretation,
             shuck_ast::SubscriptInterpretation::Associative
         ) || owner_name.is_some_and(|name| {
-            self.name_uses_associative_word_semantics(name, subscript.span().start.offset)
+            self.name_uses_associative_word_semantics(name, subscript.span().start.offset())
         });
         if !uses_associative_word_semantics
             && let Some(expression) = subscript.arithmetic_ast.as_ref()

--- a/crates/shuck-semantic/src/call_facts.rs
+++ b/crates/shuck-semantic/src/call_facts.rs
@@ -282,7 +282,7 @@ impl FileCallFacts {
             .source_refs()
             .iter()
             .map(|source_ref| {
-                let scope = model.scope_at(source_ref.span.start.offset);
+                let scope = model.scope_at(source_ref.span.start.offset());
                 let enclosing_function = model
                     .ancestor_scopes(scope)
                     .find_map(|scope| functions_by_scope.get(&scope))
@@ -313,7 +313,7 @@ impl FileCallFacts {
                 });
             }
         }
-        source_effects.sort_by_key(|effect| effect.span.start.offset);
+        source_effects.sort_by_key(|effect| effect.span.start.offset());
         let has_dynamic_command_dispatch =
             model.recorded_program().commands().iter().any(|command| {
                 command.command_info.is_some_and(|info| {
@@ -603,16 +603,16 @@ impl WorkspaceCallIndex {
             CallNodeKind::TopLevel => self.resolve_exact_events(
                 from_path,
                 &site.callee,
-                ExactQuery::top_level(site.name_span.start.offset),
+                ExactQuery::top_level(site.name_span.start.offset()),
                 &mut stack,
             ),
             CallNodeKind::Function(function) => {
                 if self.called_source_function_may_mutate(from_path, function)
                     || facts.source_effects.iter().any(|effect| {
                         (effect.enclosing_function.is_none()
-                            && effect.span.start.offset >= function.definition_start)
+                            && effect.span.start.offset() >= function.definition_start)
                             || (effect.enclosing_function.as_ref() == Some(function)
-                                && effect.span.start.offset >= site.name_span.start.offset)
+                                && effect.span.start.offset() >= site.name_span.start.offset())
                     })
                 {
                     return None;
@@ -625,7 +625,7 @@ impl WorkspaceCallIndex {
                         local_definition: site.local_definition_span,
                         include_top_level_definitions: false,
                         enclosing_function: Some(function),
-                        local_call_offset: Some(site.name_span.start.offset),
+                        local_call_offset: Some(site.name_span.start.offset()),
                     },
                     &mut stack,
                 )
@@ -686,11 +686,11 @@ impl WorkspaceCallIndex {
             || facts.source_effects.iter().any(|effect| {
                 !effect.persistent
                     && ((effect.enclosing_function.is_none()
-                        && effect.span.start.offset < query.top_level_cutoff)
+                        && effect.span.start.offset() < query.top_level_cutoff)
                         || (effect.enclosing_function.as_ref() == query.enclosing_function
                             && query
                                 .local_call_offset
-                                .is_some_and(|offset| effect.span.start.offset < offset)))
+                                .is_some_and(|offset| effect.span.start.offset() < offset)))
             })
         {
             return ExactResolution::Ambiguous;
@@ -706,10 +706,10 @@ impl WorkspaceCallIndex {
             for definition in facts.definitions.iter().filter(|definition| {
                 definition.persistent_top_level
                     && &definition.name == callee
-                    && definition.def_span.start.offset < query.top_level_cutoff
+                    && definition.def_span.start.offset() < query.top_level_cutoff
             }) {
                 events.push((
-                    definition.def_span.start.offset,
+                    definition.def_span.start.offset(),
                     Event::Definition(definition),
                 ));
             }
@@ -720,20 +720,20 @@ impl WorkspaceCallIndex {
                 .find(|definition| definition.def_span == definition_span)
         {
             events.push((
-                definition.def_span.start.offset,
+                definition.def_span.start.offset(),
                 Event::Definition(definition),
             ));
         }
         for effect in facts.source_effects.iter().filter(|effect| {
             effect.persistent
                 && ((effect.enclosing_function.is_none()
-                    && effect.span.start.offset < query.top_level_cutoff)
+                    && effect.span.start.offset() < query.top_level_cutoff)
                     || (effect.enclosing_function.as_ref() == query.enclosing_function
                         && query
                             .local_call_offset
-                            .is_some_and(|offset| effect.span.start.offset < offset)))
+                            .is_some_and(|offset| effect.span.start.offset() < offset)))
         }) {
-            events.push((effect.span.start.offset, Event::Source(effect)));
+            events.push((effect.span.start.offset(), Event::Source(effect)));
         }
         events.sort_by_key(|(offset, _)| *offset);
 

--- a/crates/shuck-semantic/src/call_facts.rs
+++ b/crates/shuck-semantic/src/call_facts.rs
@@ -78,8 +78,8 @@ impl CallFunctionId {
     pub fn new(name: Name, definition_span: Span) -> Self {
         Self {
             name,
-            definition_start: definition_span.start.offset,
-            definition_end: definition_span.end.offset,
+            definition_start: definition_span.start.offset(),
+            definition_end: definition_span.end.offset(),
         }
     }
 }
@@ -217,7 +217,7 @@ impl FileCallFacts {
         mut source_edges: Vec<CallFactSourceEdge>,
     ) -> Self {
         let analysis = model.analysis();
-        source_edges.sort_by_key(|edge| edge.span.start.offset);
+        source_edges.sort_by_key(|edge| edge.span.start.offset());
 
         let mut functions_by_scope: FxHashMap<ScopeId, Vec<(CallFunctionId, Span)>> =
             FxHashMap::default();
@@ -339,8 +339,8 @@ impl FileCallFacts {
     pub fn definition(&self, function: &CallFunctionId) -> Option<&CallFactDefinition> {
         self.definitions.iter().find(|definition| {
             definition.name == function.name
-                && definition.def_span.start.offset == function.definition_start
-                && definition.def_span.end.offset == function.definition_end
+                && definition.def_span.start.offset() == function.definition_start
+                && definition.def_span.end.offset() == function.definition_end
         })
     }
 }
@@ -562,7 +562,7 @@ impl WorkspaceCallIndex {
             .iter()
             .find(|site| site.name_span == name_span)?;
         let cutoff = match site.enclosing {
-            CallNodeKind::TopLevel => Some(site.name_span.start.offset),
+            CallNodeKind::TopLevel => Some(site.name_span.start.offset()),
             CallNodeKind::Function(_) => None,
         };
         let sourced = self.resolve_through_edges_before(from_path, &site.callee, cutoff);
@@ -807,7 +807,7 @@ impl WorkspaceCallIndex {
             .rev()
             .filter(|edge| {
                 edge.span == Span::new()
-                    || cutoff.is_none_or(|offset| edge.span.start.offset < offset)
+                    || cutoff.is_none_or(|offset| edge.span.start.offset() < offset)
             })
             .find_map(|edge| {
                 self.resolve_exported(&edge.path, callee, &mut stack)
@@ -840,12 +840,12 @@ impl WorkspaceCallIndex {
         let mut events = Vec::new();
         for definition in facts.definitions.iter().filter(|def| &def.name == callee) {
             events.push((
-                definition.def_span.start.offset,
+                definition.def_span.start.offset(),
                 Event::Definition(definition),
             ));
         }
         for edge in &facts.source_edges {
-            events.push((edge.span.start.offset, Event::Source(edge)));
+            events.push((edge.span.start.offset(), Event::Source(edge)));
         }
         events.sort_by_key(|(offset, _)| *offset);
 
@@ -884,7 +884,7 @@ impl WorkspaceCallIndex {
                 continue;
             }
             let cutoff = match site.enclosing {
-                CallNodeKind::TopLevel => Some(site.name_span.start.offset),
+                CallNodeKind::TopLevel => Some(site.name_span.start.offset()),
                 CallNodeKind::Function(_) => None,
             };
             let sourced = resolved
@@ -955,7 +955,7 @@ impl WorkspaceCallIndex {
                     continue;
                 }
                 let cutoff = match site.enclosing {
-                    CallNodeKind::TopLevel => Some(site.name_span.start.offset),
+                    CallNodeKind::TopLevel => Some(site.name_span.start.offset()),
                     CallNodeKind::Function(_) => None,
                 };
                 let sourced = edge_resolutions
@@ -966,8 +966,9 @@ impl WorkspaceCallIndex {
                     choose_resolved_target(caller_path, site.local_definition_span, sourced)
                         .is_some_and(|target| {
                             target.path.as_path() == target_path
-                                && target.def_span.start.offset == target_function.definition_start
-                                && target.def_span.end.offset == target_function.definition_end
+                                && target.def_span.start.offset()
+                                    == target_function.definition_start
+                                && target.def_span.end.offset() == target_function.definition_end
                         });
                 if !resolves {
                     continue;
@@ -1015,7 +1016,8 @@ fn choose_resolved_target(
 ) -> Option<ResolvedDefinition> {
     match (local_definition, sourced) {
         (Some(definition), Some((target, source_span)))
-            if source_span != Span::new() && source_span.start.offset > definition.start.offset =>
+            if source_span != Span::new()
+                && source_span.start.offset() > definition.start.offset() =>
         {
             Some(target)
         }
@@ -1787,7 +1789,7 @@ mod tests {
             .definitions
             .iter()
             .filter(|definition| definition.name == name("greet"))
-            .max_by_key(|definition| definition.def_span.start.offset)
+            .max_by_key(|definition| definition.def_span.start.offset())
             .expect("final greet definition should be projected")
             .def_span;
         index.insert(caller_path.clone(), caller_facts);
@@ -1829,7 +1831,7 @@ mod tests {
         let final_definition = target_facts
             .definitions
             .iter()
-            .max_by_key(|definition| definition.def_span.start.offset)
+            .max_by_key(|definition| definition.def_span.start.offset())
             .expect("final sourced definition should be projected")
             .clone();
 

--- a/crates/shuck-semantic/src/call_facts.rs
+++ b/crates/shuck-semantic/src/call_facts.rs
@@ -412,7 +412,7 @@ impl WorkspaceCallIndex {
             from_path,
             facts.source_edges.iter().filter(|edge| {
                 edge.completion_visible
-                    && (edge.span == Span::new() || edge.span.start.offset < cutoff)
+                    && (edge.span == Span::new() || edge.span.start.offset() < cutoff)
             }),
         )
     }
@@ -498,7 +498,7 @@ impl WorkspaceCallIndex {
             .filter(|definition| definition.unconditional && definition.persistent_top_level)
             .map(|definition| {
                 (
-                    definition.def_span.start.offset,
+                    definition.def_span.start.offset(),
                     Event::Definition(definition),
                 )
             })
@@ -507,7 +507,7 @@ impl WorkspaceCallIndex {
                     .source_edges
                     .iter()
                     .filter(|edge| edge.completion_visible)
-                    .map(|edge| (edge.span.start.offset, Event::Source(edge))),
+                    .map(|edge| (edge.span.start.offset(), Event::Source(edge))),
             )
             .collect::<Vec<_>>();
         events.sort_by_key(|(offset, _)| *offset);
@@ -1057,7 +1057,7 @@ mod tests {
             .iter()
             .zip(paths)
             .map(|(source_ref, path)| {
-                let scope = model.scope_at(source_ref.span.start.offset);
+                let scope = model.scope_at(source_ref.span.start.offset());
                 CallFactSourceEdge {
                     path: PathBuf::from(path),
                     span: source_ref.span,

--- a/crates/shuck-semantic/src/call_graph.rs
+++ b/crates/shuck-semantic/src/call_graph.rs
@@ -126,9 +126,9 @@ pub(crate) fn build_call_graph(
                         .into_iter()
                         .flat_map(|sites| sites.iter())
                         .any(|site| {
-                            let first = bindings[pair[0].index()].span.start.offset;
-                            let second = bindings[pair[1].index()].span.start.offset;
-                            site.span.start.offset > first && site.span.start.offset < second
+                            let first = bindings[pair[0].index()].span.start.offset();
+                            let second = bindings[pair[1].index()].span.start.offset();
+                            site.span.start.offset() > first && site.span.start.offset() < second
                         }),
                 })
         })

--- a/crates/shuck-semantic/src/cfg/termination.rs
+++ b/crates/shuck-semantic/src/cfg/termination.rs
@@ -134,12 +134,12 @@ fn command_can_return_before(
     before_offset: usize,
 ) -> bool {
     let command = program.command(command_id);
-    if command.span.start.offset >= before_offset {
+    if command.span.start.offset() >= before_offset {
         return false;
     }
 
     match program.command(command_id).kind {
-        RecordedCommandKind::Return => command.span.start.offset < before_offset,
+        RecordedCommandKind::Return => command.span.start.offset() < before_offset,
         RecordedCommandKind::List { first, rest } => {
             command_can_return_before(program, first, before_offset)
                 || program
@@ -209,7 +209,7 @@ fn resolve_script_terminating_call_spans(
         }
         if file_entry_can_return_before_function_definition(
             program,
-            bindings[call.binding.index()].span.start.offset,
+            bindings[call.binding.index()].span.start.offset(),
         ) {
             continue;
         }
@@ -241,8 +241,8 @@ pub(crate) fn recorded_command_span_for_call_site(
         })
         .min_by_key(|command| {
             (
-                command.span.end.offset - command.span.start.offset,
-                command.span.start.offset,
+                command.span.end.offset() - command.span.start.offset(),
+                command.span.start.offset(),
             )
         })
         .or_else(|| {
@@ -252,8 +252,8 @@ pub(crate) fn recorded_command_span_for_call_site(
                 .filter(|command| span_contains(command.span, site.span))
                 .min_by_key(|command| {
                     (
-                        command.span.end.offset - command.span.start.offset,
-                        command.span.start.offset,
+                        command.span.end.offset() - command.span.start.offset(),
+                        command.span.start.offset(),
                     )
                 })
         })
@@ -359,7 +359,7 @@ fn command_exit_effect(
 }
 
 fn span_contains(outer: Span, inner: Span) -> bool {
-    outer.start.offset <= inner.start.offset && inner.end.offset <= outer.end.offset
+    outer.start.offset() <= inner.start.offset() && inner.end.offset() <= outer.end.offset()
 }
 
 fn list_exit_effect(

--- a/crates/shuck-semantic/src/command_topology.rs
+++ b/crates/shuck-semantic/src/command_topology.rs
@@ -891,14 +891,14 @@ fn build_command_containing_offset_entries(
             };
             [
                 CommandContainingOffsetEvent {
-                    offset: span.start.offset,
-                    end_offset: span.end.offset,
+                    offset: span.start.offset(),
+                    end_offset: span.end.offset(),
                     id,
                     kind: CommandContainingOffsetEventKind::Start,
                 },
                 CommandContainingOffsetEvent {
-                    offset: span.end.offset.saturating_add(1),
-                    end_offset: span.end.offset,
+                    offset: span.end.offset().saturating_add(1),
+                    end_offset: span.end.offset(),
                     id,
                     kind: CommandContainingOffsetEventKind::End,
                 },
@@ -1263,7 +1263,7 @@ fn attach_function_body_commands(
         let child_span = model.command_syntax_span(child);
         while let Some(function_id) = function_ids.get(next_function).copied() {
             let function_span = model.command_syntax_span(function_id);
-            if function_span.start.offset > child_span.start.offset {
+            if function_span.start.offset() > child_span.start.offset() {
                 break;
             }
             while active_functions.last().is_some_and(|active| {
@@ -1290,7 +1290,7 @@ fn attach_function_body_commands(
 }
 
 fn contains_command_span(outer: Span, inner: Span) -> bool {
-    outer.start.offset <= inner.start.offset && inner.end.offset <= outer.end.offset
+    outer.start.offset() <= inner.start.offset() && inner.end.offset() <= outer.end.offset()
 }
 
 fn compare_command_ids_by_syntax_span(
@@ -1302,8 +1302,8 @@ fn compare_command_ids_by_syntax_span(
     let right_span = model.command_syntax_span(right);
     left_span
         .start
-        .offset
-        .cmp(&right_span.start.offset)
-        .then_with(|| right_span.end.offset.cmp(&left_span.end.offset))
+        .offset()
+        .cmp(&right_span.start.offset())
+        .then_with(|| right_span.end.offset().cmp(&left_span.end.offset()))
         .then_with(|| right.index().cmp(&left.index()))
 }

--- a/crates/shuck-semantic/src/dataflow/dead_code.rs
+++ b/crates/shuck-semantic/src/dataflow/dead_code.rs
@@ -28,7 +28,11 @@ pub(super) fn build_dead_code(cfg: &ControlFlowGraph) -> Vec<DeadCode> {
                     kind: UnreachableCauseKind::ShellTerminator,
                 });
         dead_code_by_cause
-            .entry((cause.span.start.offset, cause.span.end.offset, cause.kind))
+            .entry((
+                cause.span.start.offset(),
+                cause.span.end.offset(),
+                cause.kind,
+            ))
             .or_insert_with(|| (cause, Vec::new()))
             .1
             .extend(block.commands.iter().copied());
@@ -41,16 +45,16 @@ pub(super) fn build_dead_code(cfg: &ControlFlowGraph) -> Vec<DeadCode> {
             cause_kind: cause.kind,
         })
         .collect::<Vec<_>>();
-    dead_code.sort_by_key(|dead| (dead.cause.start.offset, dead.cause.end.offset));
+    dead_code.sort_by_key(|dead| (dead.cause.start.offset(), dead.cause.end.offset()));
     dead_code
 }
 
 fn outermost_unreachable_spans(mut spans: Vec<Span>) -> Vec<Span> {
     spans.sort_by(|left, right| {
         left.start
-            .offset
-            .cmp(&right.start.offset)
-            .then_with(|| right.end.offset.cmp(&left.end.offset))
+            .offset()
+            .cmp(&right.start.offset())
+            .then_with(|| right.end.offset().cmp(&left.end.offset()))
     });
 
     let mut outermost = Vec::new();
@@ -70,5 +74,5 @@ fn outermost_unreachable_spans(mut spans: Vec<Span>) -> Vec<Span> {
 }
 
 fn span_contained_by(inner: Span, outer: Span) -> bool {
-    outer.start.offset <= inner.start.offset && inner.end.offset <= outer.end.offset
+    outer.start.offset() <= inner.start.offset() && inner.end.offset() <= outer.end.offset()
 }

--- a/crates/shuck-semantic/src/dataflow/scope_reads.rs
+++ b/crates/shuck-semantic/src/dataflow/scope_reads.rs
@@ -340,7 +340,7 @@ pub(super) fn build_scope_read_plans(
             plan.direct_reads.insert(compact);
         }
         plan.events.push(ScopeReadEvent {
-            offset: reference.span.start.offset,
+            offset: reference.span.start.offset(),
             block: reference_blocks[reference_index],
             kind: ScopeReadEventKind::Direct(name_id),
         });
@@ -353,7 +353,7 @@ pub(super) fn build_scope_read_plans(
             plan.direct_reads.insert(compact);
         }
         plan.events.push(ScopeReadEvent {
-            offset: synthetic_read.span.start.offset,
+            offset: synthetic_read.span.start.offset(),
             block: command_block_for_span(cfg, synthetic_read.span),
             kind: ScopeReadEventKind::Direct(name_id),
         });
@@ -559,8 +559,8 @@ pub(super) fn binding_has_future_reads_before_local_shadow(
             escape_reads_visible
                 || future_reads_contain_after_without_shadow(
                     binding.scope,
-                    binding.span.start.offset,
-                    shadow.span.start.offset,
+                    binding.span.start.offset(),
+                    shadow.span.start.offset(),
                     binding_block,
                     shadow_block,
                     name_id,
@@ -573,8 +573,8 @@ pub(super) fn binding_has_future_reads_before_local_shadow(
             escape_reads_visible
                 || future_reads_contain_after_until(
                     binding.scope,
-                    binding.span.start.offset,
-                    shadow.span.start.offset,
+                    binding.span.start.offset(),
+                    shadow.span.start.offset(),
                     name_id,
                     compact_name,
                     read_plans,
@@ -584,7 +584,7 @@ pub(super) fn binding_has_future_reads_before_local_shadow(
     } else {
         future_reads_contain_after(
             binding.scope,
-            binding.span.start.offset,
+            binding.span.start.offset(),
             compact_name,
             read_plans,
             future_reads,
@@ -760,7 +760,7 @@ pub(super) fn resolved_calls_by_scope(
             .entry(call.site.scope)
             .or_default()
             .push(ResolvedCallSite {
-                offset: call.site.span.start.offset,
+                offset: call.site.span.start.offset(),
                 span: call.site.span,
                 callee_scope: call.callee_scope,
             });

--- a/crates/shuck-semantic/src/dataflow/tests.rs
+++ b/crates/shuck-semantic/src/dataflow/tests.rs
@@ -513,7 +513,7 @@ printf '%s\\n' \"$value\"
         .dataflow()
         .unused_assignments
         .iter()
-        .map(|unused| model.binding(unused.binding).span.start.line)
+        .map(|unused| model.binding(unused.binding).span.start.line())
         .collect::<Vec<_>>();
 
     assert_eq!(unused_lines, vec![1, 2]);
@@ -715,7 +715,7 @@ f
             .iter()
             .map(|binding| {
                 let binding = model.binding(*binding);
-                (binding.name.to_string(), binding.span.start.line)
+                (binding.name.to_string(), binding.span.start.line())
             })
             .collect::<Vec<_>>()
     );
@@ -746,7 +746,7 @@ f
             .iter()
             .map(|binding| {
                 let binding = model.binding(*binding);
-                (binding.name.to_string(), binding.span.start.line)
+                (binding.name.to_string(), binding.span.start.line())
             })
             .collect::<Vec<_>>()
     );

--- a/crates/shuck-semantic/src/dataflow/uninitialized.rs
+++ b/crates/shuck-semantic/src/dataflow/uninitialized.rs
@@ -124,7 +124,7 @@ impl ParameterGuardFlowIndex {
             offsets_by_block_name
                 .entry((block, name))
                 .or_default()
-                .push(guard.span.start.offset);
+                .push(guard.span.start.offset());
         }
         for offsets in offsets_by_block_name.values_mut() {
             offsets.sort_unstable();
@@ -138,7 +138,7 @@ impl ParameterGuardFlowIndex {
         self.offsets_by_block_name
             .get(&(block, name))
             .is_some_and(|offsets| {
-                offsets.partition_point(|offset| *offset < reference.span.start.offset) > 0
+                offsets.partition_point(|offset| *offset < reference.span.start.offset()) > 0
             })
     }
 }

--- a/crates/shuck-semantic/src/dataflow/unused.rs
+++ b/crates/shuck-semantic/src/dataflow/unused.rs
@@ -761,7 +761,7 @@ fn build_unused_assignment_events(
         for reference_id in &block.references {
             let reference = &context.references[reference_id.index()];
             block_events.push(UnusedAssignmentEvent {
-                offset: reference.span.start.offset,
+                offset: reference.span.start.offset(),
                 order: 0,
                 kind: UnusedAssignmentEventKind::Reference(*reference_id),
             });
@@ -769,7 +769,7 @@ fn build_unused_assignment_events(
         for binding_id in &block.bindings {
             let binding = &context.bindings[binding_id.index()];
             block_events.push(UnusedAssignmentEvent {
-                offset: binding.span.start.offset,
+                offset: binding.span.start.offset(),
                 order: 1,
                 kind: UnusedAssignmentEventKind::Binding(*binding_id),
             });
@@ -779,7 +779,7 @@ fn build_unused_assignment_events(
     for (read_index, synthetic_read) in context.synthetic_reads.iter().enumerate() {
         let mut push_synthetic_read = |block_id: BlockId| {
             events[block_id.index()].push(UnusedAssignmentEvent {
-                offset: synthetic_read.span.start.offset,
+                offset: synthetic_read.span.start.offset(),
                 order: 0,
                 kind: UnusedAssignmentEventKind::SyntheticRead(read_index),
             });
@@ -817,7 +817,7 @@ fn build_unused_assignment_events(
         };
         let binding = &context.bindings[binding_id.index()];
         events[block_id.index()].push(UnusedAssignmentEvent {
-            offset: binding.span.start.offset,
+            offset: binding.span.start.offset(),
             order: 0,
             kind: UnusedAssignmentEventKind::FunctionDefinition(scope_id),
         });

--- a/crates/shuck-semantic/src/editor.rs
+++ b/crates/shuck-semantic/src/editor.rs
@@ -327,7 +327,7 @@ impl<'model> EditorQuery<'model> {
             let index = pending.len();
             let function_scope = analysis.function_scope_for_binding(binding.id);
             pending.push(PendingDocumentSymbol {
-                sort_offset: binding.span.start.offset,
+                sort_offset: binding.span.start.offset(),
                 symbol,
                 parent: None,
             });
@@ -360,7 +360,7 @@ impl<'model> EditorQuery<'model> {
                 continue;
             };
             pending.push(PendingDocumentSymbol {
-                sort_offset: binding.span.start.offset,
+                sort_offset: binding.span.start.offset(),
                 symbol,
                 parent,
             });
@@ -647,7 +647,7 @@ struct HoverTargetRank {
 }
 
 fn span_contains_offset(span: Span, offset: usize) -> bool {
-    span.start.offset <= offset && offset < span.end.offset
+    span.start.offset() <= offset && offset < span.end.offset()
 }
 
 fn hover_target_rank(target: &EditorHoverTarget) -> HoverTargetRank {
@@ -661,8 +661,8 @@ fn hover_target_rank(target: &EditorHoverTarget) -> HoverTargetRank {
         width: target
             .span
             .end
-            .offset
-            .saturating_sub(target.span.start.offset),
+            .offset()
+            .saturating_sub(target.span.start.offset()),
     }
 }
 
@@ -670,11 +670,11 @@ fn find_editor_target(model: &SemanticModel, offset: usize) -> Option<&EditorHov
     let targets = model
         .editor_hover_targets
         .get_or_init(|| build_editor_hover_targets(model));
-    let upper = targets.partition_point(|target| target.span.start.offset <= offset);
+    let upper = targets.partition_point(|target| target.span.start.offset() <= offset);
 
     let mut best: Option<(&EditorHoverTarget, HoverTargetRank)> = None;
     for target in targets[..upper].iter().rev() {
-        if target.span.end.offset <= offset {
+        if target.span.end.offset() <= offset {
             break;
         }
         if !span_contains_offset(target.span, offset) {
@@ -756,7 +756,7 @@ fn build_editor_hover_targets(model: &SemanticModel) -> EditorHoverTargets {
             }
         }
     }
-    targets.sort_by_key(|target| (target.span.start.offset, target.span.end.offset));
+    targets.sort_by_key(|target| (target.span.start.offset(), target.span.end.offset()));
     targets
 }
 
@@ -1021,7 +1021,7 @@ fn rename_span_for_binding(binding: &Binding) -> Span {
 }
 
 fn source_backed_reference(reference: &Reference) -> bool {
-    reference.name_span.start.offset < reference.name_span.end.offset
+    reference.name_span.start.offset() < reference.name_span.end.offset()
         && !matches!(
             reference.kind,
             ReferenceKind::ImplicitRead | ReferenceKind::RequiredRead
@@ -1031,23 +1031,23 @@ fn source_backed_reference(reference: &Reference) -> bool {
 fn sort_dedup_occurrences(occurrences: &mut Vec<EditorOccurrence>) {
     occurrences.sort_by_key(|occurrence| {
         (
-            occurrence.span.start.offset,
-            occurrence.span.end.offset,
+            occurrence.span.start.offset(),
+            occurrence.span.end.offset(),
             occurrence.kind == EditorOccurrenceKind::Read,
         )
     });
     occurrences.dedup_by_key(|occurrence| {
         (
-            occurrence.span.start.offset,
-            occurrence.span.end.offset,
+            occurrence.span.start.offset(),
+            occurrence.span.end.offset(),
             occurrence.kind,
         )
     });
 }
 
 fn sort_dedup_spans(spans: &mut Vec<Span>) {
-    spans.sort_by_key(|span| (span.start.offset, span.end.offset));
-    spans.dedup_by_key(|span| (span.start.offset, span.end.offset));
+    spans.sort_by_key(|span| (span.start.offset(), span.end.offset()));
+    spans.dedup_by_key(|span| (span.start.offset(), span.end.offset()));
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -1068,12 +1068,12 @@ fn completion_context(source: &str, indexer: &Indexer, offset: usize) -> Option<
         return Some(CompletionContext::Parameter { replacement_span });
     }
     let word_span = current_word_span(source, offset);
-    if declaration_operand_context(source, indexer, word_span.start.offset) {
+    if declaration_operand_context(source, indexer, word_span.start.offset()) {
         return Some(CompletionContext::Declaration {
             replacement_span: word_span,
         });
     }
-    if command_position_context(source, word_span.start.offset) {
+    if command_position_context(source, word_span.start.offset()) {
         return Some(CompletionContext::Command {
             replacement_span: word_span,
         });
@@ -1359,11 +1359,7 @@ fn position_at_offset(source: &str, offset: usize) -> shuck_ast::Position {
 }
 
 fn position_with_offset(offset: usize) -> shuck_ast::Position {
-    shuck_ast::Position {
-        line: 1,
-        column: offset + 1,
-        offset,
-    }
+    shuck_ast::Position::at(1, offset + 1, offset)
 }
 
 fn valid_variable_name(name: &str) -> bool {
@@ -1446,7 +1442,7 @@ fn runtime_hover(model: &SemanticModel, name: Name, target_span: Span) -> Editor
             kind,
             definition_span: target_span,
             selection_span: target_span,
-            scope: model.scope_at(target_span.start.offset),
+            scope: model.scope_at(target_span.start.offset()),
             binding: None,
         },
         target_span,

--- a/crates/shuck-semantic/src/function_call_reachability.rs
+++ b/crates/shuck-semantic/src/function_call_reachability.rs
@@ -174,7 +174,7 @@ impl<'analysis, 'model> DirectFunctionCallReachability<'analysis, 'model> {
         window: DirectFunctionCallWindow,
     ) -> bool {
         let binding = self.analysis.model.binding(binding_id);
-        let after_offset = window.after_offset.max(binding.span.start.offset);
+        let after_offset = window.after_offset.max(binding.span.start.offset());
         if let Some(boundary_scope) = window.scope_boundary {
             let window = BoundaryCallWindow {
                 after_offset,
@@ -310,7 +310,7 @@ impl<'analysis, 'model> DirectFunctionCallReachability<'analysis, 'model> {
                     self.add_activation_edge(
                         target_binding,
                         target_scope,
-                        binding.span.start.offset,
+                        binding.span.start.offset(),
                         &call,
                         &mut seen_edges,
                         &mut edges_by_caller,
@@ -339,7 +339,7 @@ impl<'analysis, 'model> DirectFunctionCallReachability<'analysis, 'model> {
             target_binding,
             target_scope,
             call_scope: call.scope,
-            call_offset: call.name_span.start.offset,
+            call_offset: call.name_span.start.offset(),
         };
         if !seen_edges.insert(key) {
             return;
@@ -348,7 +348,7 @@ impl<'analysis, 'model> DirectFunctionCallReachability<'analysis, 'model> {
         let edge = FunctionActivationEdge {
             target_scope,
             target_binding_offset,
-            call_offset: call.name_span.start.offset,
+            call_offset: call.name_span.start.offset(),
             persistent: !self.analysis.scope_runs_in_transient_context(call.scope),
         };
         edges_by_caller
@@ -535,11 +535,11 @@ impl<'analysis, 'model> DirectFunctionCallReachability<'analysis, 'model> {
         visiting: &mut FxHashSet<ScopeId>,
     ) -> bool {
         let binding = self.model().binding(function_binding);
-        let required_after = after_offset.max(binding.span.start.offset);
+        let required_after = after_offset.max(binding.span.start.offset());
         self.call_candidates_for(&binding.name)
             .into_iter()
             .any(|call| {
-                let call_offset = call.name_span.start.offset;
+                let call_offset = call.name_span.start.offset();
                 call_offset <= before_offset
                     && (!require_non_transient_call
                         || !self.analysis.scope_runs_in_transient_context(call.scope))
@@ -614,13 +614,13 @@ impl<'analysis, 'model> DirectFunctionCallReachability<'analysis, 'model> {
     ) -> bool {
         let binding = self.model().binding(function_binding);
         let nested_window = BoundaryCallWindow {
-            after_offset: window.after_offset.max(binding.span.start.offset),
+            after_offset: window.after_offset.max(binding.span.start.offset()),
             ..window
         };
         self.call_candidates_for(&binding.name)
             .into_iter()
             .any(|call| {
-                let call_offset = call.name_span.start.offset;
+                let call_offset = call.name_span.start.offset();
                 call_offset <= window.before_offset
                     && self.call_is_inside_scope(call.scope, window.boundary_scope)
                     && (!window.require_non_transient_call
@@ -698,10 +698,10 @@ impl<'analysis, 'model> DirectFunctionCallReachability<'analysis, 'model> {
         let key = FunctionCallResolutionKey {
             binding: binding_id,
             call_scope: call.scope,
-            visibility_start: call.name_span.start.offset,
-            visibility_end: call.name_span.end.offset,
-            cfg_start: call.command_span.start.offset,
-            cfg_end: call.command_span.end.offset,
+            visibility_start: call.name_span.start.offset(),
+            visibility_end: call.name_span.end.offset(),
+            cfg_start: call.command_span.start.offset(),
+            cfg_end: call.command_span.end.offset(),
         };
         if let Some(cached) = self.call_resolution_cache.get(&key) {
             return *cached;

--- a/crates/shuck-semantic/src/function_resolution.rs
+++ b/crates/shuck-semantic/src/function_resolution.rs
@@ -81,7 +81,7 @@ impl FunctionBindingLookup<'_> {
         for (name, sites) in self.call_sites {
             for site in sites {
                 let Some(binding) =
-                    resolver.visible_function_binding(name, site.scope, site.span.start.offset)
+                    resolver.visible_function_binding(name, site.scope, site.span.start.offset())
                 else {
                     continue;
                 };
@@ -273,7 +273,7 @@ impl FunctionCallResolver<'_> {
                 }
 
                 if scope_id == scope {
-                    if candidate.span.start.offset <= offset
+                    if candidate.span.start.offset() <= offset
                         && self.unconditional_function_bindings.contains(&binding)
                     {
                         return Some(binding);
@@ -299,7 +299,7 @@ impl FunctionCallResolver<'_> {
         candidate: &Binding,
         scope: ScopeId,
     ) -> bool {
-        if candidate.span.start.offset <= self.scopes[scope.index()].span.start.offset {
+        if candidate.span.start.offset() <= self.scopes[scope.index()].span.start.offset() {
             return true;
         }
 
@@ -307,7 +307,7 @@ impl FunctionCallResolver<'_> {
         !self.scope_has_known_entry_before_offset(
             scope,
             candidate.scope,
-            candidate.span.start.offset,
+            candidate.span.start.offset(),
             &mut visiting,
         )
     }
@@ -364,7 +364,7 @@ impl FunctionCallResolver<'_> {
     ) -> bool {
         let command_start = crate::cfg::recorded_command_span_for_call_site(self.program, site)
             .start
-            .offset;
+            .offset();
         let Some(enclosing_function) = self.enclosing_function_scope(site.scope) else {
             if self.scope_has_ancestor(site.scope, call_scope) {
                 return command_start < offset;
@@ -394,11 +394,11 @@ impl FunctionCallResolver<'_> {
             return self.lexically_visible_function_binding_in_scope(
                 &target.name,
                 site.scope,
-                site.span.start.offset,
+                site.span.start.offset(),
             ) == Some(binding);
         }
 
-        target.span.start.offset < offset
+        target.span.start.offset() < offset
     }
 
     fn enclosing_function_scope(&self, scope: ScopeId) -> Option<ScopeId> {
@@ -449,6 +449,6 @@ pub(crate) fn lexically_visible_function_binding_in_scope(
     candidates.iter().rev().copied().find(|binding| {
         let candidate = &bindings[binding.index()];
         matches!(candidate.kind, BindingKind::FunctionDefinition)
-            && candidate.span.start.offset <= offset
+            && candidate.span.start.offset() <= offset
     })
 }

--- a/crates/shuck-semantic/src/lib.rs
+++ b/crates/shuck-semantic/src/lib.rs
@@ -367,8 +367,8 @@ pub(crate) struct SpanKey {
 impl SpanKey {
     pub(crate) fn new(span: Span) -> Self {
         Self {
-            start: span.start.offset,
-            end: span.end.offset,
+            start: span.start.offset(),
+            end: span.end.offset(),
         }
     }
 }
@@ -602,7 +602,7 @@ fn dedup_synthetic_reads(reads: Vec<SyntheticRead>) -> Vec<SyntheticRead> {
     let mut seen = FxHashSet::default();
     let mut deduped = Vec::new();
     for read in reads {
-        if seen.insert((read.scope, read.span.start.offset, read.name.clone())) {
+        if seen.insert((read.scope, read.span.start.offset(), read.name.clone())) {
             deduped.push(read);
         }
     }
@@ -629,8 +629,9 @@ fn previous_visible_binding_id_from_slice(
     offset: usize,
     ignored_binding_span: Option<Span>,
 ) -> Option<BindingId> {
-    let candidate_count = bindings
-        .partition_point(|binding_id| all_bindings[binding_id.index()].span.start.offset <= offset);
+    let candidate_count = bindings.partition_point(|binding_id| {
+        all_bindings[binding_id.index()].span.start.offset() <= offset
+    });
 
     bindings[..candidate_count]
         .iter()
@@ -675,11 +676,11 @@ fn insert_binding_id_sorted(
     let target = &all_bindings[id.index()];
     let insertion = bindings.as_slice().partition_point(|candidate_id| {
         let candidate = &all_bindings[candidate_id.index()];
-        candidate.span.start.offset < target.span.start.offset
-            || (candidate.span.start.offset == target.span.start.offset
-                && candidate.span.end.offset < target.span.end.offset)
-            || (candidate.span.start.offset == target.span.start.offset
-                && candidate.span.end.offset == target.span.end.offset
+        candidate.span.start.offset() < target.span.start.offset()
+            || (candidate.span.start.offset() == target.span.start.offset()
+                && candidate.span.end.offset() < target.span.end.offset())
+            || (candidate.span.start.offset() == target.span.start.offset()
+                && candidate.span.end.offset() == target.span.end.offset()
                 && candidate.id.index() < target.id.index())
     });
     bindings.insert_binding_id(insertion, id);
@@ -714,7 +715,7 @@ impl ScopeLookup {
         for scope_ids in &mut children {
             scope_ids.sort_by_key(|scope_id| {
                 let span = scopes[scope_id.index()].span;
-                (span.start.offset, span.end.offset)
+                (span.start.offset(), span.end.offset())
             });
         }
 
@@ -740,7 +741,7 @@ impl ScopeLookup {
     fn child_scope_at(&self, scopes: &[Scope], parent: ScopeId, offset: usize) -> Option<ScopeId> {
         let children = self.children.get(parent.index())?;
         let cutoff = children
-            .partition_point(|scope_id| scopes[scope_id.index()].span.start.offset <= offset);
+            .partition_point(|scope_id| scopes[scope_id.index()].span.start.offset() <= offset);
         let mut best: Option<ScopeId> = None;
         let mut index = cutoff;
 
@@ -748,7 +749,7 @@ impl ScopeLookup {
             index -= 1;
             let scope_id = children[index];
             let span = scopes[scope_id.index()].span;
-            if span.end.offset < offset {
+            if span.end.offset() < offset {
                 break;
             }
             if contains_offset(span, offset) {
@@ -866,7 +867,7 @@ impl SemanticModel {
         let mut reference_index = built.reference_index;
         for reference_ids in reference_index.values_mut() {
             reference_ids.sort_by_key(|reference_id| {
-                built.references[reference_id.index()].span.start.offset
+                built.references[reference_id.index()].span.start.offset()
             });
         }
         let indirect_targets_by_binding =
@@ -1048,7 +1049,7 @@ impl SemanticModel {
         &self,
         function_scope: ScopeId,
     ) -> Option<ZshOptionAnalysis> {
-        let function_entry_offset = self.scope(function_scope).span.start.offset;
+        let function_entry_offset = self.scope(function_scope).span.start.offset();
         let mut function_entry = *self.zsh_options_at(function_entry_offset)?;
         for field in self.zsh_runtime_ambiguous_entry_mask().iter() {
             crate::zsh_options::set_public_option_field(
@@ -1150,7 +1151,7 @@ impl SemanticModel {
                     || reference_has_local_positional_reset(
                         self,
                         reference.scope,
-                        reference.span.start.offset,
+                        reference.span.start.offset(),
                         local_reset_offsets_by_scope,
                     )
                 {
@@ -1184,12 +1185,12 @@ impl SemanticModel {
             .references_sorted_by_start
             .get_or_init(|| build_references_sorted_by_start(&self.references));
         let lower = sorted.partition_point(|id| {
-            self.references[id.index()].span.start.offset < outer.start.offset
+            self.references[id.index()].span.start.offset() < outer.start.offset()
         });
         ReferencesInSpan {
             references: &self.references,
             ids: sorted[lower..].iter(),
-            end: outer.end.offset,
+            end: outer.end.offset(),
         }
     }
 
@@ -1232,12 +1233,13 @@ impl SemanticModel {
         let sorted = self
             .bindings_sorted_by_start
             .get_or_init(|| build_bindings_sorted_by_start(&self.bindings));
-        let lower = sorted
-            .partition_point(|id| self.bindings[id.index()].span.start.offset < outer.start.offset);
+        let lower = sorted.partition_point(|id| {
+            self.bindings[id.index()].span.start.offset() < outer.start.offset()
+        });
         BindingsInSpan {
             bindings: &self.bindings,
             ids: sorted[lower..].iter(),
-            end: outer.end.offset,
+            end: outer.end.offset(),
         }
     }
 
@@ -1357,7 +1359,7 @@ impl SemanticModel {
             .chain(all_bindings.iter().copied().filter(|binding_id| {
                 let binding = self.binding(*binding_id);
                 binding.scope != reference.scope
-                    && binding.span.start.offset < reference.span.start.offset
+                    && binding.span.start.offset() < reference.span.start.offset()
             }))
             .collect::<FxHashSet<_>>()
             .into_iter()
@@ -1369,9 +1371,9 @@ impl SemanticModel {
     #[doc(hidden)]
     pub fn binding_visible_at(&self, binding_id: BindingId, at: Span) -> bool {
         let binding = self.binding(binding_id);
-        binding.span.start.offset <= at.start.offset
+        binding.span.start.offset() <= at.start.offset()
             && self
-                .ancestor_scopes(self.scope_at(at.start.offset))
+                .ancestor_scopes(self.scope_at(at.start.offset()))
                 .any(|scope| scope == binding.scope)
     }
 
@@ -1383,7 +1385,8 @@ impl SemanticModel {
             .get(&(binding.scope, binding.name.clone()))
             .is_some_and(|cleared_offsets| {
                 cleared_offsets.iter().any(|cleared_offset| {
-                    *cleared_offset > binding.span.start.offset && *cleared_offset < at.start.offset
+                    *cleared_offset > binding.span.start.offset()
+                        && *cleared_offset < at.start.offset()
                 })
             })
     }
@@ -1397,11 +1400,11 @@ impl SemanticModel {
         at: Span,
         ignored_binding_span: Option<Span>,
     ) -> Option<&Binding> {
-        let scope = self.scope_at(at.start.offset);
+        let scope = self.scope_at(at.start.offset());
         self.previous_visible_binding_id_in_scope_chain(
             name,
             scope,
-            at.start.offset,
+            at.start.offset(),
             ignored_binding_span,
         )
         .map(|binding_id| self.binding(binding_id))
@@ -1416,7 +1419,7 @@ impl SemanticModel {
         at: Span,
     ) -> Option<&Binding> {
         if let Some(binding_id) =
-            self.previous_assoc_lookup_binding_id_in_scope(current_scope, name, at.start.offset)
+            self.previous_assoc_lookup_binding_id_in_scope(current_scope, name, at.start.offset())
         {
             return Some(self.binding(binding_id));
         }
@@ -1424,7 +1427,7 @@ impl SemanticModel {
         self.ancestor_scopes(current_scope)
             .skip(1)
             .find_map(|scope| {
-                self.previous_visible_binding_id_in_scope(scope, name, at.start.offset, None)
+                self.previous_visible_binding_id_in_scope(scope, name, at.start.offset(), None)
             })
             .map(|binding_id| self.binding(binding_id))
     }
@@ -1440,7 +1443,7 @@ impl SemanticModel {
         if let Some(binding_id) = self.previous_visible_binding_id_in_scope_chain(
             name,
             current_scope,
-            at.start.offset,
+            at.start.offset(),
             None,
         ) {
             return Some(self.binding(binding_id));
@@ -1581,7 +1584,7 @@ impl SemanticModel {
                 if let Some(binding_id) = self.previous_visible_binding_id_in_scope_chain(
                     name,
                     call_site.scope,
-                    call_site.name_span.start.offset,
+                    call_site.name_span.start.offset(),
                     None,
                 ) {
                     return Some(self.binding(binding_id));
@@ -1783,7 +1786,10 @@ impl SemanticModel {
                     })
                     .min_by_key(|(index, (candidate, _))| {
                         (
-                            candidate.end.offset.saturating_sub(candidate.start.offset),
+                            candidate
+                                .end
+                                .offset()
+                                .saturating_sub(candidate.start.offset()),
                             std::cmp::Reverse(*index),
                         )
                     })
@@ -2139,7 +2145,7 @@ impl SemanticModel {
             };
 
             for binding in bindings.iter().rev().copied() {
-                if self.bindings[binding.index()].span.start.offset <= span.start.offset {
+                if self.bindings[binding.index()].span.start.offset() <= span.start.offset() {
                     return Some(binding);
                 }
             }
@@ -2560,7 +2566,7 @@ fn infer_bash_from_shebang(source: &str) -> Option<bool> {
 }
 
 fn contains_offset(span: Span, offset: usize) -> bool {
-    span.start.offset <= offset && offset <= span.end.offset
+    span.start.offset() <= offset && offset <= span.end.offset()
 }
 
 /// Flattens the scope tree into (start offset, innermost scope) segments.
@@ -2573,8 +2579,8 @@ fn build_scope_at_segments(scopes: &[Scope], lookup: &ScopeLookup) -> Vec<(usize
     let mut breakpoints = Vec::with_capacity(scopes.len() * 2 + 1);
     breakpoints.push(0usize);
     for scope in scopes {
-        breakpoints.push(scope.span.start.offset);
-        breakpoints.push(scope.span.end.offset + 1);
+        breakpoints.push(scope.span.start.offset());
+        breakpoints.push(scope.span.end.offset() + 1);
     }
     breakpoints.sort_unstable();
     breakpoints.dedup();
@@ -2591,7 +2597,7 @@ fn build_scope_at_segments(scopes: &[Scope], lookup: &ScopeLookup) -> Vec<(usize
 
 fn build_references_sorted_by_start(references: &[Reference]) -> Vec<ReferenceId> {
     let mut ids: Vec<ReferenceId> = (0..references.len() as u32).map(ReferenceId).collect();
-    ids.sort_by_key(|id| references[id.index()].span.start.offset);
+    ids.sort_by_key(|id| references[id.index()].span.start.offset());
     ids
 }
 
@@ -2630,7 +2636,7 @@ fn reference_has_local_positional_reset(
 
 fn build_bindings_sorted_by_start(bindings: &[Binding]) -> Vec<BindingId> {
     let mut ids: Vec<BindingId> = (0..bindings.len() as u32).map(BindingId).collect();
-    ids.sort_by_key(|id| bindings[id.index()].span.start.offset);
+    ids.sort_by_key(|id| bindings[id.index()].span.start.offset());
     ids
 }
 
@@ -2648,7 +2654,7 @@ fn build_guarded_or_defaulting_reference_offsets_by_name(
             offsets_by_name
                 .entry(reference.name.clone())
                 .or_default()
-                .push(reference.span.start.offset);
+                .push(reference.span.start.offset());
         }
     }
 
@@ -2696,10 +2702,10 @@ impl<'a> Iterator for ReferencesInSpan<'a> {
         loop {
             let id = self.ids.next()?;
             let reference = &self.references[id.index()];
-            if reference.span.start.offset > self.end {
+            if reference.span.start.offset() > self.end {
                 return None;
             }
-            if reference.span.end.offset <= self.end {
+            if reference.span.end.offset() <= self.end {
                 return Some(reference);
             }
         }
@@ -2749,10 +2755,10 @@ impl<'a> Iterator for BindingsInSpan<'a> {
         loop {
             let id = self.ids.next()?;
             let binding = &self.bindings[id.index()];
-            if binding.span.start.offset > self.end {
+            if binding.span.start.offset() > self.end {
                 return None;
             }
-            if binding.span.end.offset <= self.end {
+            if binding.span.end.offset() <= self.end {
                 return Some(binding);
             }
         }
@@ -2760,11 +2766,11 @@ impl<'a> Iterator for BindingsInSpan<'a> {
 }
 
 fn scope_span_width(span: Span) -> usize {
-    span.end.offset.saturating_sub(span.start.offset)
+    span.end.offset().saturating_sub(span.start.offset())
 }
 
 fn contains_span(outer: Span, inner: Span) -> bool {
-    outer.start.offset <= inner.start.offset && outer.end.offset >= inner.end.offset
+    outer.start.offset() <= inner.start.offset() && outer.end.offset() >= inner.end.offset()
 }
 
 #[cfg(test)]

--- a/crates/shuck-semantic/src/lib.rs
+++ b/crates/shuck-semantic/src/lib.rs
@@ -2229,10 +2229,10 @@ impl SemanticModel {
     /// Returns whether a source operation is guaranteed to have executed in
     /// the completion point's enclosing execution scope.
     pub fn source_ref_visible_at_offset(&self, source_ref: &SourceRef, offset: usize) -> bool {
-        if source_ref.conditionally_executed || source_ref.span.start.offset >= offset {
+        if source_ref.conditionally_executed || source_ref.span.start.offset() >= offset {
             return false;
         }
-        let source_scope = self.scope_at(source_ref.span.start.offset);
+        let source_scope = self.scope_at(source_ref.span.start.offset());
         let cursor_scope = self.scope_at(offset);
         if let Some(transient_scope) = self.innermost_transient_scope_within_function(source_scope)
         {

--- a/crates/shuck-semantic/src/nonpersistent.rs
+++ b/crates/shuck-semantic/src/nonpersistent.rs
@@ -164,8 +164,8 @@ impl SemanticModel {
             candidate_bindings_by_scope
                 .entry((
                     binding.name.clone(),
-                    nonpersistent_scope.span.start.offset,
-                    nonpersistent_scope.span.end.offset,
+                    nonpersistent_scope.span.start.offset(),
+                    nonpersistent_scope.span.end.offset(),
                 ))
                 .or_insert(CandidateNonpersistentAssignment {
                     binding_id: binding.id,
@@ -174,8 +174,8 @@ impl SemanticModel {
                     execution_context: self
                         .innermost_transient_scope_within_function(binding.scope),
                     assignment_span: binding.span,
-                    subshell_start: nonpersistent_scope.span.start.offset,
-                    subshell_end: nonpersistent_scope.span.end.offset,
+                    subshell_start: nonpersistent_scope.span.start.offset(),
+                    subshell_end: nonpersistent_scope.span.end.offset(),
                 });
         }
 
@@ -194,8 +194,8 @@ impl SemanticModel {
             candidates.sort_by_key(|candidate| {
                 (
                     candidate.subshell_end,
-                    candidate.assignment_span.start.offset,
-                    candidate.assignment_span.end.offset,
+                    candidate.assignment_span.start.offset(),
+                    candidate.assignment_span.end.offset(),
                 )
             });
         }
@@ -210,8 +210,8 @@ impl SemanticModel {
             persistent_reset_offsets_by_name
                 .entry(binding.name.clone())
                 .or_default()
-                .push(binding.span.start.offset);
-            command_query_offsets.push(binding.span.start.offset);
+                .push(binding.span.start.offset());
+            command_query_offsets.push(binding.span.start.offset());
         }
 
         for reference in self.references() {
@@ -222,7 +222,7 @@ impl SemanticModel {
                 continue;
             }
             if candidate_bindings_by_name.contains_key(&reference.name) {
-                command_query_offsets.push(reference.span.start.offset);
+                command_query_offsets.push(reference.span.start.offset());
                 relevant_references.push(reference);
             }
         }
@@ -232,7 +232,7 @@ impl SemanticModel {
                 continue;
             }
             if candidate_bindings_by_name.contains_key(synthetic_read.name()) {
-                command_query_offsets.push(synthetic_read.span().start.offset);
+                command_query_offsets.push(synthetic_read.span().start.offset());
                 relevant_synthetic_reads.push(synthetic_read);
             }
         }
@@ -242,7 +242,7 @@ impl SemanticModel {
                 continue;
             }
             if candidate_bindings_by_name.contains_key(&read.name) {
-                command_query_offsets.push(read.span.start.offset);
+                command_query_offsets.push(read.span.start.offset());
             }
         }
 
@@ -258,7 +258,7 @@ impl SemanticModel {
                                 precomputed_command_index_for_offset(&command_offsets, offset);
                             let command_end_offset = command_index
                                 .and_then(|index| context.commands.get(index))
-                                .map(|command| command.span.end.offset)
+                                .map(|command| command.span.end.offset())
                                 .unwrap_or(offset);
 
                             PersistentReset {
@@ -282,27 +282,29 @@ impl SemanticModel {
                 .get(&reference.name)
                 .map(Vec::as_slice)
                 .unwrap_or(&[]);
-            let event_command_index =
-                precomputed_command_index_for_offset(&command_offsets, reference.span.start.offset);
+            let event_command_index = precomputed_command_index_for_offset(
+                &command_offsets,
+                reference.span.start.offset(),
+            );
             let resolved = self.resolved_binding(reference.id);
             let reference_function_scope = self.enclosing_function_scope(reference.scope);
             if let Some(candidate) = candidates.iter().rev().find(|candidate| {
-                reference.span.start.offset > candidate.subshell_end
+                reference.span.start.offset() > candidate.subshell_end
                     && !has_intervening_persistent_reset(
                         reset_offsets,
                         candidate.subshell_end,
-                        reference.span.start.offset,
+                        reference.span.start.offset(),
                         event_command_index,
                     )
                     && resolved_binding_allows_subshell_later_use(
                         resolved,
                         candidate,
-                        reference.span.start.offset,
+                        reference.span.start.offset(),
                         reference_function_scope,
                     )
                     && self.return_later_use_allows_candidate(
                         candidate,
-                        reference.span.start.offset,
+                        reference.span.start.offset(),
                         context.options.require_return_use_same_execution_context,
                     )
             }) {
@@ -326,7 +328,7 @@ impl SemanticModel {
                 .unwrap_or(&[]);
             let synthetic_command_index = precomputed_command_index_for_offset(
                 &command_offsets,
-                synthetic_read.span().start.offset,
+                synthetic_read.span().start.offset(),
             );
             let same_command_prefix_reset = synthetic_command_index
                 .and_then(|index| context.commands.get(index))
@@ -338,11 +340,11 @@ impl SemanticModel {
                 });
             let synthetic_command_end_offset = synthetic_command_index
                 .and_then(|index| context.commands.get(index))
-                .map(|command| command.span.end.offset)
-                .unwrap_or(synthetic_read.span().start.offset);
+                .map(|command| command.span.end.offset())
+                .unwrap_or(synthetic_read.span().start.offset());
             let synthetic_function_scope = self.enclosing_function_scope(synthetic_read.scope());
             if let Some(candidate) = candidates.iter().rev().find(|candidate| {
-                synthetic_read.span().start.offset > candidate.subshell_end
+                synthetic_read.span().start.offset() > candidate.subshell_end
                     && !same_command_prefix_reset
                     && candidate_allows_unresolved_later_use(candidate, synthetic_function_scope)
                     && !has_intervening_persistent_reset(
@@ -371,15 +373,15 @@ impl SemanticModel {
                 .map(Vec::as_slice)
                 .unwrap_or(&[]);
             let event_command_index =
-                precomputed_command_index_for_offset(&command_offsets, read.span.start.offset);
+                precomputed_command_index_for_offset(&command_offsets, read.span.start.offset());
             let read_function_scope = self.enclosing_function_scope(read.scope);
             if let Some(candidate) = candidates.iter().rev().find(|candidate| {
-                read.span.start.offset > candidate.subshell_end
+                read.span.start.offset() > candidate.subshell_end
                     && candidate_allows_unresolved_later_use(candidate, read_function_scope)
                     && !has_intervening_persistent_reset(
                         reset_offsets,
                         candidate.subshell_end,
-                        read.span.start.offset,
+                        read.span.start.offset(),
                         event_command_index,
                     )
             }) {
@@ -410,12 +412,12 @@ impl SemanticModel {
                 .unwrap_or(&[]);
             let binding_function_scope = self.enclosing_function_scope(binding.scope);
             if let Some(candidate) = candidates.iter().rev().find(|candidate| {
-                binding.span.start.offset > candidate.subshell_end
+                binding.span.start.offset() > candidate.subshell_end
                     && candidate_allows_unresolved_later_use(candidate, binding_function_scope)
                     && !has_intervening_persistent_reset(
                         reset_offsets,
                         candidate.subshell_end,
-                        binding.span.start.offset,
+                        binding.span.start.offset(),
                         None,
                     )
             }) {
@@ -432,17 +434,17 @@ impl SemanticModel {
         effects.retain(|effect| {
             seen.insert((
                 effect.assignment_binding,
-                effect.later_use_span.start.offset,
-                effect.later_use_span.end.offset,
+                effect.later_use_span.start.offset(),
+                effect.later_use_span.end.offset(),
                 effect.name.clone(),
             ))
         });
         effects.sort_by_key(|effect| {
             (
-                effect.later_use_span.start.offset,
-                effect.later_use_span.end.offset,
-                effect.assignment_span.start.offset,
-                effect.assignment_span.end.offset,
+                effect.later_use_span.start.offset(),
+                effect.later_use_span.end.offset(),
+                effect.assignment_span.start.offset(),
+                effect.assignment_span.end.offset(),
             )
         });
 
@@ -588,10 +590,10 @@ fn resolved_binding_allows_subshell_later_use(
     if resolved.id == candidate.binding_id {
         return false;
     }
-    if resolved.span.start.offset > reference_offset {
+    if resolved.span.start.offset() > reference_offset {
         return true;
     }
-    if resolved.span.start.offset < candidate.subshell_start {
+    if resolved.span.start.offset() < candidate.subshell_start {
         return true;
     }
 
@@ -659,9 +661,9 @@ fn build_command_offset_lookup(
         let right_span = commands[*right].span;
         left_span
             .start
-            .offset
-            .cmp(&right_span.start.offset)
-            .then_with(|| right_span.end.offset.cmp(&left_span.end.offset))
+            .offset()
+            .cmp(&right_span.start.offset())
+            .then_with(|| right_span.end.offset().cmp(&left_span.end.offset()))
             .then_with(|| right.cmp(left))
     });
 
@@ -673,13 +675,13 @@ fn build_command_offset_lookup(
 
         while let Some(index) = command_order.get(next_command).copied() {
             let span = commands[index].span;
-            if span.start.offset > offset {
+            if span.start.offset() > offset {
                 break;
             }
 
-            pop_finished_commands(&mut active_commands, span.start.offset);
+            pop_finished_commands(&mut active_commands, span.start.offset());
             active_commands.push(OpenCommand {
-                end_offset: span.end.offset,
+                end_offset: span.end.offset(),
                 index,
             });
             next_command += 1;

--- a/crates/shuck-semantic/src/reachability.rs
+++ b/crates/shuck-semantic/src/reachability.rs
@@ -129,7 +129,7 @@ impl<'model> SemanticAnalysis<'model> {
             && visible.id != binding_id
             && visible.scope != binding.scope
             && matches!(visible.kind, BindingKind::FunctionDefinition)
-            && visible.span.start.offset < visibility_span.start.offset
+            && visible.span.start.offset() < visibility_span.start.offset()
             && self
                 .model
                 .ancestor_scopes(call_scope)
@@ -144,7 +144,7 @@ impl<'model> SemanticAnalysis<'model> {
             .is_some_and(|visible| {
                 visible.id != binding_id
                     && matches!(visible.kind, BindingKind::FunctionDefinition)
-                    && visible.span.start.offset < visibility_span.start.offset
+                    && visible.span.start.offset() < visibility_span.start.offset()
                     && self
                         .model
                         .ancestor_scopes(call_scope)
@@ -160,7 +160,7 @@ impl<'model> SemanticAnalysis<'model> {
                         return false;
                     }
                     let other_binding = self.model.binding(other);
-                    other_binding.span.start.offset < visibility_span.start.offset
+                    other_binding.span.start.offset() < visibility_span.start.offset()
                         && self
                             .model
                             .ancestor_scopes(call_scope)
@@ -310,7 +310,7 @@ impl<'model> SemanticAnalysis<'model> {
                             &function.name,
                             caller,
                             function_binding,
-                            function.span.start.offset,
+                            function.span.start.offset(),
                             binding_blocks,
                             shadow_blocks,
                             unreachable,
@@ -664,7 +664,8 @@ impl<'model> SemanticAnalysis<'model> {
             }
         }
 
-        unreached.sort_by_key(|unreached| self.model.binding(unreached.binding).span.start.offset);
+        unreached
+            .sort_by_key(|unreached| self.model.binding(unreached.binding).span.start.offset());
         unreached
     }
 
@@ -808,7 +809,7 @@ impl<'model> SemanticAnalysis<'model> {
                             script_terminators,
                         ) && self.call_site_can_execute_after_function_definition(
                             site,
-                            function.span.start.offset,
+                            function.span.start.offset(),
                         ) && self.call_site_context_can_run_before_termination(
                             site,
                             cfg,
@@ -864,7 +865,7 @@ impl<'model> SemanticAnalysis<'model> {
                             script_terminators,
                         ) && self.call_site_can_execute_after_function_definition(
                             site,
-                            function.span.start.offset,
+                            function.span.start.offset(),
                         ) && !self.scope_runs_in_transient_context(site.scope)
                             && self.call_site_context_can_run_persistently_before_termination(
                                 site,
@@ -887,7 +888,7 @@ impl<'model> SemanticAnalysis<'model> {
         site: &CallSite,
         function_offset: usize,
     ) -> bool {
-        site.span.start.offset > function_offset || {
+        site.span.start.offset() > function_offset || {
             let mut visiting_scopes = FxHashSet::default();
             self.call_site_context_can_run_after_offset(site, function_offset, &mut visiting_scopes)
         }
@@ -900,7 +901,7 @@ impl<'model> SemanticAnalysis<'model> {
         visiting_scopes: &mut FxHashSet<ScopeId>,
     ) -> bool {
         let Some(function_scope) = self.enclosing_function_scope(site.scope) else {
-            return site.span.start.offset > after_offset;
+            return site.span.start.offset() > after_offset;
         };
         if !visiting_scopes.insert(function_scope) {
             return false;
@@ -924,7 +925,7 @@ impl<'model> SemanticAnalysis<'model> {
                             &function.name,
                             caller,
                             function_binding,
-                        ) && (caller.span.start.offset > after_offset
+                        ) && (caller.span.start.offset() > after_offset
                             || self.call_site_context_can_run_after_offset(
                                 caller,
                                 after_offset,
@@ -1215,7 +1216,7 @@ impl<'model> SemanticAnalysis<'model> {
                             self.model.binding(*other).kind,
                             BindingKind::FunctionDefinition
                         )
-                        && self.model.binding(*other).span.start.offset < site.span.start.offset
+                        && self.model.binding(*other).span.start.offset() < site.span.start.offset()
                 })
             {
                 return true;
@@ -1237,7 +1238,7 @@ impl<'model> SemanticAnalysis<'model> {
         let consumer_execution_scope = self.call_site_execution_scope(site.scope);
         if self.function_scope_is_called_before_offset(
             consumer_execution_scope,
-            binding.span.start.offset,
+            binding.span.start.offset(),
             window,
         ) {
             return false;
@@ -1261,7 +1262,7 @@ impl<'model> SemanticAnalysis<'model> {
                     .call_sites_for(&provider.name)
                     .iter()
                     .any(|provider_site| {
-                        provider_site.span.start.offset < site.span.start.offset
+                        provider_site.span.start.offset() < site.span.start.offset()
                             && self.call_site_execution_scope(provider_site.scope)
                                 == consumer_execution_scope
                             && self.overwrite_call_site_resolves_to_binding(
@@ -1307,7 +1308,7 @@ impl<'model> SemanticAnalysis<'model> {
                     .call_sites_for(&function.name)
                     .iter()
                     .any(|site| {
-                        site.span.start.offset < offset
+                        site.span.start.offset() < offset
                             && self.overwrite_call_site_resolves_to_binding(
                                 &function.name,
                                 site,
@@ -1401,7 +1402,7 @@ impl<'model> SemanticAnalysis<'model> {
             .any(|function_binding| {
                 let function = self.model.binding(function_binding);
                 let function_name = function.name.clone();
-                let function_offset = function.span.start.offset;
+                let function_offset = function.span.start.offset();
                 self.model
                     .call_sites_for(&function_name)
                     .iter()
@@ -1444,7 +1445,7 @@ impl<'model> SemanticAnalysis<'model> {
             .filter(|other| {
                 let other_binding = self.model.binding(*other);
                 other_binding.scope == binding.scope
-                    && other_binding.span.start.offset > binding.span.start.offset
+                    && other_binding.span.start.offset() > binding.span.start.offset()
             })
             .flat_map(|other| {
                 binding_blocks
@@ -1472,7 +1473,7 @@ impl<'model> SemanticAnalysis<'model> {
             .filter(|other| {
                 let other_binding = self.model.binding(*other);
                 other_binding.scope == binding.scope
-                    && other_binding.span.start.offset > binding.span.start.offset
+                    && other_binding.span.start.offset() > binding.span.start.offset()
             })
             .flat_map(|other| {
                 self.blocks_containing_binding(other)
@@ -1522,7 +1523,7 @@ impl<'model> SemanticAnalysis<'model> {
 
             for scope_bindings in bindings_by_scope.values_mut() {
                 scope_bindings
-                    .sort_by_key(|binding| self.model.binding(*binding).span.start.offset);
+                    .sort_by_key(|binding| self.model.binding(*binding).span.start.offset());
 
                 for pair in scope_bindings.windows(2) {
                     let first = pair[0];
@@ -1580,8 +1581,8 @@ impl<'model> SemanticAnalysis<'model> {
 
         overwritten.sort_by_key(|overwritten| {
             (
-                self.model.binding(overwritten.first).span.start.offset,
-                self.model.binding(overwritten.second).span.start.offset,
+                self.model.binding(overwritten.first).span.start.offset(),
+                self.model.binding(overwritten.second).span.start.offset(),
             )
         });
         overwritten
@@ -1712,12 +1713,12 @@ fn block_min_offset(block: &BasicBlock, model: &SemanticModel) -> Option<usize> 
     block
         .commands
         .iter()
-        .map(|span| span.start.offset)
+        .map(|span| span.start.offset())
         .chain(
             block
                 .bindings
                 .iter()
-                .map(|binding| model.binding(*binding).span.start.offset),
+                .map(|binding| model.binding(*binding).span.start.offset()),
         )
         .min()
 }

--- a/crates/shuck-semantic/src/source_closure/mod.rs
+++ b/crates/shuck-semantic/src/source_closure/mod.rs
@@ -206,7 +206,7 @@ pub(crate) fn collect_source_ref_metadata(
     let mut source_ref_diagnostic_classes = Vec::new();
 
     for source_ref in model.source_refs() {
-        let scope = model.scope_at(source_ref.span.start.offset);
+        let scope = model.scope_at(source_ref.span.start.offset());
         let template = effective_source_template(
             model,
             source_ref,
@@ -274,7 +274,7 @@ fn collect_source_closure_contracts_with_cache(
     let mut source_ref_diagnostic_classes = Vec::new();
 
     for source_ref in model.source_refs() {
-        let scope = model.scope_at(source_ref.span.start.offset);
+        let scope = model.scope_at(source_ref.span.start.offset());
         let template = effective_source_template(
             model,
             source_ref,
@@ -340,7 +340,7 @@ fn collect_source_closure_contracts_with_cache(
 
     if let Some(plugin_resolver) = context.plugin_resolver {
         for request in collect_plugin_requests(model, file, source, source_path, plugin_resolver) {
-            let scope = model.scope_at(request.span.start.offset);
+            let scope = model.scope_at(request.span.start.offset());
             let resolution = plugin_resolver.resolve_plugin_request(source_path, &request);
             requesting_file_contract = FileContract::merge_candidate_contracts(&[
                 requesting_file_contract,
@@ -381,7 +381,7 @@ fn collect_source_closure_contracts_with_cache(
             &imported_functions,
             &call.name,
             call.scope,
-            call.span.start.offset,
+            call.span.start.offset(),
         );
         if let Some(function_site) = imported_function_site {
             for name in &function_site.contract.required_reads {
@@ -407,7 +407,7 @@ fn collect_source_closure_contracts_with_cache(
         }
         if imported_function_site.is_none()
             && function_binding_lookup
-                .visible_function_binding(&call.name, call.scope, call.span.start.offset)
+                .visible_function_binding(&call.name, call.scope, call.span.start.offset())
                 .is_none()
             && let Some(bindings) = unresolved_zsh_reply_bindings_for_call(
                 source_path,
@@ -603,7 +603,7 @@ fn dedup_synthetic_reads(reads: Vec<SyntheticRead>) -> Vec<SyntheticRead> {
     let mut seen = FxHashSet::default();
     let mut deduped = Vec::new();
     for read in reads {
-        if seen.insert((read.scope, read.span.start.offset, read.name.clone())) {
+        if seen.insert((read.scope, read.span.start.offset(), read.name.clone())) {
             deduped.push(read);
         }
     }
@@ -621,7 +621,12 @@ fn dedup_imported_bindings(
             binding,
             origin_paths,
         } = site;
-        let key = (scope, span.start.offset, binding.name.clone(), binding.kind);
+        let key = (
+            scope,
+            span.start.offset(),
+            binding.name.clone(),
+            binding.kind,
+        );
         let entry = merged
             .entry(key)
             .or_insert((span, binding.certainty, Vec::<PathBuf>::new()));
@@ -726,7 +731,7 @@ fn visible_imported_function_contract<'a>(
         .map(|binding| {
             (
                 VisibleFunctionTarget::Local,
-                model.binding(binding).span.start.offset,
+                model.binding(binding).span.start.offset(),
             )
         });
         let imported =
@@ -734,7 +739,7 @@ fn visible_imported_function_contract<'a>(
                 .map(|site| {
                     (
                         VisibleFunctionTarget::Imported(site),
-                        site.span.start.offset,
+                        site.span.start.offset(),
                     )
                 });
 
@@ -769,8 +774,8 @@ fn visible_imported_function_in_scope<'a>(
     imported_functions
         .iter()
         .filter(|site| site.scope == target_scope && site.contract.name == *name)
-        .filter(|site| target_scope != call_scope || site.span.start.offset <= offset)
-        .max_by_key(|site| site.span.start.offset)
+        .filter(|site| target_scope != call_scope || site.span.start.offset() <= offset)
+        .max_by_key(|site| site.span.start.offset())
 }
 
 #[derive(Debug, Clone)]
@@ -809,7 +814,7 @@ fn collect_ast_facts(model: &SemanticModel) -> AstFacts {
     };
     let program = model.recorded_program();
     let mut commands = program.commands().iter().collect::<Vec<_>>();
-    commands.sort_by_key(|command| (command.span.start.offset, command.span.end.offset));
+    commands.sort_by_key(|command| (command.span.start.offset(), command.span.end.offset()));
 
     for command in commands {
         let Some(info) = program.command_info_for_span(command.span) else {
@@ -826,7 +831,7 @@ fn collect_ast_facts(model: &SemanticModel) -> AstFacts {
         let is_source_builtin = matches!(name.as_str(), "source" | ".");
         facts.calls.push(CallInfo {
             name,
-            scope: model.scope_at(command.span.start.offset),
+            scope: model.scope_at(command.span.start.offset()),
             span: command.span,
             args: info.static_args.to_vec(),
         });
@@ -1090,12 +1095,13 @@ where
             SourcePathTemplate::Interpolated(vec![TemplatePart::SourceFile])
         }
         ZshExpansionTarget::Reference(reference) => {
-            let span =
-                if reference.name_span.start.offset == 0 && reference.name_span.end.offset == 0 {
-                    expansion_span
-                } else {
-                    reference.name_span
-                };
+            let span = if reference.name_span.start.offset() == 0
+                && reference.name_span.end.offset() == 0
+            {
+                expansion_span
+            } else {
+                reference.name_span
+            };
             (context.resolve_variable_template)(&reference.name, span)?
         }
         ZshExpansionTarget::Nested(nested_expansion) => {
@@ -1530,7 +1536,7 @@ fn resolve_literal_call_args_by_scope(
             (
                 &call.name,
                 call.scope,
-                call.span.start.offset,
+                call.span.start.offset(),
                 call.args.clone(),
             )
         }),
@@ -2273,7 +2279,11 @@ set_flag() {
             explicit: false,
             root_hint: None,
         };
-        alpha_implicit.span.start.offset = 7;
+        alpha_implicit.span.start = shuck_ast::Position::at(
+            alpha_implicit.span.start.line(),
+            alpha_implicit.span.start.column(),
+            7,
+        );
 
         let mut beta_explicit = PluginRequest {
             framework: PluginFramework::OhMyZsh,
@@ -2283,7 +2293,11 @@ set_flag() {
             explicit: true,
             root_hint: None,
         };
-        beta_explicit.span.start.offset = 7;
+        beta_explicit.span.start = shuck_ast::Position::at(
+            beta_explicit.span.start.line(),
+            beta_explicit.span.start.column(),
+            7,
+        );
 
         let mut alpha_explicit = alpha_implicit.clone();
         alpha_explicit.explicit = true;

--- a/crates/shuck-semantic/src/source_closure/plugin_managers/generic_zsh_runtime.rs
+++ b/crates/shuck-semantic/src/source_closure/plugin_managers/generic_zsh_runtime.rs
@@ -127,7 +127,7 @@ fn source_time_registration_scopes(
             let Some(binding) = analysis.visible_function_binding_defined_before(
                 &call.name,
                 call.scope,
-                call.span.start.offset,
+                call.span.start.offset(),
             ) else {
                 continue;
             };
@@ -213,7 +213,7 @@ fn function_scopes_by_name(
                 .map(|function_scope| (binding, function_scope))
         })
         .collect::<Vec<_>>();
-    definitions.sort_by_key(|(binding, _)| binding.span.start.offset);
+    definitions.sort_by_key(|(binding, _)| binding.span.start.offset());
 
     for (binding, function_scope) in definitions {
         if semantic.scope(function_scope).parent != Some(scope) {
@@ -330,8 +330,8 @@ fn generated_eval_calls_for_scope(
     args: &[Option<compact_str::CompactString>],
 ) -> Vec<Name> {
     let scope = &semantic.scopes()[scope.index()];
-    let body =
-        &source[scope.span.start.offset.min(source.len())..scope.span.end.offset.min(source.len())];
+    let body = &source
+        [scope.span.start.offset().min(source.len())..scope.span.end.offset().min(source.len())];
     let aliases = positional_aliases(body);
     let member_scopes = scope_members_excluding_functions(semantic.scopes(), scope.id);
     let mut calls = Vec::new();

--- a/crates/shuck-semantic/src/source_closure/plugin_managers/mod.rs
+++ b/crates/shuck-semantic/src/source_closure/plugin_managers/mod.rs
@@ -145,7 +145,7 @@ fn plugin_request_dependency_key(
         request.framework.clone(),
         request.kind,
         request.name.clone(),
-        request.span.start.offset,
+        request.span.start.offset(),
         request.root_hint.clone(),
     )
 }
@@ -246,8 +246,10 @@ mod tests {
             root_hint: None,
         };
         let mut second = first.clone();
-        first.span.start.offset = 10;
-        second.span.start.offset = 20;
+        first.span.start =
+            shuck_ast::Position::at(first.span.start.line(), first.span.start.column(), 10);
+        second.span.start =
+            shuck_ast::Position::at(second.span.start.line(), second.span.start.column(), 20);
 
         assert_ne!(
             plugin_request_dependency_key(&first),

--- a/crates/shuck-semantic/src/source_closure/plugin_managers/oh_my_zsh.rs
+++ b/crates/shuck-semantic/src/source_closure/plugin_managers/oh_my_zsh.rs
@@ -566,10 +566,12 @@ fn anchor_configured_plugin_requests(
     anchored
 }
 
-fn position_after(mut position: shuck_ast::Position) -> shuck_ast::Position {
-    position.offset += 1;
-    position.column += 1;
-    position
+fn position_after(position: shuck_ast::Position) -> shuck_ast::Position {
+    shuck_ast::Position::at(
+        position.line(),
+        position.column() + 1,
+        position.offset() + 1,
+    )
 }
 
 pub(in crate::source_closure) fn dedup_plugin_requests(
@@ -591,7 +593,7 @@ pub(in crate::source_closure) fn dedup_plugin_requests(
             request.framework.clone(),
             request.kind,
             request.name.clone(),
-            request.span.start.offset,
+            request.span.start.offset(),
             request.root_hint.clone(),
         );
         if let Some(&position) = positions.get(&key) {

--- a/crates/shuck-semantic/src/tests.rs
+++ b/crates/shuck-semantic/src/tests.rs
@@ -177,7 +177,7 @@ echo \"$foo\"
     let reference_span = span_for_nth(source, "foo", 1);
     let reference = model
         .editor_query()
-        .hover_at_offset(reference_span.start.offset)
+        .hover_at_offset(reference_span.start.offset())
         .expect("reference should have hover");
     assert_eq!(reference.symbol.name.as_str(), "foo");
     assert_eq!(reference.symbol.definition_span.slice(source), "foo");
@@ -196,7 +196,7 @@ build() {
     let declaration = span_for_nth(source, "items", 0);
     let hover = model
         .editor_query()
-        .hover_at_offset(declaration.start.offset)
+        .hover_at_offset(declaration.start.offset())
         .expect("declaration should have hover");
     assert_eq!(hover.symbol.name.as_str(), "items");
     assert_eq!(hover.symbol.kind, EditorSymbolKind::Array);
@@ -214,7 +214,7 @@ build
     let call = span_for_nth(source, "build", 1);
     let hover = model
         .editor_query()
-        .hover_at_offset(call.start.offset)
+        .hover_at_offset(call.start.offset())
         .expect("function call should have hover");
     assert_eq!(hover.symbol.name.as_str(), "build");
     assert_eq!(hover.symbol.kind, EditorSymbolKind::Function);
@@ -233,7 +233,7 @@ fn editor_hover_reports_runtime_names_without_definitions() {
     let name = span_for_nth(source, "HOME", 0);
     let hover = model
         .editor_query()
-        .hover_at_offset(name.start.offset)
+        .hover_at_offset(name.start.offset())
         .expect("runtime name should have hover");
     assert_eq!(hover.symbol.name.as_str(), "HOME");
     assert_eq!(hover.symbol.kind, EditorSymbolKind::RuntimeName);
@@ -254,14 +254,14 @@ printf '%s\\n' \"${created:=fallback}\"
 
     let braced_reference = span_for_nth(source, "foo", 1);
     let hover = query
-        .hover_at_offset(braced_reference.start.offset)
+        .hover_at_offset(braced_reference.start.offset())
         .expect("braced reference name should have hover");
     assert_eq!(hover.symbol.name.as_str(), "foo");
     assert_eq!(hover.target_span, braced_reference);
 
     let default_assignment = span_for_nth(source, "created", 0);
     let hover = query
-        .hover_at_offset(default_assignment.start.offset)
+        .hover_at_offset(default_assignment.start.offset())
         .expect("default assignment name should have hover");
     assert_eq!(hover.symbol.name.as_str(), "created");
     assert_eq!(hover.target_span, default_assignment);
@@ -269,8 +269,8 @@ printf '%s\\n' \"${created:=fallback}\"
     for offset in [
         source.find(":-").unwrap(),
         source.find(":=").unwrap(),
-        span_for_nth(source, "fallback", 0).start.offset,
-        span_for_nth(source, "fallback", 1).start.offset,
+        span_for_nth(source, "fallback", 0).start.offset(),
+        span_for_nth(source, "fallback", 1).start.offset(),
     ] {
         assert!(query.hover_at_offset(offset).is_none(), "{offset}");
     }
@@ -284,7 +284,7 @@ fn editor_hover_skips_known_runtime_names_that_are_not_active_for_shell() {
     assert!(
         model
             .editor_query()
-            .hover_at_offset(name.start.offset)
+            .hover_at_offset(name.start.offset())
             .is_none()
     );
 }
@@ -314,7 +314,7 @@ build
     let query = model.editor_query();
 
     let variable_ref = span_for_nth(source, "name", 2);
-    let definitions = query.definition_spans_at_offset(variable_ref.start.offset);
+    let definitions = query.definition_spans_at_offset(variable_ref.start.offset());
     assert_eq!(
         definitions
             .iter()
@@ -323,7 +323,7 @@ build
         ["name", "name"]
     );
 
-    let variable_occurrences = query.occurrences_at_offset(variable_ref.start.offset, true);
+    let variable_occurrences = query.occurrences_at_offset(variable_ref.start.offset(), true);
     assert_eq!(
         variable_occurrences
             .iter()
@@ -339,7 +339,7 @@ build
     let function_call = span_for_nth(source, "build", 1);
     assert_eq!(
         query
-            .definition_spans_at_offset(function_call.start.offset)
+            .definition_spans_at_offset(function_call.start.offset())
             .iter()
             .map(|span| span.slice(source))
             .collect::<Vec<_>>(),
@@ -347,7 +347,7 @@ build
     );
     assert_eq!(
         query
-            .occurrences_at_offset(function_call.start.offset, true)
+            .occurrences_at_offset(function_call.start.offset(), true)
             .iter()
             .map(|occurrence| (occurrence.span.slice(source), occurrence.kind))
             .collect::<Vec<_>>(),
@@ -413,7 +413,7 @@ fn editor_call_hierarchy_preserves_zsh_multi_name_function_bodies() {
 
     let itunes_def = span_for_nth(source, "itunes", 0);
     let itunes = query
-        .prepare_call_hierarchy(itunes_def.start.offset)
+        .prepare_call_hierarchy(itunes_def.start.offset())
         .expect("itunes should resolve to a function node");
     let outgoing = query.outgoing_calls(&itunes);
     assert_eq!(outgoing.len(), 1);
@@ -421,7 +421,7 @@ fn editor_call_hierarchy_preserves_zsh_multi_name_function_bodies() {
 
     let helper_def = span_for_nth(source, "helper", 1);
     let helper = query
-        .prepare_call_hierarchy(helper_def.start.offset)
+        .prepare_call_hierarchy(helper_def.start.offset())
         .expect("helper should resolve to a function node");
     let mut callers = query
         .incoming_calls(&helper)
@@ -760,7 +760,7 @@ build
 
     let variable_ref = span_for_nth(source, "name", 1);
     let rename = query
-        .rename_set_at_offset(variable_ref.start.offset)
+        .rename_set_at_offset(variable_ref.start.offset())
         .expect("plain variable should be renameable");
     assert_eq!(rename.name.as_str(), "name");
     assert_eq!(
@@ -774,7 +774,7 @@ build
 
     let function_call = span_for_nth(source, "build", 1);
     let rename = query
-        .rename_set_at_offset(function_call.start.offset)
+        .rename_set_at_offset(function_call.start.offset())
         .expect("function call should be renameable");
     assert_eq!(
         rename
@@ -787,7 +787,7 @@ build
 
     let nameref = span_for_nth(source, "ref", 0);
     assert_eq!(
-        query.rename_set_at_offset(nameref.start.offset),
+        query.rename_set_at_offset(nameref.start.offset()),
         Err(RenameUnavailable::Nameref)
     );
 }
@@ -1119,11 +1119,11 @@ printf '%s\\n' \"$fd\"
 
     let redirect_target_ref = fd_refs
         .iter()
-        .find(|reference| reference.span.start.line == 3)
+        .find(|reference| reference.span.start.line() == 3)
         .unwrap();
     let later_ref = fd_refs
         .iter()
-        .find(|reference| reference.span.start.line == 4)
+        .find(|reference| reference.span.start.line() == 4)
         .unwrap();
 
     assert_eq!(
@@ -1165,11 +1165,11 @@ printf '%s\\n' \"$scoped\"
 
     let inner_ref = scoped_refs
         .iter()
-        .find(|reference| reference.span.start.line == 4)
+        .find(|reference| reference.span.start.line() == 4)
         .unwrap();
     let outer_ref = scoped_refs
         .iter()
-        .find(|reference| reference.span.start.line == 6)
+        .find(|reference| reference.span.start.line() == 6)
         .unwrap();
 
     assert_eq!(
@@ -1238,11 +1238,11 @@ fn zsh_anonymous_functions_create_function_scoped_locals() {
 
     let inner_ref = scoped_refs
         .iter()
-        .find(|reference| reference.span.start.line == 1)
+        .find(|reference| reference.span.start.line() == 1)
         .unwrap();
     let outer_ref = scoped_refs
         .iter()
-        .find(|reference| reference.span.start.line == 2)
+        .find(|reference| reference.span.start.line() == 2)
         .unwrap();
 
     assert_eq!(
@@ -1290,7 +1290,7 @@ fn zsh_nested_expansion_subscript_references_are_source_anchored() {
     let reference = model
         .references()
         .iter()
-        .find(|reference| reference.name == "i" && reference.span.start.line > 0)
+        .find(|reference| reference.name == "i" && reference.span.start.line() > 0)
         .expect("nested arithmetic subscript should reference `i`");
     assert_eq!(reference.span.slice(source), "i");
 }
@@ -2227,7 +2227,7 @@ print -r -- \"$value\"
     let pipeline_assignment = model
         .bindings()
         .iter()
-        .find(|binding| binding.span.start.offset == source.find("value=new").unwrap())
+        .find(|binding| binding.span.start.offset() == source.find("value=new").unwrap())
         .unwrap();
     assert!(!matches!(
         model.scope_kind(pipeline_assignment.scope),
@@ -2248,7 +2248,7 @@ print -r -- \"$value\"
     let pipeline_assignment = model
         .bindings()
         .iter()
-        .find(|binding| binding.span.start.offset == source.find("value=new").unwrap())
+        .find(|binding| binding.span.start.offset() == source.find("value=new").unwrap())
         .unwrap();
     assert!(matches!(
         model.scope_kind(pipeline_assignment.scope),
@@ -2274,7 +2274,7 @@ print -r -- \"$value\"
     let pipeline_assignment = model
         .bindings()
         .iter()
-        .find(|binding| binding.span.start.offset == source.find("value=new").unwrap())
+        .find(|binding| binding.span.start.offset() == source.find("value=new").unwrap())
         .unwrap();
     assert!(matches!(
         model.scope_kind(pipeline_assignment.scope),
@@ -2295,7 +2295,7 @@ print -r -- \"$value\"
     let pipeline_assignment = model
         .bindings()
         .iter()
-        .find(|binding| binding.span.start.offset == source.find("value=new").unwrap())
+        .find(|binding| binding.span.start.offset() == source.find("value=new").unwrap())
         .unwrap();
     assert!(matches!(
         model.scope_kind(pipeline_assignment.scope),
@@ -2316,7 +2316,7 @@ print -r -- \"$value\"
     let pipeline_assignment = model
         .bindings()
         .iter()
-        .find(|binding| binding.span.start.offset == source.find("value=new").unwrap())
+        .find(|binding| binding.span.start.offset() == source.find("value=new").unwrap())
         .unwrap();
     assert!(matches!(
         model.scope_kind(pipeline_assignment.scope),
@@ -2337,7 +2337,7 @@ print -r -- \"$value\"
     let pipeline_assignment = model
         .bindings()
         .iter()
-        .find(|binding| binding.span.start.offset == source.find("value=new").unwrap())
+        .find(|binding| binding.span.start.offset() == source.find("value=new").unwrap())
         .unwrap();
     assert!(matches!(
         model.scope_kind(pipeline_assignment.scope),
@@ -2358,7 +2358,7 @@ print -r -- \"$value\"
     let pipeline_assignment = model
         .bindings()
         .iter()
-        .find(|binding| binding.span.start.offset == source.find("value=new").unwrap())
+        .find(|binding| binding.span.start.offset() == source.find("value=new").unwrap())
         .unwrap();
     assert!(matches!(
         model.scope_kind(pipeline_assignment.scope),
@@ -2379,7 +2379,7 @@ print -r -- \"$value\"
     let pipeline_assignment = model
         .bindings()
         .iter()
-        .find(|binding| binding.span.start.offset == source.find("value=new").unwrap())
+        .find(|binding| binding.span.start.offset() == source.find("value=new").unwrap())
         .unwrap();
     assert!(matches!(
         model.scope_kind(pipeline_assignment.scope),
@@ -2400,7 +2400,7 @@ print -r -- \"$value\"
     let pipeline_assignment = model
         .bindings()
         .iter()
-        .find(|binding| binding.span.start.offset == source.find("value=new").unwrap())
+        .find(|binding| binding.span.start.offset() == source.find("value=new").unwrap())
         .unwrap();
     assert!(matches!(
         model.scope_kind(pipeline_assignment.scope),
@@ -2422,7 +2422,7 @@ print -r -- \"$value\"
     let pipeline_assignment = model
         .bindings()
         .iter()
-        .find(|binding| binding.span.start.offset == source.find("value=new").unwrap())
+        .find(|binding| binding.span.start.offset() == source.find("value=new").unwrap())
         .unwrap();
     assert!(!matches!(
         model.scope_kind(pipeline_assignment.scope),
@@ -2443,7 +2443,7 @@ print -r -- \"$value\"
         let binding = model
             .bindings()
             .iter()
-            .find(|binding| binding.span.start.offset == source.find(assignment).unwrap())
+            .find(|binding| binding.span.start.offset() == source.find(assignment).unwrap())
             .unwrap();
         assert!(matches!(
             model.scope_kind(binding.scope),
@@ -2521,7 +2521,7 @@ outer() {
         })
         .min_by_key(|id| {
             let span = model.command_syntax_span(*id);
-            span.end.offset - span.start.offset
+            span.end.offset() - span.start.offset()
         })
         .unwrap();
 
@@ -2562,8 +2562,9 @@ fn command_topology_exposes_syntax_backed_commands_in_source_order() {
         let left = model.command_syntax_span(ids[0]);
         let right = model.command_syntax_span(ids[1]);
         assert!(
-            left.start.offset < right.start.offset
-                || (left.start.offset == right.start.offset && left.end.offset >= right.end.offset),
+            left.start.offset() < right.start.offset()
+                || (left.start.offset() == right.start.offset()
+                    && left.end.offset() >= right.end.offset()),
             "commands are out of source order: {left:?} before {right:?}"
         );
     }
@@ -3318,7 +3319,7 @@ printf '%s\\n' \"$(
     let scope = model.scope_at(
         span_for_nth(source, "printf '%s\\n' \"$1\"", 0)
             .start
-            .offset,
+            .offset(),
     );
 
     assert!(
@@ -3351,7 +3352,7 @@ caller() {
     let scope = model.scope_at(
         span_for_nth(source, "printf '%s\\n' \"$1\"", 0)
             .start
-            .offset,
+            .offset(),
     );
     let transients = model
         .transient_ancestor_scopes_within_function(scope)
@@ -3381,7 +3382,7 @@ exit
 ";
     let model = model(source);
     let binding = function_binding_id(&model, "target", 0);
-    let cutoff = span_for_nth(source, "exit", 0).start.offset;
+    let cutoff = span_for_nth(source, "exit", 0).start.offset();
     let analysis = model.analysis();
     let mut reachability = analysis.direct_function_call_reachability(Vec::new());
 
@@ -3401,9 +3402,9 @@ exit
 ";
     let model = model(source);
     let binding = function_binding_id(&model, "target", 0);
-    let after = span_for_nth(source, "echo", 0).start.offset;
-    let before = span_for_nth(source, "exit", 0).start.offset;
-    let early_before = span_for_nth(source, "target", 1).start.offset - 1;
+    let after = span_for_nth(source, "echo", 0).start.offset();
+    let before = span_for_nth(source, "exit", 0).start.offset();
+    let early_before = span_for_nth(source, "target", 1).start.offset() - 1;
     let analysis = model.analysis();
     let mut reachability = analysis.direct_function_call_reachability(Vec::new());
 
@@ -3519,7 +3520,7 @@ command target
     let command_span = span_for_nth(source, "command target", 0);
     let supplemental = vec![FunctionCallCandidate {
         callee: Name::from("target"),
-        scope: model.scope_at(target_span.start.offset),
+        scope: model.scope_at(target_span.start.offset()),
         name_span: target_span,
         command_span,
     }];
@@ -5557,7 +5558,7 @@ foo=bar
     );
     let plain_unused = plain.analysis().unused_assignments().to_vec();
     assert_eq!(plain_unused.len(), 1);
-    assert_eq!(plain.binding(plain_unused[0]).span.start.line, 3);
+    assert_eq!(plain.binding(plain_unused[0]).span.start.line(), 3);
 
     let local = model(
         "\
@@ -5571,7 +5572,7 @@ f
     );
     let local_unused = local.analysis().unused_assignments().to_vec();
     assert_eq!(local_unused.len(), 1);
-    assert_eq!(local.binding(local_unused[0]).span.start.line, 4);
+    assert_eq!(local.binding(local_unused[0]).span.start.line(), 4);
 }
 
 #[test]
@@ -5708,8 +5709,8 @@ printf '%s\\n' \"$foo\"
     let reference_block = analysis
         .block_for_reference_id(reference.id)
         .expect("expected reference block");
-    let entry =
-        analysis.flow_entry_block_for_binding_scopes(&[binding.scope], reference.span.start.offset);
+    let entry = analysis
+        .flow_entry_block_for_binding_scopes(&[binding.scope], reference.span.start.offset());
     let cover_blocks = FxHashSet::from_iter([binding_block]);
 
     assert!(!analysis.blocks_cover_all_paths_to_block(entry, reference_block, &cover_blocks));
@@ -5857,8 +5858,8 @@ printf done
     let value_flow = analysis.value_flow();
     let use_span = model.command_span(printf);
     let synthetic_use_block = analysis.flow_entry_block_for_binding_scopes(
-        &[model.scope_at(use_span.start.offset)],
-        use_span.start.offset,
+        &[model.scope_at(use_span.start.offset())],
+        use_span.start.offset(),
     );
 
     assert_eq!(
@@ -5928,7 +5929,7 @@ printf done
     assert!(value_flow.name_can_fan_out_when_unquoted_without_reference(
         &Name::from("foo"),
         use_span,
-        model.scope_at(use_span.start.offset),
+        model.scope_at(use_span.start.offset()),
     ));
 
     let scalar_source = "\
@@ -5947,7 +5948,7 @@ printf done
         !scalar_value_flow.name_can_fan_out_when_unquoted_without_reference(
             &Name::from("foo"),
             scalar_use_span,
-            scalar_model.scope_at(scalar_use_span.start.offset),
+            scalar_model.scope_at(scalar_use_span.start.offset()),
         )
     );
 }
@@ -6243,9 +6244,9 @@ printf '%s\\n' \"$foo\"
         .expect("expected helper scope");
     let analysis = model.analysis();
     let value_flow = analysis.value_flow();
-    let caller_scope = model.scope_at(reference.span.start.offset);
+    let caller_scope = model.scope_at(reference.span.start.offset());
     let callee_scopes = value_flow
-        .transitively_called_function_scopes_before(caller_scope, reference.span.start.offset);
+        .transitively_called_function_scopes_before(caller_scope, reference.span.start.offset());
 
     assert!(callee_scopes.contains(&helper_scope));
 }
@@ -6967,7 +6968,7 @@ printf '%s\\n' \
             expected
                 .entry(reference.name.as_str().to_owned())
                 .or_default()
-                .push(reference.span.start.offset);
+                .push(reference.span.start.offset());
         }
     }
 
@@ -7002,10 +7003,10 @@ relay() {
 
     let greet_use_offset = span_for_nth(source, "printf '%s\\n' \"$1\"", 0)
         .start
-        .offset;
+        .offset();
     let relay_use_offset = span_for_nth(source, "printf '%s\\n' \"$@\"", 0)
         .start
-        .offset;
+        .offset();
     let greet_scope = model
         .enclosing_function_scope(model.scope_at(greet_use_offset))
         .unwrap();
@@ -7048,7 +7049,7 @@ relay() {
     let transient_scope = model
         .innermost_transient_scope_within_function(model.scope_at(greet_use_offset))
         .unwrap();
-    let reset_offset = span_for_nth(source, "set -- inner", 0).start.offset;
+    let reset_offset = span_for_nth(source, "set -- inner", 0).start.offset();
     let mut local_resets = FxHashMap::default();
     local_resets.insert(transient_scope, vec![reset_offset]);
 
@@ -7219,8 +7220,8 @@ rvm_info=\"
         .find(|reference| reference.name == "_system_info")
         .unwrap();
 
-    assert_eq!(reference.span.start.line, 3);
-    assert_eq!(reference.span.start.column, 12);
+    assert_eq!(reference.span.start.line(), 3);
+    assert_eq!(reference.span.start.column(), 12);
     assert_eq!(reference.span.slice(source), "${_system_info}");
 }
 
@@ -7249,8 +7250,8 @@ payload=\"{
         .find(|reference| reference.name == "serverfilesdu")
         .unwrap();
 
-    assert_eq!(reference.span.start.line, 10);
-    assert_eq!(reference.span.start.column, 20);
+    assert_eq!(reference.span.start.line(), 10);
+    assert_eq!(reference.span.start.column(), 20);
     assert_eq!(reference.span.slice(source), "${serverfilesdu}");
 }
 
@@ -7303,9 +7304,9 @@ fi
         rvm_gem_home.span.slice(source),
         "${rvm_ruby_gem_home%%${rvm_gemset_separator:-\"@\"}*}"
     );
-    assert_eq!(rvm_gem_home.span.end.column, 71);
+    assert_eq!(rvm_gem_home.span.end.column(), 71);
     assert_eq!(skiprdeps.span.slice(source), "${skiprdeps/${_lf}/}");
-    assert_eq!(skiprdeps.span.end.column, 27);
+    assert_eq!(skiprdeps.span.end.column(), 27);
 }
 
 #[test]

--- a/crates/shuck-semantic/src/tests.rs
+++ b/crates/shuck-semantic/src/tests.rs
@@ -716,7 +716,7 @@ fn editor_function_completion_retains_the_latest_visible_definition() {
         .find(|item| item.name.as_str() == "dup")
         .and_then(|item| item.definition_span)
         .expect("duplicate function completion should retain a definition");
-    assert!(definition.start.offset > source.find("source lib.sh").unwrap());
+    assert!(definition.start.offset() > source.find("source lib.sh").unwrap());
 }
 
 #[test]

--- a/crates/shuck-semantic/src/uninitialized.rs
+++ b/crates/shuck-semantic/src/uninitialized.rs
@@ -45,16 +45,16 @@ impl<'model> SemanticAnalysis<'model> {
             self.model.references[reference_id.index()]
                 .span
                 .start
-                .offset
-                < at.start.offset
+                .offset()
+                < at.start.offset()
         });
 
         references[first_candidate..]
             .iter()
             .find_map(|reference_id| {
                 let reference = &self.model.references[reference_id.index()];
-                (reference.span.start.offset >= at.start.offset
-                    && reference.span.end.offset <= at.end.offset
+                (reference.span.start.offset() >= at.start.offset()
+                    && reference.span.end.offset() <= at.end.offset()
                     && !matches!(
                         reference.kind,
                         ReferenceKind::DeclarationName | ReferenceKind::ImplicitRead

--- a/crates/shuck-semantic/src/value_flow.rs
+++ b/crates/shuck-semantic/src/value_flow.rs
@@ -80,7 +80,7 @@ impl<'analysis, 'model> SemanticValueFlow<'analysis, 'model> {
         let reference = self.model().reference(reference_id);
         let policy = self
             .model()
-            .shell_behavior_at(reference.span.start.offset)
+            .shell_behavior_at(reference.span.start.offset())
             .array_reference_policy();
         self.reference_can_fan_out_when_unquoted_with_policy(reference_id, policy)
     }
@@ -144,7 +144,7 @@ impl<'analysis, 'model> SemanticValueFlow<'analysis, 'model> {
     ) -> bool {
         let policy = self
             .model()
-            .shell_behavior_at(at.start.offset)
+            .shell_behavior_at(at.start.offset())
             .array_reference_policy();
         self.name_can_fan_out_when_unquoted_without_reference_with_policy(name, at, scope, policy)
     }
@@ -179,7 +179,7 @@ impl<'analysis, 'model> SemanticValueFlow<'analysis, 'model> {
 
         let synthetic_use_block = self
             .analysis
-            .flow_entry_block_for_binding_scopes(&[scope], at.start.offset);
+            .flow_entry_block_for_binding_scopes(&[scope], at.start.offset());
         self.reaching_value_bindings_for_name_without_reference(name, at, synthetic_use_block)
             .into_iter()
             .any(|binding_id| self.model().binding_has_array_value_shape(binding_id))
@@ -267,7 +267,7 @@ impl<'analysis, 'model> SemanticValueFlow<'analysis, 'model> {
             .filter(|binding_id| {
                 let binding = self.model().binding(*binding_id);
                 visible_scopes.contains(&binding.scope)
-                    && binding.span.end.offset <= at.start.offset
+                    && binding.span.end.offset() <= at.start.offset()
             })
             .collect::<Vec<_>>();
         self.retain_value_bindings(&mut bindings);
@@ -279,7 +279,7 @@ impl<'analysis, 'model> SemanticValueFlow<'analysis, 'model> {
     pub fn helper_value_bindings_before(&mut self, name: &Name, at: Span) -> Vec<BindingId> {
         let mut bindings = self
             .model()
-            .ancestor_scopes(self.model().scope_at(at.start.offset))
+            .ancestor_scopes(self.model().scope_at(at.start.offset()))
             .flat_map(|scope| {
                 self.nonlocal_value_bindings_from_called_functions_before(name, scope, at)
             })
@@ -342,7 +342,8 @@ impl<'analysis, 'model> SemanticValueFlow<'analysis, 'model> {
                 if site.scope == scope {
                     continue;
                 }
-                if seen_sites.insert((site.scope, site.span.start.offset, site.span.end.offset)) {
+                if seen_sites.insert((site.scope, site.span.start.offset(), site.span.end.offset()))
+                {
                     caller_sites.push(site.clone());
                 }
             }
@@ -385,7 +386,7 @@ impl<'analysis, 'model> SemanticValueFlow<'analysis, 'model> {
             }
         }
 
-        scopes.sort_by_key(|scope| self.model().scope(*scope).span.start.offset);
+        scopes.sort_by_key(|scope| self.model().scope(*scope).span.start.offset());
         scopes
     }
 
@@ -416,7 +417,7 @@ impl<'analysis, 'model> SemanticValueFlow<'analysis, 'model> {
                     .iter()
                     .any(|site| {
                         site.scope == scope
-                            && site.span.start.offset < limit_offset
+                            && site.span.start.offset() < limit_offset
                             && self
                                 .definition_command_resolves_at_call(definition_command, site.span)
                     })
@@ -426,7 +427,7 @@ impl<'analysis, 'model> SemanticValueFlow<'analysis, 'model> {
             }
         }
 
-        scopes.sort_by_key(|callee_scope| self.model().scope(*callee_scope).span.start.offset);
+        scopes.sort_by_key(|callee_scope| self.model().scope(*callee_scope).span.start.offset());
         scopes
     }
 
@@ -501,7 +502,7 @@ impl<'analysis, 'model> SemanticValueFlow<'analysis, 'model> {
             .collect::<Vec<_>>();
         let entry = self
             .analysis
-            .flow_entry_block_for_binding_scopes(&binding_scopes, target_span.start.offset);
+            .flow_entry_block_for_binding_scopes(&binding_scopes, target_span.start.offset());
         target_blocks.iter().copied().all(|target_block| {
             self.analysis
                 .blocks_cover_all_paths_to_block(entry, target_block, &cover_blocks)
@@ -573,8 +574,8 @@ impl<'analysis, 'model> SemanticValueFlow<'analysis, 'model> {
         candidates.iter().any(|(other_id, other_block)| {
             *other_id != binding_id && *other_block == binding_block && {
                 let other = self.model().binding(*other_id);
-                other.span.start.offset > binding.span.start.offset
-                    && other.span.start.offset < at.start.offset
+                other.span.start.offset() > binding.span.start.offset()
+                    && other.span.start.offset() < at.start.offset()
             }
         })
     }
@@ -621,7 +622,7 @@ impl<'analysis, 'model> SemanticValueFlow<'analysis, 'model> {
             .copied()
             .filter(|binding_id| self.binding_can_supply_parameter_value(*binding_id))
             .filter(|binding_id| self.model().binding_visible_at(*binding_id, at))
-            .max_by_key(|binding_id| self.model().binding(*binding_id).span.start.offset)
+            .max_by_key(|binding_id| self.model().binding(*binding_id).span.start.offset())
     }
 
     fn block_for_name_use_site(&self, name: &Name, at: Span) -> Option<BlockId> {
@@ -631,8 +632,8 @@ impl<'analysis, 'model> SemanticValueFlow<'analysis, 'model> {
 
         let command_id = self
             .model()
-            .innermost_command_id_at(at.start.offset)
-            .or_else(|| self.innermost_command_id_containing_offset(at.start.offset))?;
+            .innermost_command_id_at(at.start.offset())
+            .or_else(|| self.innermost_command_id_containing_offset(at.start.offset()))?;
         self.analysis
             .block_ids_for_span(self.model().command_syntax_span(command_id))
             .first()
@@ -646,16 +647,16 @@ impl<'analysis, 'model> SemanticValueFlow<'analysis, 'model> {
             .copied()
             .filter(|command_id| {
                 let span = self.model().command_syntax_span(*command_id);
-                span.start.offset <= offset && offset <= span.end.offset
+                span.start.offset() <= offset && offset <= span.end.offset()
             })
             .max_by(|left, right| {
                 let left_span = self.model().command_syntax_span(*left);
                 let right_span = self.model().command_syntax_span(*right);
                 left_span
                     .start
-                    .offset
-                    .cmp(&right_span.start.offset)
-                    .then_with(|| right_span.end.offset.cmp(&left_span.end.offset))
+                    .offset()
+                    .cmp(&right_span.start.offset())
+                    .then_with(|| right_span.end.offset().cmp(&left_span.end.offset()))
             })
     }
 
@@ -683,7 +684,7 @@ impl<'analysis, 'model> SemanticValueFlow<'analysis, 'model> {
                                 function_name,
                                 site,
                             )
-                            && self.call_site_dominates_offset(site.span, at.start.offset)
+                            && self.call_site_dominates_offset(site.span, at.start.offset())
                     })
             });
             if !called_before {
@@ -743,7 +744,8 @@ impl<'analysis, 'model> SemanticValueFlow<'analysis, 'model> {
                 if !self.function_scope_resolves_at_call_site(scope, function_name, site) {
                     continue;
                 }
-                if seen_sites.insert((site.scope, site.span.start.offset, site.span.end.offset)) {
+                if seen_sites.insert((site.scope, site.span.start.offset(), site.span.end.offset()))
+                {
                     caller_sites.push(site.clone());
                 }
             }
@@ -892,7 +894,7 @@ impl<'analysis, 'model> SemanticValueFlow<'analysis, 'model> {
             .function_bindings_for_scope(scope)
             .into_iter()
             .filter_map(|binding_id| self.function_definition_command_for_binding(binding_id))
-            .min_by_key(|command_id| self.model().command_span(*command_id).start.offset);
+            .min_by_key(|command_id| self.model().command_span(*command_id).start.offset());
         self.function_definition_command_memo
             .borrow_mut()
             .insert(scope, command_id);
@@ -922,8 +924,8 @@ impl<'analysis, 'model> SemanticValueFlow<'analysis, 'model> {
                 self.function_definition_command_for_binding(*candidate)
                     .is_some_and(|command_id| {
                         self.definition_command_scope_can_reach_call(command_id, site.span)
-                            && self.model().command_span(command_id).end.offset
-                                <= site.span.start.offset
+                            && self.model().command_span(command_id).end.offset()
+                                <= site.span.start.offset()
                     })
             })
             .collect::<Vec<_>>();
@@ -940,16 +942,16 @@ impl<'analysis, 'model> SemanticValueFlow<'analysis, 'model> {
         let command_span = self.model().command_span(command_id);
         let definition_scope = self
             .analysis
-            .enclosing_function_scope_at(command_span.start.offset);
+            .enclosing_function_scope_at(command_span.start.offset());
         let call_scope = self
             .analysis
-            .enclosing_function_scope_at(call_span.start.offset);
+            .enclosing_function_scope_at(call_span.start.offset());
 
         if definition_scope.is_none() && call_scope.is_some() {
             return true;
         }
 
-        command_span.end.offset <= call_span.start.offset
+        command_span.end.offset() <= call_span.start.offset()
     }
 
     fn definition_command_scope_can_reach_call(
@@ -960,10 +962,10 @@ impl<'analysis, 'model> SemanticValueFlow<'analysis, 'model> {
         let command_span = self.model().command_span(command_id);
         let command_scope = self
             .analysis
-            .enclosing_function_scope_at(command_span.start.offset);
+            .enclosing_function_scope_at(command_span.start.offset());
         let call_scope = self
             .analysis
-            .enclosing_function_scope_at(call_span.start.offset);
+            .enclosing_function_scope_at(call_span.start.offset());
         command_scope.is_none() || command_scope == call_scope
     }
 
@@ -988,14 +990,14 @@ impl<'analysis, 'model> SemanticValueFlow<'analysis, 'model> {
     }
 
     fn call_site_dominates_offset(&self, call_span: Span, limit_offset: usize) -> bool {
-        if call_span.start.offset >= limit_offset {
+        if call_span.start.offset() >= limit_offset {
             return false;
         }
 
         let Some(mut command_id) = self
             .model()
-            .innermost_command_id_at(call_span.start.offset)
-            .or_else(|| self.innermost_command_id_containing_offset(call_span.start.offset))
+            .innermost_command_id_at(call_span.start.offset())
+            .or_else(|| self.innermost_command_id_containing_offset(call_span.start.offset()))
         else {
             return true;
         };
@@ -1010,10 +1012,10 @@ impl<'analysis, 'model> SemanticValueFlow<'analysis, 'model> {
         let mut current = self.model().command_parent_id(command_id);
         while let Some(command_id) = current {
             let command_span = self.model().command_syntax_span(command_id);
-            if command_span.end.offset > limit_offset {
+            if command_span.end.offset() > limit_offset {
                 break;
             }
-            if command_span.start.offset < call_span.start.offset
+            if command_span.start.offset() < call_span.start.offset()
                 && self.command_is_dominance_barrier(command_id)
             {
                 return false;
@@ -1046,8 +1048,8 @@ impl<'analysis, 'model> SemanticValueFlow<'analysis, 'model> {
 
             let next_limit_offset = self
                 .function_definition_command_for_scope(callee_scope)
-                .map(|command_id| self.model().command_span(command_id).end.offset)
-                .unwrap_or_else(|| self.model().scope(callee_scope).span.end.offset);
+                .map(|command_id| self.model().command_span(command_id).end.offset())
+                .unwrap_or_else(|| self.model().scope(callee_scope).span.end.offset());
             self.collect_transitively_called_function_scopes_before(
                 callee_scope,
                 next_limit_offset,
@@ -1088,7 +1090,7 @@ impl<'analysis, 'model> SemanticValueFlow<'analysis, 'model> {
             .any(|binding_id| {
                 let binding = self.model().binding(binding_id);
                 binding.scope == scope
-                    && binding.span.end.offset <= at.start.offset
+                    && binding.span.end.offset() <= at.start.offset()
                     && binding.attributes.contains(BindingAttributes::LOCAL)
             })
     }
@@ -1098,7 +1100,7 @@ impl<'analysis, 'model> SemanticValueFlow<'analysis, 'model> {
     }
 
     fn sort_and_dedup_bindings(&self, bindings: &mut Vec<BindingId>) {
-        bindings.sort_by_key(|binding_id| self.model().binding(*binding_id).span.start.offset);
+        bindings.sort_by_key(|binding_id| self.model().binding(*binding_id).span.start.offset());
         bindings.dedup();
     }
 
@@ -1107,5 +1109,5 @@ impl<'analysis, 'model> SemanticValueFlow<'analysis, 'model> {
     }
 }
 fn span_contains(outer: Span, inner: Span) -> bool {
-    outer.start.offset <= inner.start.offset && inner.end.offset <= outer.end.offset
+    outer.start.offset() <= inner.start.offset() && inner.end.offset() <= outer.end.offset()
 }

--- a/crates/shuck-semantic/src/zsh_options.rs
+++ b/crates/shuck-semantic/src/zsh_options.rs
@@ -325,8 +325,8 @@ pub(crate) fn analyze(
     let mut scope_index: Vec<ScopeIndexEntry> = scopes
         .iter()
         .map(|scope| ScopeIndexEntry {
-            start: scope.span.start.offset,
-            end: scope.span.end.offset,
+            start: scope.span.start.offset(),
+            end: scope.span.end.offset(),
             scope: scope.id,
         })
         .collect();
@@ -385,12 +385,12 @@ pub(crate) fn function_runtime_analysis_with_entry(
     let mut scope_index: Vec<ScopeIndexEntry> = scopes
         .iter()
         .filter(|scope| {
-            function_span.start.offset <= scope.span.start.offset
-                && scope.span.end.offset <= function_span.end.offset
+            function_span.start.offset() <= scope.span.start.offset()
+                && scope.span.end.offset() <= function_span.end.offset()
         })
         .map(|scope| ScopeIndexEntry {
-            start: scope.span.start.offset,
-            end: scope.span.end.offset,
+            start: scope.span.start.offset(),
+            end: scope.span.end.offset(),
             scope: scope.id,
         })
         .collect();
@@ -673,7 +673,7 @@ impl<'a> Analyzer<'a> {
             for bindings in self.scopes[scope_id.index()].bindings.values() {
                 for binding_id in bindings.iter().rev().copied() {
                     let binding = &self.bindings[binding_id.index()];
-                    if binding.span.start.offset > at.start.offset
+                    if binding.span.start.offset() > at.start.offset()
                         || binding.kind != BindingKind::FunctionDefinition
                     {
                         continue;
@@ -704,7 +704,7 @@ impl<'a> Analyzer<'a> {
     ) -> EvalState {
         self.record_scope_entry(scope, &state.current);
         let recorded = self.recorded_program.command(command);
-        self.record_snapshot(scope, recorded.span.start.offset, &state.current);
+        self.record_snapshot(scope, recorded.span.start.offset(), &state.current);
         self.analyze_command(scope, command, state, leak)
     }
 
@@ -718,7 +718,7 @@ impl<'a> Analyzer<'a> {
         self.record_scope_entry(scope, &state.current);
         for &command in self.recorded_program.commands_in(commands) {
             let recorded = self.recorded_program.command(command);
-            self.record_snapshot(scope, recorded.span.start.offset, &state.current);
+            self.record_snapshot(scope, recorded.span.start.offset(), &state.current);
             state = self.analyze_command(scope, command, state, leak);
         }
         state
@@ -794,7 +794,7 @@ impl<'a> Analyzer<'a> {
             RecordedCommandKind::Case { arms } => self.analyze_case(scope, &state, *arms, leak),
             RecordedCommandKind::Subshell { body } => {
                 self.analyze_sequence(
-                    self.subshell_scope_for(command.span.start.offset)
+                    self.subshell_scope_for(command.span.start.offset())
                         .unwrap_or(scope),
                     *body,
                     EvalState::new(state.current.clone()),
@@ -918,7 +918,7 @@ impl<'a> Analyzer<'a> {
         if let Some(function_scope) = info
             .and_then(|info| info.static_callee.as_deref())
             .and_then(|name| {
-                self.resolve_visible_function_scope(scope, command.span.start.offset, name)
+                self.resolve_visible_function_scope(scope, command.span.start.offset(), name)
             })
         {
             let summary =
@@ -1112,7 +1112,11 @@ impl<'a> Analyzer<'a> {
             .map(|info_id| self.recorded_program.command_info(info_id))
         {
             if let Some(function_scope) = info.static_callee.as_deref().and_then(|name| {
-                self.resolve_visible_function_scope(command_scope, command.span.start.offset, name)
+                self.resolve_visible_function_scope(
+                    command_scope,
+                    command.span.start.offset(),
+                    name,
+                )
             }) {
                 push_unique_scope(seen, callees, function_scope);
             } else if let Some(name_span) = info.dynamic_name_span {
@@ -1220,7 +1224,7 @@ impl<'a> Analyzer<'a> {
             }
             RecordedCommandKind::Subshell { body } => {
                 let subshell_scope = self
-                    .subshell_scope_for(command.span.start.offset)
+                    .subshell_scope_for(command.span.start.offset())
                     .unwrap_or(command_scope);
                 self.collect_direct_function_callees_in_range(subshell_scope, *body, seen, callees);
             }
@@ -1248,7 +1252,7 @@ impl<'a> Analyzer<'a> {
             if let Some(bindings) = self.scopes[scope_id.index()].bindings.get(name) {
                 for binding_id in bindings.iter().rev().copied() {
                     let binding = &self.bindings[binding_id.index()];
-                    if binding.span.start.offset > offset
+                    if binding.span.start.offset() > offset
                         || binding.kind != BindingKind::FunctionDefinition
                     {
                         continue;
@@ -1269,14 +1273,14 @@ impl<'a> Analyzer<'a> {
         self.scopes
             .iter()
             .filter(|scope| {
-                scope.span.start.offset <= offset
-                    && offset <= scope.span.end.offset
+                scope.span.start.offset() <= offset
+                    && offset <= scope.span.end.offset()
                     && matches!(
                         scope.kind,
                         ScopeKind::Subshell | ScopeKind::CommandSubstitution
                     )
             })
-            .min_by_key(|scope| scope.span.end.offset - scope.span.start.offset)
+            .min_by_key(|scope| scope.span.end.offset() - scope.span.start.offset())
             .map(|scope| scope.id)
     }
 
@@ -1489,7 +1493,7 @@ impl FunctionSummary {
 }
 
 fn contains_span(outer: Span, inner: Span) -> bool {
-    outer.start.offset <= inner.start.offset && inner.end.offset <= outer.end.offset
+    outer.start.offset() <= inner.start.offset() && inner.end.offset() <= outer.end.offset()
 }
 
 fn push_unique_scope(
@@ -1503,7 +1507,7 @@ fn push_unique_scope(
 }
 
 fn binding_visible_at(scopes: &[Scope], binding: &Binding, scope: ScopeId, at: Span) -> bool {
-    binding.span.start.offset <= at.start.offset
+    binding.span.start.offset() <= at.start.offset()
         && ancestor_scopes(scopes, scope).any(|ancestor| ancestor == binding.scope)
 }
 

--- a/crates/shuck-server/src/editor_features.rs
+++ b/crates/shuck-server/src/editor_features.rs
@@ -103,7 +103,7 @@ where
                     && item.name == sourced.name
                     && item
                         .definition_span
-                        .is_some_and(|span| span.start.offset > sourced.import_span.start.offset)
+                        .is_some_and(|span| span.start.offset() > sourced.import_span.start.offset())
             });
             if local_wins {
                 continue;

--- a/crates/shuck-server/src/editor_features.rs
+++ b/crates/shuck-server/src/editor_features.rs
@@ -134,8 +134,8 @@ where
             let data = if let Some(sourced) = sourced {
                 Some(CompletionData::SourcedFunction {
                     path: sourced.path.display().to_string(),
-                    line: sourced.selection_span.start.line,
-                    column: sourced.selection_span.start.column,
+                    line: sourced.selection_span.start.line(),
+                    column: sourced.selection_span.start.column(),
                 })
             } else {
                 match completion.kind {
@@ -144,8 +144,8 @@ where
                             .definition_span
                             .map(|span| CompletionData::Symbol {
                                 symbol_kind: completion_kind_label(completion.kind).to_owned(),
-                                line: span.start.line,
-                                column: span.start.column,
+                                line: span.start.line(),
+                                column: span.start.column(),
                             })
                     }
                     EditorCompletionKind::Function => completion
@@ -162,8 +162,8 @@ where
                         })
                         .map(|span| CompletionData::Symbol {
                             symbol_kind: completion_kind_label(completion.kind).to_owned(),
-                            line: span.start.line,
-                            column: span.start.column,
+                            line: span.start.line(),
+                            column: span.start.column(),
                         }),
                     EditorCompletionKind::RuntimeName => Some(CompletionData::RuntimeName),
                     EditorCompletionKind::Builtin => Some(CompletionData::Builtin),
@@ -357,8 +357,8 @@ pub(crate) fn call_hierarchy_function_item(
         range,
         selection_range,
         data: serde_json::to_value(CallHierarchyData::Function {
-            definition_start: definition_span.start.offset,
-            definition_end: definition_span.end.offset,
+            definition_start: definition_span.start.offset(),
+            definition_end: definition_span.end.offset(),
         })
         .ok(),
     }

--- a/crates/shuck-server/src/editor_features.rs
+++ b/crates/shuck-server/src/editor_features.rs
@@ -101,9 +101,9 @@ where
             let local_wins = completions.items.iter().any(|item| {
                 item.kind == EditorCompletionKind::Function
                     && item.name == sourced.name
-                    && item
-                        .definition_span
-                        .is_some_and(|span| span.start.offset() > sourced.import_span.start.offset())
+                    && item.definition_span.is_some_and(|span| {
+                        span.start.offset() > sourced.import_span.start.offset()
+                    })
             });
             if local_wins {
                 continue;

--- a/crates/shuck-server/src/format.rs
+++ b/crates/shuck-server/src/format.rs
@@ -196,11 +196,12 @@ fn record_smaller_span(best: &mut Option<Span>, candidate: Span) {
 }
 
 fn span_width(span: Span) -> usize {
-    span.end.offset.saturating_sub(span.start.offset)
+    span.end.offset().saturating_sub(span.start.offset())
 }
 
 fn span_contains_text_range(span: Span, range: TextRange) -> bool {
-    span.start.offset <= usize::from(range.start()) && usize::from(range.end()) <= span.end.offset
+    span.start.offset() <= usize::from(range.start())
+        && usize::from(range.end()) <= span.end.offset()
 }
 
 #[cfg(test)]

--- a/crates/shuck-server/src/lint.rs
+++ b/crates/shuck-server/src/lint.rs
@@ -70,7 +70,7 @@ pub fn generate_diagnostics(snapshot: &DocumentSnapshot) -> Vec<types::Diagnosti
         .iter()
         .map(|diagnostic| {
             let directive_edit = directive_edits
-                .get(&diagnostic.span.start.line)
+                .get(&diagnostic.span.start.line())
                 .cloned()
                 .flatten();
             to_lsp_diagnostic(
@@ -286,7 +286,7 @@ fn directive_edits_by_line(
 
     for line in diagnostics
         .iter()
-        .map(|diagnostic| diagnostic.span.start.line)
+        .map(|diagnostic| diagnostic.span.start.line())
     {
         edits.entry(line).or_insert_with(|| {
             shuck_linter::build_ignore_edit_for_line(

--- a/crates/shuck-server/src/resolve.rs
+++ b/crates/shuck-server/src/resolve.rs
@@ -140,7 +140,8 @@ fn render_semantic_hover(
     } else {
         markdown.push_str(&format!(
             "\n\nDefined at line {}, column {}.",
-            hover.symbol.definition_span.start.line, hover.symbol.definition_span.start.column
+            hover.symbol.definition_span.start.line(),
+            hover.symbol.definition_span.start.column()
         ));
     }
 

--- a/crates/shuck-server/src/workspace_functions.rs
+++ b/crates/shuck-server/src/workspace_functions.rs
@@ -539,7 +539,7 @@ fn insert_file(
         .source_refs()
         .iter()
         .filter_map(|source_ref| {
-            let scope = model.scope_at(source_ref.span.start.offset);
+            let scope = model.scope_at(source_ref.span.start.offset());
             source_ref_candidate_paths(
                 input.path,
                 source_ref,

--- a/fuzz/fuzz_targets/linter_common.rs
+++ b/fuzz/fuzz_targets/linter_common.rs
@@ -36,22 +36,22 @@ impl LintCase {
 
 pub(crate) fn assert_span_valid(span: Span, source: &str) {
     assert!(
-        span.start.offset <= span.end.offset,
+        span.start.offset() <= span.end.offset(),
         "invalid span ordering: {:?}",
         span
     );
     assert!(
-        span.end.offset <= source.len(),
+        span.end.offset() <= source.len(),
         "span end is out of bounds: {:?}",
         span
     );
     assert!(
-        source.is_char_boundary(span.start.offset),
+        source.is_char_boundary(span.start.offset()),
         "span start is not a char boundary: {:?}",
         span
     );
     assert!(
-        source.is_char_boundary(span.end.offset),
+        source.is_char_boundary(span.end.offset()),
         "span end is not a char boundary: {:?}",
         span
     );

--- a/fuzz/fuzz_targets/lsp_common.rs
+++ b/fuzz/fuzz_targets/lsp_common.rs
@@ -122,7 +122,10 @@ pub(crate) fn client_options_from_byte(byte: u8) -> ClientOptions {
     }
 }
 
-pub(crate) fn capabilities_from_byte(byte: u8, encoding: PositionEncoding) -> types::ClientCapabilities {
+pub(crate) fn capabilities_from_byte(
+    byte: u8,
+    encoding: PositionEncoding,
+) -> types::ClientCapabilities {
     let encoding_name = match encoding {
         PositionEncoding::UTF8 => "utf-8",
         PositionEncoding::UTF16 => "utf-16",
@@ -170,7 +173,11 @@ pub(crate) fn validate_lsp_ranges_in_values(
     }
 }
 
-pub(crate) fn validate_lsp_ranges_in_value(source: &str, encoding: PositionEncoding, value: &Value) {
+pub(crate) fn validate_lsp_ranges_in_value(
+    source: &str,
+    encoding: PositionEncoding,
+    value: &Value,
+) {
     match value {
         Value::Array(values) => {
             for value in values {
@@ -191,11 +198,7 @@ pub(crate) fn validate_lsp_ranges_in_value(source: &str, encoding: PositionEncod
     }
 }
 
-pub(crate) fn assert_valid_range(
-    source: &str,
-    encoding: PositionEncoding,
-    range: types::Range,
-) {
+pub(crate) fn assert_valid_range(source: &str, encoding: PositionEncoding, range: types::Range) {
     assert!(
         position_leq(range.start, range.end),
         "LSP range is not ordered: {:?}",

--- a/fuzz/fuzz_targets/lsp_protocol_sequence_fuzz.rs
+++ b/fuzz/fuzz_targets/lsp_protocol_sequence_fuzz.rs
@@ -62,11 +62,7 @@ fn run_protocol_sequence(source: &str, data: &[u8]) -> Result<(), String> {
         }),
     )?;
     recv_response(&client_connection, 1)?;
-    send_notification(
-        &client_connection,
-        "initialized",
-        serde_json::json!({}),
-    )?;
+    send_notification(&client_connection, "initialized", serde_json::json!({}))?;
 
     let mut current_source = source.to_owned();
     let mut version = 1i32;
@@ -383,7 +379,10 @@ fn send_notification(
 ) -> Result<(), String> {
     connection
         .sender
-        .send(Message::Notification(Notification::new(method.to_owned(), params)))
+        .send(Message::Notification(Notification::new(
+            method.to_owned(),
+            params,
+        )))
         .map_err(|error| format!("send notification {method}: {error}"))
 }
 
@@ -394,7 +393,9 @@ fn recv_response(connection: &Connection, id: i32) -> Result<(), String> {
         if now >= deadline {
             return Err(format!("timed out waiting for response {id}"));
         }
-        let timeout = deadline.saturating_duration_since(now).min(Duration::from_millis(25));
+        let timeout = deadline
+            .saturating_duration_since(now)
+            .min(Duration::from_millis(25));
         match connection.receiver.recv_timeout(timeout) {
             Ok(Message::Response(response)) if response.id == RequestId::from(id) => {
                 return Ok(());

--- a/fuzz/fuzz_targets/lsp_request_surface_fuzz.rs
+++ b/fuzz/fuzz_targets/lsp_request_surface_fuzz.rs
@@ -16,11 +16,13 @@ fuzz_target!(|data: &[u8]| -> Corpus {
     let encoding = lsp_common::encoding_from_byte(data.first().copied().unwrap_or_default());
     let language_id = lsp_common::language_id_from_byte(data.get(1).copied().unwrap_or_default());
     let file_name = lsp_common::file_name_for_language(language_id);
-    let position = lsp_common::position_from_bytes(input, data.get(2..).unwrap_or_default(), encoding);
+    let position =
+        lsp_common::position_from_bytes(input, data.get(2..).unwrap_or_default(), encoding);
     let range = lsp_common::range_from_bytes(input, data.get(4..).unwrap_or_default(), encoding);
     let capabilities =
         lsp_common::capabilities_from_byte(data.get(6).copied().unwrap_or_default(), encoding);
-    let client_options = lsp_common::client_options_from_byte(data.get(7).copied().unwrap_or_default());
+    let client_options =
+        lsp_common::client_options_from_byte(data.get(7).copied().unwrap_or_default());
     let new_name = lsp_common::new_name_from_byte(data.get(8).copied().unwrap_or_default());
     let workspace_query =
         lsp_common::workspace_query_from_byte(data.get(9).copied().unwrap_or_default());

--- a/fuzz/fuzz_targets/recovered_common.rs
+++ b/fuzz/fuzz_targets/recovered_common.rs
@@ -14,22 +14,22 @@ pub(crate) const PARSER_DIALECTS: [ParseDialect; 4] = [
 
 pub(crate) fn assert_span_valid(span: Span, source: &str) {
     assert!(
-        span.start.offset <= span.end.offset,
+        span.start.offset() <= span.end.offset(),
         "invalid span ordering: {:?}",
         span
     );
     assert!(
-        span.end.offset <= source.len(),
+        span.end.offset() <= source.len(),
         "span end is out of bounds: {:?}",
         span
     );
     assert!(
-        source.is_char_boundary(span.start.offset),
+        source.is_char_boundary(span.start.offset()),
         "span start is not a char boundary: {:?}",
         span
     );
     assert!(
-        source.is_char_boundary(span.end.offset),
+        source.is_char_boundary(span.end.offset()),
         "span end is not a char boundary: {:?}",
         span
     );

--- a/fuzz/fuzz_targets/recovered_parser_fuzz.rs
+++ b/fuzz/fuzz_targets/recovered_parser_fuzz.rs
@@ -27,7 +27,7 @@ fn validate_recovered_parse(source: &str, parse_result: &ParseResult) {
     recovered_common::assert_span_valid(parse_result.file.span, source);
     if parse_result.status != ParseStatus::Fatal {
         assert_eq!(
-            parse_result.file.span.end.offset,
+            parse_result.file.span.end.offset(),
             source.len(),
             "non-fatal parse should cover the full source"
         );
@@ -87,5 +87,5 @@ fn validate_recovered_parse(source: &str, parse_result: &ParseResult) {
 
 fn validate_non_overlapping_root_span(span: Span, source: &str) {
     recovered_common::assert_span_valid(span, source);
-    assert_eq!(span.start.offset, 0, "root span should start at offset 0");
+    assert_eq!(span.start.offset(), 0, "root span should start at offset 0");
 }


### PR DESCRIPTION
## Summary

The deep fix behind the remaining allocator/memcpy hotspot: `Position` stored line/column/offset as `usize` (24 B), making every `Span` 48 B — and spans are embedded in every AST node, fact, and diagnostic, so position width set the size floor for the whole tree.

- `Position` now stores the three values as `u32` → 12 B, `Span` → 24 B (inputs capped at 4 GiB)
- Fields become private with `usize`-returning accessors (`line()`/`column()`/`offset()`) plus a `Position::at(line, column, offset)` constructor, so callers keep computing in `usize`
- ~3,100 call sites migrated mechanically (compiler-diagnostics-driven rewrite); a handful of in-place mutation sites were restructured to construct new positions

**BREAKING CHANGE**: `Position` fields are no longer public — use the accessors and `Position::at`.

## Cascaded type sizes (on top of #1229; session-start values in parentheses)

| Type | After #1229 | This PR | (original) |
|---|---:|---:|---:|
| `Position` | 24 B | **12 B** | (24 B) |
| `Span` | 48 B | **24 B** | (48 B) |
| `Stmt` | 360 B | **256 B** | (696 B) |
| `Command` | 200 B | **144 B** | (536 B) |
| `Word` | 96 B | **72 B** | (96 B) |
| `WordPartNode` | 176 B | **128 B** | (352 B) |
| `Redirect` | 240 B | **160 B** | (400 B) |

## Measured impact (xwmx/nb fixture, interleaved A/B vs #1229)

| Metric | Before | After | Delta |
|---|---|---|---|
| Lint wall / iteration | 161.4 ms | 142.1 ms | **−12.0%** |
| Total allocated bytes (2 iters) | 533 MB | 448 MB | **−16%** |
| Allocation count | 1,308,709 | 1,308,713 | ±0 |

Diagnostics unchanged.

## Testing

- `cargo test` (full workspace) passes
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean (pinned 1.94.1 toolchain)
- `make test-large-corpus SHUCK_LARGE_CORPUS_SAMPLE_PERCENT=10` conformance passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)