### PR TITLE
feat(server): rename sourced functions

### DIFF
--- a/crates/shuck-semantic/src/call_facts.rs
+++ b/crates/shuck-semantic/src/call_facts.rs
@@ -395,6 +395,27 @@ pub struct ExactFunctionReference {
     pub span: Span,
 }
 
+/// Exact references and all indexed files whose source relationship can
+/// affect a cross-file function rename.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ExactFunctionRename {
+    /// Call tokens proven to resolve to the selected function binding.
+    pub references: Vec<ExactFunctionReference>,
+    /// Source-connected files whose snapshots must still match the index.
+    pub relevant_paths: Vec<PathBuf>,
+}
+
+/// Why an exact cross-file function rename set could not be proven.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ExactFunctionRenameError {
+    /// A same-named call in the relevant source graph has ambiguous binding
+    /// identity and therefore cannot be safely included or excluded.
+    AmbiguousReference,
+    /// A source operation in the relevant graph could not be resolved to a
+    /// file represented by the workspace index.
+    IncompleteSourceGraph,
+}
+
 type ExactReferenceIndex = FxHashMap<(PathBuf, CallNodeKind), Vec<ExactFunctionReference>>;
 
 #[derive(Clone, Debug)]
@@ -624,6 +645,28 @@ impl SourceGraphIndex {
 
     fn component_reaches(&self, from: usize, to: usize) -> bool {
         bit_is_set(&self.component_reachability[from], to)
+    }
+
+    fn source_environment_components(
+        &self,
+        target: usize,
+        is_cancelled: &impl Fn() -> bool,
+    ) -> Option<Vec<u64>> {
+        let mut shared = vec![0; self.component_reachability[target].len()];
+        for ancestor in 0..self.component_edges.len() {
+            if is_cancelled() {
+                return None;
+            }
+            if self.component_reaches(ancestor, target) {
+                for (word, reachable) in shared
+                    .iter_mut()
+                    .zip(&self.component_reachability[ancestor])
+                {
+                    *word |= reachable;
+                }
+            }
+        }
+        Some(shared)
     }
 }
 
@@ -1088,6 +1131,36 @@ impl WorkspaceCallIndex {
         context: &ExactWorkspaceContext,
         is_cancelled: &impl Fn() -> bool,
     ) -> Option<CrossFileCall> {
+        let (site, resolution) = self.call_site_exact_resolution_with_context(
+            from_path,
+            name_span,
+            context,
+            is_cancelled,
+        )?;
+        let ExactResolution::Defined(target) = resolution else {
+            return None;
+        };
+        let definition = self.files.get(&target.path).and_then(|facts| {
+            facts.definitions.iter().find(|definition| {
+                definition.name == site.callee && definition.def_span == target.def_span
+            })
+        });
+        Some(CrossFileCall {
+            path: target.path,
+            node: CallNodeKind::Function(CallFunctionId::new(site.callee.clone(), target.def_span)),
+            def_span: Some(target.def_span),
+            selection_span: definition.map(|definition| definition.selection_span),
+            call_spans: vec![site.name_span],
+        })
+    }
+
+    fn call_site_exact_resolution_with_context<'a>(
+        &'a self,
+        from_path: &Path,
+        name_span: Span,
+        context: &ExactWorkspaceContext,
+        is_cancelled: &impl Fn() -> bool,
+    ) -> Option<(&'a CallFactSite, ExactResolution)> {
         let facts = self.files.get(from_path)?;
         let site = facts
             .call_sites
@@ -1108,9 +1181,13 @@ impl WorkspaceCallIndex {
                 is_cancelled,
             ),
             CallNodeKind::Function(function) => {
-                if context
+                let may_mutate = context
                     .called_mutator_function_may_mutate(from_path, function, is_cancelled)
-                    .unwrap_or(true)
+                    .unwrap_or(true);
+                if is_cancelled() {
+                    return None;
+                }
+                if may_mutate
                     || self.top_level_prefix_may_invoke_source(
                         from_path,
                         function.definition_start,
@@ -1125,7 +1202,7 @@ impl WorkspaceCallIndex {
                                 && effect.span.start.offset >= site.name_span.start.offset)
                     })
                 {
-                    return None;
+                    return Some((site, ExactResolution::Ambiguous));
                 }
                 let resolution = self.resolve_exact_events(
                     from_path,
@@ -1157,26 +1234,15 @@ impl WorkspaceCallIndex {
                     &mut FxHashSet::default(),
                     is_cancelled,
                 ) {
-                    return None;
+                    if is_cancelled() {
+                        return None;
+                    }
+                    return Some((site, ExactResolution::Ambiguous));
                 }
                 resolution
             }
         };
