### PR TITLE
feat(server): find sourced function references

### DIFF
--- a/crates/shuck-semantic/src/call_facts.rs
+++ b/crates/shuck-semantic/src/call_facts.rs
@@ -12,6 +12,7 @@
 //! layer stays pure graph logic and is unit-testable without a filesystem.
 
 use std::path::{Path, PathBuf};
+use std::sync::{Mutex, OnceLock};
 
 use rustc_hash::{FxHashMap, FxHashSet};
 use shuck_ast::{Name, Span};
@@ -188,6 +189,7 @@ pub struct FileCallFacts {
     pub source_edges: Vec<CallFactSourceEdge>,
     /// All source operations, including unresolved or conditional effects.
     pub source_effects: Vec<CallFactSourceEffect>,
+    binding_mutators: Vec<CallFunctionId>,
     has_dynamic_command_dispatch: bool,
     analyzable: bool,
 }
@@ -324,12 +326,32 @@ impl FileCallFacts {
                         .is_some()
                 })
             });
+        let mut binding_mutators = FxHashSet::default();
+        for binding in model.function_definition_bindings() {
+            if model
+                .innermost_transient_scope_within_function(binding.scope)
+                .is_some()
+            {
+                continue;
+            }
+            if let Some(enclosing_functions) = model
+                .ancestor_scopes(binding.scope)
+                .find_map(|scope| functions_by_scope.get(&scope))
+            {
+                binding_mutators.extend(
+                    enclosing_functions
+                        .iter()
+                        .map(|(function, _)| function.clone()),
+                );
+            }
+        }
 
         Self {
             definitions,
             call_sites,
             source_edges,
             source_effects,
+            binding_mutators: binding_mutators.into_iter().collect(),
             has_dynamic_command_dispatch,
             analyzable: true,
         }
@@ -364,10 +386,460 @@ pub struct CrossFileCall {
     pub call_spans: Vec<Span>,
 }
 
