### PR TITLE
feat(server): provide AST-based selection ranges

### DIFF
--- a/crates/shuck-indexer/src/lib.rs
+++ b/crates/shuck-indexer/src/lib.rs
@@ -23,6 +23,7 @@ mod comment_index;
 mod folding_range_index;
 mod line_index;
 mod region_index;
+mod selection_range_index;
 
 /// Structural close-delimiter lookup types derived from parser output.
 pub use close_delimiter_index::{CloseDelimiterIndex, CloseDelimiterKind, IndexedCloseDelimiter};
@@ -34,6 +35,8 @@ pub use folding_range_index::{FoldingRangeIndex, FoldingRangeKind, IndexedFoldin
 pub use line_index::{LineEndingStyle, LineIndex};
 /// Structural region indexes over parsed shell source.
 pub use region_index::{IndexedHeredoc, RegionIndex, RegionKind};
+/// Syntax-containment ranges used by editor selection expansion.
+pub use selection_range_index::SelectionRangeIndex;
 
 use line_index::{RawContinuationCandidate, RawContinuationMode};
 use shuck_ast::{File, TextSize};
@@ -49,6 +52,7 @@ use shuck_parser::parser::ParseResult;
 pub struct IndexerOptions {
     source_layout_indexes: bool,
     folding_ranges: bool,
+    selection_ranges: bool,
 }
 
 impl IndexerOptions {
@@ -74,7 +78,6 @@ impl IndexerOptions {
     pub fn source_layout_indexes(self) -> bool {
         self.source_layout_indexes
     }
-
     /// Enable or disable syntax-aware folding range collection.
     ///
     /// Folding data is intended for editor integrations and is disabled by
@@ -88,6 +91,20 @@ impl IndexerOptions {
     /// Return whether syntax-aware folding ranges are enabled.
     pub fn folding_ranges(self) -> bool {
         self.folding_ranges
+    }
+
+    /// Enable or disable syntax-containment collection for editor selections.
+    ///
+    /// This is disabled by default so lint-only consumers do not retain
+    /// editor-specific syntax range data.
+    pub fn with_selection_ranges(mut self, enabled: bool) -> Self {
+        self.selection_ranges = enabled;
+        self
+    }
+
+    /// Return whether syntax-containment selection ranges are enabled.
+    pub fn selection_ranges(self) -> bool {
+        self.selection_ranges
     }
 }
 
@@ -109,6 +126,7 @@ pub struct Indexer {
     close_delimiter_index: CloseDelimiterIndex,
     continuation_lines: Vec<TextSize>,
     folding_range_index: FoldingRangeIndex,
+    selection_range_index: SelectionRangeIndex,
 }
 
 impl Indexer {
@@ -155,6 +173,7 @@ impl Indexer {
             file,
             options.source_layout_indexes(),
             options.folding_ranges(),
+            options.selection_ranges(),
         );
         let close_delimiter_index = if options.source_layout_indexes() {
             CloseDelimiterIndex::new(source, file)
@@ -174,6 +193,11 @@ impl Indexer {
         } else {
             FoldingRangeIndex::default()
         };
+        let selection_range_index = if options.selection_ranges() {
+            SelectionRangeIndex::new(source, &comment_index, &region_index)
+        } else {
+            SelectionRangeIndex::default()
+        };
 
         Self {
             line_index,
@@ -182,6 +206,7 @@ impl Indexer {
             close_delimiter_index,
             continuation_lines,
             folding_range_index,
+            selection_range_index,
         }
     }
 
@@ -230,6 +255,11 @@ impl Indexer {
     /// Return stable syntax-aware folding ranges for this source file.
     pub fn folding_range_index(&self) -> &FoldingRangeIndex {
         &self.folding_range_index
+    }
+
+    /// Return syntax-containment ranges for editor selection expansion.
+    pub fn selection_range_index(&self) -> &SelectionRangeIndex {
+        &self.selection_range_index
     }
 
     /// Return whether `offset` is on a semantic continuation line.

--- a/crates/shuck-indexer/src/region_index.rs
+++ b/crates/shuck-indexer/src/region_index.rs
@@ -70,6 +70,7 @@ pub struct RegionIndex {
     expansion_brace_edges: Vec<TextSize>,
     dollar_brace_pairs: Vec<TextRange>,
     structural_folding_ranges: Vec<TextRange>,
+    selection_ranges: Vec<TextRange>,
 }
 
 impl RegionIndex {
@@ -80,7 +81,7 @@ impl RegionIndex {
     /// driven by AST spans from `file`. `source` and `file` should describe the
     /// same parsed text.
     pub fn new(source: &str, file: &File) -> Self {
-        Self::new_with_options(source, file, false, false)
+        Self::new_with_options(source, file, false, false, false)
     }
 
     /// Build a region index that also retains source-layout metadata.
@@ -90,7 +91,7 @@ impl RegionIndex {
     /// build an [`crate::Indexer`] with
     /// [`crate::IndexerOptions::with_source_layout_indexes`].
     pub fn with_source_layout_indexes(source: &str, file: &File) -> Self {
-        Self::new_with_options(source, file, true, false)
+        Self::new_with_options(source, file, true, false, false)
     }
 
     pub(crate) fn new_with_options(
@@ -98,8 +99,14 @@ impl RegionIndex {
         file: &File,
         source_layout_indexes: bool,
         folding_ranges: bool,
+        selection_ranges: bool,
     ) -> Self {
-        let mut collector = RegionCollector::new(source, source_layout_indexes, folding_ranges);
+        let mut collector = RegionCollector::new(
+            source,
+            source_layout_indexes,
+            folding_ranges,
+            selection_ranges,
+        );
         collector.visit_file(file);
         collector.finish()
     }
@@ -239,9 +246,12 @@ impl RegionIndex {
             .copied()
             .filter(|pair| pair.start() < range.end())
     }
-
     pub(crate) fn structural_folding_ranges(&self) -> &[TextRange] {
         &self.structural_folding_ranges
+    }
+
+    pub(crate) fn selection_ranges(&self) -> &[TextRange] {
+        &self.selection_ranges
     }
 }
 
@@ -249,6 +259,7 @@ struct RegionCollector<'a> {
     _source: &'a str,
     source_layout_indexes: bool,
     collect_folding_ranges: bool,
+    collect_selection_ranges: bool,
     single_quoted: Vec<TextRange>,
     double_quoted: Vec<TextRange>,
     heredocs: Vec<TextRange>,
@@ -261,14 +272,21 @@ struct RegionCollector<'a> {
     expansion_brace_edges: Vec<TextSize>,
     dollar_brace_pairs: Vec<TextRange>,
     structural_folding_ranges: Vec<TextRange>,
+    selection_ranges: Vec<TextRange>,
 }
 
 impl<'a> RegionCollector<'a> {
-    fn new(source: &'a str, source_layout_indexes: bool, collect_folding_ranges: bool) -> Self {
+    fn new(
+        source: &'a str,
+        source_layout_indexes: bool,
+        collect_folding_ranges: bool,
+        collect_selection_ranges: bool,
+    ) -> Self {
         Self {
             _source: source,
             source_layout_indexes,
             collect_folding_ranges,
+            collect_selection_ranges,
             single_quoted: Vec::new(),
             double_quoted: Vec::new(),
             heredocs: Vec::new(),
@@ -281,6 +299,7 @@ impl<'a> RegionCollector<'a> {
             expansion_brace_edges: Vec::new(),
             dollar_brace_pairs: Vec::new(),
             structural_folding_ranges: Vec::new(),
+            selection_ranges: Vec::new(),
         }
     }
 
@@ -307,6 +326,8 @@ impl<'a> RegionCollector<'a> {
             .dedup_by_key(|range| (range.start(), range.end()));
         sort_ranges(&mut self.structural_folding_ranges);
         self.structural_folding_ranges.dedup();
+        sort_ranges(&mut self.selection_ranges);
+        self.selection_ranges.dedup();
 
         let mut regions = Vec::with_capacity(
             self.single_quoted.len()
@@ -378,14 +399,17 @@ impl<'a> RegionCollector<'a> {
             expansion_brace_edges: self.expansion_brace_edges,
             dollar_brace_pairs: self.dollar_brace_pairs,
             structural_folding_ranges: self.structural_folding_ranges,
+            selection_ranges: self.selection_ranges,
         }
     }
 
     fn visit_file(&mut self, file: &File) {
+        self.push_selection_range(file.span.to_range());
         self.visit_stmt_seq(&file.body);
     }
 
     fn visit_stmt_seq(&mut self, commands: &StmtSeq) {
+        self.push_selection_range(commands.span.to_range());
         for stmt in commands.iter() {
             self.visit_stmt(stmt);
         }
@@ -396,6 +420,7 @@ impl<'a> RegionCollector<'a> {
     }
 
     fn visit_stmt_with_folding(&mut self, stmt: &Stmt, record_folding_range: bool) {
+        self.push_selection_range(stmt.span.to_range());
         for redirect in &stmt.redirects {
             self.visit_redirect(redirect);
         }
@@ -408,6 +433,7 @@ impl<'a> RegionCollector<'a> {
         statement_range: TextRange,
         record_folding_range: bool,
     ) {
+        self.push_selection_range(command_range(command));
         match command {
             Command::Simple(command) => {
                 self.visit_word(&command.name);
@@ -565,6 +591,16 @@ impl<'a> RegionCollector<'a> {
             }
             CompoundCommand::ArithmeticFor(command) => {
                 self.push_arithmetic_range(command);
+                for expression in [
+                    command.init_ast.as_ref(),
+                    command.condition_ast.as_ref(),
+                    command.step_ast.as_ref(),
+                ]
+                .into_iter()
+                .flatten()
+                {
+                    self.visit_arithmetic_shell_words(expression);
+                }
                 self.visit_stmt_seq(&command.body);
             }
             CompoundCommand::While(command) => {
@@ -599,6 +635,9 @@ impl<'a> RegionCollector<'a> {
             }
             CompoundCommand::Arithmetic(command) => {
                 push_range(&mut self.arithmetic, command.span.to_range());
+                if let Some(expression) = command.expr_ast.as_ref() {
+                    self.visit_arithmetic_shell_words(expression);
+                }
             }
             CompoundCommand::Time(command) => {
                 if let Some(command) = &command.command {
@@ -700,6 +739,7 @@ impl<'a> RegionCollector<'a> {
     }
 
     fn visit_conditional_expr(&mut self, expression: &ConditionalExpr) {
+        self.push_selection_range(expression.span().to_range());
         match expression {
             ConditionalExpr::Binary(expression) => {
                 self.visit_conditional_expr(&expression.left);
@@ -716,6 +756,7 @@ impl<'a> RegionCollector<'a> {
     }
 
     fn visit_redirect(&mut self, redirect: &Redirect) {
+        self.push_selection_range(redirect.span.to_range());
         match redirect.kind {
             RedirectKind::HereDoc | RedirectKind::HereDocStrip => {
                 let Some(heredoc) = redirect.heredoc() else {
@@ -751,6 +792,7 @@ impl<'a> RegionCollector<'a> {
     }
 
     fn visit_assignment(&mut self, assignment: &Assignment) {
+        self.push_selection_range(assignment.span.to_range());
         self.visit_var_ref_subscript(&assignment.target);
         match &assignment.value {
             AssignmentValue::Scalar(word) => self.visit_word(word),
@@ -770,7 +812,9 @@ impl<'a> RegionCollector<'a> {
     }
 
     fn visit_word(&mut self, word: &Word) {
+        self.push_selection_range(word.span.to_range());
         for brace in word.brace_syntax.iter().copied() {
+            self.push_selection_range(brace.span.to_range());
             if brace.expands() {
                 self.push_expansion_brace_pair(brace.span.to_range());
             }
@@ -925,15 +969,18 @@ impl<'a> RegionCollector<'a> {
     }
 
     fn visit_heredoc_body(&mut self, body: &HeredocBody) {
+        self.push_selection_range(body.span.to_range());
         self.visit_heredoc_body_parts(&body.parts);
     }
 
     fn visit_pattern(&mut self, pattern: &Pattern) {
+        self.push_selection_range(pattern.span.to_range());
         self.visit_pattern_parts(&pattern.parts);
     }
 
     fn visit_pattern_parts(&mut self, parts: &[PatternPartNode]) {
         for part in parts {
+            self.push_selection_range(part.span.to_range());
             match &part.kind {
                 PatternPart::Group { patterns, .. } => {
                     for pattern in patterns {
@@ -952,6 +999,7 @@ impl<'a> RegionCollector<'a> {
     fn visit_word_parts(&mut self, parts: &[WordPartNode]) {
         for part in parts {
             let range = part.span.to_range();
+            self.push_selection_range(range);
             match &part.kind {
                 WordPart::ZshQualifiedGlob(glob) => {
                     for segment in &glob.segments {
@@ -1062,6 +1110,7 @@ impl<'a> RegionCollector<'a> {
     fn visit_heredoc_body_parts(&mut self, parts: &[HeredocBodyPartNode]) {
         for part in parts {
             let range = part.span.to_range();
+            self.push_selection_range(range);
             match &part.kind {
                 HeredocBodyPart::CommandSubstitution { body, syntax } => {
                     push_range(&mut self.command_substitutions, range);
@@ -1090,6 +1139,8 @@ impl<'a> RegionCollector<'a> {
     }
 
     fn visit_var_ref_subscript(&mut self, reference: &VarRef) {
+        self.push_selection_range(reference.name_span.to_range());
+        self.push_selection_range(reference.span.to_range());
         self.visit_subscript(reference.subscript.as_deref());
     }
 
@@ -1097,6 +1148,7 @@ impl<'a> RegionCollector<'a> {
         let Some(subscript) = subscript else {
             return;
         };
+        self.push_selection_range(subscript.span().to_range());
         if subscript.selector().is_some() {
             return;
         }
@@ -1117,6 +1169,7 @@ impl<'a> RegionCollector<'a> {
     }
 
     fn visit_arithmetic_shell_words(&mut self, expression: &shuck_ast::ArithmeticExprNode) {
+        self.push_selection_range(expression.span.to_range());
         match &expression.kind {
             shuck_ast::ArithmeticExpr::Number(_) | shuck_ast::ArithmeticExpr::Variable(_) => {}
             shuck_ast::ArithmeticExpr::Indexed { index, .. } => {
@@ -1150,6 +1203,55 @@ impl<'a> RegionCollector<'a> {
                 self.visit_arithmetic_shell_words(value);
             }
         }
+    }
+
+    fn push_selection_range(&mut self, range: TextRange) {
+        if self.collect_selection_ranges {
+            push_range(&mut self.selection_ranges, range);
+        }
+    }
+}
+
+fn command_range(command: &Command) -> TextRange {
+    match command {
+        Command::Simple(command) => command.span.to_range(),
+        Command::Builtin(command) => builtin_range(command),
+        Command::Decl(command) => command.span.to_range(),
+        Command::Binary(command) => command.span.to_range(),
+        Command::Compound(command) => compound_range(command),
+        Command::Function(command) => command.span.to_range(),
+        Command::AnonymousFunction(command) => command.span.to_range(),
+    }
+}
+
+fn builtin_range(command: &BuiltinCommand) -> TextRange {
+    match command {
+        BuiltinCommand::Break(command) => command.span.to_range(),
+        BuiltinCommand::Continue(command) => command.span.to_range(),
+        BuiltinCommand::Return(command) => command.span.to_range(),
+        BuiltinCommand::Exit(command) => command.span.to_range(),
+    }
+}
+
+fn compound_range(command: &CompoundCommand) -> TextRange {
+    match command {
+        CompoundCommand::If(command) => command.span.to_range(),
+        CompoundCommand::For(command) => command.span.to_range(),
+        CompoundCommand::Repeat(command) => command.span.to_range(),
+        CompoundCommand::Foreach(command) => command.span.to_range(),
+        CompoundCommand::ArithmeticFor(command) => command.span.to_range(),
+        CompoundCommand::While(command) => command.span.to_range(),
+        CompoundCommand::Until(command) => command.span.to_range(),
+        CompoundCommand::Case(command) => command.span.to_range(),
+        CompoundCommand::Select(command) => command.span.to_range(),
+        CompoundCommand::Subshell(sequence) | CompoundCommand::BraceGroup(sequence) => {
+            sequence.span.to_range()
+        }
+        CompoundCommand::Arithmetic(command) => command.span.to_range(),
+        CompoundCommand::Time(command) => command.span.to_range(),
+        CompoundCommand::Conditional(command) => command.span.to_range(),
+        CompoundCommand::Coproc(command) => command.span.to_range(),
+        CompoundCommand::Always(command) => command.span.to_range(),
     }
 }
 

--- a/crates/shuck-indexer/src/selection_range_index.rs
+++ b/crates/shuck-indexer/src/selection_range_index.rs
@@ -1,0 +1,204 @@
+use std::cmp::Reverse;
+
+use shuck_ast::{TextRange, TextSize};
+
+use crate::{CommentIndex, RegionIndex};
+
+/// Precomputed syntax spans used to expand editor selections.
+///
+/// The index stores parser-owned ranges in source order. Queries return one
+/// strict containment chain from the smallest syntax range at an offset to the
+/// full file range, with equal spans removed.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct SelectionRangeIndex {
+    ranges: Vec<TextRange>,
+    file_range: TextRange,
+}
+
+impl SelectionRangeIndex {
+    pub(crate) fn new(
+        source: &str,
+        comment_index: &CommentIndex,
+        region_index: &RegionIndex,
+    ) -> Self {
+        let file_range = TextRange::new(TextSize::new(0), TextSize::new(source.len() as u32));
+        let mut ranges = region_index.selection_ranges().to_vec();
+        ranges.extend(comment_index.comments().iter().map(|comment| comment.range));
+        ranges.push(file_range);
+        ranges.retain(|range| valid_range(source, *range));
+        ranges.sort_unstable_by_key(|range| (range.start(), range.end()));
+        ranges.dedup();
+
+        Self { ranges, file_range }
+    }
+
+    /// Return a strict inner-to-outer syntax containment chain for `offset`.
+    ///
+    /// Offsets past the end of the source are clamped to the file boundary.
+    /// Whitespace, malformed syntax, and EOF always retain the file range even
+    /// when no smaller parser-owned node contains the requested position.
+    pub fn selection_chain(&self, offset: TextSize) -> Vec<TextRange> {
+        let offset = TextSize::new(offset.to_u32().min(self.file_range.end().to_u32()));
+        let end = self.ranges.partition_point(|range| range.start() <= offset);
+        let mut candidates = self.ranges[..end]
+            .iter()
+            .copied()
+            .filter(|range| contains_offset(*range, offset) || *range == self.file_range)
+            .collect::<Vec<_>>();
+        candidates.sort_unstable_by_key(|range| {
+            (range.len().to_u32(), Reverse(range.start()), range.end())
+        });
+        candidates.dedup();
+
+        let mut chain = Vec::with_capacity(candidates.len());
+        for candidate in candidates {
+            let Some(inner) = chain.last().copied() else {
+                chain.push(candidate);
+                continue;
+            };
+            if strictly_contains(candidate, inner) {
+                chain.push(candidate);
+            }
+        }
+
+        if chain.last().copied() != Some(self.file_range) {
+            chain.push(self.file_range);
+        }
+        chain
+    }
+}
+
+fn valid_range(source: &str, range: TextRange) -> bool {
+    let start = usize::from(range.start());
+    let end = usize::from(range.end());
+    start <= end
+        && end <= source.len()
+        && source.is_char_boundary(start)
+        && source.is_char_boundary(end)
+}
+
+fn contains_offset(range: TextRange, offset: TextSize) -> bool {
+    range.start() <= offset && offset < range.end()
+}
+
+fn strictly_contains(outer: TextRange, inner: TextRange) -> bool {
+    outer != inner && outer.start() <= inner.start() && inner.end() <= outer.end()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{Indexer, IndexerOptions};
+    use shuck_parser::{ShellDialect, parser::Parser};
+
+    fn index(source: &str) -> Indexer {
+        let parsed = Parser::with_dialect(source, ShellDialect::Bash).parse();
+        Indexer::new_with_options(
+            source,
+            &parsed,
+            IndexerOptions::new().with_selection_ranges(true),
+        )
+    }
+
+    fn assert_strict_chain(chain: &[TextRange]) {
+        assert!(!chain.is_empty());
+        for pair in chain.windows(2) {
+            assert!(
+                strictly_contains(pair[1], pair[0]),
+                "selection chain is not strict: {chain:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn expands_nested_substitutions_through_commands_and_file() {
+        let source = "foo() {\n  printf '%s\\n' \"$(echo \"${arr[$((i + 1))]}\")\"\n}\n";
+        let indexer = index(source);
+        let offset = TextSize::new(source.find("i + 1").unwrap() as u32);
+        let chain = indexer.selection_range_index().selection_chain(offset);
+
+        assert_strict_chain(&chain);
+        assert!(
+            chain.len() >= 6,
+            "selection chain was too shallow: {chain:?}"
+        );
+        assert_eq!(
+            chain.last().copied(),
+            Some(TextRange::new(
+                TextSize::new(0),
+                TextSize::new(source.len() as u32)
+            ))
+        );
+    }
+
+    #[test]
+    fn handles_comments_whitespace_heredocs_and_malformed_input() {
+        let source = "# comment\n\ncat <<EOF\nbody $value\nEOF\n";
+        let indexer = index(source);
+
+        let comment = indexer
+            .selection_range_index()
+            .selection_chain(TextSize::new(2));
+        assert_strict_chain(&comment);
+        assert_eq!(comment[0].start(), TextSize::new(0));
+
+        let whitespace = indexer
+            .selection_range_index()
+            .selection_chain(TextSize::new("# comment\n".len() as u32));
+        assert_strict_chain(&whitespace);
+
+        let heredoc = indexer
+            .selection_range_index()
+            .selection_chain(TextSize::new(source.find("$value").unwrap() as u32));
+        assert_strict_chain(&heredoc);
+        assert!(
+            heredoc.len() >= 3,
+            "heredoc chain was too shallow: {heredoc:?}"
+        );
+
+        for malformed in ["if true; then\n  echo nope\n", "echo ok\r\n"] {
+            let indexer = index(malformed);
+            let chain = indexer
+                .selection_range_index()
+                .selection_chain(TextSize::new(malformed.len() as u32));
+            assert_strict_chain(&chain);
+            assert_eq!(chain.len(), 1);
+        }
+    }
+
+    #[test]
+    fn expands_conditional_and_redirect_expressions() {
+        let source = "if [[ -n \"${value}\" ]]; then\n  printf '%s\\n' \"$value\" >\"$out\"\nfi\n";
+        let indexer = index(source);
+
+        for needle in ["value", "out"] {
+            let offset = TextSize::new(source.rfind(needle).unwrap() as u32);
+            let chain = indexer.selection_range_index().selection_chain(offset);
+            assert_strict_chain(&chain);
+            assert!(
+                chain.len() >= 4,
+                "selection chain for {needle:?} was too shallow: {chain:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn expands_standalone_and_loop_arithmetic_expressions() {
+        for (source, needle) in [
+            ("((total += arr[index + 1]))\n", "index"),
+            (
+                "for ((i = 0; i < limits[index]; i++)); do\n  :\ndone\n",
+                "index",
+            ),
+        ] {
+            let indexer = index(source);
+            let offset = TextSize::new(source.find(needle).unwrap() as u32);
+            let chain = indexer.selection_range_index().selection_chain(offset);
+            assert_strict_chain(&chain);
+            assert!(
+                chain.len() >= 4,
+                "arithmetic selection chain was too shallow: {chain:?}"
+            );
+        }
+    }
+}

--- a/crates/shuck-server/src/analysis.rs
+++ b/crates/shuck-server/src/analysis.rs
@@ -150,7 +150,9 @@ impl DocumentAnalysis {
         let indexer = Indexer::new_with_options(
             source,
             &parse_result,
-            IndexerOptions::new().with_folding_ranges(true),
+            IndexerOptions::new()
+                .with_folding_ranges(true)
+                .with_selection_ranges(true),
         );
 
         Some(Self {

--- a/crates/shuck-server/src/lib.rs
+++ b/crates/shuck-server/src/lib.rs
@@ -30,6 +30,7 @@ pub mod fuzzing;
 mod lint;
 mod logging;
 mod resolve;
+mod selection;
 mod server;
 mod session;
 mod symbols;

--- a/crates/shuck-server/src/selection.rs
+++ b/crates/shuck-server/src/selection.rs
@@ -1,0 +1,57 @@
+use lsp_types as types;
+
+use crate::session::{DocumentSnapshot, RequestCancellationToken};
+
+pub(crate) type SelectionRangeResponse = Option<Vec<types::SelectionRange>>;
+
+pub(crate) fn selection_ranges(
+    snapshot: DocumentSnapshot,
+    positions: &[types::Position],
+    cancellation: &RequestCancellationToken,
+) -> SelectionRangeResponse {
+    if cancellation.is_cancelled() {
+        return None;
+    }
+    let analysis = snapshot.analysis()?;
+    let mut selections = Vec::with_capacity(positions.len());
+
+    for position in positions {
+        if cancellation.is_cancelled() {
+            return None;
+        }
+        let point = types::Range::new(*position, *position);
+        let offset = crate::edit::to_text_range(
+            &point,
+            analysis.source(),
+            analysis.line_index(),
+            snapshot.encoding(),
+        )
+        .start();
+        let chain = analysis
+            .indexer()
+            .selection_range_index()
+            .selection_chain(offset);
+
+        let mut parent = None;
+        for range in chain.into_iter().rev() {
+            if cancellation.is_cancelled() {
+                return None;
+            }
+            parent = Some(Box::new(types::SelectionRange {
+                range: crate::edit::to_lsp_range(
+                    range,
+                    analysis.source(),
+                    analysis.line_index(),
+                    snapshot.encoding(),
+                ),
+                parent,
+            }));
+        }
+        let Some(selection) = parent else {
+            continue;
+        };
+        selections.push(*selection);
+    }
+
+    Some(selections)
+}

--- a/crates/shuck-server/src/server.rs
+++ b/crates/shuck-server/src/server.rs
@@ -196,6 +196,7 @@ impl Server {
                     work_done_progress: Some(true),
                 },
             })),
+            selection_range_provider: Some(types::SelectionRangeProviderCapability::Simple(true)),
             text_document_sync: Some(TextDocumentSyncCapability::Options(
                 TextDocumentSyncOptions {
                     open_close: Some(true),

--- a/crates/shuck-server/src/server/api.rs
+++ b/crates/shuck-server/src/server/api.rs
@@ -101,6 +101,9 @@ pub(super) fn request(req: server::Request) -> Task {
         request::Rename::METHOD => {
             background_session_request_task::<request::Rename>(req, BackgroundSchedule::Worker)
         }
+        request::SelectionRanges::METHOD => background_session_request_task::<
+            request::SelectionRanges,
+        >(req, BackgroundSchedule::Worker),
         request::WorkspaceSymbols::METHOD => {
             background_session_request_task::<request::WorkspaceSymbols>(
                 req,

--- a/crates/shuck-server/src/server/api/requests.rs
+++ b/crates/shuck-server/src/server/api/requests.rs
@@ -19,6 +19,7 @@ mod hover;
 mod prepare_rename;
 mod references;
 mod rename;
+mod selection_range;
 mod shutdown;
 mod workspace_symbol;
 
@@ -47,5 +48,6 @@ pub(super) use hover::Hover;
 pub(super) use prepare_rename::PrepareRename;
 pub(super) use references::References;
 pub(super) use rename::Rename;
+pub(super) use selection_range::SelectionRanges;
 pub(super) use shutdown::ShutdownHandler;
 pub(super) use workspace_symbol::WorkspaceSymbols;

--- a/crates/shuck-server/src/server/api/requests/selection_range.rs
+++ b/crates/shuck-server/src/server/api/requests/selection_range.rs
@@ -1,0 +1,45 @@
+use lsp_types::{self as types, request as req};
+
+use crate::selection;
+use crate::session::{Client, DocumentSnapshot, RequestCancellationToken, Session};
+
+pub(crate) struct SelectionRanges;
+
+pub(crate) struct SelectionRangesSnapshot {
+    document: Option<DocumentSnapshot>,
+    cancellation: RequestCancellationToken,
+}
+
+impl super::RequestHandler for SelectionRanges {
+    type RequestType = req::SelectionRangeRequest;
+}
+
+impl super::super::traits::BackgroundRequestHandler for SelectionRanges {
+    type Snapshot = SelectionRangesSnapshot;
+
+    fn snapshot(
+        session: &Session,
+        params: &types::SelectionRangeParams,
+        cancellation: RequestCancellationToken,
+    ) -> crate::server::Result<Self::Snapshot> {
+        Ok(SelectionRangesSnapshot {
+            document: session.take_snapshot(params.text_document.uri.clone()),
+            cancellation,
+        })
+    }
+
+    fn run_with_snapshot(
+        snapshot: Self::Snapshot,
+        _client: &Client,
+        params: types::SelectionRangeParams,
+    ) -> crate::server::Result<selection::SelectionRangeResponse> {
+        let Some(document) = snapshot.document else {
+            return Ok(None);
+        };
+        Ok(selection::selection_ranges(
+            document,
+            &params.positions,
+            &snapshot.cancellation,
+        ))
+    }
+}

--- a/crates/shuck-server/tests/manual.rs
+++ b/crates/shuck-server/tests/manual.rs
@@ -133,6 +133,10 @@ fn replays_a_small_lsp_session() {
         initialize["capabilities"]["renameProvider"]["prepareProvider"],
         serde_json::json!(true)
     );
+    assert_eq!(
+        initialize["capabilities"]["selectionRangeProvider"],
+        serde_json::json!(true)
+    );
 
     client_connection
         .sender
@@ -405,6 +409,107 @@ fn folding_ranges_use_utf16_positions() {
 #[test]
 fn folding_ranges_use_utf32_positions() {
     folding_ranges_for_encoding("utf-32", 7);
+}
+
+fn selection_ranges_for_encoding(encoding: &str, echo_start: u64, name_start: u64) {
+    let (server_connection, client_connection) = Connection::memory();
+    let server_thread = thread::spawn(move || shuck_server::run_connection(server_connection));
+
+    let workspace = tempfile::tempdir().expect("tempdir should be created");
+    let script_path = workspace.path().join("script.sh");
+    let script_uri = Url::from_file_path(&script_path).unwrap();
+    let source = ": '😀'; echo \"${name:-$(printf '%s' value)}\"\n";
+    std::fs::write(&script_path, source).unwrap();
+
+    let mut capabilities = serde_json::to_value(replay_capabilities()).unwrap();
+    capabilities["general"]["positionEncodings"] = serde_json::json!([encoding]);
+    capabilities["textDocument"]["selectionRange"] = serde_json::json!({});
+    send_request(
+        &client_connection,
+        1,
+        "initialize",
+        serde_json::json!({
+            "capabilities": capabilities,
+            "rootUri": Url::from_file_path(workspace.path()).unwrap(),
+        }),
+    );
+    let initialize = recv_response(&client_connection, 1);
+    assert_eq!(initialize["capabilities"]["positionEncoding"], encoding);
+    assert_eq!(initialize["capabilities"]["selectionRangeProvider"], true);
+    client_connection
+        .sender
+        .send(Message::Notification(Notification::new(
+            "initialized".to_owned(),
+            serde_json::json!({}),
+        )))
+        .expect("initialized should send");
+    open_document(&client_connection, &script_uri, source);
+
+    send_request(
+        &client_connection,
+        2,
+        "textDocument/selectionRange",
+        serde_json::json!({
+            "textDocument": { "uri": script_uri },
+            "positions": [
+                { "line": 0, "character": name_start },
+                { "line": 0, "character": echo_start },
+            ],
+        }),
+    );
+    let response: Vec<lsp_types::SelectionRange> =
+        serde_json::from_value(recv_response(&client_connection, 2)).unwrap();
+    assert_eq!(response.len(), 2);
+
+    for (selection, expected_start, expected_end) in [
+        (&response[0], name_start, name_start + 4),
+        (&response[1], echo_start, echo_start + 4),
+    ] {
+        assert_eq!(
+            selection.range.start,
+            Position::new(0, expected_start as u32)
+        );
+        assert_eq!(selection.range.end, Position::new(0, expected_end as u32));
+
+        let mut current = selection;
+        while let Some(parent) = current.parent.as_deref() {
+            assert_ne!(current.range, parent.range);
+            assert!(parent.range.start <= current.range.start);
+            assert!(current.range.end <= parent.range.end);
+            current = parent;
+        }
+        assert_eq!(current.range.start, Position::new(0, 0));
+        assert_eq!(current.range.end, Position::new(1, 0));
+    }
+
+    send_request(&client_connection, 99, "shutdown", serde_json::json!(null));
+    let _ = recv_response(&client_connection, 99);
+    client_connection
+        .sender
+        .send(Message::Notification(Notification::new(
+            "exit".to_owned(),
+            serde_json::json!({}),
+        )))
+        .expect("exit notification should send");
+    server_thread
+        .join()
+        .expect("server thread should join")
+        .expect("server should exit cleanly");
+}
+
+#[test]
+fn selection_ranges_use_utf8_positions() {
+    selection_ranges_for_encoding("utf-8", 10, 18);
+}
+
+#[test]
+fn selection_ranges_use_utf16_positions() {
+    selection_ranges_for_encoding("utf-16", 8, 16);
+}
+
+#[test]
+fn selection_ranges_use_utf32_positions() {
+    selection_ranges_for_encoding("utf-32", 7, 15);
 }
 
 fn cross_file_rename_for_encoding(

--- a/specs/023-lsp-editor-features.md
+++ b/specs/023-lsp-editor-features.md
@@ -3,24 +3,24 @@
 ## Status
 
 Implemented (document-local v1 plus statically resolved source-aware
-completion, definition, hover, references, document links, and opt-in
-cross-file rename, plus syntax-aware folding ranges).
+completion, definition, hover, references, document links, opt-in cross-file
+rename, syntax-aware folding ranges, and AST-based selection ranges).
 
 Delivered: completion, semantic hover, go-to-definition, references, document
 links, document highlights, document and workspace symbols, conservative
-rename, document/range formatting, and folding ranges. Function completion follows the
-statically resolvable source graph, and resolvable source paths are exposed as
-document links. Definition, hover, references, and opt-in cross-file function
-rename require exact source bindings. Cross-file call hierarchy is specified
-separately in spec 025.
+rename, AST-based selection ranges, document/range formatting, and folding
+ranges. Function completion follows the statically resolvable source graph, and
+resolvable source paths are exposed as document links. Definition, hover,
+references, and opt-in cross-file function rename require exact source bindings.
+Cross-file call hierarchy is specified separately in spec 025.
 
 ## Summary
 
 Extend `shuck server` beyond diagnostics, quick fixes, directive hovers, and
 document synchronization to cover the remaining editor-facing LSP features:
 completion, symbol hover, go-to-definition, find references, occurrence
-highlighting, document symbols, workspace symbols, rename, formatting, and
-folding ranges.
+highlighting, document symbols, workspace symbols, rename, formatting, folding
+ranges, and selection ranges.
 The implementation builds on spec 018 by adding a shared document-analysis
 cache, editor-symbol indexes over Shuck's semantic model, conservative rename
 sets, and advertised formatting support once the existing formatter handlers
@@ -84,8 +84,8 @@ linter, and formatter crates.
   It requires command-specific metadata that Shuck does not currently author.
 - Shell command manual-page hovers are out of scope. General hover starts with
   Shuck semantic symbols and repo-authored metadata.
-- Semantic tokens, inlay hints, and selection ranges are not covered by this
-  spec. Cross-file call hierarchy is specified separately in spec 025.
+- Semantic tokens and inlay hints are not covered by this spec. Cross-file call
+  hierarchy is specified separately in spec 025.
 - Rename across dynamically sourced files is out of scope unless Shuck can map
   every affected document to a concrete workspace URI and prove the rename set.
 - This spec does not change lint rule behavior or diagnostic parity.
@@ -110,6 +110,7 @@ land:
 | Document symbols | `textDocument/documentSymbol` | Hierarchical symbols for functions plus top-level declarations and assignments |
 | Workspace symbols | `workspace/symbol` | Fuzzy search over indexed shell files in workspace folders |
 | Rename | `textDocument/prepareRename`, `textDocument/rename` | Conservative variable and function rename sets |
+| Selection ranges | `textDocument/selectionRange` | Strict parser-owned containment chains from the innermost syntax node through the complete file |
 | Formatting | `textDocument/formatting`, `textDocument/rangeFormatting` | Full-document formatting; range requests format the smallest complete statement span that contains the requested range |
 | Folding ranges | `textDocument/foldingRange` | Parser-backed multiline shell constructs, heredocs, comment blocks, and active continuation regions with duplicate and crossing ranges removed |
 
@@ -526,6 +527,7 @@ Feature handlers use the existing scheduler:
 | Prepare rename | Worker |
 | Rename | Worker |
 | Folding ranges | Worker |
+| Selection range | Worker |
 | Formatting | Fmt |
 | Range formatting | Fmt |
 

--- a/website/content/editors/index.mdx
+++ b/website/content/editors/index.mdx
@@ -28,6 +28,7 @@ files.
 | Formatting | `textDocument/formatting`, `textDocument/rangeFormatting` | Whole-document formatting or the smallest complete statement containing the selected range. Incomplete syntactic fragments are left unchanged. |
 | Folding ranges | `textDocument/foldingRange` | Functions, conditionals, loops, case statements, subshells, brace groups, heredocs, own-line comment blocks, and active continuation regions. Closing delimiters remain visible, malformed or crossing ranges are omitted, and client range limits are honored. |
 | Call hierarchy | `textDocument/prepareCallHierarchy`, `callHierarchy/incomingCalls`, `callHierarchy/outgoingCalls` | Preparation, incoming calls, and outgoing calls work across the statically resolvable source graph. Preparing on a sourced function call returns the exact target definition, including when a file redefines the same function name. Literal sources and valid `# shuck: source=` hints participate; runtime-only dispatch and unresolved dynamic sources do not. |
+| Selection ranges | `textDocument/selectionRange` | Parser-backed expansion from words and nested expressions through commands, compound constructs, and the complete file. Comments, whitespace, heredocs, incomplete input, multiple positions, and UTF-8/16/32 position encodings are handled predictably. |
 
 Editor formatting uses the same parser-backed formatter as [`shuck format`](/docs/formatting). Once `shuck server` is attached, use your editor's normal LSP format command or format-on-save integration.
 
@@ -39,9 +40,9 @@ Editor formatting uses the same parser-backed formatter as [`shuck format`](/doc
 ### Not currently planned
 
 Shuck does not currently advertise semantic tokens, inlay hints, signature
-help, selection ranges, notebook documents, or workspace-wide
-diagnostics. These are not permanent prohibitions, but there is no accepted
-implementation design for them today.
+help, notebook documents, or workspace-wide diagnostics. These are not
+permanent prohibitions, but there is no accepted implementation design for them
+today.
 
 This page is the user-facing support contract. The repository's
 [design specs](https://github.com/ewhauser/shuck/tree/main/specs) record the


### PR DESCRIPTION
## Summary

- advertise and handle `textDocument/selectionRange` on the worker scheduler
- build opt-in parser-owned containment ranges in `shuck-indexer` without affecting CLI lint paths
- return strict, deduplicated inner-to-outer chains for words, expansions, arithmetic, tests, redirects, heredocs, comments, compound commands, and the complete file
- preserve request order, cancellation, incomplete-input behavior, and UTF-8/16/32 position encodings
- update the LSP support contract

## Validation

- `cargo test -q -p shuck-indexer -p shuck-server`
- `cargo clippy -q -p shuck-indexer -p shuck-server --all-targets --no-deps -- -D warnings`
- `git diff --check`
- dedicated review agent; arithmetic-expression gap fixed and follow-up review clean

Closes #1216