-        let ExactResolution::Defined(target) = resolution else {
-            return None;
-        };
-        let definition = self.files.get(&target.path).and_then(|facts| {
-            facts.definitions.iter().find(|definition| {
-                definition.name == site.callee && definition.def_span == target.def_span
-            })
-        });
-        Some(CrossFileCall {
-            path: target.path,
-            node: CallNodeKind::Function(CallFunctionId::new(site.callee.clone(), target.def_span)),
-            def_span: Some(target.def_span),
-            selection_span: definition.map(|definition| definition.selection_span),
-            call_spans: vec![site.name_span],
-        })
+        (!is_cancelled()).then_some((site, resolution))
     }
 
     fn exact_workspace_context(
@@ -1386,6 +1452,90 @@ impl WorkspaceCallIndex {
                 .map(Vec::as_slice)
                 .unwrap_or(&[]),
         )
+    }
+
+    /// Builds the exact reference set required for a safe cross-file rename.
+    ///
+    /// In addition to returning proven references, this rejects a same-named
+    /// call in the source-connected graph when its binding identity is
+    /// ambiguous. The returned paths let callers verify that every snapshot
+    /// which influenced the proof is still current before emitting edits.
+    pub fn exact_function_rename(
+        &self,
+        target_path: &Path,
+        target_node: &CallNodeKind,
+        is_cancelled: impl Fn() -> bool,
+    ) -> Option<Result<ExactFunctionRename, ExactFunctionRenameError>> {
+        let CallNodeKind::Function(target_function) = target_node else {
+            return Some(Err(ExactFunctionRenameError::AmbiguousReference));
+        };
+        let context = self.exact_workspace_context(&is_cancelled)?;
+        let target_component = context.graph.component_for_path(target_path)?;
+        let source_environment = context
+            .graph
+            .source_environment_components(target_component, &is_cancelled)?;
+        let relevant_paths = context
+            .graph
+            .paths
+            .iter()
+            .enumerate()
+            .filter(|(node, _)| bit_is_set(&source_environment, context.graph.components[*node]))
+            .map(|(_, path)| path.clone())
+            .collect::<Vec<_>>();
+        let mut references = Vec::new();
+        for path in &relevant_paths {
+            if is_cancelled() {
+                return None;
+            }
+            let facts = self.files.get(path)?;
+            if facts.source_effects.iter().any(|effect| {
+                effect
+                    .path
+                    .as_ref()
+                    .is_none_or(|target| !self.files.contains_key(target))
+            }) {
+                return Some(Err(ExactFunctionRenameError::IncompleteSourceGraph));
+            }
+            for site in facts
+                .call_sites
+                .iter()
+                .filter(|site| site.callee == target_function.name)
+            {
+                let (_, resolution) = self.call_site_exact_resolution_with_context(
+                    path,
+                    site.name_span,
+                    context,
+                    &is_cancelled,
+                )?;
+                match resolution {
+                    ExactResolution::Defined(target)
+                        if target.path == target_path
+                            && target.def_span.start.offset == target_function.definition_start
+                            && target.def_span.end.offset == target_function.definition_end =>
+                    {
+                        references.push(ExactFunctionReference {
+                            path: path.clone(),
+                            span: site.name_span,
+                        });
+                    }
+                    ExactResolution::Defined(_) | ExactResolution::Absent => {}
+                    ExactResolution::Ambiguous => {
+                        return Some(Err(ExactFunctionRenameError::AmbiguousReference));
+                    }
+                }
+            }
+        }
+        references.sort_by(|left, right| {
+            left.path.cmp(&right.path).then_with(|| {
+                (left.span.start.offset, left.span.end.offset)
+                    .cmp(&(right.span.start.offset, right.span.end.offset))
+            })
+        });
+        references.dedup();
+        Some(Ok(ExactFunctionRename {
+            references,
+            relevant_paths,
+        }))
     }
 
     fn build_exact_reference_index(
@@ -2491,6 +2641,127 @@ mod tests {
     }
 
     #[test]
+    fn exact_function_rename_rejects_ambiguous_calls_in_the_source_graph() {
+        let target_path = PathBuf::from("/w/a.sh");
+        let caller_path = PathBuf::from("/w/caller.sh");
+        let mut index = WorkspaceCallIndex::new();
+        index.insert(target_path.clone(), facts("foo() { :; }\n", &[]));
+        index.insert(
+            caller_path,
+            facts_with_positioned_sources("if true; then source a.sh; fi\nfoo\n", &["/w/a.sh"]),
+        );
+
+        let target = function_node(&index, "/w/a.sh", "foo", 0);
+        assert_eq!(
+            index.exact_function_rename(&target_path, &target, || false),
+            Some(Err(ExactFunctionRenameError::AmbiguousReference))
+        );
+    }
+
+    #[test]
+    fn exact_function_rename_rejects_an_unresolved_source_edge() {
+        let target_path = PathBuf::from("/w/a.sh");
+        let mut index = WorkspaceCallIndex::new();
+        index.insert(
+            target_path.clone(),
+            facts("foo() { :; }\nfoo\nsource \"$dynamic\"\n", &[]),
+        );
+
+        let target = function_node(&index, "/w/a.sh", "foo", 0);
+        assert_eq!(
+            index.exact_function_rename(&target_path, &target, || false),
+            Some(Err(ExactFunctionRenameError::IncompleteSourceGraph))
+        );
+    }
+
+    #[test]
+    fn exact_function_rename_rejects_an_unindexed_source_target() {
+        let target_path = PathBuf::from("/w/a.sh");
+        let mut index = WorkspaceCallIndex::new();
+        index.insert(
+            target_path.clone(),
+            facts_with_positioned_sources(
+                "foo() { :; }\nfoo\nsource missing.sh\n",
+                &["/w/missing.sh"],
+            ),
+        );
+
+        let target = function_node(&index, "/w/a.sh", "foo", 0);
+        assert_eq!(
+            index.exact_function_rename(&target_path, &target, || false),
+            Some(Err(ExactFunctionRenameError::IncompleteSourceGraph))
+        );
+    }
+
+    #[test]
+    fn exact_function_rename_ignores_disconnected_ambiguous_calls() {
+        let target_path = PathBuf::from("/w/main.sh");
+        let unrelated_path = PathBuf::from("/w/unrelated.sh");
+        let main = facts("foo() { :; }\nfoo\n", &[]);
+        let call_span = main.call_sites[0].name_span;
+        let mut index = WorkspaceCallIndex::new();
+        index.insert(target_path.clone(), main);
+        index.insert(unrelated_path, facts("source \"$dynamic\"\nfoo\n", &[]));
+
+        let target = function_node(&index, "/w/main.sh", "foo", 0);
+        assert_eq!(
+            index
+                .exact_function_rename(&target_path, &target, || false)
+                .expect("rename analysis should complete")
+                .expect("disconnected ambiguity should not block rename"),
+            ExactFunctionRename {
+                references: vec![ExactFunctionReference {
+                    path: target_path.clone(),
+                    span: call_span,
+                }],
+                relevant_paths: vec![target_path],
+            }
+        );
+    }
+
+    #[test]
+    fn exact_function_rename_does_not_connect_files_through_a_shared_child() {
+        let target_path = PathBuf::from("/w/target.sh");
+        let unrelated_path = PathBuf::from("/w/unrelated.sh");
+        let common_path = PathBuf::from("/w/common.sh");
+        let target = facts_with_positioned_sources(
+            "source common.sh\nfoo() { :; }\nfoo\n",
+            &["/w/common.sh"],
+        );
+        let target_call = target
+            .call_sites
+            .iter()
+            .find(|site| site.callee == name("foo"))
+            .unwrap()
+            .name_span;
+        let mut index = WorkspaceCallIndex::new();
+        index.insert(target_path.clone(), target);
+        index.insert(
+            unrelated_path,
+            facts_with_positioned_sources(
+                "source common.sh\nsource \"$dynamic\"\nfoo\n",
+                &["/w/common.sh"],
+            ),
+        );
+        index.insert(common_path.clone(), facts(":\n", &[]));
+
+        let target = function_node(&index, "/w/target.sh", "foo", 0);
+        assert_eq!(
+            index
+                .exact_function_rename(&target_path, &target, || false)
+                .expect("rename analysis should complete")
+                .expect("a shared child must not import the target into its other parent"),
+            ExactFunctionRename {
+                references: vec![ExactFunctionReference {
+                    path: target_path.clone(),
+                    span: target_call,
+                }],
+                relevant_paths: vec![common_path, target_path],
+            }
+        );
+    }
+
+    #[test]
     fn exact_reference_index_inherits_bindings_at_source_sites() {
         let main_path = PathBuf::from("/w/main.sh");
         let child_path = PathBuf::from("/w/child.sh");
@@ -2803,6 +3074,16 @@ mod tests {
             .expect("retry should build a complete reverse index");
         assert_eq!(references.len(), 1);
         assert_eq!(references[0].path, caller_path);
+        assert!(
+            index
+                .exact_function_rename(&target_path, &target, || true)
+                .is_none()
+        );
+        let rename = index
+            .exact_function_rename(&target_path, &target, || false)
+            .expect("rename retry should complete")
+            .expect("rename retry should remain exact");
+        assert_eq!(rename.references, references);
     }
 
     #[test]

--- a/crates/shuck-semantic/src/lib.rs
+++ b/crates/shuck-semantic/src/lib.rs
@@ -44,8 +44,8 @@ pub use binding::{
 /// Workspace call-graph index types for cross-file call hierarchy.
 pub use call_facts::{
     CallFactDefinition, CallFactSite, CallFactSourceEdge, CallFunctionId, CallNodeKind,
-    CrossFileCall, ExactFunctionReference, FileCallFacts, VisibleSourcedFunction,
-    WorkspaceCallIndex,
+    CrossFileCall, ExactFunctionReference, ExactFunctionRename, ExactFunctionRenameError,
+    FileCallFacts, VisibleSourcedFunction, WorkspaceCallIndex,
 };
 pub use call_graph::{
     CallGraph, CallSite, OverwrittenFunction, UnreachedFunction, UnreachedFunctionReason,

--- a/crates/shuck-server/src/editor_features.rs
+++ b/crates/shuck-server/src/editor_features.rs
@@ -435,7 +435,6 @@ pub(crate) fn prepare_rename(
     _client: &Client,
     params: types::TextDocumentPositionParams,
 ) -> crate::server::Result<PrepareRenameResponse> {
-    reject_unsupported_cross_file_rename(&snapshot)?;
     let Some(analysis) = snapshot.analysis() else {
         return Ok(None);
     };
@@ -464,7 +463,6 @@ pub(crate) fn rename(
     _client: &Client,
     params: types::RenameParams,
 ) -> crate::server::Result<RenameResponse> {
-    reject_unsupported_cross_file_rename(&snapshot)?;
     let Some(analysis) = snapshot.analysis() else {
         return Ok(None);
     };
@@ -494,16 +492,6 @@ pub(crate) fn rename(
         &rename,
         &params.new_name,
     )))
-}
-
-fn reject_unsupported_cross_file_rename(snapshot: &DocumentSnapshot) -> crate::server::Result<()> {
-    if snapshot.client_settings().rename().allow_cross_file {
-        return Err(Error::new(
-            anyhow!("cross-file rename is not supported yet"),
-            ErrorCode::InvalidRequest,
-        ));
-    }
-    Ok(())
 }
 
 fn workspace_edit_for_rename(
@@ -635,7 +623,7 @@ fn valid_variable_name(name: &str) -> bool {
         && chars.all(|ch| ch == '_' || ch.is_ascii_alphanumeric())
 }
 
-fn valid_function_name(name: &str) -> bool {
+pub(crate) fn valid_function_name(name: &str) -> bool {
     !name.is_empty()
         && !name.chars().any(|ch| {
             ch.is_whitespace()
@@ -955,7 +943,7 @@ mod tests {
     }
 
     #[test]
-    fn rename_rejects_cross_file_mode_until_supported() {
+    fn cross_file_mode_keeps_local_variable_rename_available() {
         let source = "name=1\necho \"$name\"\n";
         let options = serde_json::from_value(serde_json::json!({
             "server": {
@@ -968,7 +956,7 @@ mod tests {
         let (snapshot, client, uri) = make_snapshot_with_options(source, options);
         let reference_position = position_for_nth(source, "name", 1);
 
-        let error = rename(
+        let edit = rename(
             snapshot,
             &client,
             RenameParams {
@@ -977,13 +965,15 @@ mod tests {
                 work_done_progress_params: WorkDoneProgressParams::default(),
             },
         )
-        .expect_err("cross-file rename mode should be rejected until supported");
-
-        assert_eq!(error.code as i32, ErrorCode::InvalidRequest as i32);
-        assert!(
-            error
-                .to_string()
-                .contains("cross-file rename is not supported yet")
+        .expect("local variable rename should still succeed")
+        .expect("local variable rename should return edits");
+        assert_eq!(
+            edit.changes
+                .expect("default test client should use changes")
+                .values()
+                .map(Vec::len)
+                .sum::<usize>(),
+            2
         );
     }
 

--- a/crates/shuck-server/src/server/api.rs
+++ b/crates/shuck-server/src/server/api.rs
@@ -81,7 +81,10 @@ pub(super) fn request(req: server::Request) -> Task {
             background_request_task::<request::Hover>(req, BackgroundSchedule::Worker)
         }
         request::PrepareRename::METHOD => {
-            background_request_task::<request::PrepareRename>(req, BackgroundSchedule::Worker)
+            background_session_request_task::<request::PrepareRename>(
+                req,
+                BackgroundSchedule::Worker,
+            )
         }
         request::References::METHOD => {
             background_session_request_task::<request::References>(
@@ -90,7 +93,7 @@ pub(super) fn request(req: server::Request) -> Task {
             )
         }
         request::Rename::METHOD => {
-            background_request_task::<request::Rename>(req, BackgroundSchedule::Worker)
+            background_session_request_task::<request::Rename>(req, BackgroundSchedule::Worker)
         }
         request::WorkspaceSymbols::METHOD => {
             background_session_request_task::<request::WorkspaceSymbols>(

--- a/crates/shuck-server/src/server/api/requests.rs
+++ b/crates/shuck-server/src/server/api/requests.rs
@@ -5,6 +5,7 @@ mod code_action;
 mod code_action_resolve;
 mod completion;
 mod completion_resolve;
+mod cross_file_rename;
 mod definition;
 mod diagnostic;
 mod document_highlight;

--- a/crates/shuck-server/src/server/api/requests/cross_file_rename.rs
+++ b/crates/shuck-server/src/server/api/requests/cross_file_rename.rs
@@ -1,0 +1,385 @@
+use std::collections::BTreeMap;
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use anyhow::anyhow;
+use lsp_server::ErrorCode;
+use lsp_types as types;
+use shuck_ast::Span;
+use shuck_semantic::{
+    BindingKind, CallFunctionId, CallNodeKind, EditorCallHierarchyTarget, EditorSymbolTarget,
+    ExactFunctionRenameError,
+};
+
+use crate::edit::RangeExt;
+use crate::editor_features;
+use crate::server::Error;
+use crate::session::{Client, DocumentSnapshot};
+use crate::workspace_functions::{
+    WorkspaceFunctionContext, WorkspaceFunctionIndex, canonical_path,
+    fresh_workspace_function_index,
+};
+
+enum FunctionResolution {
+    NotFunction,
+    Unavailable,
+    Resolved(ResolvedFunction),
+}
+
+struct ResolvedFunction {
+    index: Arc<WorkspaceFunctionIndex>,
+    target_path: PathBuf,
+    target_node: CallNodeKind,
+    declaration_span: Span,
+    editable_span: Span,
+    name: String,
+}
+
+pub(super) fn prepare(
+    snapshot: DocumentSnapshot,
+    workspace: WorkspaceFunctionContext,
+    client: &Client,
+    params: types::TextDocumentPositionParams,
+) -> crate::server::Result<editor_features::PrepareRenameResponse> {
+    if !snapshot.client_settings().rename().allow_cross_file {
+        return editor_features::prepare_rename(snapshot, client, params);
+    }
+    let position = params.position;
+    match resolve_function(&snapshot, &workspace, position)? {
+        FunctionResolution::NotFunction => {
+            editor_features::prepare_rename(snapshot, client, params)
+        }
+        FunctionResolution::Unavailable => Ok(None),
+        FunctionResolution::Resolved(target) => {
+            if !snapshot.resolved_client_capabilities().document_changes {
+                return Ok(None);
+            }
+            if collect_rename_spans(&target, &workspace).is_err() {
+                return Ok(None);
+            }
+            let Some(analysis) = snapshot.analysis() else {
+                return Ok(None);
+            };
+            Ok(Some(types::PrepareRenameResponse::RangeWithPlaceholder {
+                range: crate::edit::to_lsp_range(
+                    target.editable_span.to_range(),
+                    analysis.source(),
+                    analysis.line_index(),
+                    snapshot.encoding(),
+                ),
+                placeholder: target.name,
+            }))
+        }
+    }
+}
+
+pub(super) fn rename(
+    snapshot: DocumentSnapshot,
+    workspace: WorkspaceFunctionContext,
+    client: &Client,
+    params: types::RenameParams,
+) -> crate::server::Result<editor_features::RenameResponse> {
+    if !snapshot.client_settings().rename().allow_cross_file {
+        return editor_features::rename(snapshot, client, params);
+    }
+    let position = params.text_document_position.position;
+    let target = match resolve_function(&snapshot, &workspace, position)? {
+        FunctionResolution::NotFunction => {
+            return editor_features::rename(snapshot, client, params);
+        }
+        FunctionResolution::Unavailable => {
+            return Err(rename_error(
+                "the function binding is ambiguous or unavailable in the current workspace index",
+            ));
+        }
+        FunctionResolution::Resolved(target) => target,
+    };
+    if !snapshot.resolved_client_capabilities().document_changes {
+        return Err(rename_error(
+            "cross-file function rename requires client support for documentChanges",
+        ));
+    }
+    if !editor_features::valid_function_name(&params.new_name) {
+        return Err(Error::new(
+            anyhow!("new name is not valid for a shell function"),
+            ErrorCode::InvalidParams,
+        ));
+    }
+    let spans = collect_rename_spans(&target, &workspace).map_err(rename_error)?;
+    let edit = workspace_edit(&target.index, spans, &params.new_name);
+    validate_workspace_snapshot(&target.index, &workspace).map_err(rename_error)?;
+    Ok(Some(edit))
+}
+
+fn resolve_function(
+    snapshot: &DocumentSnapshot,
+    workspace: &WorkspaceFunctionContext,
+    position: types::Position,
+) -> crate::server::Result<FunctionResolution> {
+    let Some(analysis) = snapshot.analysis() else {
+        return Ok(FunctionResolution::Unavailable);
+    };
+    let offset = usize::from(
+        types::Range {
+            start: position,
+            end: position,
+        }
+        .to_text_range(
+            analysis.source(),
+            analysis.line_index(),
+            snapshot.encoding(),
+        )
+        .start(),
+    );
+    let Some(target) = analysis.semantic().editor_query().target_at_offset(offset) else {
+        return Ok(FunctionResolution::NotFunction);
+    };
+    let Some(path) = snapshot
+        .query()
+        .file_url()
+        .to_file_path()
+        .ok()
+        .map(|path| canonical_path(&path))
+    else {
+        return Ok(FunctionResolution::NotFunction);
+    };
+
+    let resolved = match target {
+        EditorSymbolTarget::FunctionCall(call) => {
+            let Some(index) = fresh_workspace_function_index(workspace) else {
+                return Ok(FunctionResolution::Unavailable);
+            };
+            let Some(target) =
+                index.resolve_call_site_exact(&path, call.name_span, &workspace.cancellation)
+            else {
+                return Ok(FunctionResolution::Unavailable);
+            };
+            let Some(declaration_span) = target.selection_span else {
+                return Ok(FunctionResolution::Unavailable);
+            };
+            ResolvedFunction {
+                index,
+                target_path: target.path,
+                target_node: target.node,
+                declaration_span,
+                editable_span: call.name_span,
+                name: call.name.to_string(),
+            }
+        }
+        EditorSymbolTarget::Binding(binding_id) => {
+            let binding = analysis.semantic().binding(binding_id);
+            if !matches!(binding.kind, BindingKind::FunctionDefinition) {
+                return Ok(FunctionResolution::NotFunction);
+            }
+            let Some(index) = fresh_workspace_function_index(workspace) else {
+                return Ok(FunctionResolution::Unavailable);
+            };
+            let Some(item) = analysis
+                .semantic()
+                .editor_query()
+                .prepare_call_hierarchy(offset)
+            else {
+                return Ok(FunctionResolution::Unavailable);
+            };
+            local_function(index, path, item, binding.span)?
+        }
+        EditorSymbolTarget::Reference(reference_id) => {
+            let Some(binding) = analysis.semantic().resolved_binding(reference_id) else {
+                return Ok(FunctionResolution::NotFunction);
+            };
+            if !matches!(binding.kind, BindingKind::FunctionDefinition) {
+                return Ok(FunctionResolution::NotFunction);
+            }
+            let Some(index) = fresh_workspace_function_index(workspace) else {
+                return Ok(FunctionResolution::Unavailable);
+            };
+            let Some(item) = analysis
+                .semantic()
+                .editor_query()
+                .prepare_call_hierarchy(offset)
+            else {
+                return Ok(FunctionResolution::Unavailable);
+            };
+            local_function(
+                index,
+                path,
+                item,
+                analysis.semantic().reference(reference_id).name_span,
+            )?
+        }
+        EditorSymbolTarget::RuntimeName(_) => return Ok(FunctionResolution::NotFunction),
+    };
+    Ok(FunctionResolution::Resolved(resolved))
+}
+
+fn local_function(
+    index: Arc<WorkspaceFunctionIndex>,
+    path: PathBuf,
+    item: shuck_semantic::EditorCallHierarchyItem,
+    editable_span: Span,
+) -> crate::server::Result<ResolvedFunction> {
+    let EditorCallHierarchyTarget::Function(_) = item.target else {
+        return Err(rename_error("the selected symbol is not a function"));
+    };
+    let Some(definition_span) = item.full_span else {
+        return Err(rename_error("the function definition has no source span"));
+    };
+    let Some(declaration_span) = item.selection_span else {
+        return Err(rename_error("the function name has no source span"));
+    };
+    Ok(ResolvedFunction {
+        index,
+        target_path: path,
+        target_node: CallNodeKind::Function(CallFunctionId::new(
+            item.name.clone(),
+            definition_span,
+        )),
+        declaration_span,
+        editable_span,
+        name: item.name.to_string(),
+    })
+}
+
+fn collect_rename_spans(
+    target: &ResolvedFunction,
+    workspace: &WorkspaceFunctionContext,
+) -> Result<BTreeMap<PathBuf, Vec<Span>>, String> {
+    if !target.index.is_complete() {
+        return Err(
+            "workspace indexing is incomplete; retry after the workspace is fully indexed".into(),
+        );
+    }
+    if workspace.cache.current_epoch() != workspace.epoch {
+        return Err("workspace state changed during rename; retry the request".into());
+    }
+    let Some(rename) = target.index.exact_function_rename(
+        &target.target_path,
+        &target.target_node,
+        &workspace.cancellation,
+    ) else {
+        return Err("the rename request was cancelled".into());
+    };
+    let rename = rename.map_err(|error| match error {
+        ExactFunctionRenameError::AmbiguousReference => {
+            "a same-named call in the source graph has ambiguous binding identity".to_owned()
+        }
+        ExactFunctionRenameError::IncompleteSourceGraph => {
+            "the source graph contains an unresolved or unindexed source operation".to_owned()
+        }
+    })?;
+    let roots = workspace
+        .workspace_roots
+        .iter()
+        .map(|root| canonical_path(root))
+        .collect::<Vec<_>>();
+    for path in &rename.relevant_paths {
+        if workspace.cancellation.is_cancelled() {
+            return Err("the rename request was cancelled".into());
+        }
+        if !roots.iter().any(|root| path.starts_with(root)) {
+            return Err(format!(
+                "the source graph reaches a file outside the workspace: {}",
+                path.display()
+            ));
+        }
+        if target.index.file(path).is_none() {
+            return Err(format!(
+                "a source-connected file is not indexed: {}",
+                path.display()
+            ));
+        }
+    }
+
+    let mut spans = BTreeMap::<PathBuf, Vec<Span>>::new();
+    spans
+        .entry(target.target_path.clone())
+        .or_default()
+        .push(target.declaration_span);
+    for reference in rename.references {
+        spans
+            .entry(reference.path)
+            .or_default()
+            .push(reference.span);
+    }
+    for (path, spans) in &mut spans {
+        spans.sort_by_key(|span| (span.start.offset, span.end.offset));
+        spans.dedup();
+        if spans
+            .windows(2)
+            .any(|pair| pair[0].end.offset > pair[1].start.offset)
+        {
+            return Err(format!(
+                "rename edits overlap in {}; no edits were produced",
+                path.display()
+            ));
+        }
+    }
+    validate_workspace_snapshot(&target.index, workspace)?;
+    Ok(spans)
+}
+
+fn validate_workspace_snapshot(
+    index: &WorkspaceFunctionIndex,
+    workspace: &WorkspaceFunctionContext,
+) -> Result<(), String> {
+    if workspace.cache.current_epoch() != workspace.epoch {
+        return Err("workspace state changed during rename; retry the request".into());
+    }
+    let Some(closed_files) = index.validate_closed_files(&workspace.cancellation) else {
+        return Err("the rename request was cancelled".into());
+    };
+    if let Err(path) = closed_files {
+        return Err(format!(
+            "an indexed file changed during rename: {}; retry the request",
+            path.display()
+        ));
+    }
+    if workspace.cache.current_epoch() != workspace.epoch {
+        return Err("workspace state changed during rename; retry the request".into());
+    }
+    Ok(())
+}
+
+fn workspace_edit(
+    index: &WorkspaceFunctionIndex,
+    spans_by_path: BTreeMap<PathBuf, Vec<Span>>,
+    new_name: &str,
+) -> types::WorkspaceEdit {
+    let mut document_edits = Vec::new();
+    for (path, mut spans) in spans_by_path {
+        let file = index
+            .file(&path)
+            .expect("rename spans should only reference validated indexed files");
+        spans.sort_by_key(|span| std::cmp::Reverse((span.start.offset, span.end.offset)));
+        let edits = spans
+            .into_iter()
+            .map(|span| {
+                types::TextEdit::new(
+                    crate::edit::to_lsp_range(
+                        span.to_range(),
+                        file.source(),
+                        file.line_index(),
+                        index.encoding(),
+                    ),
+                    new_name.to_owned(),
+                )
+            })
+            .collect::<Vec<_>>();
+        document_edits.push(types::TextDocumentEdit {
+            text_document: types::OptionalVersionedTextDocumentIdentifier {
+                uri: file.editor_uri().clone(),
+                version: file.version(),
+            },
+            edits: edits.into_iter().map(types::OneOf::Left).collect(),
+        });
+    }
+    types::WorkspaceEdit {
+        changes: None,
+        document_changes: Some(types::DocumentChanges::Edits(document_edits)),
+        change_annotations: None,
+    }
+}
+
+fn rename_error(message: impl Into<String>) -> Error {
+    Error::new(anyhow!(message.into()), ErrorCode::InvalidRequest)
+}

--- a/crates/shuck-server/src/server/api/requests/prepare_rename.rs
+++ b/crates/shuck-server/src/server/api/requests/prepare_rename.rs
@@ -1,33 +1,42 @@
 use lsp_types::{self as types, request as req};
 
 use crate::editor_features;
-use crate::session::{Client, DocumentSnapshot};
+use crate::session::{Client, DocumentSnapshot, RequestCancellationToken, Session};
+use crate::workspace_functions::WorkspaceFunctionContext;
 
 pub(crate) struct PrepareRename;
+
+pub(crate) struct PrepareRenameSnapshot {
+    document: Option<DocumentSnapshot>,
+    workspace: WorkspaceFunctionContext,
+}
 
 impl super::RequestHandler for PrepareRename {
     type RequestType = req::PrepareRenameRequest;
 }
 
-impl super::BackgroundDocumentRequestHandler for PrepareRename {
-    fn document_url(
-        params: &types::TextDocumentPositionParams,
-    ) -> std::borrow::Cow<'_, types::Url> {
-        std::borrow::Cow::Borrowed(&params.text_document.uri)
-    }
+impl super::super::traits::BackgroundRequestHandler for PrepareRename {
+    type Snapshot = PrepareRenameSnapshot;
 
-    fn run_without_snapshot(
-        _client: &Client,
-        _params: types::TextDocumentPositionParams,
-    ) -> crate::server::Result<editor_features::PrepareRenameResponse> {
-        Ok(None)
+    fn snapshot(
+        session: &Session,
+        params: &types::TextDocumentPositionParams,
+        cancellation: RequestCancellationToken,
+    ) -> crate::server::Result<Self::Snapshot> {
+        Ok(PrepareRenameSnapshot {
+            document: session.take_snapshot(params.text_document.uri.clone()),
+            workspace: session.workspace_function_context(cancellation),
+        })
     }
 
     fn run_with_snapshot(
-        snapshot: DocumentSnapshot,
+        snapshot: Self::Snapshot,
         client: &Client,
         params: types::TextDocumentPositionParams,
     ) -> crate::server::Result<editor_features::PrepareRenameResponse> {
-        editor_features::prepare_rename(snapshot, client, params)
+        let Some(document) = snapshot.document else {
+            return Ok(None);
+        };
+        super::cross_file_rename::prepare(document, snapshot.workspace, client, params)
     }
 }

--- a/crates/shuck-server/src/server/api/requests/rename.rs
+++ b/crates/shuck-server/src/server/api/requests/rename.rs
@@ -1,31 +1,43 @@
 use lsp_types::{self as types, request as req};
 
 use crate::editor_features;
-use crate::session::{Client, DocumentSnapshot};
+use crate::session::{Client, DocumentSnapshot, RequestCancellationToken, Session};
+use crate::workspace_functions::WorkspaceFunctionContext;
 
 pub(crate) struct Rename;
+
+pub(crate) struct RenameSnapshot {
+    document: Option<DocumentSnapshot>,
+    workspace: WorkspaceFunctionContext,
+}
 
 impl super::RequestHandler for Rename {
     type RequestType = req::Rename;
 }
 
-impl super::BackgroundDocumentRequestHandler for Rename {
-    fn document_url(params: &types::RenameParams) -> std::borrow::Cow<'_, types::Url> {
-        std::borrow::Cow::Borrowed(&params.text_document_position.text_document.uri)
-    }
+impl super::super::traits::BackgroundRequestHandler for Rename {
+    type Snapshot = RenameSnapshot;
 
-    fn run_without_snapshot(
-        _client: &Client,
-        _params: types::RenameParams,
-    ) -> crate::server::Result<editor_features::RenameResponse> {
-        Ok(None)
+    fn snapshot(
+        session: &Session,
+        params: &types::RenameParams,
+        cancellation: RequestCancellationToken,
+    ) -> crate::server::Result<Self::Snapshot> {
+        Ok(RenameSnapshot {
+            document: session
+                .take_snapshot(params.text_document_position.text_document.uri.clone()),
+            workspace: session.workspace_function_context(cancellation),
+        })
     }
 
     fn run_with_snapshot(
-        snapshot: DocumentSnapshot,
+        snapshot: Self::Snapshot,
         client: &Client,
         params: types::RenameParams,
     ) -> crate::server::Result<editor_features::RenameResponse> {
-        editor_features::rename(snapshot, client, params)
+        let Some(document) = snapshot.document else {
+            return Ok(None);
+        };
+        super::cross_file_rename::rename(document, snapshot.workspace, client, params)
     }
 }

--- a/crates/shuck-server/src/workspace_functions.rs
+++ b/crates/shuck-server/src/workspace_functions.rs
@@ -20,8 +20,8 @@ use shuck_config::{
 use shuck_indexer::LineIndex;
 use shuck_linter::ShellDialect;
 use shuck_semantic::{
-    CallFactSourceEdge, CallNodeKind, CrossFileCall, FileCallFacts, VisibleSourcedFunction,
-    WorkspaceCallIndex, source_ref_candidate_paths,
+    CallFactSourceEdge, CallNodeKind, CrossFileCall, ExactFunctionRename, ExactFunctionRenameError,
+    FileCallFacts, VisibleSourcedFunction, WorkspaceCallIndex, source_ref_candidate_paths,
 };
 
 use crate::PositionEncoding;
@@ -101,15 +101,34 @@ pub(crate) fn workspace_function_index(
     Some(built)
 }
 
+/// Builds a new index for a mutation request instead of trusting a cached
+/// discovery snapshot.
+///
+/// Cross-file edits need to observe closed files that changed without a file
+/// watcher notification, including files whose previous contents were not
+/// connected to the selected function. Epoch checks on both sides of the build
+/// reject concurrent session invalidation.
+pub(crate) fn fresh_workspace_function_index(
+    context: &WorkspaceFunctionContext,
+) -> Option<Arc<WorkspaceFunctionIndex>> {
+    if context.cancellation.is_cancelled() || context.cache.current_epoch() != context.epoch {
+        return None;
+    }
+    let built = Arc::new(WorkspaceFunctionIndex::build(context)?);
+    if context.cancellation.is_cancelled() || context.cache.current_epoch() != context.epoch {
+        return None;
+    }
+    context.cache.store(context.epoch, built.clone());
+    Some(built)
+}
+
 /// Source snapshot retained for one indexed file.
 pub(crate) struct IndexedWorkspaceFile {
     uri: types::Url,
     open_uri: Option<types::Url>,
     source: String,
     line_index: LineIndex,
-    #[allow(dead_code)] // Used by the upcoming cross-file rename safety check.
     version: Option<DocumentVersion>,
-    #[allow(dead_code)] // Used by the upcoming cross-file rename safety check.
     content_hash: [u8; 32],
 }
 
@@ -133,13 +152,11 @@ impl IndexedWorkspaceFile {
     }
 
     /// Open-document version captured by the request, or `None` for disk input.
-    #[allow(dead_code)]
     pub(crate) fn version(&self) -> Option<DocumentVersion> {
         self.version
     }
 
     /// SHA-256 of the exact content used to build semantic facts and ranges.
-    #[allow(dead_code)]
     pub(crate) fn content_hash(&self) -> [u8; 32] {
         self.content_hash
     }
@@ -150,7 +167,6 @@ pub(crate) struct WorkspaceFunctionIndex {
     graph: WorkspaceCallIndex,
     files: BTreeMap<PathBuf, IndexedWorkspaceFile>,
     encoding: PositionEncoding,
-    #[allow(dead_code)] // Mutation features must reject partial workspace indexes.
     complete: bool,
 }
 
@@ -375,6 +391,19 @@ impl WorkspaceFunctionIndex {
         Some(locations)
     }
 
+    pub(crate) fn exact_function_rename(
+        &self,
+        target_path: &Path,
+        target_node: &CallNodeKind,
+        cancellation: &RequestCancellationToken,
+    ) -> Option<Result<ExactFunctionRename, ExactFunctionRenameError>> {
+        if cancellation.is_cancelled() {
+            return None;
+        }
+        self.graph
+            .exact_function_rename(target_path, target_node, || cancellation.is_cancelled())
+    }
+
     pub(crate) fn visible_sourced_functions(
         &self,
         from_path: &Path,
@@ -414,6 +443,10 @@ impl WorkspaceFunctionIndex {
         ))
     }
 
+    pub(crate) fn encoding(&self) -> PositionEncoding {
+        self.encoding
+    }
+
     pub(crate) fn ranges_in(&self, path: &Path, spans: &[Span]) -> Vec<types::Range> {
         spans
             .iter()
@@ -423,14 +456,12 @@ impl WorkspaceFunctionIndex {
 
     /// Whether discovery and source-edge expansion completed within the file
     /// budget and without unreadable inputs.
-    #[allow(dead_code)]
     pub(crate) fn is_complete(&self) -> bool {
         self.complete
     }
 
     /// Returns whether a closed file still matches the content used to build
     /// this index. Open documents are versioned by the LSP session instead.
-    #[allow(dead_code)]
     pub(crate) fn closed_file_is_current(&self, path: &Path) -> bool {
         let Some(file) = self.file(path) else {
             return false;
@@ -441,6 +472,24 @@ impl WorkspaceFunctionIndex {
         std::fs::read(path)
             .map(|contents| content_hash(&contents) == file.content_hash())
             .unwrap_or(false)
+    }
+
+    /// Verifies every closed snapshot retained by this index, including files
+    /// which were disconnected from the selected binding when the index was
+    /// built. The outer `None` denotes cancellation.
+    pub(crate) fn validate_closed_files(
+        &self,
+        cancellation: &RequestCancellationToken,
+    ) -> Option<Result<(), PathBuf>> {
+        for (path, file) in &self.files {
+            if cancellation.is_cancelled() {
+                return None;
+            }
+            if file.version().is_none() && !self.closed_file_is_current(path) {
+                return Some(Err(path.clone()));
+            }
+        }
+        Some(Ok(()))
     }
 
     #[cfg(test)]
@@ -1000,8 +1049,16 @@ mod tests {
         };
         let built = WorkspaceFunctionIndex::build(&context).unwrap();
         assert!(built.closed_file_is_current(&file));
+        assert_eq!(
+            built.validate_closed_files(&context.cancellation),
+            Some(Ok(()))
+        );
         std::fs::write(&file, "two() { :; }\n").unwrap();
         assert!(!built.closed_file_is_current(&file));
+        assert_eq!(
+            built.validate_closed_files(&context.cancellation),
+            Some(Err(file))
+        );
     }
 
     #[test]

--- a/crates/shuck-server/tests/manual.rs
+++ b/crates/shuck-server/tests/manual.rs
@@ -1,7 +1,7 @@
 use std::thread;
 use std::time::Duration;
 
-use lsp_server::{Connection, Message, Notification, Request, RequestId};
+use lsp_server::{Connection, Message, Notification, Request, RequestId, Response};
 use lsp_types::{
     ClientCapabilities, CodeAction, CodeActionContext, CodeActionParams, DocumentDiagnosticParams,
     DocumentDiagnosticReport, DocumentDiagnosticReportResult, HoverParams, PartialResultParams,
@@ -21,6 +21,18 @@ fn send_request(connection: &Connection, id: i32, method: &str, params: serde_js
 }
 
 fn recv_response(connection: &Connection, id: i32) -> serde_json::Value {
+    let response = recv_lsp_response(connection, id);
+    assert!(
+        response.error.is_none(),
+        "unexpected LSP error: {:?}",
+        response.error
+    );
+    response
+        .result
+        .expect("successful response should carry a result")
+}
+
+fn recv_lsp_response(connection: &Connection, id: i32) -> Response {
     loop {
         let message = connection
             .receiver
@@ -28,14 +40,7 @@ fn recv_response(connection: &Connection, id: i32) -> serde_json::Value {
             .expect("server should respond");
         match message {
             Message::Response(response) if response.id == RequestId::from(id) => {
-                assert!(
-                    response.error.is_none(),
-                    "unexpected LSP error: {:?}",
-                    response.error
-                );
-                return response
-                    .result
-                    .expect("successful response should carry a result");
+                return response;
             }
             Message::Notification(_) => continue,
             Message::Request(request) => panic!(
@@ -286,6 +291,271 @@ fn open_document(connection: &Connection, uri: &Url, text: &str) {
             }),
         )))
         .expect("didOpen should send");
+}
+
+fn change_document(connection: &Connection, uri: &Url, version: i32, text: &str) {
+    connection
+        .sender
+        .send(Message::Notification(Notification::new(
+            "textDocument/didChange".to_owned(),
+            serde_json::json!({
+                "textDocument": { "uri": uri, "version": version },
+                "contentChanges": [{ "text": text }],
+            }),
+        )))
+        .expect("didChange should send");
+}
+
+fn cross_file_rename_for_encoding(
+    encoding: &str,
+    name_start: u64,
+    supports_document_changes: bool,
+) {
+    let (server_connection, client_connection) = Connection::memory();
+    let server_thread = thread::spawn(move || shuck_server::run_connection(server_connection));
+
+    let workspace = tempfile::tempdir().expect("tempdir should be created");
+    let lib = workspace.path().join("lib");
+    std::fs::create_dir(&lib).unwrap();
+    std::fs::write(
+        workspace.path().join("shuck.toml"),
+        "[lint]\nsource-paths = [\"lib\"]\n",
+    )
+    .unwrap();
+    let target_path = lib.join("target.sh");
+    let cycle_path = lib.join("cycle.sh");
+    let main_path = workspace.path().join("main.sh");
+    let caller_path = workspace.path().join("caller.sh");
+    let shadow_path = workspace.path().join("shadow.sh");
+    let unrelated_path = workspace.path().join("unrelated.sh");
+    let target_source = "source cycle.sh\n: '😀'; foo() { :; }\n";
+    let main_source = "# shuck: source=target.sh\nsource \"$DIR/target.sh\"\n: '😀'; foo\n";
+    let caller_source = "source main.sh\nfoo\n";
+    let shadow_source = "source main.sh\nfoo\nfoo() { :; }\nfoo\n";
+    std::fs::write(&target_path, "stale_target() { :; }\n").unwrap();
+    std::fs::write(&cycle_path, "source target.sh\n").unwrap();
+    std::fs::write(&main_path, "stale_main\n").unwrap();
+    std::fs::write(&caller_path, caller_source).unwrap();
+    std::fs::write(&shadow_path, shadow_source).unwrap();
+    std::fs::write(&unrelated_path, "foo() { :; }\nfoo\n").unwrap();
+
+    let target_uri = Url::from_file_path(&target_path).unwrap();
+    let main_uri = Url::from_file_path(&main_path).unwrap();
+    let caller_uri = Url::from_file_path(std::fs::canonicalize(&caller_path).unwrap()).unwrap();
+    let shadow_uri = Url::from_file_path(std::fs::canonicalize(&shadow_path).unwrap()).unwrap();
+    let unrelated_uri =
+        Url::from_file_path(std::fs::canonicalize(&unrelated_path).unwrap()).unwrap();
+
+    let mut capabilities = serde_json::to_value(replay_capabilities()).unwrap();
+    capabilities["general"]["positionEncodings"] = serde_json::json!([encoding]);
+    capabilities["workspace"]["workspaceEdit"]["documentChanges"] =
+        serde_json::json!(supports_document_changes);
+    send_request(
+        &client_connection,
+        1,
+        "initialize",
+        serde_json::json!({
+            "capabilities": capabilities,
+            "rootUri": Url::from_file_path(workspace.path()).unwrap(),
+            "initializationOptions": {
+                "shuck": { "server": { "rename": { "allowCrossFile": true } } }
+            },
+        }),
+    );
+    let initialize = recv_response(&client_connection, 1);
+    assert_eq!(initialize["capabilities"]["positionEncoding"], encoding);
+    client_connection
+        .sender
+        .send(Message::Notification(Notification::new(
+            "initialized".to_owned(),
+            serde_json::json!({}),
+        )))
+        .expect("initialized should send");
+    open_document(&client_connection, &target_uri, target_source);
+    open_document(&client_connection, &main_uri, main_source);
+
+    if !supports_document_changes {
+        send_request(
+            &client_connection,
+            2,
+            "textDocument/rename",
+            serde_json::json!({
+                "textDocument": { "uri": main_uri },
+                "position": { "line": 2, "character": name_start },
+                "newName": "unsafe_without_versions",
+            }),
+        );
+        let unsupported = recv_lsp_response(&client_connection, 2);
+        let unsupported_error = unsupported
+            .error
+            .expect("cross-file rename should require versioned document changes");
+        assert!(
+            unsupported_error
+                .message
+                .contains("requires client support")
+        );
+        send_request(&client_connection, 99, "shutdown", serde_json::json!(null));
+        let _ = recv_response(&client_connection, 99);
+        client_connection
+            .sender
+            .send(Message::Notification(Notification::new(
+                "exit".to_owned(),
+                serde_json::json!({}),
+            )))
+            .expect("exit notification should send");
+        server_thread
+            .join()
+            .expect("server thread should join")
+            .expect("server should exit cleanly");
+        return;
+    }
+
+    send_request(
+        &client_connection,
+        2,
+        "textDocument/prepareRename",
+        serde_json::json!({
+            "textDocument": { "uri": main_uri },
+            "position": { "line": 2, "character": name_start },
+        }),
+    );
+    let prepared = recv_response(&client_connection, 2);
+    assert_eq!(prepared["placeholder"], "foo");
+    assert_eq!(
+        prepared["range"],
+        serde_json::json!({
+            "start": { "line": 2, "character": name_start },
+            "end": { "line": 2, "character": name_start + 3 },
+        })
+    );
+
+    send_request(
+        &client_connection,
+        3,
+        "textDocument/rename",
+        serde_json::json!({
+            "textDocument": { "uri": main_uri },
+            "position": { "line": 2, "character": name_start },
+            "newName": "renamed",
+        }),
+    );
+    let rename = recv_response(&client_connection, 3);
+    let documents = rename["documentChanges"]
+        .as_array()
+        .expect("cross-file rename should use documentChanges");
+    assert_eq!(documents.len(), 4);
+    let document = |uri: &Url| {
+        documents
+            .iter()
+            .find(|document| document["textDocument"]["uri"] == uri.as_str())
+            .unwrap_or_else(|| panic!("missing rename edits for {uri}: {rename:#}"))
+    };
+    let target = document(&target_uri);
+    assert_eq!(target["textDocument"]["version"], 1);
+    assert_eq!(target["edits"].as_array().unwrap().len(), 1);
+    assert_eq!(
+        target["edits"][0]["range"]["start"]["character"],
+        name_start
+    );
+    let main = document(&main_uri);
+    assert_eq!(main["textDocument"]["version"], 1);
+    assert_eq!(main["edits"].as_array().unwrap().len(), 1);
+    let caller = document(&caller_uri);
+    assert!(caller["textDocument"]["version"].is_null());
+    assert_eq!(caller["edits"].as_array().unwrap().len(), 1);
+    let shadow = document(&shadow_uri);
+    assert!(shadow["textDocument"]["version"].is_null());
+    assert_eq!(shadow["edits"].as_array().unwrap().len(), 1);
+    assert!(
+        documents
+            .iter()
+            .all(|document| { document["textDocument"]["uri"] != unrelated_uri.as_str() })
+    );
+
+    std::fs::write(&unrelated_path, "source main.sh\nfoo\n").unwrap();
+    send_request(
+        &client_connection,
+        4,
+        "textDocument/rename",
+        serde_json::json!({
+            "textDocument": { "uri": main_uri },
+            "position": { "line": 2, "character": name_start },
+            "newName": "freshly_connected",
+        }),
+    );
+    let refreshed = recv_response(&client_connection, 4);
+    let refreshed_documents = refreshed["documentChanges"]
+        .as_array()
+        .expect("fresh rename should use documentChanges");
+    let newly_connected = refreshed_documents
+        .iter()
+        .find(|document| document["textDocument"]["uri"] == unrelated_uri.as_str())
+        .expect("fresh mutation index should include the newly connected closed file");
+    assert_eq!(newly_connected["edits"].as_array().unwrap().len(), 1);
+
+    std::fs::write(&unrelated_path, "foo() { :; }\nfoo\n").unwrap();
+    change_document(
+        &client_connection,
+        &main_uri,
+        2,
+        "# shuck: source=target.sh\nsource \"$DIR/target.sh\"\n: '😀'; foo\nsource \"$dynamic\"\n",
+    );
+    send_request(
+        &client_connection,
+        5,
+        "textDocument/rename",
+        serde_json::json!({
+            "textDocument": { "uri": main_uri },
+            "position": { "line": 2, "character": name_start },
+            "newName": "ambiguous_rejected",
+        }),
+    );
+    let unresolved = recv_lsp_response(&client_connection, 5);
+    let unresolved_error = unresolved
+        .error
+        .expect("unresolved source should fail rename");
+    assert!(
+        unresolved_error.message.contains("unresolved or unindexed")
+            || unresolved_error
+                .message
+                .contains("ambiguous binding identity"),
+        "unexpected unresolved-source error: {}",
+        unresolved_error.message
+    );
+
+    send_request(&client_connection, 99, "shutdown", serde_json::json!(null));
+    let _ = recv_response(&client_connection, 99);
+    client_connection
+        .sender
+        .send(Message::Notification(Notification::new(
+            "exit".to_owned(),
+            serde_json::json!({}),
+        )))
+        .expect("exit notification should send");
+    server_thread
+        .join()
+        .expect("server thread should join")
+        .expect("server should exit cleanly");
+}
+
+#[test]
+fn cross_file_rename_uses_utf8_positions() {
+    cross_file_rename_for_encoding("utf-8", 10, true);
+}
+
+#[test]
+fn cross_file_rename_uses_utf16_positions() {
+    cross_file_rename_for_encoding("utf-16", 8, true);
+}
+
+#[test]
+fn cross_file_rename_uses_utf32_positions() {
+    cross_file_rename_for_encoding("utf-32", 7, true);
+}
+
+#[test]
+fn cross_file_rename_requires_versioned_document_changes() {
+    cross_file_rename_for_encoding("utf-16", 8, false);
 }
 
 #[test]

--- a/specs/023-lsp-editor-features.md
+++ b/specs/023-lsp-editor-features.md
@@ -3,15 +3,14 @@
 ## Status
 
 Implemented (document-local v1 plus sourced function completion, definition,
-and references).
+references, and opt-in cross-file rename).
 
 Delivered: completion, semantic hover, go-to-definition, references, document
-highlights, document and workspace symbols, conservative same-file rename, and
+highlights, document and workspace symbols, conservative rename, and
 document/range formatting. Function completion follows the statically
-resolvable source graph, while definition and references require exact source
-bindings. Cross-file rename remains deferred until closed-file edit safety is
-proven. Cross-file call hierarchy is specified separately in spec 025; other
-cross-file navigation remains deferred.
+resolvable source graph, while definition, references, and opt-in cross-file
+function rename require exact source bindings. Cross-file call hierarchy is
+specified separately in spec 025; other cross-file navigation remains deferred.
 
 ## Summary
 
@@ -485,16 +484,17 @@ is true:
 
 ### Workspace Edits
 
-Rename and future cross-file quick fixes use `WorkspaceEdit` with
-`documentChanges` when the client supports them. Otherwise they fall back to
-the `changes` map. Edits are sorted by URI and descending start position within
-each document before conversion so overlapping edits can be detected and
-reported as an internal error during development.
+Document-local rename uses `WorkspaceEdit.documentChanges` when the client
+supports it and otherwise falls back to the `changes` map. Cross-file function
+rename requires `documentChanges` so every open-document edit carries the
+captured document version. Edits are sorted by URI and descending start
+position within each document before conversion so overlapping edits can be
+detected and rejected before any edit is returned.
 
 Closed-file edits are allowed only when the file was indexed from disk and the
 content hash still matches at edit construction time. If the file changed on
-disk since indexing, rename fails with `CrossFileUnindexed` and asks the user
-to retry after re-indexing.
+disk since indexing, rename fails with an `InvalidRequest` response and asks
+the user to retry after re-indexing.
 
 ### Request Scheduling
 
@@ -554,8 +554,8 @@ Defaults:
 
 - workspace symbols enabled, `max_files = 5000`;
 - runtime-name and keyword completions enabled;
-- cross-file rename disabled until source-closure-backed workspace edits have
-  enough black-box coverage.
+- cross-file function rename disabled by default and enabled with
+  `server.rename.allowCrossFile = true`.
 
 ### Implementation Stages
 
@@ -569,8 +569,8 @@ Defaults:
    same symbol target resolution.
 5. **Completion.** Add context classification and semantic completions.
 6. **Rename.** Add conservative rename sets, `prepareRename`, and same-file
-   `rename`; cross-file rename can be enabled after closed-file edit safety
-   is proven.
+   `rename`, then opt-in cross-file function rename once closed-file edit
+   safety and exact workspace references are available.
 
 Each stage must advertise only the capabilities implemented in that stage.
 
@@ -678,6 +678,8 @@ Manual editor black-box scenarios should cover:
   contents when a file is edited;
 - prepare-rename rejects positional parameters, special parameters, dynamic
   names, namerefs, imported bindings, and ambiguous references;
-- same-file rename edits only the proven symbol set;
+- rename edits only the proven symbol set; opt-in cross-file function rename
+  rejects partial indexes, ambiguous calls, stale files, out-of-workspace
+  dependencies, and overlapping edits;
 - formatting and range formatting return stable, minimal edits and do not
   publish diagnostics directly.

--- a/website/content/editors/index.mdx
+++ b/website/content/editors/index.mdx
@@ -23,7 +23,7 @@ files.
 | Document highlights | `textDocument/documentHighlight` | Read and write occurrences within the active document. |
 | Document symbols | `textDocument/documentSymbol` | Functions, declarations, and assignments from the active document. |
 | Workspace symbols | `workspace/symbol` | Fuzzy search over open buffers and discovered shell files in workspace folders, subject to a configurable file limit. |
-| Rename | `textDocument/prepareRename`, `textDocument/rename` | Conservative, semantically resolved edits within the active document. Cross-file rename is not supported. |
+| Rename | `textDocument/prepareRename`, `textDocument/rename` | Variables remain document-local. Function rename can span the exact statically resolved source graph when `server.rename.allowCrossFile` is enabled and the client supports `documentChanges`; open buffers then use versioned edits. Incomplete, ambiguous, stale, overlapping, or out-of-workspace edits are rejected atomically. |
 | Formatting | `textDocument/formatting`, `textDocument/rangeFormatting` | Whole-document formatting or the smallest complete statement containing the selected range. Incomplete syntactic fragments are left unchanged. |
 | Call hierarchy | `textDocument/prepareCallHierarchy`, `callHierarchy/incomingCalls`, `callHierarchy/outgoingCalls` | Preparation, incoming calls, and outgoing calls work across the statically resolvable source graph. Preparing on a sourced function call returns the exact target definition, including when a file redefines the same function name. Literal sources and valid `# shuck: source=` hints participate; runtime-only dispatch and unresolved dynamic sources do not. |
 
@@ -31,8 +31,6 @@ Editor formatting uses the same parser-backed formatter as [`shuck format`](/doc
 
 ### Planned or deferred
 
-- Cross-file rename is intentionally disabled until Shuck can prove safe edits
-  for every affected open or closed file.
 - Language-server support for embedded shell regions, such as scripts inside
   GitHub Actions YAML, needs a separate position-remapping design.
 


### PR DESCRIPTION
## Summary

- add opt-in cross-file function rename across the exact statically resolvable source graph
- preserve binding identity through source order, shadowing, cycles, source hints, and configured source paths
- fail closed for incomplete, ambiguous, unresolved, unindexed, stale, overlapping, or out-of-workspace edits
- build a fresh mutation index, validate the session epoch and every closed-file snapshot, and require versioned `documentChanges` for open buffers
- document the feature and cover UTF-8, UTF-16, UTF-32, cycles, fresh disconnected-file discovery, closed-file freshness, unresolved sources, and client capability handling

## Dependency

This draft is stacked on #1234 because exact cross-file references are a prerequisite. After #1234 merges, this branch should be rebased and the PR retargeted to `main` before merge.

## Validation

- `cargo test -p shuck-semantic -p shuck-server`
- `cargo clippy -p shuck-semantic -p shuck-server --all-targets --all-features --no-deps -- -D warnings -A clippy::question_mark`
- `cargo fmt --all -- --check`
- `git diff --check`
- dedicated code review, fixes applied, and clean re-review

Closes #1210