### PR TITLE
feat(server): resolve sourced function definitions

### DIFF
--- a/crates/shuck-semantic/src/builder/special_builtins.rs
+++ b/crates/shuck-semantic/src/builder/special_builtins.rs
@@ -210,6 +210,7 @@ impl<'a, 'idx, 'observer> SemanticModelBuilder<'a, 'idx, 'observer> {
                         kind,
                         span: source_span,
                         path_span: argument.span,
+                        conditionally_executed: flow.conditionally_executed,
                         resolution: SourceRefResolution::Unchecked,
                         explicitly_provided: false,
                         directive,

--- a/crates/shuck-semantic/src/call_facts.rs
+++ b/crates/shuck-semantic/src/call_facts.rs
@@ -29,6 +29,34 @@ struct ResolvedDefinition {
 /// in the referring file for source-order precedence.
 type SourceResolution = Option<(ResolvedDefinition, Span)>;
 
+#[derive(Clone, Debug, PartialEq, Eq)]
+enum ExactResolution {
+    Defined(ResolvedDefinition),
+    Absent,
+    Ambiguous,
+}
+
+#[derive(Clone, Copy)]
+struct ExactQuery<'a> {
+    top_level_cutoff: usize,
+    local_definition: Option<Span>,
+    include_top_level_definitions: bool,
+    enclosing_function: Option<&'a CallFunctionId>,
+    local_call_offset: Option<usize>,
+}
+
+impl ExactQuery<'_> {
+    fn top_level(cutoff: usize) -> Self {
+        Self {
+            top_level_cutoff: cutoff,
+            local_definition: None,
+            include_top_level_definitions: true,
+            enclosing_function: None,
+            local_call_offset: None,
+        }
+    }
+}
+
 /// Stable identity of one function node within its file.
 ///
 /// Function names alone are insufficient because shell permits later
@@ -75,6 +103,10 @@ pub struct CallFactDefinition {
     pub def_span: Span,
     /// Span to select when navigating to the definition (the name token).
     pub selection_span: Span,
+    /// Whether every path through the containing command installs it.
+    pub unconditional: bool,
+    /// Whether the definition executes in the persistent file scope.
+    pub persistent_top_level: bool,
 }
 
 impl CallFactDefinition {
@@ -109,6 +141,22 @@ pub struct CallFactSourceEdge {
     pub span: Span,
 }
 
+/// A source operation that may affect function visibility, including
+/// operations whose target could not be resolved statically.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct CallFactSourceEffect {
+    /// Resolved target, or `None` when the operation is dynamic or unavailable.
+    pub path: Option<PathBuf>,
+    /// Span of the source operation in the referring file.
+    pub span: Span,
+    /// Whether control flow may skip the operation.
+    pub conditional: bool,
+    /// Innermost function containing the operation, if any.
+    pub enclosing_function: Option<CallFunctionId>,
+    /// Whether the operation's effects survive its containing execution scope.
+    pub persistent: bool,
+}
+
 /// Call-relevant facts projected from one file, plus its resolved source edges.
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct FileCallFacts {
@@ -119,6 +167,10 @@ pub struct FileCallFacts {
     /// Resolved on-disk paths of this file's determinable source edges (literal
     /// resolvable paths plus `source=` directive targets).
     pub source_edges: Vec<CallFactSourceEdge>,
+    /// All source operations, including unresolved or conditional effects.
+    pub source_effects: Vec<CallFactSourceEffect>,
+    has_dynamic_command_dispatch: bool,
+    analyzable: bool,
 }
 
 impl FileCallFacts {
@@ -154,6 +206,11 @@ impl FileCallFacts {
                 name: binding.name.clone(),
                 def_span: binding_definition_span(binding),
                 selection_span: binding.span,
+                unconditional: model.function_binding_is_unconditional(binding.id),
+                persistent_top_level: model.enclosing_function_scope(binding.scope).is_none()
+                    && model
+                        .innermost_transient_scope_within_function(binding.scope)
+                        .is_none(),
             };
             if let Some(scope) = analysis.function_scope_for_binding(binding.id) {
                 functions_by_scope
@@ -200,10 +257,60 @@ impl FileCallFacts {
             }
         }
 
+        let mut source_effects = model
+            .source_refs()
+            .iter()
+            .map(|source_ref| {
+                let scope = model.scope_at(source_ref.span.start.offset);
+                let enclosing_function = model
+                    .ancestor_scopes(scope)
+                    .find_map(|scope| functions_by_scope.get(&scope))
+                    .and_then(|functions| functions.first())
+                    .map(|(function, _)| function.clone());
+                CallFactSourceEffect {
+                    path: source_edges
+                        .iter()
+                        .find(|edge| edge.span == source_ref.span)
+                        .map(|edge| edge.path.clone()),
+                    span: source_ref.span,
+                    conditional: source_ref.conditionally_executed,
+                    enclosing_function,
+                    persistent: model
+                        .innermost_transient_scope_within_function(scope)
+                        .is_none(),
+                }
+            })
+            .collect::<Vec<_>>();
+        for edge in &source_edges {
+            if !source_effects.iter().any(|effect| effect.span == edge.span) {
+                source_effects.push(CallFactSourceEffect {
+                    path: Some(edge.path.clone()),
+                    span: edge.span,
+                    conditional: false,
+                    enclosing_function: None,
+                    persistent: true,
+                });
+            }
+        }
+        source_effects.sort_by_key(|effect| effect.span.start.offset);
+        let has_dynamic_command_dispatch =
+            model.recorded_program().commands().iter().any(|command| {
+                command.command_info.is_some_and(|info| {
+                    model
+                        .recorded_program()
+                        .command_info(info)
+                        .dynamic_name_span
+                        .is_some()
+                })
+            });
+
         Self {
             definitions,
             call_sites,
             source_edges,
+            source_effects,
+            has_dynamic_command_dispatch,
+            analyzable: true,
         }
     }
 
@@ -316,6 +423,214 @@ impl WorkspaceCallIndex {
             selection_span: definition.map(|definition| definition.selection_span),
             call_spans: vec![site.name_span],
         })
