### PR TITLE
fix(server): use position accessors in sourced hover

### DIFF
--- a/crates/shuck-server/src/resolve.rs
+++ b/crates/shuck-server/src/resolve.rs
@@ -198,8 +198,8 @@ pub(crate) fn render_sourced_function_hover(
         "### {}\n\nFunction\n\nDefined in {} at line {}, column {}.\n\nScope: top-level.",
         markdown_code(hover.name),
         markdown_code(&definition_file),
-        hover.definition_span.start.line,
-        hover.definition_span.start.column,
+        hover.definition_span.start.line(),
+        hover.definition_span.start.column(),
     );
     types::Hover {
         contents: types::HoverContents::Markup(types::MarkupContent {


### PR DESCRIPTION
## Summary

- replace direct `Position.line` and `Position.column` field access in sourced-function hover rendering with the public accessor methods
- restore `shuck-server` compilation on `main` after #1233 landed on top of the position-storage refactor from #1230

## Root cause

#1233 was validated before #1230 reached `main`. Its hover renderer retained direct field access that became private after positions moved to the accessor-backed representation, causing E0616 in every main CI job that compiles `shuck-server`.

## Validation

- `cargo test -p shuck-server`
- `cargo clippy -p shuck-server --all-targets --all-features --no-deps -- -D warnings -A clippy::question_mark`
- `cargo fmt --all -- --check`
- `git diff --check`
- dedicated code review: no actionable findings

This fixes the failures in main CI run 30750250105.