+/// One call token proven to resolve to an exact workspace function binding.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ExactFunctionReference {
+    /// File containing the call token.
+    pub path: PathBuf,
+    /// Span of the callee token in `path`.
+    pub span: Span,
+}
+
+type ExactReferenceIndex = FxHashMap<(PathBuf, CallNodeKind), Vec<ExactFunctionReference>>;
+
+#[derive(Clone, Debug)]
+struct ExactIncomingSource {
+    parent_path: PathBuf,
+    span: Span,
+    conditional: bool,
+    persistent: bool,
+    enclosing_function: Option<CallFunctionId>,
+}
+
+#[derive(Debug)]
+struct ExactWorkspaceContext {
+    graph: SourceGraphIndex,
+    incoming: FxHashMap<PathBuf, Vec<ExactIncomingSource>>,
+    calls_by_component: Vec<FxHashSet<Name>>,
+    dynamic_dispatch_by_component: Vec<bool>,
+    mutator_functions_by_name: FxHashMap<Name, Vec<(usize, PathBuf, CallFunctionId, bool)>>,
+    function_calls_by_name: FxHashMap<Name, Vec<(usize, Name)>>,
+    may_mutate_cache: Mutex<FxHashMap<(usize, Name), bool>>,
+    mutation_summary_cache: Mutex<FxHashMap<usize, MutationSummary>>,
+}
+
+#[derive(Clone, Debug)]
+enum MutationSummary {
+    None,
+    Single(PathBuf, CallFunctionId, bool),
+    Multiple,
+}
+
+impl MutationSummary {
+    fn add(&mut self, path: &Path, function: &CallFunctionId, can_exclude_current: bool) {
+        match self {
+            Self::None => {
+                *self = Self::Single(path.to_path_buf(), function.clone(), can_exclude_current);
+            }
+            Self::Single(existing_path, existing_function, existing_can_exclude)
+                if existing_path.as_path() == path && existing_function == function =>
+            {
+                *existing_can_exclude &= can_exclude_current;
+            }
+            Self::Single(_, _, _) => *self = Self::Multiple,
+            Self::Multiple => {}
+        }
+    }
+
+    fn may_mutate_other_than(&self, path: &Path, function: &CallFunctionId) -> bool {
+        match self {
+            Self::None => false,
+            Self::Single(candidate_path, candidate, can_exclude_current) => {
+                candidate_path.as_path() != path || candidate != function || !can_exclude_current
+            }
+            Self::Multiple => true,
+        }
+    }
+}
+
+#[derive(Debug)]
+struct SourceGraphIndex {
+    paths: Vec<PathBuf>,
+    nodes: FxHashMap<PathBuf, usize>,
+    components: Vec<usize>,
+    component_reachability: Vec<Vec<u64>>,
+    component_edges: Vec<Vec<usize>>,
+}
+
 /// A workspace-wide index of per-file call facts.
 #[derive(Debug, Default)]
 pub struct WorkspaceCallIndex {
     files: FxHashMap<PathBuf, FileCallFacts>,
+    exact_context: OnceLock<ExactWorkspaceContext>,
+    exact_references: OnceLock<ExactReferenceIndex>,
+}
+
+impl SourceGraphIndex {
+    fn build(
+        files: &FxHashMap<PathBuf, FileCallFacts>,
+        is_cancelled: &impl Fn() -> bool,
+    ) -> Option<Self> {
+        let mut paths = files.keys().cloned().collect::<Vec<_>>();
+        paths.sort();
+        let nodes = paths
+            .iter()
+            .cloned()
+            .enumerate()
+            .map(|(index, path)| (path, index))
+            .collect::<FxHashMap<_, _>>();
+        let mut edges = vec![Vec::new(); paths.len()];
+        let mut reverse_edges = vec![Vec::new(); paths.len()];
+        for (from, path) in paths.iter().enumerate() {
+            if is_cancelled() {
+                return None;
+            }
+            for edge in &files.get(path)?.source_edges {
+                let Some(&to) = nodes.get(&edge.path) else {
+                    continue;
+                };
+                edges[from].push(to);
+                reverse_edges[to].push(from);
+            }
+            edges[from].sort_unstable();
+            edges[from].dedup();
+        }
+
+        let mut visited = vec![false; paths.len()];
+        let mut order = Vec::with_capacity(paths.len());
+        for start in 0..paths.len() {
+            if visited[start] {
+                continue;
+            }
+            visited[start] = true;
+            let mut stack = vec![(start, 0usize)];
+            while let Some((node, next_edge)) = stack.last_mut() {
+                if is_cancelled() {
+                    return None;
+                }
+                if *next_edge < edges[*node].len() {
+                    let next = edges[*node][*next_edge];
+                    *next_edge += 1;
+                    if !visited[next] {
+                        visited[next] = true;
+                        stack.push((next, 0));
+                    }
+                } else {
+                    let (node, _) = stack.pop()?;
+                    order.push(node);
+                }
+            }
+        }
+
+        let mut components = vec![usize::MAX; paths.len()];
+        let mut component_count = 0usize;
+        for &start in order.iter().rev() {
+            if components[start] != usize::MAX {
+                continue;
+            }
+            components[start] = component_count;
+            let mut stack = vec![start];
+            while let Some(node) = stack.pop() {
+                if is_cancelled() {
+                    return None;
+                }
+                for &next in &reverse_edges[node] {
+                    if components[next] == usize::MAX {
+                        components[next] = component_count;
+                        stack.push(next);
+                    }
+                }
+            }
+            component_count += 1;
+        }
+
+        let mut component_edges = vec![Vec::new(); component_count];
+        for (from, outgoing) in edges.iter().enumerate() {
+            for &to in outgoing {
+                let from_component = components[from];
+                let to_component = components[to];
+                if from_component != to_component {
+                    component_edges[from_component].push(to_component);
+                }
+            }
+        }
+        for outgoing in &mut component_edges {
+            outgoing.sort_unstable();
+            outgoing.dedup();
+        }
+
+        let mut component_postorder = Vec::with_capacity(component_count);
+        let mut visited = vec![false; component_count];
+        for start in 0..component_count {
+            if visited[start] {
+                continue;
+            }
+            visited[start] = true;
+            let mut stack = vec![(start, 0usize)];
+            while let Some((component, next_edge)) = stack.last_mut() {
+                if is_cancelled() {
+                    return None;
+                }
+                if *next_edge < component_edges[*component].len() {
+                    let next = component_edges[*component][*next_edge];
+                    *next_edge += 1;
+                    if !visited[next] {
+                        visited[next] = true;
+                        stack.push((next, 0));
+                    }
+                } else {
+                    let (component, _) = stack.pop()?;
+                    component_postorder.push(component);
+                }
+            }
+        }
+
+        let word_count = component_count.div_ceil(64);
+        let mut component_reachability = vec![vec![0u64; word_count]; component_count];
+        for &component in &component_postorder {
+            if is_cancelled() {
+                return None;
+            }
+            set_bit(&mut component_reachability[component], component);
+            for &successor in &component_edges[component] {
+                let successor_reachability = component_reachability[successor].clone();
+                for (word, value) in component_reachability[component]
+                    .iter_mut()
+                    .zip(successor_reachability)
+                {
+                    if is_cancelled() {
+                        return None;
+                    }
+                    *word |= value;
+                }
+            }
+        }
+
+        Some(Self {
+            paths,
+            nodes,
+            components,
+            component_reachability,
+            component_edges,
+        })
+    }
+
+    fn component_for_path(&self, path: &Path) -> Option<usize> {
+        self.nodes.get(path).map(|&node| self.components[node])
+    }
+
+    fn component_reaches(&self, from: usize, to: usize) -> bool {
+        bit_is_set(&self.component_reachability[from], to)
+    }
+}
+
+impl ExactWorkspaceContext {
+    fn build(
+        files: &FxHashMap<PathBuf, FileCallFacts>,
+        is_cancelled: &impl Fn() -> bool,
+    ) -> Option<Self> {
+        let graph = SourceGraphIndex::build(files, is_cancelled)?;
+        let mut incoming: FxHashMap<PathBuf, Vec<ExactIncomingSource>> = FxHashMap::default();
+        let mut function_calls_by_name: FxHashMap<Name, Vec<(usize, Name)>> = FxHashMap::default();
+        let mut calls_by_component = vec![FxHashSet::default(); graph.component_edges.len()];
+        let mut dynamic_dispatch_by_component = vec![false; graph.component_edges.len()];
+        let mut mutators: FxHashMap<(PathBuf, CallFunctionId), (usize, bool)> =
+            FxHashMap::default();
+        for (node, path) in graph.paths.iter().enumerate() {
+            if is_cancelled() {
+                return None;
+            }
+            let facts = files.get(path)?;
+            let component = graph.components[node];
+            dynamic_dispatch_by_component[component] |= facts.has_dynamic_command_dispatch;
+            for site in &facts.call_sites {
+                calls_by_component[component].insert(site.callee.clone());
+                if let CallNodeKind::Function(function) = &site.enclosing {
+                    function_calls_by_name
+                        .entry(function.name.clone())
+                        .or_default()
+                        .push((component, site.callee.clone()));
+                }
+            }
+            for effect in &facts.source_effects {
+                if let Some(function) = &effect.enclosing_function {
+                    mutators
+                        .entry((path.clone(), function.clone()))
+                        .or_insert((component, true));
+                }
+                if let Some(target) = &effect.path {
+                    incoming
+                        .entry(target.clone())
+                        .or_default()
+                        .push(ExactIncomingSource {
+                            parent_path: path.clone(),
+                            span: effect.span,
+                            conditional: effect.conditional,
+                            persistent: effect.persistent,
+                            enclosing_function: effect.enclosing_function.clone(),
+                        });
+                }
+            }
+            for function in &facts.binding_mutators {
+                mutators
+                    .entry((path.clone(), function.clone()))
+                    .and_modify(|(_, can_exclude_current)| *can_exclude_current = false)
+                    .or_insert((component, false));
+            }
+        }
+        let mut mutator_functions_by_name: FxHashMap<
+            Name,
+            Vec<(usize, PathBuf, CallFunctionId, bool)>,
+        > = FxHashMap::default();
+        for ((path, function), (component, can_exclude_current)) in mutators {
+            mutator_functions_by_name
+                .entry(function.name.clone())
+                .or_default()
+                .push((component, path, function, can_exclude_current));
+        }
+        for edges in incoming.values_mut() {
+            edges.sort_by(|left, right| {
+                left.parent_path
+                    .cmp(&right.parent_path)
+                    .then_with(|| left.span.start.offset.cmp(&right.span.start.offset))
+            });
+        }
+
+        Some(Self {
+            graph,
+            incoming,
+            calls_by_component,
+            dynamic_dispatch_by_component,
+            mutator_functions_by_name,
+            function_calls_by_name,
+            may_mutate_cache: Mutex::new(FxHashMap::default()),
+            mutation_summary_cache: Mutex::new(FxHashMap::default()),
+        })
+    }
+
+    fn called_mutator_function_may_mutate(
+        &self,
+        current_path: &Path,
+        current_function: &CallFunctionId,
+        is_cancelled: &impl Fn() -> bool,
+    ) -> Option<bool> {
+        let Some(component) = self.graph.component_for_path(current_path) else {
+            return Some(true);
+        };
+        if let Ok(cache) = self.mutation_summary_cache.lock()
+            && let Some(summary) = cache.get(&component)
+        {
+            return Some(summary.may_mutate_other_than(current_path, current_function));
+        }
+        let mut summary = MutationSummary::None;
+        let dynamic =
+            self.dynamic_dispatch_by_component
+                .iter()
+                .enumerate()
+                .any(|(candidate, &dynamic)| {
+                    self.graph.component_reaches(component, candidate) && dynamic
+                });
+        if dynamic {
+            for mutators in self.mutator_functions_by_name.values() {
+                for (mutator_component, path, function, can_exclude_current) in mutators {
+                    if is_cancelled() {
+                        return None;
+                    }
+                    if self.graph.component_reaches(component, *mutator_component) {
+                        summary.add(path, function, *can_exclude_current);
+                    }
+                }
+            }
+        } else {
+            let mut called_names = FxHashSet::default();
+            for (candidate, calls) in self.calls_by_component.iter().enumerate() {
+                if is_cancelled() {
+                    return None;
+                }
+                if self.graph.component_reaches(component, candidate) {
+                    called_names.extend(calls.iter().cloned());
+                }
+            }
+            for name in called_names {
+                self.collect_mutators(component, &name, &mut summary, is_cancelled)?;
+                if matches!(summary, MutationSummary::Multiple) {
+                    break;
+                }
+            }
+        }
+        if let Ok(mut cache) = self.mutation_summary_cache.lock() {
+            cache.insert(component, summary.clone());
+        }
+        Some(summary.may_mutate_other_than(current_path, current_function))
+    }
+
+    fn name_may_mutate(
+        &self,
+        from_path: &Path,
+        name: &Name,
+        is_cancelled: &impl Fn() -> bool,
+    ) -> Option<bool> {
+        let Some(component) = self.graph.component_for_path(from_path) else {
+            return Some(true);
+        };
+        let key = (component, name.clone());
+        if let Ok(cache) = self.may_mutate_cache.lock()
+            && let Some(&cached) = cache.get(&key)
+        {
+            return Some(cached);
+        }
+        let mut summary = MutationSummary::None;
+        self.collect_mutators(component, name, &mut summary, is_cancelled)?;
+        let result = !matches!(summary, MutationSummary::None);
+        if let Ok(mut cache) = self.may_mutate_cache.lock() {
+            cache.insert(key, result);
+        }
+        Some(result)
+    }
+
+    fn collect_mutators(
+        &self,
+        component: usize,
+        name: &Name,
+        summary: &mut MutationSummary,
+        is_cancelled: &impl Fn() -> bool,
+    ) -> Option<()> {
+        let mut pending = vec![name.clone()];
+        let mut visited = FxHashSet::default();
+        while let Some(name) = pending.pop() {
+            if is_cancelled() {
+                return None;
+            }
+            if !visited.insert(name.clone()) {
+                continue;
+            }
+            for (mutator_component, path, function, can_exclude_current) in self
+                .mutator_functions_by_name
+                .get(&name)
+                .into_iter()
+                .flatten()
+            {
+                if self.graph.component_reaches(component, *mutator_component) {
+                    summary.add(path, function, *can_exclude_current);
+                }
+            }
+            if matches!(summary, MutationSummary::Multiple) {
+                return Some(());
+            }
+            for (call_component, callee) in
+                self.function_calls_by_name.get(&name).into_iter().flatten()
+            {
+                if self.graph.component_reaches(component, *call_component) {
+                    pending.push(callee.clone());
+                }
+            }
+        }
+        Some(())
+    }
+}
+
+fn set_bit(words: &mut [u64], bit: usize) {
+    words[bit / 64] |= 1u64 << (bit % 64);
+}
+
+fn bit_is_set(words: &[u64], bit: usize) -> bool {
+    words
+        .get(bit / 64)
+        .is_some_and(|word| word & (1u64 << (bit % 64)) != 0)
 }
 
 impl WorkspaceCallIndex {
@@ -379,6 +851,8 @@ impl WorkspaceCallIndex {
     /// Inserts or replaces the facts for `path`.
     pub fn insert(&mut self, path: PathBuf, facts: FileCallFacts) {
         self.files.insert(path, facts);
+        self.exact_context.take();
+        self.exact_references.take();
     }
 
     /// Returns whether `path` is indexed.
@@ -592,22 +1066,58 @@ impl WorkspaceCallIndex {
         from_path: &Path,
         name_span: Span,
     ) -> Option<CrossFileCall> {
+        self.resolve_call_site_exact_cancellable(from_path, name_span, || false)
+    }
+
+    /// Resolves one exact call token while allowing workspace-context analysis
+    /// to stop before publishing a partial answer.
+    pub fn resolve_call_site_exact_cancellable(
+        &self,
+        from_path: &Path,
+        name_span: Span,
+        is_cancelled: impl Fn() -> bool,
+    ) -> Option<CrossFileCall> {
+        let context = self.exact_workspace_context(&is_cancelled)?;
+        self.resolve_call_site_exact_with_context(from_path, name_span, context, &is_cancelled)
+    }
+
+    fn resolve_call_site_exact_with_context(
+        &self,
+        from_path: &Path,
+        name_span: Span,
+        context: &ExactWorkspaceContext,
+        is_cancelled: &impl Fn() -> bool,
+    ) -> Option<CrossFileCall> {
         let facts = self.files.get(from_path)?;
         let site = facts
             .call_sites
             .iter()
             .find(|site| site.name_span == name_span)?;
+        if is_cancelled() {
+            return None;
+        }
         let mut stack = FxHashSet::default();
         stack.insert(from_path.to_path_buf());
         let resolution = match &site.enclosing {
-            CallNodeKind::TopLevel => self.resolve_exact_events(
+            CallNodeKind::TopLevel => self.resolve_top_level_with_incoming(
                 from_path,
                 &site.callee,
-                ExactQuery::top_level(site.name_span.start.offset()),
+                site.name_span.start.offset(),
+                context,
                 &mut stack,
+                is_cancelled,
             ),
             CallNodeKind::Function(function) => {
-                if self.called_source_function_may_mutate(from_path, function)
+                if context
+                    .called_mutator_function_may_mutate(from_path, function, is_cancelled)
+                    .unwrap_or(true)
+                    || self.top_level_prefix_may_invoke_source(
+                        from_path,
+                        function.definition_start,
+                        context,
+                        &mut FxHashSet::default(),
+                        is_cancelled,
+                    )
                     || facts.source_effects.iter().any(|effect| {
                         (effect.enclosing_function.is_none()
                             && effect.span.start.offset() >= function.definition_start)
@@ -617,7 +1127,7 @@ impl WorkspaceCallIndex {
                 {
                     return None;
                 }
-                self.resolve_exact_events(
+                let resolution = self.resolve_exact_events(
                     from_path,
                     &site.callee,
                     ExactQuery {
@@ -628,7 +1138,28 @@ impl WorkspaceCallIndex {
                         local_call_offset: Some(site.name_span.start.offset()),
                     },
                     &mut stack,
-                )
+                );
+                let resolution = if resolution == ExactResolution::Absent {
+                    self.resolve_incoming_environment(
+                        from_path,
+                        &site.callee,
+                        context,
+                        &mut stack,
+                        is_cancelled,
+                    )
+                } else {
+                    resolution
+                };
+                if !self.deferred_incoming_contexts_are_stable(
+                    from_path,
+                    &site.callee,
+                    context,
+                    &mut FxHashSet::default(),
+                    is_cancelled,
+                ) {
+                    return None;
+                }
+                resolution
             }
         };
         let ExactResolution::Defined(target) = resolution else {
@@ -648,28 +1179,255 @@ impl WorkspaceCallIndex {
         })
     }
 
-    fn called_source_function_may_mutate(
+    fn exact_workspace_context(
         &self,
-        current_path: &Path,
-        current_function: &CallFunctionId,
+        is_cancelled: &impl Fn() -> bool,
+    ) -> Option<&ExactWorkspaceContext> {
+        if self.exact_context.get().is_none() {
+            let context = ExactWorkspaceContext::build(&self.files, is_cancelled)?;
+            let _ = self.exact_context.set(context);
+        }
+        if is_cancelled() {
+            return None;
+        }
+        self.exact_context.get()
+    }
+
+    fn resolve_top_level_with_incoming(
+        &self,
+        path: &Path,
+        callee: &Name,
+        cutoff: usize,
+        context: &ExactWorkspaceContext,
+        stack: &mut FxHashSet<PathBuf>,
+        is_cancelled: &impl Fn() -> bool,
+    ) -> ExactResolution {
+        if is_cancelled() {
+            return ExactResolution::Ambiguous;
+        }
+        if self.top_level_prefix_may_invoke_source(
+            path,
+            cutoff,
+            context,
+            &mut FxHashSet::default(),
+            is_cancelled,
+        ) {
+            return ExactResolution::Ambiguous;
+        }
+        let resolution =
+            self.resolve_exact_events(path, callee, ExactQuery::top_level(cutoff), stack);
+        if resolution != ExactResolution::Absent {
+            return resolution;
+        }
+        self.resolve_incoming_environment(path, callee, context, stack, is_cancelled)
+    }
+
+    fn top_level_prefix_may_invoke_source(
+        &self,
+        path: &Path,
+        cutoff: usize,
+        context: &ExactWorkspaceContext,
+        visiting: &mut FxHashSet<PathBuf>,
+        is_cancelled: &impl Fn() -> bool,
     ) -> bool {
-        let called_names = self
-            .files
-            .values()
-            .flat_map(|facts| facts.call_sites.iter().map(|site| &site.callee))
-            .collect::<FxHashSet<_>>();
-        let has_dynamic_dispatch = self
-            .files
-            .values()
-            .any(|facts| facts.has_dynamic_command_dispatch);
-        self.files.iter().any(|(path, facts)| {
-            facts.source_effects.iter().any(|effect| {
-                effect.enclosing_function.as_ref().is_some_and(|function| {
-                    (path.as_path() != current_path || function != current_function)
-                        && (has_dynamic_dispatch || called_names.contains(&function.name))
-                })
+        if is_cancelled() {
+            return true;
+        }
+        if !visiting.insert(path.to_path_buf()) {
+            return false;
+        }
+        let Some(facts) = self.files.get(path) else {
+            visiting.remove(path);
+            return true;
+        };
+        let may_invoke = facts.has_dynamic_command_dispatch
+            || facts.call_sites.iter().any(|site| {
+                matches!(site.enclosing, CallNodeKind::TopLevel)
+                    && site.name_span.start.offset < cutoff
+                    && context
+                        .name_may_mutate(path, &site.callee, is_cancelled)
+                        .unwrap_or(true)
             })
-        })
+            || facts.source_effects.iter().any(|effect| {
+                effect.enclosing_function.is_none()
+                    && effect.persistent
+                    && effect.span.start.offset < cutoff
+                    && effect.path.as_deref().is_some_and(|target| {
+                        self.top_level_prefix_may_invoke_source(
+                            target,
+                            usize::MAX,
+                            context,
+                            visiting,
+                            is_cancelled,
+                        )
+                    })
+            });
+        visiting.remove(path);
+        may_invoke
+    }
+
+    fn resolve_incoming_environment(
+        &self,
+        path: &Path,
+        callee: &Name,
+        context: &ExactWorkspaceContext,
+        stack: &mut FxHashSet<PathBuf>,
+        is_cancelled: &impl Fn() -> bool,
+    ) -> ExactResolution {
+        let Some(incoming) = context.incoming.get(path) else {
+            return ExactResolution::Absent;
+        };
+        let mut inherited = None;
+        for edge in incoming {
+            if is_cancelled()
+                || edge.conditional
+                || !edge.persistent
+                || edge.enclosing_function.is_some()
+                || !stack.insert(edge.parent_path.clone())
+            {
+                return ExactResolution::Ambiguous;
+            }
+            let resolution = self.resolve_top_level_with_incoming(
+                &edge.parent_path,
+                callee,
+                edge.span.start.offset,
+                context,
+                stack,
+                is_cancelled,
+            );
+            stack.remove(&edge.parent_path);
+            match (&inherited, resolution) {
+                (_, ExactResolution::Ambiguous) => return ExactResolution::Ambiguous,
+                (None, resolution) => inherited = Some(resolution),
+                (Some(previous), resolution) if previous == &resolution => {}
+                _ => return ExactResolution::Ambiguous,
+            }
+        }
+        inherited.unwrap_or(ExactResolution::Absent)
+    }
+
+    fn deferred_incoming_contexts_are_stable(
+        &self,
+        path: &Path,
+        callee: &Name,
+        context: &ExactWorkspaceContext,
+        visited: &mut FxHashSet<PathBuf>,
+        is_cancelled: &impl Fn() -> bool,
+    ) -> bool {
+        if !visited.insert(path.to_path_buf()) {
+            return false;
+        }
+        let stable = context.incoming.get(path).is_none_or(|incoming| {
+            incoming.iter().all(|edge| {
+                if is_cancelled()
+                    || edge.conditional
+                    || !edge.persistent
+                    || edge.enclosing_function.is_some()
+                {
+                    return false;
+                }
+                let Some(parent) = self.files.get(&edge.parent_path) else {
+                    return false;
+                };
+                if !parent.analyzable
+                    || parent.has_dynamic_command_dispatch
+                    || parent.definitions.iter().any(|definition| {
+                        definition.name == *callee
+                            && definition.def_span.start.offset > edge.span.start.offset
+                    })
+                    || parent
+                        .source_effects
+                        .iter()
+                        .any(|effect| effect.span.start.offset > edge.span.start.offset)
+                    || parent.call_sites.iter().any(|site| {
+                        matches!(site.enclosing, CallNodeKind::TopLevel)
+                            && site.name_span.start.offset > edge.span.start.offset
+                            && context
+                                .name_may_mutate(&edge.parent_path, &site.callee, is_cancelled)
+                                .unwrap_or(true)
+                    })
+                {
+                    return false;
+                }
+                self.deferred_incoming_contexts_are_stable(
+                    &edge.parent_path,
+                    callee,
+                    context,
+                    visited,
+                    is_cancelled,
+                )
+            })
+        });
+        visited.remove(path);
+        stable
+    }
+
+    /// Returns call tokens proven to resolve to `target_node` in `target_path`.
+    ///
+    /// The reverse index is built lazily and retained only after a complete,
+    /// uncancelled pass. Ambiguous or unresolved calls are deliberately absent.
+    pub fn exact_function_references(
+        &self,
+        target_path: &Path,
+        target_node: &CallNodeKind,
+        is_cancelled: impl Fn() -> bool,
+    ) -> Option<&[ExactFunctionReference]> {
+        if self.exact_references.get().is_none() {
+            let built = self.build_exact_reference_index(&is_cancelled)?;
+            let _ = self.exact_references.set(built);
+        }
+        if is_cancelled() {
+            return None;
+        }
+        Some(
+            self.exact_references
+                .get()?
+                .get(&(target_path.to_path_buf(), target_node.clone()))
+                .map(Vec::as_slice)
+                .unwrap_or(&[]),
+        )
+    }
+
+    fn build_exact_reference_index(
+        &self,
+        is_cancelled: &impl Fn() -> bool,
+    ) -> Option<ExactReferenceIndex> {
+        let context = self.exact_workspace_context(is_cancelled)?;
+        let mut paths = self.files.keys().cloned().collect::<Vec<_>>();
+        paths.sort();
+        let mut references = ExactReferenceIndex::default();
+        for path in paths {
+            if is_cancelled() {
+                return None;
+            }
+            let mut call_spans = self
+                .files
+                .get(&path)?
+                .call_sites
+                .iter()
+                .map(|site| site.name_span)
+                .collect::<Vec<_>>();
+            call_spans.sort_by_key(|span| (span.start.offset, span.end.offset));
+            call_spans.dedup();
+            for span in call_spans {
+                if is_cancelled() {
+                    return None;
+                }
+                let Some(target) =
+                    self.resolve_call_site_exact_with_context(&path, span, context, is_cancelled)
+                else {
+                    continue;
+                };
+                references
+                    .entry((target.path, target.node))
+                    .or_default()
+                    .push(ExactFunctionReference {
+                        path: path.clone(),
+                        span,
+                    });
+            }
+        }
+        Some(references)
     }
 
     fn resolve_exact_events(
@@ -1680,6 +2438,447 @@ mod tests {
                 .visible_sourced_functions(&caller_path, usize::MAX)
                 .is_empty()
         );
+    }
+
+    #[test]
+    fn exact_reference_index_preserves_binding_identity_and_source_order() {
+        let a_path = PathBuf::from("/w/a.sh");
+        let b_path = PathBuf::from("/w/b.sh");
+        let caller_path = PathBuf::from("/w/caller.sh");
+        let local_path = PathBuf::from("/w/local.sh");
+        let caller_source = "source a.sh\nfoo\nsource b.sh\nfoo\n";
+        let caller = facts_with_positioned_sources(caller_source, &["/w/a.sh", "/w/b.sh"]);
+        let caller_spans = caller
+            .call_sites
+            .iter()
+            .filter(|site| site.callee == name("foo"))
+            .map(|site| site.name_span)
+            .collect::<Vec<_>>();
+
+        let mut index = WorkspaceCallIndex::new();
+        index.insert(a_path.clone(), facts("foo() { :; }\n", &[]));
+        index.insert(b_path.clone(), facts("foo() { :; }\n", &[]));
+        index.insert(caller_path.clone(), caller);
+        index.insert(
+            local_path,
+            facts_with_positioned_sources(
+                "source a.sh\nfoo() { echo local; }\nfoo\n",
+                &["/w/a.sh"],
+            ),
+        );
+
+        let a_node = function_node(&index, "/w/a.sh", "foo", 0);
+        let a_references = index
+            .exact_function_references(&a_path, &a_node, || false)
+            .expect("reference build should complete");
+        assert_eq!(
+            a_references,
+            &[ExactFunctionReference {
+                path: caller_path.clone(),
+                span: caller_spans[0],
+            }]
+        );
+
+        let b_node = function_node(&index, "/w/b.sh", "foo", 0);
+        let b_references = index
+            .exact_function_references(&b_path, &b_node, || false)
+            .expect("cached reference lookup should complete");
+        assert_eq!(
+            b_references,
+            &[ExactFunctionReference {
+                path: caller_path,
+                span: caller_spans[1],
+            }]
+        );
+    }
+
+    #[test]
+    fn exact_reference_index_inherits_bindings_at_source_sites() {
+        let main_path = PathBuf::from("/w/main.sh");
+        let child_path = PathBuf::from("/w/child.sh");
+        let child = facts("foo\n", &[]);
+        let child_call = child.call_sites[0].name_span;
+        let mut index = WorkspaceCallIndex::new();
+        index.insert(
+            main_path.clone(),
+            facts_with_positioned_sources("foo() { :; }\nsource child.sh\n", &["/w/child.sh"]),
+        );
+        index.insert(child_path.clone(), child);
+
+        let target = function_node(&index, "/w/main.sh", "foo", 0);
+        assert_eq!(
+            index
+                .exact_function_references(&main_path, &target, || false)
+                .expect("inherited source environment should resolve"),
+            &[ExactFunctionReference {
+                path: child_path,
+                span: child_call,
+            }]
+        );
+    }
+
+    #[test]
+    fn exact_reference_index_omits_deferred_calls_with_incoming_overrides() {
+        let base_path = PathBuf::from("/w/base.sh");
+        let lib_path = PathBuf::from("/w/lib.sh");
+        let caller_path = PathBuf::from("/w/caller.sh");
+        let mut index = WorkspaceCallIndex::new();
+        index.insert(base_path.clone(), facts("foo() { :; }\n", &[]));
+        index.insert(
+            lib_path,
+            facts_with_positioned_sources("source base.sh\nrun() { foo; }\n", &["/w/base.sh"]),
+        );
+        index.insert(
+            caller_path,
+            facts_with_positioned_sources(
+                "source lib.sh\nfoo() { echo override; }\nrun\nsource base.sh\n",
+                &["/w/lib.sh", "/w/base.sh"],
+            ),
+        );
+
+        let target = function_node(&index, "/w/base.sh", "foo", 0);
+        assert!(
+            index
+                .exact_function_references(&base_path, &target, || false)
+                .is_some_and(<[_]>::is_empty)
+        );
+    }
+
+    #[test]
+    fn exact_reference_index_rejects_top_level_source_function_side_effects() {
+        let base_path = PathBuf::from("/w/base.sh");
+        let override_path = PathBuf::from("/w/override.sh");
+        let main_path = PathBuf::from("/w/main.sh");
+        let child_path = PathBuf::from("/w/child.sh");
+        let mut index = WorkspaceCallIndex::new();
+        index.insert(base_path.clone(), facts("foo() { :; }\n", &[]));
+        index.insert(override_path, facts("foo() { echo override; }\n", &[]));
+        index.insert(
+            main_path,
+            facts_with_positioned_sources(
+                "source base.sh\nload() { source override.sh; }\nload\nfoo\nsource child.sh\n",
+                &["/w/base.sh", "/w/override.sh", "/w/child.sh"],
+            ),
+        );
+        index.insert(child_path, facts("foo\n", &[]));
+
+        let target = function_node(&index, "/w/base.sh", "foo", 0);
+        assert!(
+            index
+                .exact_function_references(&base_path, &target, || false)
+                .is_some_and(<[_]>::is_empty)
+        );
+    }
+
+    #[test]
+    fn invoked_nested_function_definitions_are_binding_mutators() {
+        let path = PathBuf::from("/w/main.sh");
+        let mut index = WorkspaceCallIndex::new();
+        index.insert(
+            path.clone(),
+            facts(
+                "foo() { echo base; }\ninstall() { foo() { echo override; }; }\ninstall\nfoo\n",
+                &[],
+            ),
+        );
+
+        let target = function_node(&index, "/w/main.sh", "foo", 0);
+        assert!(
+            index
+                .exact_function_references(&path, &target, || false)
+                .is_some_and(<[_]>::is_empty)
+        );
+    }
+
+    #[test]
+    fn repeated_current_binding_mutator_does_not_get_excluded() {
+        let path = PathBuf::from("/w/main.sh");
+        let mut index = WorkspaceCallIndex::new();
+        index.insert(
+            path.clone(),
+            facts(
+                "foo() { echo base; }\nrun() { foo; foo() { echo override; }; }\nrun\nrun\n",
+                &[],
+            ),
+        );
+
+        let target = function_node(&index, "/w/main.sh", "foo", 0);
+        assert!(
+            index
+                .exact_function_references(&path, &target, || false)
+                .is_some_and(<[_]>::is_empty)
+        );
+    }
+
+    #[test]
+    fn conditional_sources_still_propagate_possible_loader_side_effects() {
+        let base_path = PathBuf::from("/w/base.sh");
+        let override_path = PathBuf::from("/w/override.sh");
+        let child_path = PathBuf::from("/w/child.sh");
+        let main_path = PathBuf::from("/w/main.sh");
+        let mut index = WorkspaceCallIndex::new();
+        index.insert(base_path.clone(), facts("foo() { :; }\n", &[]));
+        index.insert(override_path, facts("foo() { echo override; }\n", &[]));
+        index.insert(
+            child_path,
+            facts_with_positioned_sources(
+                "load() { source override.sh; }\nload\n",
+                &["/w/override.sh"],
+            ),
+        );
+        index.insert(
+            main_path,
+            facts_with_positioned_sources(
+                "source base.sh\nif enabled; then source child.sh; fi\nfoo\n",
+                &["/w/base.sh", "/w/child.sh"],
+            ),
+        );
+
+        let target = function_node(&index, "/w/base.sh", "foo", 0);
+        assert!(
+            index
+                .exact_function_references(&base_path, &target, || false)
+                .is_some_and(<[_]>::is_empty)
+        );
+    }
+
+    #[test]
+    fn exact_reference_index_rejects_transitive_source_function_wrappers() {
+        let base_path = PathBuf::from("/w/base.sh");
+        let lib_path = PathBuf::from("/w/lib.sh");
+        let override_path = PathBuf::from("/w/override.sh");
+        let caller_path = PathBuf::from("/w/caller.sh");
+        let mut index = WorkspaceCallIndex::new();
+        index.insert(base_path.clone(), facts("foo() { :; }\n", &[]));
+        index.insert(
+            lib_path,
+            facts_with_positioned_sources("source base.sh\nrun() { foo; }\n", &["/w/base.sh"]),
+        );
+        index.insert(override_path, facts("foo() { echo override; }\n", &[]));
+        index.insert(
+            caller_path,
+            facts_with_positioned_sources(
+                "source lib.sh\nload() { source override.sh; }\nouter() { load; }\nouter\nrun\n",
+                &["/w/lib.sh", "/w/override.sh"],
+            ),
+        );
+
+        let target = function_node(&index, "/w/base.sh", "foo", 0);
+        assert!(
+            index
+                .exact_function_references(&base_path, &target, || false)
+                .is_some_and(<[_]>::is_empty)
+        );
+    }
+
+    #[test]
+    fn source_wrapper_cycles_do_not_cache_query_order_dependent_negatives() {
+        let path = PathBuf::from("/w/main.sh");
+        let mut index = WorkspaceCallIndex::new();
+        index.insert(
+            path.clone(),
+            facts_with_positioned_sources(
+                "a() { b; load; }\nb() { a; }\nload() { source plugin.sh; }\n",
+                &["/w/plugin.sh"],
+            ),
+        );
+        index.insert(PathBuf::from("/w/plugin.sh"), facts(":\n", &[]));
+        let context = ExactWorkspaceContext::build(&index.files, &|| false)
+            .expect("exact context should build");
+
+        assert_eq!(
+            context.name_may_mutate(&path, &name("a"), &|| false),
+            Some(true)
+        );
+        assert_eq!(
+            context.name_may_mutate(&path, &name("b"), &|| false),
+            Some(true)
+        );
+    }
+
+    #[test]
+    fn deep_mutator_wrapper_walk_is_iterative_and_cancellable() {
+        let path = PathBuf::from("/w/main.sh");
+        let depth = 4_096usize;
+        let mut call_sites = Vec::with_capacity(depth - 1);
+        for index in 0..depth - 1 {
+            call_sites.push(CallFactSite {
+                callee: name(&format!("wrapper_{}", index + 1)),
+                name_span: Span::new(),
+                enclosing: CallNodeKind::Function(CallFunctionId::new(
+                    name(&format!("wrapper_{index}")),
+                    Span::new(),
+                )),
+                local_definition_span: None,
+            });
+        }
+        let mut index = WorkspaceCallIndex::new();
+        index.insert(
+            path.clone(),
+            FileCallFacts {
+                definitions: Vec::new(),
+                call_sites,
+                source_edges: Vec::new(),
+                source_effects: Vec::new(),
+                binding_mutators: vec![CallFunctionId::new(
+                    name(&format!("wrapper_{}", depth - 1)),
+                    Span::new(),
+                )],
+                has_dynamic_command_dispatch: false,
+                analyzable: true,
+            },
+        );
+        let context = ExactWorkspaceContext::build(&index.files, &|| false)
+            .expect("exact context should build");
+        let checks = std::cell::Cell::new(0usize);
+        assert_eq!(
+            context.name_may_mutate(&path, &name("wrapper_0"), &|| {
+                checks.set(checks.get() + 1);
+                checks.get() > 16
+            }),
+            None
+        );
+        assert_eq!(
+            context.name_may_mutate(&path, &name("wrapper_0"), &|| false),
+            Some(true)
+        );
+    }
+
+    #[test]
+    fn unrelated_source_functions_do_not_suppress_exact_references() {
+        let main_path = PathBuf::from("/w/main.sh");
+        let unrelated_path = PathBuf::from("/w/unrelated.sh");
+        let plugin_path = PathBuf::from("/w/plugin.sh");
+        let main = facts("foo() { :; }\nrun() { foo; }\nrun\n", &[]);
+        let inner_call = main
+            .call_sites
+            .iter()
+            .find(|site| site.callee == name("foo"))
+            .expect("inner foo call")
+            .name_span;
+        let mut index = WorkspaceCallIndex::new();
+        index.insert(main_path.clone(), main);
+        index.insert(
+            unrelated_path,
+            facts_with_positioned_sources(
+                "load() { source plugin.sh; }\nload\n",
+                &["/w/plugin.sh"],
+            ),
+        );
+        index.insert(plugin_path, facts(":\n", &[]));
+
+        let target = function_node(&index, "/w/main.sh", "foo", 0);
+        assert_eq!(
+            index
+                .exact_function_references(&main_path, &target, || false)
+                .expect("unrelated source closure should not interfere"),
+            &[ExactFunctionReference {
+                path: main_path,
+                span: inner_call,
+            }]
+        );
+    }
+
+    #[test]
+    fn exact_reference_index_cancels_without_caching_partial_results() {
+        let target_path = PathBuf::from("/w/a.sh");
+        let caller_path = PathBuf::from("/w/caller.sh");
+        let mut index = WorkspaceCallIndex::new();
+        index.insert(target_path.clone(), facts("foo() { :; }\n", &[]));
+        index.insert(
+            caller_path.clone(),
+            facts_with_positioned_sources("source a.sh\nfoo\n", &["/w/a.sh"]),
+        );
+        let target = function_node(&index, "/w/a.sh", "foo", 0);
+        let checks = std::cell::Cell::new(0usize);
+        assert!(
+            index
+                .exact_function_references(&target_path, &target, || {
+                    checks.set(checks.get() + 1);
+                    checks.get() > 1
+                })
+                .is_none()
+        );
+
+        let references = index
+            .exact_function_references(&target_path, &target, || false)
+            .expect("retry should build a complete reverse index");
+        assert_eq!(references.len(), 1);
+        assert_eq!(references[0].path, caller_path);
+    }
+
+    #[test]
+    fn exact_call_resolution_cancels_without_caching_partial_context() {
+        let path = PathBuf::from("/w/main.sh");
+        let facts = facts("foo() { :; }\nfoo\n", &[]);
+        let call_span = facts.call_sites[0].name_span;
+        let mut index = WorkspaceCallIndex::new();
+        index.insert(path.clone(), facts);
+
+        assert!(
+            index
+                .resolve_call_site_exact_cancellable(&path, call_span, || true)
+                .is_none()
+        );
+        assert!(index.exact_context.get().is_none());
+        assert!(
+            index
+                .resolve_call_site_exact_cancellable(&path, call_span, || false)
+                .is_some()
+        );
+    }
+
+    #[test]
+    fn replacing_file_facts_invalidates_exact_reference_index() {
+        let target_path = PathBuf::from("/w/a.sh");
+        let caller_path = PathBuf::from("/w/caller.sh");
+        let mut index = WorkspaceCallIndex::new();
+        index.insert(target_path.clone(), facts("foo() { :; }\n", &[]));
+        index.insert(
+            caller_path.clone(),
+            facts_with_positioned_sources("source a.sh\nfoo\n", &["/w/a.sh"]),
+        );
+        let target = function_node(&index, "/w/a.sh", "foo", 0);
+        assert_eq!(
+            index
+                .exact_function_references(&target_path, &target, || false)
+                .map(<[_]>::len),
+            Some(1)
+        );
+
+        index.insert(caller_path, facts("unrelated\n", &[]));
+        assert!(
+            index
+                .exact_function_references(&target_path, &target, || false)
+                .is_some_and(<[_]>::is_empty)
+        );
+    }
+
+    #[test]
+    fn exact_reference_index_terminates_source_cycles() {
+        let target_path = PathBuf::from("/w/a.sh");
+        let cycle_path = PathBuf::from("/w/cycle.sh");
+        let caller_path = PathBuf::from("/w/caller.sh");
+        let mut index = WorkspaceCallIndex::new();
+        index.insert(
+            target_path.clone(),
+            facts_with_positioned_sources("source cycle.sh\nfoo() { :; }\n", &["/w/cycle.sh"]),
+        );
+        index.insert(
+            cycle_path,
+            facts_with_positioned_sources("source a.sh\n", &["/w/a.sh"]),
+        );
+        index.insert(
+            caller_path.clone(),
+            facts_with_positioned_sources("source a.sh\nfoo\n", &["/w/a.sh"]),
+        );
+        let target = function_node(&index, "/w/a.sh", "foo", 0);
+
+        let references = index
+            .exact_function_references(&target_path, &target, || false)
+            .expect("cyclic graph should terminate");
+        assert_eq!(references.len(), 1);
+        assert_eq!(references[0].path, caller_path);
     }
 
     #[test]

--- a/crates/shuck-semantic/src/call_facts.rs
+++ b/crates/shuck-semantic/src/call_facts.rs
@@ -395,6 +395,27 @@ pub struct ExactFunctionReference {
     pub span: Span,
 }
 
+/// Exact references and all indexed files whose source relationship can
+/// affect a cross-file function rename.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ExactFunctionRename {
+    /// Call tokens proven to resolve to the selected function binding.
+    pub references: Vec<ExactFunctionReference>,
+    /// Source-connected files whose snapshots must still match the index.
+    pub relevant_paths: Vec<PathBuf>,
+}
+
+/// Why an exact cross-file function rename set could not be proven.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ExactFunctionRenameError {
+    /// A same-named call in the relevant source graph has ambiguous binding
+    /// identity and therefore cannot be safely included or excluded.
+    AmbiguousReference,
+    /// A source operation in the relevant graph could not be resolved to a
+    /// file represented by the workspace index.
+    IncompleteSourceGraph,
+}
+
 type ExactReferenceIndex = FxHashMap<(PathBuf, CallNodeKind), Vec<ExactFunctionReference>>;
 
 #[derive(Clone, Debug)]
@@ -625,6 +646,28 @@ impl SourceGraphIndex {
     fn component_reaches(&self, from: usize, to: usize) -> bool {
         bit_is_set(&self.component_reachability[from], to)
     }
+
+    fn source_environment_components(
+        &self,
+        target: usize,
+        is_cancelled: &impl Fn() -> bool,
+    ) -> Option<Vec<u64>> {
+        let mut shared = vec![0; self.component_reachability[target].len()];
+        for ancestor in 0..self.component_edges.len() {
+            if is_cancelled() {
+                return None;
+            }
+            if self.component_reaches(ancestor, target) {
+                for (word, reachable) in shared
+                    .iter_mut()
+                    .zip(&self.component_reachability[ancestor])
+                {
+                    *word |= reachable;
+                }
+            }
+        }
+        Some(shared)
+    }
 }
 
 impl ExactWorkspaceContext {
@@ -695,7 +738,7 @@ impl ExactWorkspaceContext {
             edges.sort_by(|left, right| {
                 left.parent_path
                     .cmp(&right.parent_path)
-                    .then_with(|| left.span.start.offset.cmp(&right.span.start.offset))
+                    .then_with(|| left.span.start.offset().cmp(&right.span.start.offset()))
             });
         }
 
@@ -1088,6 +1131,36 @@ impl WorkspaceCallIndex {
         context: &ExactWorkspaceContext,
         is_cancelled: &impl Fn() -> bool,
     ) -> Option<CrossFileCall> {
+        let (site, resolution) = self.call_site_exact_resolution_with_context(
+            from_path,
+            name_span,
+            context,
+            is_cancelled,
+        )?;
+        let ExactResolution::Defined(target) = resolution else {
+            return None;
+        };
+        let definition = self.files.get(&target.path).and_then(|facts| {
+            facts.definitions.iter().find(|definition| {
+                definition.name == site.callee && definition.def_span == target.def_span
+            })
+        });
+        Some(CrossFileCall {
+            path: target.path,
+            node: CallNodeKind::Function(CallFunctionId::new(site.callee.clone(), target.def_span)),
+            def_span: Some(target.def_span),
+            selection_span: definition.map(|definition| definition.selection_span),
+            call_spans: vec![site.name_span],
+        })
+    }
+
+    fn call_site_exact_resolution_with_context<'a>(
+        &'a self,
+        from_path: &Path,
+        name_span: Span,
+        context: &ExactWorkspaceContext,
+        is_cancelled: &impl Fn() -> bool,
+    ) -> Option<(&'a CallFactSite, ExactResolution)> {
         let facts = self.files.get(from_path)?;
         let site = facts
             .call_sites
@@ -1108,9 +1181,13 @@ impl WorkspaceCallIndex {
                 is_cancelled,
             ),
             CallNodeKind::Function(function) => {
-                if context
+                let may_mutate = context
                     .called_mutator_function_may_mutate(from_path, function, is_cancelled)
-                    .unwrap_or(true)
+                    .unwrap_or(true);
+                if is_cancelled() {
+                    return None;
+                }
+                if may_mutate
                     || self.top_level_prefix_may_invoke_source(
                         from_path,
                         function.definition_start,
@@ -1125,7 +1202,7 @@ impl WorkspaceCallIndex {
                                 && effect.span.start.offset() >= site.name_span.start.offset())
                     })
                 {
-                    return None;
+                    return Some((site, ExactResolution::Ambiguous));
                 }
                 let resolution = self.resolve_exact_events(
                     from_path,
@@ -1157,26 +1234,15 @@ impl WorkspaceCallIndex {
                     &mut FxHashSet::default(),
                     is_cancelled,
                 ) {
-                    return None;
+                    if is_cancelled() {
+                        return None;
+                    }
+                    return Some((site, ExactResolution::Ambiguous));
                 }
                 resolution
             }
         };
-        let ExactResolution::Defined(target) = resolution else {
-            return None;
-        };
-        let definition = self.files.get(&target.path).and_then(|facts| {
-            facts.definitions.iter().find(|definition| {
-                definition.name == site.callee && definition.def_span == target.def_span
-            })
-        });
-        Some(CrossFileCall {
-            path: target.path,
-            node: CallNodeKind::Function(CallFunctionId::new(site.callee.clone(), target.def_span)),
-            def_span: Some(target.def_span),
-            selection_span: definition.map(|definition| definition.selection_span),
-            call_spans: vec![site.name_span],
-        })
+        (!is_cancelled()).then_some((site, resolution))
     }
 
     fn exact_workspace_context(
@@ -1243,7 +1309,7 @@ impl WorkspaceCallIndex {
         let may_invoke = facts.has_dynamic_command_dispatch
             || facts.call_sites.iter().any(|site| {
                 matches!(site.enclosing, CallNodeKind::TopLevel)
-                    && site.name_span.start.offset < cutoff
+                    && site.name_span.start.offset() < cutoff
                     && context
                         .name_may_mutate(path, &site.callee, is_cancelled)
                         .unwrap_or(true)
@@ -1251,7 +1317,7 @@ impl WorkspaceCallIndex {
             || facts.source_effects.iter().any(|effect| {
                 effect.enclosing_function.is_none()
                     && effect.persistent
-                    && effect.span.start.offset < cutoff
+                    && effect.span.start.offset() < cutoff
                     && effect.path.as_deref().is_some_and(|target| {
                         self.top_level_prefix_may_invoke_source(
                             target,
@@ -1290,7 +1356,7 @@ impl WorkspaceCallIndex {
             let resolution = self.resolve_top_level_with_incoming(
                 &edge.parent_path,
                 callee,
-                edge.span.start.offset,
+                edge.span.start.offset(),
                 context,
                 stack,
                 is_cancelled,
@@ -1333,15 +1399,15 @@ impl WorkspaceCallIndex {
                     || parent.has_dynamic_command_dispatch
                     || parent.definitions.iter().any(|definition| {
                         definition.name == *callee
-                            && definition.def_span.start.offset > edge.span.start.offset
+                            && definition.def_span.start.offset() > edge.span.start.offset()
                     })
                     || parent
                         .source_effects
                         .iter()
-                        .any(|effect| effect.span.start.offset > edge.span.start.offset)
+                        .any(|effect| effect.span.start.offset() > edge.span.start.offset())
                     || parent.call_sites.iter().any(|site| {
                         matches!(site.enclosing, CallNodeKind::TopLevel)
-                            && site.name_span.start.offset > edge.span.start.offset
+                            && site.name_span.start.offset() > edge.span.start.offset()
                             && context
                                 .name_may_mutate(&edge.parent_path, &site.callee, is_cancelled)
                                 .unwrap_or(true)
@@ -1388,6 +1454,91 @@ impl WorkspaceCallIndex {
         )
     }
 
+    /// Builds the exact reference set required for a safe cross-file rename.
+    ///
+    /// In addition to returning proven references, this rejects a same-named
+    /// call in the source-connected graph when its binding identity is
+    /// ambiguous. The returned paths let callers verify that every snapshot
+    /// which influenced the proof is still current before emitting edits.
+    pub fn exact_function_rename(
+        &self,
+        target_path: &Path,
+        target_node: &CallNodeKind,
+        is_cancelled: impl Fn() -> bool,
+    ) -> Option<Result<ExactFunctionRename, ExactFunctionRenameError>> {
+        let CallNodeKind::Function(target_function) = target_node else {
+            return Some(Err(ExactFunctionRenameError::AmbiguousReference));
+        };
+        let context = self.exact_workspace_context(&is_cancelled)?;
+        let target_component = context.graph.component_for_path(target_path)?;
+        let source_environment = context
+            .graph
+            .source_environment_components(target_component, &is_cancelled)?;
+        let relevant_paths = context
+            .graph
+            .paths
+            .iter()
+            .enumerate()
+            .filter(|(node, _)| bit_is_set(&source_environment, context.graph.components[*node]))
+            .map(|(_, path)| path.clone())
+            .collect::<Vec<_>>();
+        let mut references = Vec::new();
+        for path in &relevant_paths {
+            if is_cancelled() {
+                return None;
+            }
+            let facts = self.files.get(path)?;
+            if facts.source_effects.iter().any(|effect| {
+                effect
+                    .path
+                    .as_ref()
+                    .is_none_or(|target| !self.files.contains_key(target))
+            }) {
+                return Some(Err(ExactFunctionRenameError::IncompleteSourceGraph));
+            }
+            for site in facts
+                .call_sites
+                .iter()
+                .filter(|site| site.callee == target_function.name)
+            {
+                let (_, resolution) = self.call_site_exact_resolution_with_context(
+                    path,
+                    site.name_span,
+                    context,
+                    &is_cancelled,
+                )?;
+                match resolution {
+                    ExactResolution::Defined(target)
+                        if target.path == target_path
+                            && target.def_span.start.offset()
+                                == target_function.definition_start
+                            && target.def_span.end.offset() == target_function.definition_end =>
+                    {
+                        references.push(ExactFunctionReference {
+                            path: path.clone(),
+                            span: site.name_span,
+                        });
+                    }
+                    ExactResolution::Defined(_) | ExactResolution::Absent => {}
+                    ExactResolution::Ambiguous => {
+                        return Some(Err(ExactFunctionRenameError::AmbiguousReference));
+                    }
+                }
+            }
+        }
+        references.sort_by(|left, right| {
+            left.path.cmp(&right.path).then_with(|| {
+                (left.span.start.offset(), left.span.end.offset())
+                    .cmp(&(right.span.start.offset(), right.span.end.offset()))
+            })
+        });
+        references.dedup();
+        Some(Ok(ExactFunctionRename {
+            references,
+            relevant_paths,
+        }))
+    }
+
     fn build_exact_reference_index(
         &self,
         is_cancelled: &impl Fn() -> bool,
@@ -1407,7 +1558,7 @@ impl WorkspaceCallIndex {
                 .iter()
                 .map(|site| site.name_span)
                 .collect::<Vec<_>>();
-            call_spans.sort_by_key(|span| (span.start.offset, span.end.offset));
+            call_spans.sort_by_key(|span| (span.start.offset(), span.end.offset()));
             call_spans.dedup();
             for span in call_spans {
                 if is_cancelled() {
@@ -2493,6 +2644,127 @@ mod tests {
     }
 
     #[test]
+    fn exact_function_rename_rejects_ambiguous_calls_in_the_source_graph() {
+        let target_path = PathBuf::from("/w/a.sh");
+        let caller_path = PathBuf::from("/w/caller.sh");
+        let mut index = WorkspaceCallIndex::new();
+        index.insert(target_path.clone(), facts("foo() { :; }\n", &[]));
+        index.insert(
+            caller_path,
+            facts_with_positioned_sources("if true; then source a.sh; fi\nfoo\n", &["/w/a.sh"]),
+        );
+
+        let target = function_node(&index, "/w/a.sh", "foo", 0);
+        assert_eq!(
+            index.exact_function_rename(&target_path, &target, || false),
+            Some(Err(ExactFunctionRenameError::AmbiguousReference))
+        );
+    }
+
+    #[test]
+    fn exact_function_rename_rejects_an_unresolved_source_edge() {
+        let target_path = PathBuf::from("/w/a.sh");
+        let mut index = WorkspaceCallIndex::new();
+        index.insert(
+            target_path.clone(),
+            facts("foo() { :; }\nfoo\nsource \"$dynamic\"\n", &[]),
+        );
+
+        let target = function_node(&index, "/w/a.sh", "foo", 0);
+        assert_eq!(
+            index.exact_function_rename(&target_path, &target, || false),
+            Some(Err(ExactFunctionRenameError::IncompleteSourceGraph))
+        );
+    }
+
+    #[test]
+    fn exact_function_rename_rejects_an_unindexed_source_target() {
+        let target_path = PathBuf::from("/w/a.sh");
+        let mut index = WorkspaceCallIndex::new();
+        index.insert(
+            target_path.clone(),
+            facts_with_positioned_sources(
+                "foo() { :; }\nfoo\nsource missing.sh\n",
+                &["/w/missing.sh"],
+            ),
+        );
+
+        let target = function_node(&index, "/w/a.sh", "foo", 0);
+        assert_eq!(
+            index.exact_function_rename(&target_path, &target, || false),
+            Some(Err(ExactFunctionRenameError::IncompleteSourceGraph))
+        );
+    }
+
+    #[test]
+    fn exact_function_rename_ignores_disconnected_ambiguous_calls() {
+        let target_path = PathBuf::from("/w/main.sh");
+        let unrelated_path = PathBuf::from("/w/unrelated.sh");
+        let main = facts("foo() { :; }\nfoo\n", &[]);
+        let call_span = main.call_sites[0].name_span;
+        let mut index = WorkspaceCallIndex::new();
+        index.insert(target_path.clone(), main);
+        index.insert(unrelated_path, facts("source \"$dynamic\"\nfoo\n", &[]));
+
+        let target = function_node(&index, "/w/main.sh", "foo", 0);
+        assert_eq!(
+            index
+                .exact_function_rename(&target_path, &target, || false)
+                .expect("rename analysis should complete")
+                .expect("disconnected ambiguity should not block rename"),
+            ExactFunctionRename {
+                references: vec![ExactFunctionReference {
+                    path: target_path.clone(),
+                    span: call_span,
+                }],
+                relevant_paths: vec![target_path],
+            }
+        );
+    }
+
+    #[test]
+    fn exact_function_rename_does_not_connect_files_through_a_shared_child() {
+        let target_path = PathBuf::from("/w/target.sh");
+        let unrelated_path = PathBuf::from("/w/unrelated.sh");
+        let common_path = PathBuf::from("/w/common.sh");
+        let target = facts_with_positioned_sources(
+            "source common.sh\nfoo() { :; }\nfoo\n",
+            &["/w/common.sh"],
+        );
+        let target_call = target
+            .call_sites
+            .iter()
+            .find(|site| site.callee == name("foo"))
+            .unwrap()
+            .name_span;
+        let mut index = WorkspaceCallIndex::new();
+        index.insert(target_path.clone(), target);
+        index.insert(
+            unrelated_path,
+            facts_with_positioned_sources(
+                "source common.sh\nsource \"$dynamic\"\nfoo\n",
+                &["/w/common.sh"],
+            ),
+        );
+        index.insert(common_path.clone(), facts(":\n", &[]));
+
+        let target = function_node(&index, "/w/target.sh", "foo", 0);
+        assert_eq!(
+            index
+                .exact_function_rename(&target_path, &target, || false)
+                .expect("rename analysis should complete")
+                .expect("a shared child must not import the target into its other parent"),
+            ExactFunctionRename {
+                references: vec![ExactFunctionReference {
+                    path: target_path.clone(),
+                    span: target_call,
+                }],
+                relevant_paths: vec![common_path, target_path],
+            }
+        );
+    }
+
+    #[test]
     fn exact_reference_index_inherits_bindings_at_source_sites() {
         let main_path = PathBuf::from("/w/main.sh");
         let child_path = PathBuf::from("/w/child.sh");
@@ -2805,6 +3077,16 @@ mod tests {
             .expect("retry should build a complete reverse index");
         assert_eq!(references.len(), 1);
         assert_eq!(references[0].path, caller_path);
+        assert!(
+            index
+                .exact_function_rename(&target_path, &target, || true)
+                .is_none()
+        );
+        let rename = index
+            .exact_function_rename(&target_path, &target, || false)
+            .expect("rename retry should complete")
+            .expect("rename retry should remain exact");
+        assert_eq!(rename.references, references);
     }
 
     #[test]

--- a/crates/shuck-semantic/src/lib.rs
+++ b/crates/shuck-semantic/src/lib.rs
@@ -44,8 +44,8 @@ pub use binding::{
 /// Workspace call-graph index types for cross-file call hierarchy.
 pub use call_facts::{
     CallFactDefinition, CallFactSite, CallFactSourceEdge, CallFunctionId, CallNodeKind,
-    CrossFileCall, ExactFunctionReference, FileCallFacts, VisibleSourcedFunction,
-    WorkspaceCallIndex,
+    CrossFileCall, ExactFunctionReference, ExactFunctionRename, ExactFunctionRenameError,
+    FileCallFacts, VisibleSourcedFunction, WorkspaceCallIndex,
 };
 pub use call_graph::{
     CallGraph, CallSite, OverwrittenFunction, UnreachedFunction, UnreachedFunctionReason,

--- a/crates/shuck-semantic/src/lib.rs
+++ b/crates/shuck-semantic/src/lib.rs
@@ -44,7 +44,8 @@ pub use binding::{
 /// Workspace call-graph index types for cross-file call hierarchy.
 pub use call_facts::{
     CallFactDefinition, CallFactSite, CallFactSourceEdge, CallFunctionId, CallNodeKind,
-    CrossFileCall, FileCallFacts, VisibleSourcedFunction, WorkspaceCallIndex,
+    CrossFileCall, ExactFunctionReference, FileCallFacts, VisibleSourcedFunction,
+    WorkspaceCallIndex,
 };
 pub use call_graph::{
     CallGraph, CallSite, OverwrittenFunction, UnreachedFunction, UnreachedFunctionReason,

--- a/crates/shuck-server/src/editor_features.rs
+++ b/crates/shuck-server/src/editor_features.rs
@@ -435,7 +435,6 @@ pub(crate) fn prepare_rename(
     _client: &Client,
     params: types::TextDocumentPositionParams,
 ) -> crate::server::Result<PrepareRenameResponse> {
-    reject_unsupported_cross_file_rename(&snapshot)?;
     let Some(analysis) = snapshot.analysis() else {
         return Ok(None);
     };
@@ -464,7 +463,6 @@ pub(crate) fn rename(
     _client: &Client,
     params: types::RenameParams,
 ) -> crate::server::Result<RenameResponse> {
-    reject_unsupported_cross_file_rename(&snapshot)?;
     let Some(analysis) = snapshot.analysis() else {
         return Ok(None);
     };
@@ -494,16 +492,6 @@ pub(crate) fn rename(
         &rename,
         &params.new_name,
     )))
-}
-
-fn reject_unsupported_cross_file_rename(snapshot: &DocumentSnapshot) -> crate::server::Result<()> {
-    if snapshot.client_settings().rename().allow_cross_file {
-        return Err(Error::new(
-            anyhow!("cross-file rename is not supported yet"),
-            ErrorCode::InvalidRequest,
-        ));
-    }
-    Ok(())
 }
 
 fn workspace_edit_for_rename(
@@ -635,7 +623,7 @@ fn valid_variable_name(name: &str) -> bool {
         && chars.all(|ch| ch == '_' || ch.is_ascii_alphanumeric())
 }
 
-fn valid_function_name(name: &str) -> bool {
+pub(crate) fn valid_function_name(name: &str) -> bool {
     !name.is_empty()
         && !name.chars().any(|ch| {
             ch.is_whitespace()
@@ -955,7 +943,7 @@ mod tests {
     }
 
     #[test]
-    fn rename_rejects_cross_file_mode_until_supported() {
+    fn cross_file_mode_keeps_local_variable_rename_available() {
         let source = "name=1\necho \"$name\"\n";
         let options = serde_json::from_value(serde_json::json!({
             "server": {
@@ -968,7 +956,7 @@ mod tests {
         let (snapshot, client, uri) = make_snapshot_with_options(source, options);
         let reference_position = position_for_nth(source, "name", 1);
 
-        let error = rename(
+        let edit = rename(
             snapshot,
             &client,
             RenameParams {
@@ -977,13 +965,15 @@ mod tests {
                 work_done_progress_params: WorkDoneProgressParams::default(),
             },
         )
-        .expect_err("cross-file rename mode should be rejected until supported");
-
-        assert_eq!(error.code as i32, ErrorCode::InvalidRequest as i32);
-        assert!(
-            error
-                .to_string()
-                .contains("cross-file rename is not supported yet")
+        .expect("local variable rename should still succeed")
+        .expect("local variable rename should return edits");
+        assert_eq!(
+            edit.changes
+                .expect("default test client should use changes")
+                .values()
+                .map(Vec::len)
+                .sum::<usize>(),
+            2
         );
     }
 

--- a/crates/shuck-server/src/resolve.rs
+++ b/crates/shuck-server/src/resolve.rs
@@ -198,8 +198,8 @@ pub(crate) fn render_sourced_function_hover(
         "### {}\n\nFunction\n\nDefined in {} at line {}, column {}.\n\nScope: top-level.",
         markdown_code(hover.name),
         markdown_code(&definition_file),
-        hover.definition_span.start.line,
-        hover.definition_span.start.column,
+        hover.definition_span.start.line(),
+        hover.definition_span.start.column(),
     );
     types::Hover {
         contents: types::HoverContents::Markup(types::MarkupContent {

--- a/crates/shuck-server/src/server/api.rs
+++ b/crates/shuck-server/src/server/api.rs
@@ -81,7 +81,10 @@ pub(super) fn request(req: server::Request) -> Task {
             background_session_request_task::<request::Hover>(req, BackgroundSchedule::Worker)
         }
         request::PrepareRename::METHOD => {
-            background_request_task::<request::PrepareRename>(req, BackgroundSchedule::Worker)
+            background_session_request_task::<request::PrepareRename>(
+                req,
+                BackgroundSchedule::Worker,
+            )
         }
         request::References::METHOD => {
             background_session_request_task::<request::References>(
@@ -90,7 +93,7 @@ pub(super) fn request(req: server::Request) -> Task {
             )
         }
         request::Rename::METHOD => {
-            background_request_task::<request::Rename>(req, BackgroundSchedule::Worker)
+            background_session_request_task::<request::Rename>(req, BackgroundSchedule::Worker)
         }
         request::WorkspaceSymbols::METHOD => {
             background_session_request_task::<request::WorkspaceSymbols>(

--- a/crates/shuck-server/src/server/api.rs
+++ b/crates/shuck-server/src/server/api.rs
@@ -84,7 +84,10 @@ pub(super) fn request(req: server::Request) -> Task {
             background_request_task::<request::PrepareRename>(req, BackgroundSchedule::Worker)
         }
         request::References::METHOD => {
-            background_request_task::<request::References>(req, BackgroundSchedule::Worker)
+            background_session_request_task::<request::References>(
+                req,
+                BackgroundSchedule::Worker,
+            )
         }
         request::Rename::METHOD => {
             background_request_task::<request::Rename>(req, BackgroundSchedule::Worker)

--- a/crates/shuck-server/src/server/api/requests.rs
+++ b/crates/shuck-server/src/server/api/requests.rs
@@ -5,6 +5,7 @@ mod code_action;
 mod code_action_resolve;
 mod completion;
 mod completion_resolve;
+mod cross_file_rename;
 mod definition;
 mod diagnostic;
 mod document_highlight;

--- a/crates/shuck-server/src/server/api/requests/cross_file_rename.rs
+++ b/crates/shuck-server/src/server/api/requests/cross_file_rename.rs
@@ -1,0 +1,385 @@
+use std::collections::BTreeMap;
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use anyhow::anyhow;
+use lsp_server::ErrorCode;
+use lsp_types as types;
+use shuck_ast::Span;
+use shuck_semantic::{
+    BindingKind, CallFunctionId, CallNodeKind, EditorCallHierarchyTarget, EditorSymbolTarget,
+    ExactFunctionRenameError,
+};
+
+use crate::edit::RangeExt;
+use crate::editor_features;
+use crate::server::Error;
+use crate::session::{Client, DocumentSnapshot};
+use crate::workspace_functions::{
+    WorkspaceFunctionContext, WorkspaceFunctionIndex, canonical_path,
+    fresh_workspace_function_index,
+};
+
+enum FunctionResolution {
+    NotFunction,
+    Unavailable,
+    Resolved(ResolvedFunction),
+}
+
+struct ResolvedFunction {
+    index: Arc<WorkspaceFunctionIndex>,
+    target_path: PathBuf,
+    target_node: CallNodeKind,
+    declaration_span: Span,
+    editable_span: Span,
+    name: String,
+}
+
+pub(super) fn prepare(
+    snapshot: DocumentSnapshot,
+    workspace: WorkspaceFunctionContext,
+    client: &Client,
+    params: types::TextDocumentPositionParams,
+) -> crate::server::Result<editor_features::PrepareRenameResponse> {
+    if !snapshot.client_settings().rename().allow_cross_file {
+        return editor_features::prepare_rename(snapshot, client, params);
+    }
+    let position = params.position;
+    match resolve_function(&snapshot, &workspace, position)? {
+        FunctionResolution::NotFunction => {
+            editor_features::prepare_rename(snapshot, client, params)
+        }
+        FunctionResolution::Unavailable => Ok(None),
+        FunctionResolution::Resolved(target) => {
+            if !snapshot.resolved_client_capabilities().document_changes {
+                return Ok(None);
+            }
+            if collect_rename_spans(&target, &workspace).is_err() {
+                return Ok(None);
+            }
+            let Some(analysis) = snapshot.analysis() else {
+                return Ok(None);
+            };
+            Ok(Some(types::PrepareRenameResponse::RangeWithPlaceholder {
+                range: crate::edit::to_lsp_range(
+                    target.editable_span.to_range(),
+                    analysis.source(),
+                    analysis.line_index(),
+                    snapshot.encoding(),
+                ),
+                placeholder: target.name,
+            }))
+        }
+    }
+}
+
+pub(super) fn rename(
+    snapshot: DocumentSnapshot,
+    workspace: WorkspaceFunctionContext,
+    client: &Client,
+    params: types::RenameParams,
+) -> crate::server::Result<editor_features::RenameResponse> {
+    if !snapshot.client_settings().rename().allow_cross_file {
+        return editor_features::rename(snapshot, client, params);
+    }
+    let position = params.text_document_position.position;
+    let target = match resolve_function(&snapshot, &workspace, position)? {
+        FunctionResolution::NotFunction => {
+            return editor_features::rename(snapshot, client, params);
+        }
+        FunctionResolution::Unavailable => {
+            return Err(rename_error(
+                "the function binding is ambiguous or unavailable in the current workspace index",
+            ));
+        }
+        FunctionResolution::Resolved(target) => target,
+    };
+    if !snapshot.resolved_client_capabilities().document_changes {
+        return Err(rename_error(
+            "cross-file function rename requires client support for documentChanges",
+        ));
+    }
+    if !editor_features::valid_function_name(&params.new_name) {
+        return Err(Error::new(
+            anyhow!("new name is not valid for a shell function"),
+            ErrorCode::InvalidParams,
+        ));
+    }
+    let spans = collect_rename_spans(&target, &workspace).map_err(rename_error)?;
+    let edit = workspace_edit(&target.index, spans, &params.new_name);
+    validate_workspace_snapshot(&target.index, &workspace).map_err(rename_error)?;
+    Ok(Some(edit))
+}
+
+fn resolve_function(
+    snapshot: &DocumentSnapshot,
+    workspace: &WorkspaceFunctionContext,
+    position: types::Position,
+) -> crate::server::Result<FunctionResolution> {
+    let Some(analysis) = snapshot.analysis() else {
+        return Ok(FunctionResolution::Unavailable);
+    };
+    let offset = usize::from(
+        types::Range {
+            start: position,
+            end: position,
+        }
+        .to_text_range(
+            analysis.source(),
+            analysis.line_index(),
+            snapshot.encoding(),
+        )
+        .start(),
+    );
+    let Some(target) = analysis.semantic().editor_query().target_at_offset(offset) else {
+        return Ok(FunctionResolution::NotFunction);
+    };
+    let Some(path) = snapshot
+        .query()
+        .file_url()
+        .to_file_path()
+        .ok()
+        .map(|path| canonical_path(&path))
+    else {
+        return Ok(FunctionResolution::NotFunction);
+    };
+
+    let resolved = match target {
+        EditorSymbolTarget::FunctionCall(call) => {
+            let Some(index) = fresh_workspace_function_index(workspace) else {
+                return Ok(FunctionResolution::Unavailable);
+            };
+            let Some(target) =
+                index.resolve_call_site_exact(&path, call.name_span, &workspace.cancellation)
+            else {
+                return Ok(FunctionResolution::Unavailable);
+            };
+            let Some(declaration_span) = target.selection_span else {
+                return Ok(FunctionResolution::Unavailable);
+            };
+            ResolvedFunction {
+                index,
+                target_path: target.path,
+                target_node: target.node,
+                declaration_span,
+                editable_span: call.name_span,
+                name: call.name.to_string(),
+            }
+        }
+        EditorSymbolTarget::Binding(binding_id) => {
+            let binding = analysis.semantic().binding(binding_id);
+            if !matches!(binding.kind, BindingKind::FunctionDefinition) {
+                return Ok(FunctionResolution::NotFunction);
+            }
+            let Some(index) = fresh_workspace_function_index(workspace) else {
+                return Ok(FunctionResolution::Unavailable);
+            };
+            let Some(item) = analysis
+                .semantic()
+                .editor_query()
+                .prepare_call_hierarchy(offset)
+            else {
+                return Ok(FunctionResolution::Unavailable);
+            };
+            local_function(index, path, item, binding.span)?
+        }
+        EditorSymbolTarget::Reference(reference_id) => {
+            let Some(binding) = analysis.semantic().resolved_binding(reference_id) else {
+                return Ok(FunctionResolution::NotFunction);
+            };
+            if !matches!(binding.kind, BindingKind::FunctionDefinition) {
+                return Ok(FunctionResolution::NotFunction);
+            }
+            let Some(index) = fresh_workspace_function_index(workspace) else {
+                return Ok(FunctionResolution::Unavailable);
+            };
+            let Some(item) = analysis
+                .semantic()
+                .editor_query()
+                .prepare_call_hierarchy(offset)
+            else {
+                return Ok(FunctionResolution::Unavailable);
+            };
+            local_function(
+                index,
+                path,
+                item,
+                analysis.semantic().reference(reference_id).name_span,
+            )?
+        }
+        EditorSymbolTarget::RuntimeName(_) => return Ok(FunctionResolution::NotFunction),
+    };
+    Ok(FunctionResolution::Resolved(resolved))
+}
+
+fn local_function(
+    index: Arc<WorkspaceFunctionIndex>,
+    path: PathBuf,
+    item: shuck_semantic::EditorCallHierarchyItem,
+    editable_span: Span,
+) -> crate::server::Result<ResolvedFunction> {
+    let EditorCallHierarchyTarget::Function(_) = item.target else {
+        return Err(rename_error("the selected symbol is not a function"));
+    };
+    let Some(definition_span) = item.full_span else {
+        return Err(rename_error("the function definition has no source span"));
+    };
+    let Some(declaration_span) = item.selection_span else {
+        return Err(rename_error("the function name has no source span"));
+    };
+    Ok(ResolvedFunction {
+        index,
+        target_path: path,
+        target_node: CallNodeKind::Function(CallFunctionId::new(
+            item.name.clone(),
+            definition_span,
+        )),
+        declaration_span,
+        editable_span,
+        name: item.name.to_string(),
+    })
+}
+
+fn collect_rename_spans(
+    target: &ResolvedFunction,
+    workspace: &WorkspaceFunctionContext,
+) -> Result<BTreeMap<PathBuf, Vec<Span>>, String> {
+    if !target.index.is_complete() {
+        return Err(
+            "workspace indexing is incomplete; retry after the workspace is fully indexed".into(),
+        );
+    }
+    if workspace.cache.current_epoch() != workspace.epoch {
+        return Err("workspace state changed during rename; retry the request".into());
+    }
+    let Some(rename) = target.index.exact_function_rename(
+        &target.target_path,
+        &target.target_node,
+        &workspace.cancellation,
+    ) else {
+        return Err("the rename request was cancelled".into());
+    };
+    let rename = rename.map_err(|error| match error {
+        ExactFunctionRenameError::AmbiguousReference => {
+            "a same-named call in the source graph has ambiguous binding identity".to_owned()
+        }
+        ExactFunctionRenameError::IncompleteSourceGraph => {
+            "the source graph contains an unresolved or unindexed source operation".to_owned()
+        }
+    })?;
+    let roots = workspace
+        .workspace_roots
+        .iter()
+        .map(|root| canonical_path(root))
+        .collect::<Vec<_>>();
+    for path in &rename.relevant_paths {
+        if workspace.cancellation.is_cancelled() {
+            return Err("the rename request was cancelled".into());
+        }
+        if !roots.iter().any(|root| path.starts_with(root)) {
+            return Err(format!(
+                "the source graph reaches a file outside the workspace: {}",
+                path.display()
+            ));
+        }
+        if target.index.file(path).is_none() {
+            return Err(format!(
+                "a source-connected file is not indexed: {}",
+                path.display()
+            ));
+        }
+    }
+
+    let mut spans = BTreeMap::<PathBuf, Vec<Span>>::new();
+    spans
+        .entry(target.target_path.clone())
+        .or_default()
+        .push(target.declaration_span);
+    for reference in rename.references {
+        spans
+            .entry(reference.path)
+            .or_default()
+            .push(reference.span);
+    }
+    for (path, spans) in &mut spans {
+        spans.sort_by_key(|span| (span.start.offset(), span.end.offset()));
+        spans.dedup();
+        if spans
+            .windows(2)
+            .any(|pair| pair[0].end.offset() > pair[1].start.offset())
+        {
+            return Err(format!(
+                "rename edits overlap in {}; no edits were produced",
+                path.display()
+            ));
+        }
+    }
+    validate_workspace_snapshot(&target.index, workspace)?;
+    Ok(spans)
+}
+
+fn validate_workspace_snapshot(
+    index: &WorkspaceFunctionIndex,
+    workspace: &WorkspaceFunctionContext,
+) -> Result<(), String> {
+    if workspace.cache.current_epoch() != workspace.epoch {
+        return Err("workspace state changed during rename; retry the request".into());
+    }
+    let Some(closed_files) = index.validate_closed_files(&workspace.cancellation) else {
+        return Err("the rename request was cancelled".into());
+    };
+    if let Err(path) = closed_files {
+        return Err(format!(
+            "an indexed file changed during rename: {}; retry the request",
+            path.display()
+        ));
+    }
+    if workspace.cache.current_epoch() != workspace.epoch {
+        return Err("workspace state changed during rename; retry the request".into());
+    }
+    Ok(())
+}
+
+fn workspace_edit(
+    index: &WorkspaceFunctionIndex,
+    spans_by_path: BTreeMap<PathBuf, Vec<Span>>,
+    new_name: &str,
+) -> types::WorkspaceEdit {
+    let mut document_edits = Vec::new();
+    for (path, mut spans) in spans_by_path {
+        let file = index
+            .file(&path)
+            .expect("rename spans should only reference validated indexed files");
+        spans.sort_by_key(|span| std::cmp::Reverse((span.start.offset(), span.end.offset())));
+        let edits = spans
+            .into_iter()
+            .map(|span| {
+                types::TextEdit::new(
+                    crate::edit::to_lsp_range(
+                        span.to_range(),
+                        file.source(),
+                        file.line_index(),
+                        index.encoding(),
+                    ),
+                    new_name.to_owned(),
+                )
+            })
+            .collect::<Vec<_>>();
+        document_edits.push(types::TextDocumentEdit {
+            text_document: types::OptionalVersionedTextDocumentIdentifier {
+                uri: file.editor_uri().clone(),
+                version: file.version(),
+            },
+            edits: edits.into_iter().map(types::OneOf::Left).collect(),
+        });
+    }
+    types::WorkspaceEdit {
+        changes: None,
+        document_changes: Some(types::DocumentChanges::Edits(document_edits)),
+        change_annotations: None,
+    }
+}
+
+fn rename_error(message: impl Into<String>) -> Error {
+    Error::new(anyhow!(message.into()), ErrorCode::InvalidRequest)
+}

--- a/crates/shuck-server/src/server/api/requests/definition.rs
+++ b/crates/shuck-server/src/server/api/requests/definition.rs
@@ -89,7 +89,8 @@ fn definition(
     let Some(index) = workspace_function_index(&workspace) else {
         return Ok(None);
     };
-    if let Some(target) = index.resolve_call_site_exact(&path, call.name_span)
+    if let Some(target) =
+        index.resolve_call_site_exact(&path, call.name_span, &workspace.cancellation)
         && let Some(definition_span) = target.def_span
         && let Some(range) = index.range_of(&target.path, definition_span)
     {

--- a/crates/shuck-server/src/server/api/requests/hover.rs
+++ b/crates/shuck-server/src/server/api/requests/hover.rs
@@ -95,7 +95,9 @@ fn hover(
     let Some(index) = workspace_function_index(&workspace) else {
         return Ok(None);
     };
-    let Some(target) = index.resolve_call_site_exact(&path, call.name_span) else {
+    let Some(target) =
+        index.resolve_call_site_exact(&path, call.name_span, &workspace.cancellation)
+    else {
         return Ok(None);
     };
     if target.path == path {

--- a/crates/shuck-server/src/server/api/requests/prepare_rename.rs
+++ b/crates/shuck-server/src/server/api/requests/prepare_rename.rs
@@ -1,33 +1,42 @@
 use lsp_types::{self as types, request as req};
 
 use crate::editor_features;
-use crate::session::{Client, DocumentSnapshot};
+use crate::session::{Client, DocumentSnapshot, RequestCancellationToken, Session};
+use crate::workspace_functions::WorkspaceFunctionContext;
 
 pub(crate) struct PrepareRename;
+
+pub(crate) struct PrepareRenameSnapshot {
+    document: Option<DocumentSnapshot>,
+    workspace: WorkspaceFunctionContext,
+}
 
 impl super::RequestHandler for PrepareRename {
     type RequestType = req::PrepareRenameRequest;
 }
 
-impl super::BackgroundDocumentRequestHandler for PrepareRename {
-    fn document_url(
-        params: &types::TextDocumentPositionParams,
-    ) -> std::borrow::Cow<'_, types::Url> {
-        std::borrow::Cow::Borrowed(&params.text_document.uri)
-    }
+impl super::super::traits::BackgroundRequestHandler for PrepareRename {
+    type Snapshot = PrepareRenameSnapshot;
 
-    fn run_without_snapshot(
-        _client: &Client,
-        _params: types::TextDocumentPositionParams,
-    ) -> crate::server::Result<editor_features::PrepareRenameResponse> {
-        Ok(None)
+    fn snapshot(
+        session: &Session,
+        params: &types::TextDocumentPositionParams,
+        cancellation: RequestCancellationToken,
+    ) -> crate::server::Result<Self::Snapshot> {
+        Ok(PrepareRenameSnapshot {
+            document: session.take_snapshot(params.text_document.uri.clone()),
+            workspace: session.workspace_function_context(cancellation),
+        })
     }
 
     fn run_with_snapshot(
-        snapshot: DocumentSnapshot,
+        snapshot: Self::Snapshot,
         client: &Client,
         params: types::TextDocumentPositionParams,
     ) -> crate::server::Result<editor_features::PrepareRenameResponse> {
-        editor_features::prepare_rename(snapshot, client, params)
+        let Some(document) = snapshot.document else {
+            return Ok(None);
+        };
+        super::cross_file_rename::prepare(document, snapshot.workspace, client, params)
     }
 }

--- a/crates/shuck-server/src/server/api/requests/references.rs
+++ b/crates/shuck-server/src/server/api/requests/references.rs
@@ -1,31 +1,158 @@
 use lsp_types::{self as types, request as req};
+use shuck_semantic::{CallFunctionId, CallNodeKind, EditorCallHierarchyTarget, EditorSymbolTarget};
 
+use crate::edit::RangeExt;
 use crate::editor_features;
-use crate::session::{Client, DocumentSnapshot};
+use crate::session::{Client, DocumentSnapshot, RequestCancellationToken, Session};
+use crate::workspace_functions::{
+    WorkspaceFunctionContext, canonical_path, workspace_function_index,
+};
 
 pub(crate) struct References;
+
+pub(crate) struct ReferencesSnapshot {
+    document: Option<DocumentSnapshot>,
+    workspace: WorkspaceFunctionContext,
+}
 
 impl super::RequestHandler for References {
     type RequestType = req::References;
 }
 
-impl super::BackgroundDocumentRequestHandler for References {
-    fn document_url(params: &types::ReferenceParams) -> std::borrow::Cow<'_, types::Url> {
-        std::borrow::Cow::Borrowed(&params.text_document_position.text_document.uri)
-    }
+impl super::super::traits::BackgroundRequestHandler for References {
+    type Snapshot = ReferencesSnapshot;
 
-    fn run_without_snapshot(
-        _client: &Client,
-        _params: types::ReferenceParams,
-    ) -> crate::server::Result<editor_features::ReferencesResponse> {
-        Ok(None)
+    fn snapshot(
+        session: &Session,
+        params: &types::ReferenceParams,
+        cancellation: RequestCancellationToken,
+    ) -> crate::server::Result<Self::Snapshot> {
+        let uri = params.text_document_position.text_document.uri.clone();
+        Ok(ReferencesSnapshot {
+            document: session.take_snapshot(uri),
+            workspace: session.workspace_function_context(cancellation),
+        })
     }
 
     fn run_with_snapshot(
-        snapshot: DocumentSnapshot,
+        snapshot: Self::Snapshot,
         client: &Client,
         params: types::ReferenceParams,
     ) -> crate::server::Result<editor_features::ReferencesResponse> {
-        editor_features::references(snapshot, client, params)
+        let Some(document) = snapshot.document else {
+            return Ok(None);
+        };
+        references(document, snapshot.workspace, client, params)
     }
+}
+
+fn references(
+    snapshot: DocumentSnapshot,
+    workspace: WorkspaceFunctionContext,
+    client: &Client,
+    params: types::ReferenceParams,
+) -> crate::server::Result<editor_features::ReferencesResponse> {
+    let Some(analysis) = snapshot.analysis() else {
+        return Ok(None);
+    };
+    let position = params.text_document_position.position;
+    let offset = usize::from(
+        types::Range {
+            start: position,
+            end: position,
+        }
+        .to_text_range(
+            analysis.source(),
+            analysis.line_index(),
+            snapshot.encoding(),
+        )
+        .start(),
+    );
+    let Some(target) = analysis.semantic().editor_query().target_at_offset(offset) else {
+        return Ok(None);
+    };
+    let Some(path) = snapshot
+        .query()
+        .file_url()
+        .to_file_path()
+        .ok()
+        .map(|path| canonical_path(&path))
+    else {
+        return editor_features::references(snapshot, client, params);
+    };
+    let (index, target_path, target_node, declaration) = match target {
+        EditorSymbolTarget::FunctionCall(call) => {
+            let Some(index) = workspace_function_index(&workspace) else {
+                return Ok(None);
+            };
+            let Some(target) =
+                index.resolve_call_site_exact(&path, call.name_span, &workspace.cancellation)
+            else {
+                return Ok(None);
+            };
+            let Some(declaration_span) = target.selection_span.or(target.def_span) else {
+                return Ok(None);
+            };
+            let Some(file) = index.file(&target.path) else {
+                return Ok(None);
+            };
+            let declaration = types::Location {
+                uri: file.editor_uri().clone(),
+                range: crate::edit::to_lsp_range(
+                    declaration_span.to_range(),
+                    file.source(),
+                    file.line_index(),
+                    snapshot.encoding(),
+                ),
+            };
+            (index, target.path, target.node, declaration)
+        }
+        EditorSymbolTarget::Binding(_)
+        | EditorSymbolTarget::Reference(_)
+        | EditorSymbolTarget::RuntimeName(_) => {
+            let Some(item) = analysis
+                .semantic()
+                .editor_query()
+                .prepare_call_hierarchy(offset)
+            else {
+                return editor_features::references(snapshot, client, params);
+            };
+            let EditorCallHierarchyTarget::Function(_) = item.target else {
+                return editor_features::references(snapshot, client, params);
+            };
+            let Some(definition_span) = item.full_span else {
+                return Ok(None);
+            };
+            let Some(index) = workspace_function_index(&workspace) else {
+                return Ok(None);
+            };
+            let declaration_span = item.selection_span.unwrap_or(definition_span);
+            let node = CallNodeKind::Function(CallFunctionId::new(item.name, definition_span));
+            let declaration = types::Location {
+                uri: snapshot.query().file_url().clone(),
+                range: crate::edit::to_lsp_range(
+                    declaration_span.to_range(),
+                    analysis.source(),
+                    analysis.line_index(),
+                    snapshot.encoding(),
+                ),
+            };
+            (index, path.clone(), node, declaration)
+        }
+    };
+
+    let Some(mut locations) = index.exact_function_reference_locations(
+        &target_path,
+        &target_node,
+        &workspace.cancellation,
+    ) else {
+        return Ok(None);
+    };
+    if workspace.cancellation.is_cancelled() {
+        return Ok(None);
+    }
+    if params.context.include_declaration && !locations.contains(&declaration) {
+        locations.insert(0, declaration);
+    }
+    Ok((!locations.is_empty()).then_some(locations))
 }

--- a/crates/shuck-server/src/server/api/requests/rename.rs
+++ b/crates/shuck-server/src/server/api/requests/rename.rs
@@ -1,31 +1,43 @@
 use lsp_types::{self as types, request as req};
 
 use crate::editor_features;
-use crate::session::{Client, DocumentSnapshot};
+use crate::session::{Client, DocumentSnapshot, RequestCancellationToken, Session};
+use crate::workspace_functions::WorkspaceFunctionContext;
 
 pub(crate) struct Rename;
+
+pub(crate) struct RenameSnapshot {
+    document: Option<DocumentSnapshot>,
+    workspace: WorkspaceFunctionContext,
+}
 
 impl super::RequestHandler for Rename {
     type RequestType = req::Rename;
 }
 
-impl super::BackgroundDocumentRequestHandler for Rename {
-    fn document_url(params: &types::RenameParams) -> std::borrow::Cow<'_, types::Url> {
-        std::borrow::Cow::Borrowed(&params.text_document_position.text_document.uri)
-    }
+impl super::super::traits::BackgroundRequestHandler for Rename {
+    type Snapshot = RenameSnapshot;
 
-    fn run_without_snapshot(
-        _client: &Client,
-        _params: types::RenameParams,
-    ) -> crate::server::Result<editor_features::RenameResponse> {
-        Ok(None)
+    fn snapshot(
+        session: &Session,
+        params: &types::RenameParams,
+        cancellation: RequestCancellationToken,
+    ) -> crate::server::Result<Self::Snapshot> {
+        Ok(RenameSnapshot {
+            document: session
+                .take_snapshot(params.text_document_position.text_document.uri.clone()),
+            workspace: session.workspace_function_context(cancellation),
+        })
     }
 
     fn run_with_snapshot(
-        snapshot: DocumentSnapshot,
+        snapshot: Self::Snapshot,
         client: &Client,
         params: types::RenameParams,
     ) -> crate::server::Result<editor_features::RenameResponse> {
-        editor_features::rename(snapshot, client, params)
+        let Some(document) = snapshot.document else {
+            return Ok(None);
+        };
+        super::cross_file_rename::rename(document, snapshot.workspace, client, params)
     }
 }

--- a/crates/shuck-server/src/workspace_functions.rs
+++ b/crates/shuck-server/src/workspace_functions.rs
@@ -20,8 +20,8 @@ use shuck_config::{
 use shuck_indexer::LineIndex;
 use shuck_linter::ShellDialect;
 use shuck_semantic::{
-    CallFactSourceEdge, CallNodeKind, CrossFileCall, FileCallFacts, VisibleSourcedFunction,
-    WorkspaceCallIndex, source_ref_candidate_paths,
+    CallFactSourceEdge, CallNodeKind, CrossFileCall, ExactFunctionRename, ExactFunctionRenameError,
+    FileCallFacts, VisibleSourcedFunction, WorkspaceCallIndex, source_ref_candidate_paths,
 };
 
 use crate::PositionEncoding;
@@ -101,15 +101,34 @@ pub(crate) fn workspace_function_index(
     Some(built)
 }
 
+/// Builds a new index for a mutation request instead of trusting a cached
+/// discovery snapshot.
+///
+/// Cross-file edits need to observe closed files that changed without a file
+/// watcher notification, including files whose previous contents were not
+/// connected to the selected function. Epoch checks on both sides of the build
+/// reject concurrent session invalidation.
+pub(crate) fn fresh_workspace_function_index(
+    context: &WorkspaceFunctionContext,
+) -> Option<Arc<WorkspaceFunctionIndex>> {
+    if context.cancellation.is_cancelled() || context.cache.current_epoch() != context.epoch {
+        return None;
+    }
+    let built = Arc::new(WorkspaceFunctionIndex::build(context)?);
+    if context.cancellation.is_cancelled() || context.cache.current_epoch() != context.epoch {
+        return None;
+    }
+    context.cache.store(context.epoch, built.clone());
+    Some(built)
+}
+
 /// Source snapshot retained for one indexed file.
 pub(crate) struct IndexedWorkspaceFile {
     uri: types::Url,
     open_uri: Option<types::Url>,
     source: String,
     line_index: LineIndex,
-    #[allow(dead_code)] // Used by the upcoming cross-file rename safety check.
     version: Option<DocumentVersion>,
-    #[allow(dead_code)] // Used by the upcoming cross-file rename safety check.
     content_hash: [u8; 32],
 }
 
@@ -133,13 +152,11 @@ impl IndexedWorkspaceFile {
     }
 
     /// Open-document version captured by the request, or `None` for disk input.
-    #[allow(dead_code)]
     pub(crate) fn version(&self) -> Option<DocumentVersion> {
         self.version
     }
 
     /// SHA-256 of the exact content used to build semantic facts and ranges.
-    #[allow(dead_code)]
     pub(crate) fn content_hash(&self) -> [u8; 32] {
         self.content_hash
     }
@@ -150,7 +167,6 @@ pub(crate) struct WorkspaceFunctionIndex {
     graph: WorkspaceCallIndex,
     files: BTreeMap<PathBuf, IndexedWorkspaceFile>,
     encoding: PositionEncoding,
-    #[allow(dead_code)] // Mutation features must reject partial workspace indexes.
     complete: bool,
 }
 
@@ -375,6 +391,19 @@ impl WorkspaceFunctionIndex {
         Some(locations)
     }
 
+    pub(crate) fn exact_function_rename(
+        &self,
+        target_path: &Path,
+        target_node: &CallNodeKind,
+        cancellation: &RequestCancellationToken,
+    ) -> Option<Result<ExactFunctionRename, ExactFunctionRenameError>> {
+        if cancellation.is_cancelled() {
+            return None;
+        }
+        self.graph
+            .exact_function_rename(target_path, target_node, || cancellation.is_cancelled())
+    }
+
     pub(crate) fn visible_sourced_functions(
         &self,
         from_path: &Path,
@@ -414,6 +443,10 @@ impl WorkspaceFunctionIndex {
         ))
     }
 
+    pub(crate) fn encoding(&self) -> PositionEncoding {
+        self.encoding
+    }
+
     pub(crate) fn ranges_in(&self, path: &Path, spans: &[Span]) -> Vec<types::Range> {
         spans
             .iter()
@@ -423,14 +456,12 @@ impl WorkspaceFunctionIndex {
 
     /// Whether discovery and source-edge expansion completed within the file
     /// budget and without unreadable inputs.
-    #[allow(dead_code)]
     pub(crate) fn is_complete(&self) -> bool {
         self.complete
     }
 
     /// Returns whether a closed file still matches the content used to build
     /// this index. Open documents are versioned by the LSP session instead.
-    #[allow(dead_code)]
     pub(crate) fn closed_file_is_current(&self, path: &Path) -> bool {
         let Some(file) = self.file(path) else {
             return false;
@@ -441,6 +472,24 @@ impl WorkspaceFunctionIndex {
         std::fs::read(path)
             .map(|contents| content_hash(&contents) == file.content_hash())
             .unwrap_or(false)
+    }
+
+    /// Verifies every closed snapshot retained by this index, including files
+    /// which were disconnected from the selected binding when the index was
+    /// built. The outer `None` denotes cancellation.
+    pub(crate) fn validate_closed_files(
+        &self,
+        cancellation: &RequestCancellationToken,
+    ) -> Option<Result<(), PathBuf>> {
+        for (path, file) in &self.files {
+            if cancellation.is_cancelled() {
+                return None;
+            }
+            if file.version().is_none() && !self.closed_file_is_current(path) {
+                return Some(Err(path.clone()));
+            }
+        }
+        Some(Ok(()))
     }
 
     #[cfg(test)]
@@ -1000,8 +1049,16 @@ mod tests {
         };
         let built = WorkspaceFunctionIndex::build(&context).unwrap();
         assert!(built.closed_file_is_current(&file));
+        assert_eq!(
+            built.validate_closed_files(&context.cancellation),
+            Some(Ok(()))
+        );
         std::fs::write(&file, "two() { :; }\n").unwrap();
         assert!(!built.closed_file_is_current(&file));
+        assert_eq!(
+            built.validate_closed_files(&context.cancellation),
+            Some(Err(file))
+        );
     }
 
     #[test]

--- a/crates/shuck-server/src/workspace_functions.rs
+++ b/crates/shuck-server/src/workspace_functions.rs
@@ -336,8 +336,43 @@ impl WorkspaceFunctionIndex {
         &self,
         from_path: &Path,
         name_span: Span,
+        cancellation: &RequestCancellationToken,
     ) -> Option<CrossFileCall> {
-        self.graph.resolve_call_site_exact(from_path, name_span)
+        self.graph
+            .resolve_call_site_exact_cancellable(from_path, name_span, || {
+                cancellation.is_cancelled()
+            })
+    }
+
+    pub(crate) fn exact_function_reference_locations(
+        &self,
+        target_path: &Path,
+        target_node: &CallNodeKind,
+        cancellation: &RequestCancellationToken,
+    ) -> Option<Vec<types::Location>> {
+        if !self.complete || cancellation.is_cancelled() {
+            return None;
+        }
+        let references = self
+            .graph
+            .exact_function_references(target_path, target_node, || cancellation.is_cancelled())?;
+        let mut locations = Vec::with_capacity(references.len());
+        for reference in references {
+            if cancellation.is_cancelled() {
+                return None;
+            }
+            let file = self.file(&reference.path)?;
+            locations.push(types::Location {
+                uri: file.editor_uri().clone(),
+                range: crate::edit::to_lsp_range(
+                    reference.span.to_range(),
+                    file.source(),
+                    file.line_index(),
+                    self.encoding,
+                ),
+            });
+        }
+        Some(locations)
     }
 
     pub(crate) fn visible_sourced_functions(

--- a/crates/shuck-server/tests/manual.rs
+++ b/crates/shuck-server/tests/manual.rs
@@ -1,7 +1,7 @@
 use std::thread;
 use std::time::Duration;
 
-use lsp_server::{Connection, Message, Notification, Request, RequestId};
+use lsp_server::{Connection, Message, Notification, Request, RequestId, Response};
 use lsp_types::{
     ClientCapabilities, CodeAction, CodeActionContext, CodeActionParams, DocumentDiagnosticParams,
     DocumentDiagnosticReport, DocumentDiagnosticReportResult, HoverParams, PartialResultParams,
@@ -21,6 +21,18 @@ fn send_request(connection: &Connection, id: i32, method: &str, params: serde_js
 }
 
 fn recv_response(connection: &Connection, id: i32) -> serde_json::Value {
+    let response = recv_lsp_response(connection, id);
+    assert!(
+        response.error.is_none(),
+        "unexpected LSP error: {:?}",
+        response.error
+    );
+    response
+        .result
+        .expect("successful response should carry a result")
+}
+
+fn recv_lsp_response(connection: &Connection, id: i32) -> Response {
     loop {
         let message = connection
             .receiver
@@ -28,14 +40,7 @@ fn recv_response(connection: &Connection, id: i32) -> serde_json::Value {
             .expect("server should respond");
         match message {
             Message::Response(response) if response.id == RequestId::from(id) => {
-                assert!(
-                    response.error.is_none(),
-                    "unexpected LSP error: {:?}",
-                    response.error
-                );
-                return response
-                    .result
-                    .expect("successful response should carry a result");
+                return response;
             }
             Message::Notification(_) => continue,
             Message::Request(request) => panic!(
@@ -286,6 +291,271 @@ fn open_document(connection: &Connection, uri: &Url, text: &str) {
             }),
         )))
         .expect("didOpen should send");
+}
+
+fn change_document(connection: &Connection, uri: &Url, version: i32, text: &str) {
+    connection
+        .sender
+        .send(Message::Notification(Notification::new(
+            "textDocument/didChange".to_owned(),
+            serde_json::json!({
+                "textDocument": { "uri": uri, "version": version },
+                "contentChanges": [{ "text": text }],
+            }),
+        )))
+        .expect("didChange should send");
+}
+
+fn cross_file_rename_for_encoding(
+    encoding: &str,
+    name_start: u64,
+    supports_document_changes: bool,
+) {
+    let (server_connection, client_connection) = Connection::memory();
+    let server_thread = thread::spawn(move || shuck_server::run_connection(server_connection));
+
+    let workspace = tempfile::tempdir().expect("tempdir should be created");
+    let lib = workspace.path().join("lib");
+    std::fs::create_dir(&lib).unwrap();
+    std::fs::write(
+        workspace.path().join("shuck.toml"),
+        "[lint]\nsource-paths = [\"lib\"]\n",
+    )
+    .unwrap();
+    let target_path = lib.join("target.sh");
+    let cycle_path = lib.join("cycle.sh");
+    let main_path = workspace.path().join("main.sh");
+    let caller_path = workspace.path().join("caller.sh");
+    let shadow_path = workspace.path().join("shadow.sh");
+    let unrelated_path = workspace.path().join("unrelated.sh");
+    let target_source = "source cycle.sh\n: '😀'; foo() { :; }\n";
+    let main_source = "# shuck: source=target.sh\nsource \"$DIR/target.sh\"\n: '😀'; foo\n";
+    let caller_source = "source main.sh\nfoo\n";
+    let shadow_source = "source main.sh\nfoo\nfoo() { :; }\nfoo\n";
+    std::fs::write(&target_path, "stale_target() { :; }\n").unwrap();
+    std::fs::write(&cycle_path, "source target.sh\n").unwrap();
+    std::fs::write(&main_path, "stale_main\n").unwrap();
+    std::fs::write(&caller_path, caller_source).unwrap();
+    std::fs::write(&shadow_path, shadow_source).unwrap();
+    std::fs::write(&unrelated_path, "foo() { :; }\nfoo\n").unwrap();
+
+    let target_uri = Url::from_file_path(&target_path).unwrap();
+    let main_uri = Url::from_file_path(&main_path).unwrap();
+    let caller_uri = Url::from_file_path(std::fs::canonicalize(&caller_path).unwrap()).unwrap();
+    let shadow_uri = Url::from_file_path(std::fs::canonicalize(&shadow_path).unwrap()).unwrap();
+    let unrelated_uri =
+        Url::from_file_path(std::fs::canonicalize(&unrelated_path).unwrap()).unwrap();
+
+    let mut capabilities = serde_json::to_value(replay_capabilities()).unwrap();
+    capabilities["general"]["positionEncodings"] = serde_json::json!([encoding]);
+    capabilities["workspace"]["workspaceEdit"]["documentChanges"] =
+        serde_json::json!(supports_document_changes);
+    send_request(
+        &client_connection,
+        1,
+        "initialize",
+        serde_json::json!({
+            "capabilities": capabilities,
+            "rootUri": Url::from_file_path(workspace.path()).unwrap(),
+            "initializationOptions": {
+                "shuck": { "server": { "rename": { "allowCrossFile": true } } }
+            },
+        }),
+    );
+    let initialize = recv_response(&client_connection, 1);
+    assert_eq!(initialize["capabilities"]["positionEncoding"], encoding);
+    client_connection
+        .sender
+        .send(Message::Notification(Notification::new(
+            "initialized".to_owned(),
+            serde_json::json!({}),
+        )))
+        .expect("initialized should send");
+    open_document(&client_connection, &target_uri, target_source);
+    open_document(&client_connection, &main_uri, main_source);
+
+    if !supports_document_changes {
+        send_request(
+            &client_connection,
+            2,
+            "textDocument/rename",
+            serde_json::json!({
+                "textDocument": { "uri": main_uri },
+                "position": { "line": 2, "character": name_start },
+                "newName": "unsafe_without_versions",
+            }),
+        );
+        let unsupported = recv_lsp_response(&client_connection, 2);
+        let unsupported_error = unsupported
+            .error
+            .expect("cross-file rename should require versioned document changes");
+        assert!(
+            unsupported_error
+                .message
+                .contains("requires client support")
+        );
+        send_request(&client_connection, 99, "shutdown", serde_json::json!(null));
+        let _ = recv_response(&client_connection, 99);
+        client_connection
+            .sender
+            .send(Message::Notification(Notification::new(
+                "exit".to_owned(),
+                serde_json::json!({}),
+            )))
+            .expect("exit notification should send");
+        server_thread
+            .join()
+            .expect("server thread should join")
+            .expect("server should exit cleanly");
+        return;
+    }
+
+    send_request(
+        &client_connection,
+        2,
+        "textDocument/prepareRename",
+        serde_json::json!({
+            "textDocument": { "uri": main_uri },
+            "position": { "line": 2, "character": name_start },
+        }),
+    );
+    let prepared = recv_response(&client_connection, 2);
+    assert_eq!(prepared["placeholder"], "foo");
+    assert_eq!(
+        prepared["range"],
+        serde_json::json!({
+            "start": { "line": 2, "character": name_start },
+            "end": { "line": 2, "character": name_start + 3 },
+        })
+    );
+
+    send_request(
+        &client_connection,
+        3,
+        "textDocument/rename",
+        serde_json::json!({
+            "textDocument": { "uri": main_uri },
+            "position": { "line": 2, "character": name_start },
+            "newName": "renamed",
+        }),
+    );
+    let rename = recv_response(&client_connection, 3);
+    let documents = rename["documentChanges"]
+        .as_array()
+        .expect("cross-file rename should use documentChanges");
+    assert_eq!(documents.len(), 4);
+    let document = |uri: &Url| {
+        documents
+            .iter()
+            .find(|document| document["textDocument"]["uri"] == uri.as_str())
+            .unwrap_or_else(|| panic!("missing rename edits for {uri}: {rename:#}"))
+    };
+    let target = document(&target_uri);
+    assert_eq!(target["textDocument"]["version"], 1);
+    assert_eq!(target["edits"].as_array().unwrap().len(), 1);
+    assert_eq!(
+        target["edits"][0]["range"]["start"]["character"],
+        name_start
+    );
+    let main = document(&main_uri);
+    assert_eq!(main["textDocument"]["version"], 1);
+    assert_eq!(main["edits"].as_array().unwrap().len(), 1);
+    let caller = document(&caller_uri);
+    assert!(caller["textDocument"]["version"].is_null());
+    assert_eq!(caller["edits"].as_array().unwrap().len(), 1);
+    let shadow = document(&shadow_uri);
+    assert!(shadow["textDocument"]["version"].is_null());
+    assert_eq!(shadow["edits"].as_array().unwrap().len(), 1);
+    assert!(
+        documents
+            .iter()
+            .all(|document| { document["textDocument"]["uri"] != unrelated_uri.as_str() })
+    );
+
+    std::fs::write(&unrelated_path, "source main.sh\nfoo\n").unwrap();
+    send_request(
+        &client_connection,
+        4,
+        "textDocument/rename",
+        serde_json::json!({
+            "textDocument": { "uri": main_uri },
+            "position": { "line": 2, "character": name_start },
+            "newName": "freshly_connected",
+        }),
+    );
+    let refreshed = recv_response(&client_connection, 4);
+    let refreshed_documents = refreshed["documentChanges"]
+        .as_array()
+        .expect("fresh rename should use documentChanges");
+    let newly_connected = refreshed_documents
+        .iter()
+        .find(|document| document["textDocument"]["uri"] == unrelated_uri.as_str())
+        .expect("fresh mutation index should include the newly connected closed file");
+    assert_eq!(newly_connected["edits"].as_array().unwrap().len(), 1);
+
+    std::fs::write(&unrelated_path, "foo() { :; }\nfoo\n").unwrap();
+    change_document(
+        &client_connection,
+        &main_uri,
+        2,
+        "# shuck: source=target.sh\nsource \"$DIR/target.sh\"\n: '😀'; foo\nsource \"$dynamic\"\n",
+    );
+    send_request(
+        &client_connection,
+        5,
+        "textDocument/rename",
+        serde_json::json!({
+            "textDocument": { "uri": main_uri },
+            "position": { "line": 2, "character": name_start },
+            "newName": "ambiguous_rejected",
+        }),
+    );
+    let unresolved = recv_lsp_response(&client_connection, 5);
+    let unresolved_error = unresolved
+        .error
+        .expect("unresolved source should fail rename");
+    assert!(
+        unresolved_error.message.contains("unresolved or unindexed")
+            || unresolved_error
+                .message
+                .contains("ambiguous binding identity"),
+        "unexpected unresolved-source error: {}",
+        unresolved_error.message
+    );
+
+    send_request(&client_connection, 99, "shutdown", serde_json::json!(null));
+    let _ = recv_response(&client_connection, 99);
+    client_connection
+        .sender
+        .send(Message::Notification(Notification::new(
+            "exit".to_owned(),
+            serde_json::json!({}),
+        )))
+        .expect("exit notification should send");
+    server_thread
+        .join()
+        .expect("server thread should join")
+        .expect("server should exit cleanly");
+}
+
+#[test]
+fn cross_file_rename_uses_utf8_positions() {
+    cross_file_rename_for_encoding("utf-8", 10, true);
+}
+
+#[test]
+fn cross_file_rename_uses_utf16_positions() {
+    cross_file_rename_for_encoding("utf-16", 8, true);
+}
+
+#[test]
+fn cross_file_rename_uses_utf32_positions() {
+    cross_file_rename_for_encoding("utf-32", 7, true);
+}
+
+#[test]
+fn cross_file_rename_requires_versioned_document_changes() {
+    cross_file_rename_for_encoding("utf-16", 8, false);
 }
 
 #[test]

--- a/crates/shuck-server/tests/manual.rs
+++ b/crates/shuck-server/tests/manual.rs
@@ -774,6 +774,169 @@ fn cross_file_hover_uses_exact_workspace_binding_and_open_buffers() {
 }
 
 #[test]
+fn cross_file_references_preserve_binding_identity_and_open_buffers() {
+    let (server_connection, client_connection) = Connection::memory();
+    let server_thread = thread::spawn(move || shuck_server::run_connection(server_connection));
+
+    let workspace = tempfile::tempdir().expect("tempdir should be created");
+    std::fs::write(
+        workspace.path().join("shuck.toml"),
+        "[lint]\nsource-paths = [\"lib\"]\n",
+    )
+    .unwrap();
+    std::fs::create_dir(workspace.path().join("lib")).unwrap();
+    let target_path = workspace.path().join("lib/a.sh");
+    let other_path = workspace.path().join("other.sh");
+    let caller_path = workspace.path().join("caller.sh");
+    let child_path = workspace.path().join("child.sh");
+    let hinted_path = workspace.path().join("hinted.sh");
+    let ambiguous_path = workspace.path().join("ambiguous.sh");
+    std::fs::write(&target_path, "stale() { :; }\n").unwrap();
+    std::fs::write(&other_path, "shared() { echo other; }\n").unwrap();
+    let caller_source = "source a.sh\nsource child.sh\nshared\nsource other.sh\nshared\n";
+    std::fs::write(&caller_path, caller_source).unwrap();
+    std::fs::write(&child_path, "shared\n").unwrap();
+    std::fs::write(
+        &hinted_path,
+        "# shuck: source=lib/a.sh\nsource \"$DIR/a.sh\"\nshared\n",
+    )
+    .unwrap();
+    std::fs::write(
+        &ambiguous_path,
+        "source a.sh\nsource \"$dynamic\"\nshared\n",
+    )
+    .unwrap();
+
+    let target_uri = Url::from_file_path(std::fs::canonicalize(&target_path).unwrap()).unwrap();
+    let caller_uri = Url::from_file_path(&caller_path).unwrap();
+    let child_uri = Url::from_file_path(std::fs::canonicalize(&child_path).unwrap()).unwrap();
+    let hinted_uri = Url::from_file_path(std::fs::canonicalize(&hinted_path).unwrap()).unwrap();
+    let ambiguous_uri =
+        Url::from_file_path(std::fs::canonicalize(&ambiguous_path).unwrap()).unwrap();
+    let other_uri = Url::from_file_path(std::fs::canonicalize(&other_path).unwrap()).unwrap();
+    let mut capabilities = serde_json::to_value(replay_capabilities()).unwrap();
+    capabilities["general"]["positionEncodings"] = serde_json::json!(["utf-8"]);
+
+    send_request(
+        &client_connection,
+        1,
+        "initialize",
+        serde_json::json!({
+            "capabilities": capabilities,
+            "rootUri": Url::from_file_path(workspace.path()).unwrap(),
+        }),
+    );
+    let initialize = recv_response(&client_connection, 1);
+    assert_eq!(initialize["capabilities"]["positionEncoding"], "utf-8");
+    client_connection
+        .sender
+        .send(Message::Notification(Notification::new(
+            "initialized".to_owned(),
+            serde_json::json!({}),
+        )))
+        .expect("initialized should send");
+    open_document(&client_connection, &target_uri, ": '😀'; shared() { :; }\n");
+    open_document(&client_connection, &caller_uri, caller_source);
+    open_document(&client_connection, &child_uri, "shared\n");
+
+    let reference_params = |uri: &Url, line, character, include_declaration| {
+        serde_json::json!({
+            "textDocument": { "uri": uri },
+            "position": { "line": line, "character": character },
+            "context": { "includeDeclaration": include_declaration },
+        })
+    };
+    send_request(
+        &client_connection,
+        2,
+        "textDocument/references",
+        reference_params(&caller_uri, 2, 0, true),
+    );
+    let with_declaration = recv_response(&client_connection, 2);
+    let locations = with_declaration
+        .as_array()
+        .unwrap_or_else(|| panic!("expected reference locations: {with_declaration:#}"));
+    assert_eq!(locations.len(), 4);
+    let target = locations
+        .iter()
+        .find(|location| location["uri"] == serde_json::json!(target_uri))
+        .expect("open-buffer declaration should be included");
+    assert_eq!(
+        target["range"]["start"],
+        serde_json::json!({ "line": 0, "character": 10 })
+    );
+    assert!(locations.iter().any(|location| {
+        location["uri"] == serde_json::json!(caller_uri) && location["range"]["start"]["line"] == 2
+    }));
+    assert!(locations.iter().any(|location| {
+        location["uri"] == serde_json::json!(child_uri) && location["range"]["start"]["line"] == 0
+    }));
+    assert!(locations.iter().any(|location| {
+        location["uri"] == serde_json::json!(hinted_uri) && location["range"]["start"]["line"] == 2
+    }));
+    assert!(locations.iter().all(|location| {
+        location["uri"] != serde_json::json!(ambiguous_uri)
+            && location["uri"] != serde_json::json!(other_uri)
+    }));
+
+    send_request(
+        &client_connection,
+        3,
+        "textDocument/references",
+        reference_params(&child_uri, 0, 0, false),
+    );
+    let without_declaration = recv_response(&client_connection, 3);
+    assert_eq!(without_declaration.as_array().map(Vec::len), Some(3));
+    assert!(
+        without_declaration
+            .as_array()
+            .unwrap()
+            .iter()
+            .all(|location| { location["uri"] != serde_json::json!(target_uri) })
+    );
+
+    send_request(
+        &client_connection,
+        4,
+        "textDocument/references",
+        reference_params(&target_uri, 0, 10, true),
+    );
+    assert_eq!(recv_response(&client_connection, 4), with_declaration);
+
+    client_connection
+        .sender
+        .send(Message::Notification(Notification::new(
+            "textDocument/didChange".to_owned(),
+            serde_json::json!({
+                "textDocument": { "uri": target_uri, "version": 2 },
+                "contentChanges": [{ "text": "renamed() { :; }\n" }],
+            }),
+        )))
+        .expect("didChange should send");
+    send_request(
+        &client_connection,
+        5,
+        "textDocument/references",
+        reference_params(&caller_uri, 2, 0, true),
+    );
+    assert!(recv_response(&client_connection, 5).is_null());
+
+    send_request(&client_connection, 99, "shutdown", serde_json::json!(null));
+    let _ = recv_response(&client_connection, 99);
+    client_connection
+        .sender
+        .send(Message::Notification(Notification::new(
+            "exit".to_owned(),
+            serde_json::json!({}),
+        )))
+        .expect("exit notification should send");
+    server_thread
+        .join()
+        .expect("server thread should join")
+        .expect("server should exit cleanly");
+}
+
+#[test]
 fn prepare_call_hierarchy_resolves_sourced_cross_file_call() {
     let (server_connection, client_connection) = Connection::memory();
     let server_thread = thread::spawn(move || shuck_server::run_connection(server_connection));

--- a/specs/023-lsp-editor-features.md
+++ b/specs/023-lsp-editor-features.md
@@ -2,14 +2,16 @@
 
 ## Status
 
-Implemented (document-local v1 plus sourced function completion, definition, and hover).
+Implemented (document-local v1 plus sourced function completion, definition,
+hover, and references).
 
 Delivered: completion, semantic hover, go-to-definition, references, document
 highlights, document and workspace symbols, conservative same-file rename, and
-document/range formatting. Function completion, definition, and hover also
-follow exact, statically resolved source edges. Cross-file rename remains
-deferred until closed-file edit safety is proven. Cross-file call hierarchy is
-specified separately in spec 025; other cross-file navigation remains deferred.
+document/range formatting. Function completion follows the statically
+resolvable source graph, while definition, hover, and references require exact
+source bindings. Cross-file rename remains deferred until closed-file edit
+safety is proven. Cross-file call hierarchy is specified separately in spec
+025; other cross-file navigation remains deferred.
 
 ## Summary
 
@@ -100,7 +102,7 @@ land:
 | Completion | `textDocument/completion`, `completionItem/resolve` | Variables, declaration names, runtime names, shell keywords, and functions visible locally or through unconditional static source edges |
 | Hover | `textDocument/hover` | Rule-code and semantic-symbol hovers, including exact function bindings through the statically resolved source graph |
 | Definition | `textDocument/definition` | Variables in the active analysis plus exact function definitions through the statically resolved source graph |
-| References | `textDocument/references` | References and definitions in the same proven symbol set |
+| References | `textDocument/references` | Exact function references through the statically resolved workspace graph; other symbols use the active analysis |
 | Document highlight | `textDocument/documentHighlight` | Read/write highlights for the symbol under the cursor |
 | Document symbols | `textDocument/documentSymbol` | Hierarchical symbols for functions plus top-level declarations and assignments |
 | Workspace symbols | `workspace/symbol` | Fuzzy search over indexed shell files in workspace folders |
@@ -314,6 +316,15 @@ References honor `ReferenceContext::include_declaration`:
 - `include_declaration = true`: include definition/write spans and read spans.
 - `include_declaration = false`: include only read-like references and call
   sites.
+
+For function bindings, the shared workspace index lazily builds a reverse map
+from exact definition identity to proven call tokens. Source order,
+redefinitions, cycles, valid source hints, configured source paths, and unsaved
+open buffers use the same fail-closed resolver as go-to-definition. Dynamic or
+ambiguous calls are omitted rather than name-matched. The reverse map is cached
+only after a complete, uncancelled build and is invalidated with the containing
+workspace index. A partial workspace index returns no cross-file reference set
+instead of presenting incomplete results as exhaustive.
 
 Document highlights are file-local and classify spans as:
 

--- a/specs/023-lsp-editor-features.md
+++ b/specs/023-lsp-editor-features.md
@@ -3,15 +3,15 @@
 ## Status
 
 Implemented (document-local v1 plus sourced function completion, definition,
-hover, and references).
+hover, references, and opt-in cross-file rename).
 
 Delivered: completion, semantic hover, go-to-definition, references, document
-highlights, document and workspace symbols, conservative same-file rename, and
+highlights, document and workspace symbols, conservative rename, and
 document/range formatting. Function completion follows the statically
-resolvable source graph, while definition, hover, and references require exact
-source bindings. Cross-file rename remains deferred until closed-file edit
-safety is proven. Cross-file call hierarchy is specified separately in spec
-025; other cross-file navigation remains deferred.
+resolvable source graph, while definition, hover, references, and opt-in
+cross-file function rename require exact source bindings. Cross-file call
+hierarchy is specified separately in spec 025; other cross-file navigation
+remains deferred.
 
 ## Summary
 
@@ -493,16 +493,17 @@ is true:
 
 ### Workspace Edits
 
-Rename and future cross-file quick fixes use `WorkspaceEdit` with
-`documentChanges` when the client supports them. Otherwise they fall back to
-the `changes` map. Edits are sorted by URI and descending start position within
-each document before conversion so overlapping edits can be detected and
-reported as an internal error during development.
+Document-local rename uses `WorkspaceEdit.documentChanges` when the client
+supports it and otherwise falls back to the `changes` map. Cross-file function
+rename requires `documentChanges` so every open-document edit carries the
+captured document version. Edits are sorted by URI and descending start
+position within each document before conversion so overlapping edits can be
+detected and rejected before any edit is returned.
 
 Closed-file edits are allowed only when the file was indexed from disk and the
 content hash still matches at edit construction time. If the file changed on
-disk since indexing, rename fails with `CrossFileUnindexed` and asks the user
-to retry after re-indexing.
+disk since indexing, rename fails with an `InvalidRequest` response and asks
+the user to retry after re-indexing.
 
 ### Request Scheduling
 
@@ -562,8 +563,8 @@ Defaults:
 
 - workspace symbols enabled, `max_files = 5000`;
 - runtime-name and keyword completions enabled;
-- cross-file rename disabled until source-closure-backed workspace edits have
-  enough black-box coverage.
+- cross-file function rename disabled by default and enabled with
+  `server.rename.allowCrossFile = true`.
 
 ### Implementation Stages
 
@@ -577,8 +578,8 @@ Defaults:
    same symbol target resolution.
 5. **Completion.** Add context classification and semantic completions.
 6. **Rename.** Add conservative rename sets, `prepareRename`, and same-file
-   `rename`; cross-file rename can be enabled after closed-file edit safety
-   is proven.
+   `rename`, then opt-in cross-file function rename once closed-file edit
+   safety and exact workspace references are available.
 
 Each stage must advertise only the capabilities implemented in that stage.
 
@@ -686,6 +687,8 @@ Manual editor black-box scenarios should cover:
   contents when a file is edited;
 - prepare-rename rejects positional parameters, special parameters, dynamic
   names, namerefs, imported bindings, and ambiguous references;
-- same-file rename edits only the proven symbol set;
+- rename edits only the proven symbol set; opt-in cross-file function rename
+  rejects partial indexes, ambiguous calls, stale files, out-of-workspace
+  dependencies, and overlapping edits;
 - formatting and range formatting return stable, minimal edits and do not
   publish diagnostics directly.

--- a/website/content/editors/index.mdx
+++ b/website/content/editors/index.mdx
@@ -23,7 +23,7 @@ files.
 | Document highlights | `textDocument/documentHighlight` | Read and write occurrences within the active document. |
 | Document symbols | `textDocument/documentSymbol` | Functions, declarations, and assignments from the active document. |
 | Workspace symbols | `workspace/symbol` | Fuzzy search over open buffers and discovered shell files in workspace folders, subject to a configurable file limit. |
-| Rename | `textDocument/prepareRename`, `textDocument/rename` | Conservative, semantically resolved edits within the active document. Cross-file rename is not supported. |
+| Rename | `textDocument/prepareRename`, `textDocument/rename` | Variables remain document-local. Function rename can span the exact statically resolved source graph when `server.rename.allowCrossFile` is enabled and the client supports `documentChanges`; open buffers then use versioned edits. Incomplete, ambiguous, stale, overlapping, or out-of-workspace edits are rejected atomically. |
 | Formatting | `textDocument/formatting`, `textDocument/rangeFormatting` | Whole-document formatting or the smallest complete statement containing the selected range. Incomplete syntactic fragments are left unchanged. |
 | Call hierarchy | `textDocument/prepareCallHierarchy`, `callHierarchy/incomingCalls`, `callHierarchy/outgoingCalls` | Preparation, incoming calls, and outgoing calls work across the statically resolvable source graph. Preparing on a sourced function call returns the exact target definition, including when a file redefines the same function name. Literal sources and valid `# shuck: source=` hints participate; runtime-only dispatch and unresolved dynamic sources do not. |
 
@@ -31,8 +31,6 @@ Editor formatting uses the same parser-backed formatter as [`shuck format`](/doc
 
 ### Planned or deferred
 
-- Cross-file rename is intentionally disabled until Shuck can prove safe edits
-  for every affected open or closed file.
 - Language-server support for embedded shell regions, such as scripts inside
   GitHub Actions YAML, needs a separate position-remapping design.
 

--- a/website/content/editors/index.mdx
+++ b/website/content/editors/index.mdx
@@ -19,7 +19,7 @@ files.
 | Completion | `textDocument/completion`, `completionItem/resolve` | Variables, declaration names, runtime names, builtins, shell keywords, and functions visible in the active document or through unconditional static `source`/`.` edges. Literal paths, valid source hints, configured source paths, and unsaved open buffers participate; dynamic or unresolved sources do not. Command-specific option completion is not supported. |
 | Hover | `textDocument/hover` | Semantic symbol information plus help for suppression codes in `# shuck:` and `# shellcheck` directives. Function calls can resolve through the same exact static source graph as go-to-definition, including source hints, configured source paths, and open buffers. Dynamic or ambiguous sources are not guessed, and Shuck does not fetch command manuals. |
 | Go to definition | `textDocument/definition` | Variables resolve within the active document. Function calls also resolve through literal sources, valid `# shuck: source=` hints, and configured source paths, with open buffers and shell source order taking precedence. Dynamic sources are not guessed. |
-| Find references | `textDocument/references` | The proven symbol set within the active document. Cross-file references are not currently indexed. |
+| Find references | `textDocument/references` | Variables remain document-local. Function references follow exact binding identity across the statically resolved source graph, including source hints, configured source paths, cycles, and open buffers. Dynamic or ambiguous calls are omitted, and `includeDeclaration` is honored. |
 | Document highlights | `textDocument/documentHighlight` | Read and write occurrences within the active document. |
 | Document symbols | `textDocument/documentSymbol` | Functions, declarations, and assignments from the active document. |
 | Workspace symbols | `workspace/symbol` | Fuzzy search over open buffers and discovered shell files in workspace folders, subject to a configurable file limit. |
@@ -33,7 +33,6 @@ Editor formatting uses the same parser-backed formatter as [`shuck format`](/doc
 
 - Cross-file rename is intentionally disabled until Shuck can prove safe edits
   for every affected open or closed file.
-- Cross-file references still need exact binding-aware workspace results; go-to-definition already uses the shared source graph for functions.
 - Language-server support for embedded shell regions, such as scripts inside
   GitHub Actions YAML, needs a separate position-remapping design.
 


### PR DESCRIPTION
## Summary

- find function references across statically resolved source graphs using exact definition identity
- reconcile inherited source environments while failing closed for dynamic or mutating binding contexts
- preserve open-buffer URIs, negotiated position encoding, cancellation, and bounded workspace indexing
- document cross-file reference behavior and limitations

## Verification

- `cargo test -p shuck-semantic -p shuck-server`
- `cargo clippy -p shuck-semantic -p shuck-server --all-targets --all-features --no-deps -- -D warnings -A clippy::question_mark`
- dedicated code-review subagent: no actionable findings after fixes and rebase

Closes #1206