+    }
+
+    /// Resolves a call only when source effects prove one exact definition.
+    ///
+    /// Unlike call hierarchy's best-effort graph, navigation must not guess
+    /// across dynamic or conditional source operations. Calls in deferred
+    /// function bodies also fail closed when a later source operation could
+    /// run either before or after the function is invoked.
+    pub fn resolve_call_site_exact(
+        &self,
+        from_path: &Path,
+        name_span: Span,
+    ) -> Option<CrossFileCall> {
+        let facts = self.files.get(from_path)?;
+        let site = facts
+            .call_sites
+            .iter()
+            .find(|site| site.name_span == name_span)?;
+        let mut stack = FxHashSet::default();
+        stack.insert(from_path.to_path_buf());
+        let resolution = match &site.enclosing {
+            CallNodeKind::TopLevel => self.resolve_exact_events(
+                from_path,
+                &site.callee,
+                ExactQuery::top_level(site.name_span.start.offset),
+                &mut stack,
+            ),
+            CallNodeKind::Function(function) => {
+                if self.called_source_function_may_mutate(from_path, function)
+                    || facts.source_effects.iter().any(|effect| {
+                        (effect.enclosing_function.is_none()
+                            && effect.span.start.offset >= function.definition_start)
+                            || (effect.enclosing_function.as_ref() == Some(function)
+                                && effect.span.start.offset >= site.name_span.start.offset)
+                    })
+                {
+                    return None;
+                }
+                self.resolve_exact_events(
+                    from_path,
+                    &site.callee,
+                    ExactQuery {
+                        top_level_cutoff: function.definition_start,
+                        local_definition: site.local_definition_span,
+                        include_top_level_definitions: false,
+                        enclosing_function: Some(function),
+                        local_call_offset: Some(site.name_span.start.offset),
+                    },
+                    &mut stack,
+                )
+            }
+        };
+        let ExactResolution::Defined(target) = resolution else {
+            return None;
+        };
+        let definition = self.files.get(&target.path).and_then(|facts| {
+            facts.definitions.iter().find(|definition| {
+                definition.name == site.callee && definition.def_span == target.def_span
+            })
+        });
+        Some(CrossFileCall {
+            path: target.path,
+            node: CallNodeKind::Function(CallFunctionId::new(site.callee.clone(), target.def_span)),
+            def_span: Some(target.def_span),
+            selection_span: definition.map(|definition| definition.selection_span),
+            call_spans: vec![site.name_span],
+        })
+    }
+
+    fn called_source_function_may_mutate(
+        &self,
+        current_path: &Path,
+        current_function: &CallFunctionId,
+    ) -> bool {
+        let called_names = self
+            .files
+            .values()
+            .flat_map(|facts| facts.call_sites.iter().map(|site| &site.callee))
+            .collect::<FxHashSet<_>>();
+        let has_dynamic_dispatch = self
+            .files
+            .values()
+            .any(|facts| facts.has_dynamic_command_dispatch);
+        self.files.iter().any(|(path, facts)| {
+            facts.source_effects.iter().any(|effect| {
+                effect.enclosing_function.as_ref().is_some_and(|function| {
+                    (path.as_path() != current_path || function != current_function)
+                        && (has_dynamic_dispatch || called_names.contains(&function.name))
+                })
+            })
+        })
+    }
+
+    fn resolve_exact_events(
+        &self,
+        path: &Path,
+        callee: &Name,
+        query: ExactQuery<'_>,
+        stack: &mut FxHashSet<PathBuf>,
+    ) -> ExactResolution {
+        let Some(facts) = self.files.get(path) else {
+            return ExactResolution::Ambiguous;
+        };
+        if !facts.analyzable
+            || facts.source_effects.iter().any(|effect| {
+                !effect.persistent
+                    && ((effect.enclosing_function.is_none()
+                        && effect.span.start.offset < query.top_level_cutoff)
+                        || (effect.enclosing_function.as_ref() == query.enclosing_function
+                            && query
+                                .local_call_offset
+                                .is_some_and(|offset| effect.span.start.offset < offset)))
+            })
+        {
+            return ExactResolution::Ambiguous;
+        }
+
+        enum Event<'a> {
+            Definition(&'a CallFactDefinition),
+            Source(&'a CallFactSourceEffect),
+        }
+
+        let mut events = Vec::new();
+        if query.include_top_level_definitions {
+            for definition in facts.definitions.iter().filter(|definition| {
+                definition.persistent_top_level
+                    && &definition.name == callee
+                    && definition.def_span.start.offset < query.top_level_cutoff
+            }) {
+                events.push((
+                    definition.def_span.start.offset,
+                    Event::Definition(definition),
+                ));
+            }
+        } else if let Some(definition_span) = query.local_definition
+            && let Some(definition) = facts
+                .definitions
+                .iter()
+                .find(|definition| definition.def_span == definition_span)
+        {
+            events.push((
+                definition.def_span.start.offset,
+                Event::Definition(definition),
+            ));
+        }
+        for effect in facts.source_effects.iter().filter(|effect| {
+            effect.persistent
+                && ((effect.enclosing_function.is_none()
+                    && effect.span.start.offset < query.top_level_cutoff)
+                    || (effect.enclosing_function.as_ref() == query.enclosing_function
+                        && query
+                            .local_call_offset
+                            .is_some_and(|offset| effect.span.start.offset < offset)))
+        }) {
+            events.push((effect.span.start.offset, Event::Source(effect)));
+        }
+        events.sort_by_key(|(offset, _)| *offset);
+
+        for (_, event) in events.into_iter().rev() {
+            match event {
+                Event::Definition(definition) => {
+                    if !definition.unconditional {
+                        return ExactResolution::Ambiguous;
+                    }
+                    return ExactResolution::Defined(ResolvedDefinition {
+                        path: path.to_path_buf(),
+                        def_span: definition.def_span,
+                    });
+                }
+                Event::Source(effect) => {
+                    let Some(target_path) = effect.path.as_deref() else {
+                        return ExactResolution::Ambiguous;
+                    };
+                    let target = self.resolve_exported_exact(target_path, callee, stack);
+                    if effect.conditional {
+                        match target {
+                            ExactResolution::Absent => continue,
+                            ExactResolution::Defined(_) | ExactResolution::Ambiguous => {
+                                return ExactResolution::Ambiguous;
+                            }
+                        }
+                    }
+                    match target {
+                        ExactResolution::Defined(target) => {
+                            return ExactResolution::Defined(target);
+                        }
+                        ExactResolution::Absent => continue,
+                        ExactResolution::Ambiguous => return ExactResolution::Ambiguous,
+                    }
+                }
+            }
+        }
+        ExactResolution::Absent
+    }
+
+    fn resolve_exported_exact(
+        &self,
+        path: &Path,
+        callee: &Name,
+        stack: &mut FxHashSet<PathBuf>,
+    ) -> ExactResolution {
+        if !stack.insert(path.to_path_buf()) {
+            return ExactResolution::Ambiguous;
+        }
+        let resolved =
+            self.resolve_exact_events(path, callee, ExactQuery::top_level(usize::MAX), stack);
+        stack.remove(path);
+        resolved
     }
 
     /// Resolves through source edges that execute before `cutoff`. A `None`
@@ -571,6 +886,24 @@ mod tests {
         let indexer = Indexer::new(source, &output);
         let model = SemanticModel::build(&output.file, source, &indexer);
         FileCallFacts::project(&model, edges.iter().map(PathBuf::from).collect())
+    }
+
+    fn facts_with_positioned_sources(source: &str, paths: &[&str]) -> FileCallFacts {
+        let output = Parser::with_dialect(source, ShellDialect::Bash)
+            .parse()
+            .unwrap();
+        let indexer = Indexer::new(source, &output);
+        let model = SemanticModel::build(&output.file, source, &indexer);
+        let edges = model
+            .source_refs()
+            .iter()
+            .zip(paths)
+            .map(|(source_ref, path)| CallFactSourceEdge {
+                path: PathBuf::from(path),
+                span: source_ref.span,
+            })
+            .collect();
+        FileCallFacts::project_with_source_edges(&model, edges)
     }
 
     fn name(text: &str) -> Name {
@@ -845,6 +1178,253 @@ mod tests {
         assert!(index.resolve_call_site(&caller_path, call_span).is_none());
         let greet = function_node(&index, "/w/a.sh", "greet", 0);
         assert!(index.incoming(Path::new("/w/a.sh"), &greet).is_empty());
+    }
+
+    #[test]
+    fn exact_resolution_rejects_dynamic_source_that_may_replace_a_local_function() {
+        let path = PathBuf::from("/w/main.sh");
+        let caller = facts("foo() { :; }\nsource \"$plugin\"\nfoo\n", &[]);
+        let call_span = caller
+            .call_sites
+            .iter()
+            .find(|site| site.callee == name("foo"))
+            .unwrap()
+            .name_span;
+        let mut index = WorkspaceCallIndex::new();
+        index.insert(path.clone(), caller);
+
+        assert!(index.resolve_call_site(&path, call_span).is_some());
+        assert!(index.resolve_call_site_exact(&path, call_span).is_none());
+    }
+
+    #[test]
+    fn exact_resolution_rejects_conditional_source_and_conditional_export() {
+        let caller_path = PathBuf::from("/w/main.sh");
+        let target_path = PathBuf::from("/w/lib.sh");
+        let caller = facts_with_positioned_sources(
+            "foo() { :; }\nif enabled; then source lib.sh; fi\nfoo\n",
+            &["/w/lib.sh"],
+        );
+        let call_span = caller
+            .call_sites
+            .iter()
+            .find(|site| site.callee == name("foo"))
+            .unwrap()
+            .name_span;
+        let mut index = WorkspaceCallIndex::new();
+        index.insert(caller_path.clone(), caller);
+        index.insert(target_path, facts("foo() { echo sourced; }\n", &[]));
+        assert!(
+            index
+                .resolve_call_site_exact(&caller_path, call_span)
+                .is_none()
+        );
+
+        let caller = facts_with_positioned_sources("source lib.sh\nfoo\n", &["/w/lib.sh"]);
+        let call_span = caller.call_sites[0].name_span;
+        let mut index = WorkspaceCallIndex::new();
+        index.insert(caller_path.clone(), caller);
+        index.insert(
+            PathBuf::from("/w/lib.sh"),
+            facts("if enabled; then foo() { :; }; fi\n", &[]),
+        );
+        assert!(
+            index
+                .resolve_call_site_exact(&caller_path, call_span)
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn exact_resolution_fails_closed_for_later_sources_after_deferred_definition() {
+        let caller_path = PathBuf::from("/w/main.sh");
+        let target_path = PathBuf::from("/w/lib.sh");
+        let caller =
+            facts_with_positioned_sources("run() { foo; }\nrun\nsource lib.sh\n", &["/w/lib.sh"]);
+        let call_span = caller
+            .call_sites
+            .iter()
+            .find(|site| site.callee == name("foo"))
+            .unwrap()
+            .name_span;
+        let mut index = WorkspaceCallIndex::new();
+        index.insert(caller_path.clone(), caller);
+        index.insert(target_path.clone(), facts("foo() { :; }\n", &[]));
+
+        assert_eq!(
+            index
+                .resolve_call_site(&caller_path, call_span)
+                .map(|call| call.path),
+            Some(target_path)
+        );
+        assert!(
+            index
+                .resolve_call_site_exact(&caller_path, call_span)
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn exact_resolution_accepts_source_before_deferred_function_definition() {
+        let caller_path = PathBuf::from("/w/main.sh");
+        let target_path = PathBuf::from("/w/lib.sh");
+        let caller =
+            facts_with_positioned_sources("source lib.sh\nrun() { foo; }\nrun\n", &["/w/lib.sh"]);
+        let call_span = caller
+            .call_sites
+            .iter()
+            .find(|site| site.callee == name("foo"))
+            .unwrap()
+            .name_span;
+        let mut index = WorkspaceCallIndex::new();
+        index.insert(caller_path.clone(), caller);
+        index.insert(target_path.clone(), facts("foo() { :; }\n", &[]));
+
+        assert_eq!(
+            index
+                .resolve_call_site_exact(&caller_path, call_span)
+                .map(|call| call.path),
+            Some(target_path)
+        );
+    }
+
+    #[test]
+    fn exact_resolution_scopes_function_local_sources_to_the_containing_function() {
+        let caller_path = PathBuf::from("/w/main.sh");
+        let target_path = PathBuf::from("/w/lib.sh");
+        let caller = facts_with_positioned_sources(
+            "unused() { source other.sh; }\nrun() { source lib.sh; foo; }\n",
+            &["/w/other.sh", "/w/lib.sh"],
+        );
+        let call_span = caller
+            .call_sites
+            .iter()
+            .find(|site| site.callee == name("foo"))
+            .unwrap()
+            .name_span;
+        let mut index = WorkspaceCallIndex::new();
+        index.insert(caller_path.clone(), caller);
+        index.insert(PathBuf::from("/w/other.sh"), facts(":\n", &[]));
+        index.insert(target_path.clone(), facts("foo() { :; }\n", &[]));
+
+        assert_eq!(
+            index
+                .resolve_call_site_exact(&caller_path, call_span)
+                .map(|call| call.path),
+            Some(target_path)
+        );
+    }
+
+    #[test]
+    fn exact_resolution_rejects_later_source_in_a_repeated_function_call() {
+        let caller_path = PathBuf::from("/w/main.sh");
+        let caller = facts_with_positioned_sources(
+            "foo() { :; }\nrun() { foo; source lib.sh; }\nrun\nrun\n",
+            &["/w/lib.sh"],
+        );
+        let call_span = caller
+            .call_sites
+            .iter()
+            .find(|site| site.callee == name("foo"))
+            .unwrap()
+            .name_span;
+        let mut index = WorkspaceCallIndex::new();
+        index.insert(caller_path.clone(), caller);
+        index.insert(
+            PathBuf::from("/w/lib.sh"),
+            facts("foo() { echo sourced; }\n", &[]),
+        );
+
+        assert!(
+            index
+                .resolve_call_site_exact(&caller_path, call_span)
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn exact_resolution_rejects_an_invoked_source_bearing_function() {
+        let caller_path = PathBuf::from("/w/main.sh");
+        let caller = facts_with_positioned_sources(
+            "foo() { :; }\nload() { source lib.sh; }\nrun() { foo; }\nrun\nload\nrun\n",
+            &["/w/lib.sh"],
+        );
+        let call_span = caller
+            .call_sites
+            .iter()
+            .find(|site| site.callee == name("foo"))
+            .unwrap()
+            .name_span;
+        let mut index = WorkspaceCallIndex::new();
+        index.insert(caller_path.clone(), caller);
+        index.insert(
+            PathBuf::from("/w/lib.sh"),
+            facts("foo() { echo sourced; }\n", &[]),
+        );
+
+        assert!(
+            index
+                .resolve_call_site_exact(&caller_path, call_span)
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn exact_resolution_rejects_a_called_sourced_function_that_can_mutate_bindings() {
+        let caller_path = PathBuf::from("/w/main.sh");
+        let library_path = PathBuf::from("/w/lib.sh");
+        let caller = facts_with_positioned_sources(
+            "source lib.sh\nfoo() { :; }\nrun() { foo; }\nrun\nload\nrun\n",
+            &["/w/lib.sh"],
+        );
+        let library =
+            facts_with_positioned_sources("load() { source override.sh; }\n", &["/w/override.sh"]);
+        let call_span = caller
+            .call_sites
+            .iter()
+            .find(|site| site.callee == name("foo"))
+            .unwrap()
+            .name_span;
+        let mut index = WorkspaceCallIndex::new();
+        index.insert(caller_path.clone(), caller);
+        index.insert(library_path, library);
+        index.insert(
+            PathBuf::from("/w/override.sh"),
+            facts("foo() { echo sourced; }\n", &[]),
+        );
+
+        assert!(
+            index
+                .resolve_call_site_exact(&caller_path, call_span)
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn exact_resolution_rejects_dynamic_dispatch_to_a_source_bearing_function() {
+        let caller_path = PathBuf::from("/w/main.sh");
+        let caller = facts_with_positioned_sources(
+            "foo() { :; }\nload() { source lib.sh; }\nrun() { foo; }\nrun\nname=load\n\"$name\"\nrun\n",
+            &["/w/lib.sh"],
+        );
+        let call_span = caller
+            .call_sites
+            .iter()
+            .find(|site| site.callee == name("foo"))
+            .unwrap()
+            .name_span;
+        let mut index = WorkspaceCallIndex::new();
+        index.insert(caller_path.clone(), caller);
+        index.insert(
+            PathBuf::from("/w/lib.sh"),
+            facts("foo() { echo sourced; }\n", &[]),
+        );
+
+        assert!(
+            index
+                .resolve_call_site_exact(&caller_path, call_span)
+                .is_none()
+        );
     }
 
     #[test]

--- a/crates/shuck-semantic/src/lib.rs
+++ b/crates/shuck-semantic/src/lib.rs
@@ -2209,6 +2209,12 @@ impl SemanticModel {
             })
     }
 
+    /// Returns whether a function definition is installed on every path
+    /// through its containing command sequence.
+    pub fn function_binding_is_unconditional(&self, id: BindingId) -> bool {
+        self.unconditional_function_bindings().contains(&id)
+    }
+
     /// Returns source-like file references discovered in the script.
     pub fn source_refs(&self) -> &[SourceRef] {
         &self.source_refs

--- a/crates/shuck-semantic/src/source_ref.rs
+++ b/crates/shuck-semantic/src/source_ref.rs
@@ -48,6 +48,8 @@ pub struct SourceRef {
     pub span: Span,
     /// Span of the path-like portion being resolved.
     pub path_span: Span,
+    /// Whether shell control flow may skip this source operation.
+    pub conditionally_executed: bool,
     /// Resolution status computed for this reference.
     pub resolution: SourceRefResolution,
     /// Whether the path came from an explicitly provided source directive.

--- a/crates/shuck-semantic/src/source_resolve.rs
+++ b/crates/shuck-semantic/src/source_resolve.rs
@@ -212,6 +212,7 @@ mod tests {
             kind: SourceRefKind::Directive("util.sh".into()),
             span: Default::default(),
             path_span: Default::default(),
+            conditionally_executed: false,
             resolution: crate::SourceRefResolution::Unchecked,
             explicitly_provided: false,
             directive: None,

--- a/crates/shuck-server/src/server/api.rs
+++ b/crates/shuck-server/src/server/api.rs
@@ -59,7 +59,7 @@ pub(super) fn request(req: server::Request) -> Task {
         }
         request::CompletionResolve::METHOD => sync_request_task::<request::CompletionResolve>(req),
         request::Definition::METHOD => {
-            background_request_task::<request::Definition>(req, BackgroundSchedule::Worker)
+            background_session_request_task::<request::Definition>(req, BackgroundSchedule::Worker)
         }
         request::DocumentDiagnostic::METHOD => {
             background_request_task::<request::DocumentDiagnostic>(req, BackgroundSchedule::Worker)

--- a/crates/shuck-server/src/server/api/requests/definition.rs
+++ b/crates/shuck-server/src/server/api/requests/definition.rs
@@ -1,31 +1,120 @@
 use lsp_types::{self as types, request as req};
+use shuck_semantic::EditorSymbolTarget;
 
+use crate::edit::RangeExt;
 use crate::editor_features;
-use crate::session::{Client, DocumentSnapshot};
+use crate::session::{Client, DocumentSnapshot, RequestCancellationToken, Session};
+use crate::workspace_functions::{
+    WorkspaceFunctionContext, canonical_path, workspace_function_index,
+};
 
 pub(crate) struct Definition;
+
+pub(crate) struct DefinitionSnapshot {
+    document: Option<DocumentSnapshot>,
+    workspace: WorkspaceFunctionContext,
+}
 
 impl super::RequestHandler for Definition {
     type RequestType = req::GotoDefinition;
 }
 
-impl super::BackgroundDocumentRequestHandler for Definition {
-    fn document_url(params: &types::GotoDefinitionParams) -> std::borrow::Cow<'_, types::Url> {
-        std::borrow::Cow::Borrowed(&params.text_document_position_params.text_document.uri)
-    }
+impl super::super::traits::BackgroundRequestHandler for Definition {
+    type Snapshot = DefinitionSnapshot;
 
-    fn run_without_snapshot(
-        _client: &Client,
-        _params: types::GotoDefinitionParams,
-    ) -> crate::server::Result<editor_features::DefinitionResponse> {
-        Ok(None)
+    fn snapshot(
+        session: &Session,
+        params: &types::GotoDefinitionParams,
+        cancellation: RequestCancellationToken,
+    ) -> crate::server::Result<Self::Snapshot> {
+        let uri = params
+            .text_document_position_params
+            .text_document
+            .uri
+            .clone();
+        Ok(DefinitionSnapshot {
+            document: session.take_snapshot(uri),
+            workspace: session.workspace_function_context(cancellation),
+        })
     }
 
     fn run_with_snapshot(
-        snapshot: DocumentSnapshot,
+        snapshot: Self::Snapshot,
         client: &Client,
         params: types::GotoDefinitionParams,
     ) -> crate::server::Result<editor_features::DefinitionResponse> {
-        editor_features::definition(snapshot, client, params)
+        let Some(document) = snapshot.document else {
+            return Ok(None);
+        };
+        definition(document, snapshot.workspace, client, params)
     }
+}
+
+fn definition(
+    snapshot: DocumentSnapshot,
+    workspace: WorkspaceFunctionContext,
+    client: &Client,
+    params: types::GotoDefinitionParams,
+) -> crate::server::Result<editor_features::DefinitionResponse> {
+    let Some(analysis) = snapshot.analysis() else {
+        return Ok(None);
+    };
+    let position = params.text_document_position_params.position;
+    let offset = usize::from(
+        types::Range {
+            start: position,
+            end: position,
+        }
+        .to_text_range(
+            analysis.source(),
+            analysis.line_index(),
+            snapshot.encoding(),
+        )
+        .start(),
+    );
+    let Some(EditorSymbolTarget::FunctionCall(call)) =
+        analysis.semantic().editor_query().target_at_offset(offset)
+    else {
+        return editor_features::definition(snapshot, client, params);
+    };
+    let Some(path) = snapshot
+        .query()
+        .file_url()
+        .to_file_path()
+        .ok()
+        .map(|path| canonical_path(&path))
+    else {
+        return editor_features::definition(snapshot, client, params);
+    };
+    let Some(index) = workspace_function_index(&workspace) else {
+        return Ok(None);
+    };
+    if let Some(target) = index.resolve_call_site_exact(&path, call.name_span)
+        && let Some(definition_span) = target.def_span
+        && let Some(range) = index.range_of(&target.path, definition_span)
+    {
+        let uri = if target.path == path {
+            snapshot.query().file_url().clone()
+        } else {
+            let Some(file) = index.file(&target.path) else {
+                return Ok(None);
+            };
+            file.editor_uri().clone()
+        };
+        return Ok(Some(types::GotoDefinitionResponse::Scalar(
+            types::Location { uri, range },
+        )));
+    }
+
+    // A partial workspace index may omit an otherwise proven local binding.
+    // Preserve the document-local answer only when no source operation could
+    // have replaced it; without the active file's projected facts, any source
+    // effect is conservatively treated as relevant.
+    if call.binding.is_some()
+        && !index.contains(&path)
+        && analysis.semantic().source_refs().is_empty()
+    {
+        return editor_features::definition(snapshot, client, params);
+    }
+    Ok(None)
 }

--- a/crates/shuck-server/src/workspace_functions.rs
+++ b/crates/shuck-server/src/workspace_functions.rs
@@ -104,6 +104,7 @@ pub(crate) fn workspace_function_index(
 /// Source snapshot retained for one indexed file.
 pub(crate) struct IndexedWorkspaceFile {
     uri: types::Url,
+    open_uri: Option<types::Url>,
     source: String,
     line_index: LineIndex,
     #[allow(dead_code)] // Used by the upcoming cross-file rename safety check.
@@ -115,6 +116,12 @@ pub(crate) struct IndexedWorkspaceFile {
 impl IndexedWorkspaceFile {
     pub(crate) fn uri(&self) -> &types::Url {
         &self.uri
+    }
+
+    /// URI used by the editor for an open buffer, falling back to the
+    /// canonical file URI for disk snapshots.
+    pub(crate) fn editor_uri(&self) -> &types::Url {
+        self.open_uri.as_ref().unwrap_or(&self.uri)
     }
 
     pub(crate) fn source(&self) -> &str {
@@ -325,6 +332,14 @@ impl WorkspaceFunctionIndex {
         self.graph.resolve_call_site(from_path, name_span)
     }
 
+    pub(crate) fn resolve_call_site_exact(
+        &self,
+        from_path: &Path,
+        name_span: Span,
+    ) -> Option<CrossFileCall> {
+        self.graph.resolve_call_site_exact(from_path, name_span)
+    }
+
     pub(crate) fn incoming(
         &self,
         target_path: &Path,
@@ -389,8 +404,7 @@ impl WorkspaceFunctionIndex {
         self.graph.file_count()
     }
 
-    #[cfg(test)]
-    fn contains(&self, path: &Path) -> bool {
+    pub(crate) fn contains(&self, path: &Path) -> bool {
         self.graph.contains(path)
     }
 }
@@ -505,6 +519,7 @@ fn insert_file(
     open_paths: &BTreeSet<PathBuf>,
 ) {
     let key = canonical_path(input.path);
+    let open_uri = input.version.is_some().then(|| input.uri.clone());
     let uri = std::fs::canonicalize(input.path)
         .ok()
         .and_then(|path| types::Url::from_file_path(path).ok())
@@ -538,6 +553,7 @@ fn insert_file(
         key,
         IndexedWorkspaceFile {
             uri,
+            open_uri,
             source: input.source.to_owned(),
             line_index: LineIndex::new(input.source),
             version: input.version,
@@ -857,6 +873,60 @@ mod tests {
             canonical_target
         );
         assert_eq!(built.file(&canonical_target).unwrap().uri(), &target_uri);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn existing_open_target_retains_the_editors_symlink_uri() {
+        use std::os::unix::fs::symlink;
+
+        let tempdir = tempfile::tempdir().unwrap();
+        let real_workspace = tempdir.path().join("real");
+        let linked_workspace = tempdir.path().join("linked");
+        std::fs::create_dir(&real_workspace).unwrap();
+        let real_workspace = std::fs::canonicalize(real_workspace).unwrap();
+        std::fs::write(
+            real_workspace.join("caller.sh"),
+            "source target.sh\ntarget\n",
+        )
+        .unwrap();
+        std::fs::write(real_workspace.join("target.sh"), "stale() { :; }\n").unwrap();
+        symlink(&real_workspace, &linked_workspace).unwrap();
+
+        let caller_uri = types::Url::from_file_path(linked_workspace.join("caller.sh")).unwrap();
+        let target_uri = types::Url::from_file_path(linked_workspace.join("target.sh")).unwrap();
+        let context = WorkspaceFunctionContext {
+            workspace_roots: vec![linked_workspace.clone()],
+            settings_workspace_roots: vec![linked_workspace, real_workspace.clone()],
+            workspace_settings: Vec::new(),
+            global_options: ClientOptions::default(),
+            open_documents: vec![
+                WorkspaceOpenDocument {
+                    uri: caller_uri,
+                    document: Arc::new(
+                        TextDocument::new("source target.sh\ntarget\n".to_owned(), 1)
+                            .with_language_id("shellscript"),
+                    ),
+                },
+                WorkspaceOpenDocument {
+                    uri: target_uri.clone(),
+                    document: Arc::new(
+                        TextDocument::new("target() { :; }\n".to_owned(), 2)
+                            .with_language_id("shellscript"),
+                    ),
+                },
+            ],
+            encoding: PositionEncoding::UTF16,
+            max_files: 100,
+            cache: Arc::new(WorkspaceFunctionIndexCache::default()),
+            epoch: 0,
+            cancellation: RequestCancellationToken::default(),
+        };
+
+        let built = WorkspaceFunctionIndex::build(&context).unwrap();
+        let file = built.file(&real_workspace.join("target.sh")).unwrap();
+        assert_ne!(file.uri(), &target_uri);
+        assert_eq!(file.editor_uri(), &target_uri);
     }
 
     #[test]

--- a/crates/shuck-server/tests/manual.rs
+++ b/crates/shuck-server/tests/manual.rs
@@ -289,6 +289,137 @@ fn open_document(connection: &Connection, uri: &Url, text: &str) {
 }
 
 #[test]
+fn cross_file_definition_uses_exact_workspace_binding_and_open_buffers() {
+    let (server_connection, client_connection) = Connection::memory();
+    let server_thread = thread::spawn(move || shuck_server::run_connection(server_connection));
+
+    let workspace = tempfile::tempdir().expect("tempdir should be created");
+    std::fs::write(
+        workspace.path().join("shuck.toml"),
+        "[lint]\nsource-paths = [\"lib\"]\n",
+    )
+    .unwrap();
+    std::fs::create_dir(workspace.path().join("lib")).unwrap();
+    let configured_path = workspace.path().join("lib/configured.sh");
+    std::fs::write(&configured_path, "configured() { :; }\n").unwrap();
+
+    let imported_path = workspace.path().join("imported.sh");
+    std::fs::write(&imported_path, "stale() { :; }\n").unwrap();
+    let imported_source = ": '😀'; imported() {\n  :\n}\n";
+
+    let caller_path = workspace.path().join("caller.sh");
+    std::fs::write(&caller_path, "stale_caller\n").unwrap();
+    let caller_source = "# shuck: source=imported.sh\nsource \"$DIR/imported.sh\"\nprintf '😀'; imported\nimported() {\n  :\n}\nimported\nsource configured.sh\nconfigured\nsource \"$dynamic\"\nimported\nunknown\n";
+
+    let imported_uri = Url::from_file_path(std::fs::canonicalize(&imported_path).unwrap()).unwrap();
+    let configured_uri =
+        Url::from_file_path(std::fs::canonicalize(&configured_path).unwrap()).unwrap();
+    let caller_uri = Url::from_file_path(&caller_path).unwrap();
+    let mut capabilities = serde_json::to_value(replay_capabilities()).unwrap();
+    capabilities["general"]["positionEncodings"] = serde_json::json!(["utf-8"]);
+
+    send_request(
+        &client_connection,
+        1,
+        "initialize",
+        serde_json::json!({
+            "capabilities": capabilities,
+            "rootUri": Url::from_file_path(workspace.path()).unwrap(),
+        }),
+    );
+    let initialize = recv_response(&client_connection, 1);
+    assert_eq!(
+        initialize["capabilities"]["positionEncoding"],
+        serde_json::json!("utf-8")
+    );
+    client_connection
+        .sender
+        .send(Message::Notification(Notification::new(
+            "initialized".to_owned(),
+            serde_json::json!({}),
+        )))
+        .expect("initialized should send");
+    open_document(&client_connection, &imported_uri, imported_source);
+    open_document(&client_connection, &caller_uri, caller_source);
+
+    // The first call sees the sourced definition from the unsaved buffer. Its
+    // UTF-8 range begins after a four-byte emoji on the same line.
+    send_request(
+        &client_connection,
+        2,
+        "textDocument/definition",
+        serde_json::json!({
+            "textDocument": { "uri": caller_uri },
+            "position": { "line": 2, "character": 15 },
+        }),
+    );
+    let imported = recv_response(&client_connection, 2);
+    assert_eq!(imported["uri"], serde_json::json!(imported_uri));
+    assert_eq!(
+        imported["range"]["start"],
+        serde_json::json!({ "line": 0, "character": 10 })
+    );
+
+    // The later local definition replaces the imported one for subsequent
+    // calls, while retaining the caller's open-document URI.
+    send_request(
+        &client_connection,
+        3,
+        "textDocument/definition",
+        serde_json::json!({
+            "textDocument": { "uri": caller_uri },
+            "position": { "line": 6, "character": 0 },
+        }),
+    );
+    let local = recv_response(&client_connection, 3);
+    assert_eq!(local["uri"], serde_json::json!(caller_uri));
+    assert_eq!(
+        local["range"]["start"],
+        serde_json::json!({ "line": 3, "character": 0 })
+    );
+
+    // Literal source operands also honor configured source paths.
+    send_request(
+        &client_connection,
+        4,
+        "textDocument/definition",
+        serde_json::json!({
+            "textDocument": { "uri": caller_uri },
+            "position": { "line": 8, "character": 0 },
+        }),
+    );
+    let configured = recv_response(&client_connection, 4);
+    assert_eq!(configured["uri"], serde_json::json!(configured_uri));
+
+    // A dynamic source may replace even a previously proven local function,
+    // so navigation fails closed instead of returning the stale binding.
+    send_request(
+        &client_connection,
+        5,
+        "textDocument/definition",
+        serde_json::json!({
+            "textDocument": { "uri": caller_uri },
+            "position": { "line": 10, "character": 0 },
+        }),
+    );
+    assert!(recv_response(&client_connection, 5).is_null());
+
+    send_request(&client_connection, 99, "shutdown", serde_json::json!(null));
+    let _ = recv_response(&client_connection, 99);
+    client_connection
+        .sender
+        .send(Message::Notification(Notification::new(
+            "exit".to_owned(),
+            serde_json::json!({}),
+        )))
+        .expect("exit notification should send");
+    server_thread
+        .join()
+        .expect("server thread should join")
+        .expect("server should exit cleanly");
+}
+
+#[test]
 fn prepare_call_hierarchy_resolves_sourced_cross_file_call() {
     let (server_connection, client_connection) = Connection::memory();
     let server_thread = thread::spawn(move || shuck_server::run_connection(server_connection));

--- a/specs/023-lsp-editor-features.md
+++ b/specs/023-lsp-editor-features.md
@@ -98,7 +98,7 @@ land:
 |---|---|---|
 | Completion | `textDocument/completion`, `completionItem/resolve` | Variables, functions, declaration names, runtime names, and shell keywords known to Shuck |
 | Hover | `textDocument/hover` | Rule-code hovers plus semantic-symbol hovers |
-| Definition | `textDocument/definition` | Variable/function definitions Shuck can resolve in the current analysis graph |
+| Definition | `textDocument/definition` | Variables in the active analysis plus exact function definitions through the statically resolved source graph |
 | References | `textDocument/references` | References and definitions in the same proven symbol set |
 | Document highlight | `textDocument/documentHighlight` | Read/write highlights for the symbol under the cursor |
 | Document symbols | `textDocument/documentSymbol` | Hierarchical symbols for functions plus top-level declarations and assignments |
@@ -303,7 +303,10 @@ Definition and references use the same symbol target resolution as rename:
 Definitions return a single location when the target is uniquely resolved and a
 location list when multiple static definitions are intentionally visible, such
 as a top-level variable with multiple declaration forms that Shuck groups into
-one storage family. If all candidates are ambiguous, the result is `None`.
+one storage family. Function calls additionally resolve through determinable
+source edges in the shared workspace function index, preserving source order,
+redefinitions, and open-buffer content. Dynamic or unresolved calls return no
+cross-file target. If all candidates are ambiguous, the result is `None`.
 
 References honor `ReferenceContext::include_declaration`:
 
@@ -644,7 +647,8 @@ Manual editor black-box scenarios should cover:
 - command-position completion includes local functions and omits variables;
 - hover on a variable shows definition and attributes;
 - hover on a rule code still shows the spec 018 rule documentation;
-- go-to-definition from a function call lands on the function name;
+- go-to-definition from a local or statically sourced function call lands on
+  the exact visible definition;
 - references honor `includeDeclaration`;
 - highlights mark reads and writes differently;
 - document symbols show functions and local declarations without noisy transient

--- a/website/content/editors/index.mdx
+++ b/website/content/editors/index.mdx
@@ -18,7 +18,7 @@ files.
 | Code actions | `textDocument/codeAction`, `codeAction/resolve` | Quick fixes, disable-this-line actions, and `source.fixAll.shuck` for the active document. |
 | Completion | `textDocument/completion`, `completionItem/resolve` | Variables, functions, declaration names, runtime names, builtins, and shell keywords known to the active document analysis. Command-specific option completion is not supported. |
 | Hover | `textDocument/hover` | Semantic symbol information plus help for suppression codes in `# shuck:` and `# shellcheck` directives. Shuck does not fetch command manuals. |
-| Go to definition | `textDocument/definition` | Definitions resolvable within the active document. A call whose definition exists only in a sourced file does not currently resolve. |
+| Go to definition | `textDocument/definition` | Variables resolve within the active document. Function calls also resolve through literal sources, valid `# shuck: source=` hints, and configured source paths, with open buffers and shell source order taking precedence. Dynamic sources are not guessed. |
 | Find references | `textDocument/references` | The proven symbol set within the active document. Cross-file references are not currently indexed. |
 | Document highlights | `textDocument/documentHighlight` | Read and write occurrences within the active document. |
 | Document symbols | `textDocument/documentSymbol` | Functions, declarations, and assignments from the active document. |
@@ -33,8 +33,7 @@ Editor formatting uses the same parser-backed formatter as [`shuck format`](/doc
 
 - Cross-file rename is intentionally disabled until Shuck can prove safe edits
   for every affected open or closed file.
-- Cross-file go-to-definition and references need a broader workspace-navigation
-  design. They are not covered by the current call-hierarchy index.
+- Cross-file references still need exact binding-aware workspace results; go-to-definition already uses the shared source graph for functions.
 - Language-server support for embedded shell regions, such as scripts inside
   GitHub Actions YAML, needs a separate position-remapping design.
 


### PR DESCRIPTION
## Summary

- resolve function definitions through literal `source`/`.` edges, source hints, and configured source paths
- preserve exact binding identity and source order while failing closed for dynamic, conditional, missing, partial, or mutation-ambiguous cases
- prefer unsaved open-buffer contents and editor URIs, with negotiated position encodings
- document cross-file definition behavior and limits

## Validation

- `cargo test -p shuck-semantic -p shuck-server`
- `cargo clippy -p shuck-semantic -p shuck-server --all-targets --no-deps -- -D warnings -A clippy::question_mark`
- dedicated implementation review completed with no remaining findings

The single allowed Clippy lint is an existing `question_mark` warning in unmodified `crates/shuck-semantic/src/builder/references.rs` on the current toolchain.

Closes #1203