### PR TITLE
feat(server): support bounded workspace diagnostics

### DIFF
--- a/crates/shuck-cli/src/commands/check/add_ignore.rs
+++ b/crates/shuck-cli/src/commands/check/add_ignore.rs
@@ -46,6 +46,7 @@ pub(super) fn run_add_ignore_with_cwd(
             parallel: false,
             cache_root: Some(cache_root.to_path_buf()),
             use_config_roots: config_arguments.use_config_roots(),
+            ..DiscoveryOptions::default()
         },
         cache_root,
         true,

--- a/crates/shuck-cli/src/commands/check/run.rs
+++ b/crates/shuck-cli/src/commands/check/run.rs
@@ -44,6 +44,7 @@ pub(super) fn run_check_with_cwd(
                 parallel: true,
                 cache_root: Some(cache_root.to_path_buf()),
                 use_config_roots: config_arguments.use_config_roots(),
+                ..DiscoveryOptions::default()
             },
             cache_root,
             no_cache: args.no_cache || fix_applicability.is_some(),

--- a/crates/shuck-cli/src/commands/format.rs
+++ b/crates/shuck-cli/src/commands/format.rs
@@ -164,6 +164,7 @@ fn run_format_with_cwd(
         parallel: true,
         cache_root: Some(cache_root.to_path_buf()),
         use_config_roots: config_arguments.use_config_roots(),
+        ..DiscoveryOptions::default()
     };
     let runs = prepare_project_runs::<FormatCacheData, ResolvedFormatSettings, _>(
         &args.files,

--- a/crates/shuck-discover/src/lib.rs
+++ b/crates/shuck-discover/src/lib.rs
@@ -3,7 +3,8 @@ use std::ffi::OsStr;
 use std::fs;
 use std::io::{BufRead, BufReader, Read};
 use std::path::{Path, PathBuf};
-use std::sync::Mutex;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
 
 use anyhow::{Context, Result, anyhow};
 use globset::{Glob, GlobSet, GlobSetBuilder};
@@ -41,6 +42,23 @@ pub struct DiscoveredFile {
     pub kind: FileKind,
 }
 
+/// Files found by a discovery pass plus whether the configured scope was fully visited.
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct DiscoveryResult {
+    /// Discovered files in stable path order.
+    pub files: Vec<DiscoveredFile>,
+    /// Whether discovery finished without hitting a work limit or cancellation.
+    pub complete: bool,
+    /// Number of filesystem entries examined during this pass.
+    pub visited_entries: usize,
+}
+
+#[derive(Default)]
+struct DiscoveryState {
+    files: BTreeMap<PathBuf, DiscoveredFile>,
+    visited_entries: usize,
+}
+
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Ord, PartialOrd)]
 pub enum FileKind {
     Shell,
@@ -56,6 +74,32 @@ pub struct DiscoveryOptions {
     pub parallel: bool,
     pub cache_root: Option<PathBuf>,
     pub use_config_roots: bool,
+    /// Stop discovery after retaining this many files.
+    pub max_files: Option<usize>,
+    /// Stop discovery after visiting this many filesystem entries.
+    pub max_entries: Option<usize>,
+    /// Optional shared cancellation signal checked during directory walks.
+    pub cancellation: Option<DiscoveryCancellationToken>,
+    /// Whether embedded host documents may be returned.
+    pub include_embedded: bool,
+    /// Exact directory subtrees to prune from recursive discovery.
+    pub excluded_subtrees: Vec<PathBuf>,
+}
+
+/// A clonable cancellation signal for bounded file discovery.
+#[derive(Clone, Debug, Default)]
+pub struct DiscoveryCancellationToken(Arc<AtomicBool>);
+
+impl DiscoveryCancellationToken {
+    /// Mark the associated discovery operation as cancelled.
+    pub fn cancel(&self) {
+        self.0.store(true, Ordering::Relaxed);
+    }
+
+    /// Return whether cancellation was requested.
+    pub fn is_cancelled(&self) -> bool {
+        self.0.load(Ordering::Relaxed)
+    }
 }
 
 impl Default for DiscoveryOptions {
@@ -68,6 +112,11 @@ impl Default for DiscoveryOptions {
             parallel: false,
             cache_root: None,
             use_config_roots: true,
+            max_files: None,
+            max_entries: None,
+            cancellation: None,
+            include_embedded: true,
+            excluded_subtrees: Vec::new(),
         }
     }
 }
@@ -77,6 +126,15 @@ pub fn discover_files(
     cwd: &Path,
     options: &DiscoveryOptions,
 ) -> Result<Vec<DiscoveredFile>> {
+    Ok(discover_files_with_status(inputs, cwd, options)?.files)
+}
+
+/// Discover files and report whether configured work bounds truncated the walk.
+pub fn discover_files_with_status(
+    inputs: &[PathBuf],
+    cwd: &Path,
+    options: &DiscoveryOptions,
+) -> Result<DiscoveryResult> {
     let exclude_matcher =
         ExcludeMatcher::new(&options.exclude_patterns, &options.extend_exclude_patterns)?;
     let mut explicit_ignore_cache = ExplicitIgnoreCache::new(cwd);
@@ -96,11 +154,21 @@ pub fn discover_files(
             .collect()
     };
 
-    let mut files = BTreeMap::new();
+    let mut state = DiscoveryState::default();
     for input in resolved_inputs {
+        if discovery_stopped(options, state.files.len(), state.visited_entries) {
+            break;
+        }
         let input = normalize_path(&input);
 
         if should_ignore_path(&input, options.cache_root.as_deref()) {
+            continue;
+        }
+        if options
+            .excluded_subtrees
+            .iter()
+            .any(|excluded| input.starts_with(excluded))
+        {
             continue;
         }
 
@@ -120,11 +188,16 @@ pub fn discover_files(
             &exclude_matcher,
             &mut explicit_ignore_cache,
             options,
-            &mut files,
+            &mut state,
         )?;
     }
 
-    Ok(files.into_values().collect())
+    let complete = !discovery_stopped(options, state.files.len(), state.visited_entries);
+    Ok(DiscoveryResult {
+        files: state.files.into_values().collect(),
+        complete,
+        visited_entries: state.visited_entries,
+    })
 }
 
 fn collect_input(
@@ -134,18 +207,22 @@ fn collect_input(
     exclude_matcher: &ExcludeMatcher,
     explicit_ignore_cache: &mut ExplicitIgnoreCache,
     options: &DiscoveryOptions,
-    files: &mut BTreeMap<PathBuf, DiscoveredFile>,
+    state: &mut DiscoveryState,
 ) -> Result<()> {
     let metadata = fs::metadata(input).with_context(|| format!("stat {}", input.display()))?;
     if metadata.is_dir() {
         if options.force_exclude && exclude_matcher.matches(input, cwd) {
             return Ok(());
         }
-        collect_directory(input, cwd, project_root, exclude_matcher, options, files)?;
+        collect_directory(input, cwd, project_root, exclude_matcher, options, state)?;
     } else if metadata.is_file() {
+        state.visited_entries += 1;
         let Some(kind) = explicit_file_kind(input)? else {
             return Ok(());
         };
+        if kind == FileKind::Embedded && !options.include_embedded {
+            return Ok(());
+        }
         if options.force_exclude {
             if exclude_matcher.matches(input, cwd) {
                 return Ok(());
@@ -166,7 +243,7 @@ fn collect_input(
             project_root,
             options.use_config_roots,
             kind,
-            files,
+            &mut state.files,
         )?;
     }
 
@@ -179,16 +256,20 @@ fn collect_directory(
     project_root: &ProjectRoot,
     exclude_matcher: &ExcludeMatcher,
     options: &DiscoveryOptions,
-    files: &mut BTreeMap<PathBuf, DiscoveredFile>,
+    state: &mut DiscoveryState,
 ) -> Result<()> {
     let mut builder = WalkBuilder::new(input);
     configure_walk_builder(
         &mut builder,
         options.respect_gitignore,
         options.cache_root.clone(),
+        options.excluded_subtrees.clone(),
     );
-
-    if options.parallel {
+    if options.parallel
+        && options.max_files.is_none()
+        && options.max_entries.is_none()
+        && options.cancellation.is_none()
+    {
         return collect_directory_parallel(
             input,
             cwd,
@@ -196,12 +277,16 @@ fn collect_directory(
             exclude_matcher,
             options.use_config_roots,
             &mut builder,
-            files,
+            &mut state.files,
         );
     }
 
     for entry in builder.build() {
+        if discovery_stopped(options, state.files.len(), state.visited_entries) {
+            break;
+        }
         let entry = entry.with_context(|| format!("walk {}", input.display()))?;
+        state.visited_entries += 1;
         let Some(file_type) = entry.file_type() else {
             continue;
         };
@@ -218,6 +303,9 @@ fn collect_directory(
         let Some(kind) = discovered_file_kind(path)? else {
             continue;
         };
+        if kind == FileKind::Embedded && !options.include_embedded {
+            continue;
+        }
 
         add_file(
             path,
@@ -226,11 +314,28 @@ fn collect_directory(
             project_root,
             options.use_config_roots,
             kind,
-            files,
+            &mut state.files,
         )?;
     }
 
     Ok(())
+}
+
+fn discovery_stopped(
+    options: &DiscoveryOptions,
+    file_count: usize,
+    visited_entries: usize,
+) -> bool {
+    options
+        .cancellation
+        .as_ref()
+        .is_some_and(DiscoveryCancellationToken::is_cancelled)
+        || options
+            .max_files
+            .is_some_and(|max_files| file_count >= max_files)
+        || options
+            .max_entries
+            .is_some_and(|max_entries| visited_entries >= max_entries)
 }
 
 fn collect_directory_parallel(
@@ -286,6 +391,7 @@ fn configure_walk_builder(
     builder: &mut WalkBuilder,
     respect_gitignore: bool,
     cache_root: Option<PathBuf>,
+    excluded_subtrees: Vec<PathBuf>,
 ) {
     builder.hidden(false);
     builder.parents(respect_gitignore);
@@ -294,17 +400,26 @@ fn configure_walk_builder(
     builder.git_global(respect_gitignore);
     builder.git_exclude(respect_gitignore);
     builder.require_git(false);
-    builder.filter_entry(move |entry| !is_ignored_directory(entry, cache_root.as_deref()));
+    builder.filter_entry(move |entry| {
+        !is_ignored_directory(entry, cache_root.as_deref(), &excluded_subtrees)
+    });
 }
 
-fn is_ignored_directory(entry: &DirEntry, cache_root: Option<&Path>) -> bool {
+fn is_ignored_directory(
+    entry: &DirEntry,
+    cache_root: Option<&Path>,
+    excluded_subtrees: &[PathBuf],
+) -> bool {
     entry
         .file_type()
         .is_some_and(|file_type| file_type.is_dir())
         && (DEFAULT_IGNORED_DIR_NAMES
             .iter()
             .any(|name| entry.file_name() == OsStr::new(name))
-            || path_matches_cache_root(entry.path(), cache_root))
+            || path_matches_cache_root(entry.path(), cache_root)
+            || excluded_subtrees
+                .iter()
+                .any(|excluded| entry.path().starts_with(excluded)))
 }
 
 #[derive(Debug)]
@@ -952,5 +1067,122 @@ mod tests {
             PathBuf::from(".github/workflows/ci.yml")
         );
         assert_eq!(files[0].kind, FileKind::Embedded);
+    }
+
+    #[test]
+    fn bounded_discovery_stops_after_the_file_limit() {
+        let tempdir = tempdir().unwrap();
+        for index in 0..20 {
+            fs::write(
+                tempdir.path().join(format!("script-{index:02}.sh")),
+                "echo ok\n",
+            )
+            .unwrap();
+        }
+
+        let files = discover_files(
+            &[tempdir.path().to_path_buf()],
+            tempdir.path(),
+            &DiscoveryOptions {
+                max_files: Some(3),
+                ..DiscoveryOptions::default()
+            },
+        )
+        .unwrap();
+
+        assert_eq!(files.len(), 3);
+    }
+
+    #[test]
+    fn bounded_discovery_stops_after_the_entry_work_limit() {
+        let tempdir = tempdir().unwrap();
+        for index in 0..20 {
+            fs::write(
+                tempdir.path().join(format!("a-note-{index:02}.txt")),
+                "not shell\n",
+            )
+            .unwrap();
+        }
+        fs::write(tempdir.path().join("z-script.sh"), "echo late\n").unwrap();
+
+        let result = discover_files_with_status(
+            &[tempdir.path().to_path_buf()],
+            tempdir.path(),
+            &DiscoveryOptions {
+                max_files: Some(10),
+                max_entries: Some(5),
+                ..DiscoveryOptions::default()
+            },
+        )
+        .unwrap();
+
+        assert!(!result.complete);
+        assert!(result.visited_entries <= 5);
+    }
+
+    #[test]
+    fn bounded_discovery_honors_preexisting_cancellation() {
+        let tempdir = tempdir().unwrap();
+        fs::write(tempdir.path().join("script.sh"), "echo ok\n").unwrap();
+        let cancellation = DiscoveryCancellationToken::default();
+        cancellation.cancel();
+
+        let files = discover_files(
+            &[tempdir.path().to_path_buf()],
+            tempdir.path(),
+            &DiscoveryOptions {
+                cancellation: Some(cancellation),
+                ..DiscoveryOptions::default()
+            },
+        )
+        .unwrap();
+
+        assert!(files.is_empty());
+    }
+
+    #[test]
+    fn discovery_can_omit_embedded_hosts_before_the_limit() {
+        let tempdir = tempdir().unwrap();
+        let workflows = tempdir.path().join(".github/workflows");
+        fs::create_dir_all(&workflows).unwrap();
+        fs::write(workflows.join("ci.yml"), "on: push\njobs: {}\n").unwrap();
+        fs::write(tempdir.path().join("script.sh"), "echo ok\n").unwrap();
+
+        let files = discover_files(
+            &[tempdir.path().to_path_buf()],
+            tempdir.path(),
+            &DiscoveryOptions {
+                max_files: Some(1),
+                include_embedded: false,
+                ..DiscoveryOptions::default()
+            },
+        )
+        .unwrap();
+
+        assert_eq!(files.len(), 1);
+        assert_eq!(files[0].kind, FileKind::Shell);
+    }
+
+    #[test]
+    fn bounded_discovery_prunes_nested_workspace_subtrees() {
+        let tempdir = tempdir().unwrap();
+        let nested = tempdir.path().join("a-nested");
+        fs::create_dir(&nested).unwrap();
+        fs::write(nested.join("nested.sh"), "echo nested\n").unwrap();
+        fs::write(tempdir.path().join("z-parent.sh"), "echo parent\n").unwrap();
+
+        let files = discover_files(
+            &[tempdir.path().to_path_buf()],
+            tempdir.path(),
+            &DiscoveryOptions {
+                max_files: Some(1),
+                excluded_subtrees: vec![nested],
+                ..DiscoveryOptions::default()
+            },
+        )
+        .unwrap();
+
+        assert_eq!(files.len(), 1);
+        assert_eq!(files[0].display_path, PathBuf::from("z-parent.sh"));
     }
 }

--- a/crates/shuck-server/src/lib.rs
+++ b/crates/shuck-server/src/lib.rs
@@ -35,6 +35,7 @@ mod server;
 mod session;
 mod symbols;
 mod workspace;
+mod workspace_diagnostics;
 mod workspace_functions;
 
 pub(crate) const SERVER_NAME: &str = "shuck";

--- a/crates/shuck-server/src/server.rs
+++ b/crates/shuck-server/src/server.rs
@@ -43,7 +43,24 @@ impl Server {
         let (id, init_params) = connection.initialize_start()?;
         let client_capabilities = init_params.capabilities;
         let position_encoding = Self::find_best_position_encoding(&client_capabilities);
-        let server_capabilities = Self::server_capabilities(position_encoding);
+        #[allow(deprecated)]
+        let InitializeParams {
+            initialization_options,
+            root_path,
+            root_uri,
+            workspace_folders,
+            ..
+        } = init_params;
+        let AllOptions { global, workspace } =
+            AllOptions::from_value(initialization_options.unwrap_or(serde_json::Value::Null));
+        let workspace_diagnostics_enabled = global.workspace_diagnostics_enabled()
+            || workspace.as_ref().is_some_and(|workspaces| {
+                workspaces
+                    .values()
+                    .any(|options| options.server.workspace_diagnostics.enabled)
+            });
+        let server_capabilities =
+            Self::server_capabilities(position_encoding, workspace_diagnostics_enabled);
         let connection = connection.initialize_finish(
             id,
             &server_capabilities,
@@ -53,20 +70,7 @@ impl Server {
 
         let (main_loop_sender, main_loop_receiver) = crossbeam::channel::bounded(32);
 
-        #[allow(deprecated)]
-        let InitializeParams {
-            initialization_options,
-            root_path,
-            root_uri,
-            workspace_folders,
-            ..
-        } = init_params;
-
         let client = Client::new(main_loop_sender.clone(), connection.sender.clone());
-        let AllOptions { global, workspace } = AllOptions::from_value(
-            initialization_options.unwrap_or(serde_json::Value::Null),
-            &client,
-        );
 
         crate::logging::init_logging(
             global.tracing.log_level.unwrap_or_default(),
@@ -123,7 +127,10 @@ impl Server {
             .unwrap_or_default()
     }
 
-    fn server_capabilities(position_encoding: PositionEncoding) -> types::ServerCapabilities {
+    fn server_capabilities(
+        position_encoding: PositionEncoding,
+        workspace_diagnostics_enabled: bool,
+    ) -> types::ServerCapabilities {
         types::ServerCapabilities {
             position_encoding: Some(position_encoding.into()),
             code_action_provider: Some(types::CodeActionProviderCapability::Options(
@@ -175,7 +182,7 @@ impl Server {
                 DiagnosticOptions {
                     identifier: Some(crate::DIAGNOSTIC_NAME.into()),
                     inter_file_dependencies: false,
-                    workspace_diagnostics: false,
+                    workspace_diagnostics: workspace_diagnostics_enabled,
                     work_done_progress_options: WorkDoneProgressOptions {
                         work_done_progress: Some(true),
                     },
@@ -326,7 +333,7 @@ mod tests {
 
     #[test]
     fn advertises_formatting_capabilities() {
-        let capabilities = Server::server_capabilities(PositionEncoding::UTF16);
+        let capabilities = Server::server_capabilities(PositionEncoding::UTF16, false);
         assert_eq!(
             capabilities.document_formatting_provider,
             Some(OneOf::Left(true))
@@ -339,7 +346,7 @@ mod tests {
 
     #[test]
     fn advertises_navigation_completion_and_rename_capabilities() {
-        let capabilities = Server::server_capabilities(PositionEncoding::UTF16);
+        let capabilities = Server::server_capabilities(PositionEncoding::UTF16, false);
         assert!(capabilities.completion_provider.is_some());
         assert_eq!(capabilities.definition_provider, Some(OneOf::Left(true)));
         assert!(capabilities.document_link_provider.is_some());
@@ -356,7 +363,7 @@ mod tests {
 
     #[test]
     fn advertises_document_symbol_capability() {
-        let capabilities = Server::server_capabilities(PositionEncoding::UTF16);
+        let capabilities = Server::server_capabilities(PositionEncoding::UTF16, false);
         assert_eq!(
             capabilities.document_symbol_provider,
             Some(OneOf::Left(true))
@@ -365,7 +372,7 @@ mod tests {
 
     #[test]
     fn advertises_workspace_symbol_capability_without_resolve() {
-        let capabilities = Server::server_capabilities(PositionEncoding::UTF16);
+        let capabilities = Server::server_capabilities(PositionEncoding::UTF16, false);
         let Some(OneOf::Right(options)) = capabilities.workspace_symbol_provider else {
             panic!("expected workspace symbol options");
         };
@@ -374,7 +381,7 @@ mod tests {
 
     #[test]
     fn advertises_only_non_formatting_execute_commands() {
-        let capabilities = Server::server_capabilities(PositionEncoding::UTF16);
+        let capabilities = Server::server_capabilities(PositionEncoding::UTF16, false);
         let commands = capabilities
             .execute_command_provider
             .expect("server should advertise execute commands")
@@ -384,6 +391,19 @@ mod tests {
         assert!(commands.contains(&"shuck.applyDirective".to_owned()));
         assert!(commands.contains(&"shuck.printDebugInformation".to_owned()));
         assert!(!commands.contains(&"shuck.applyFormat".to_owned()));
+    }
+
+    #[test]
+    fn advertises_workspace_diagnostics_only_when_enabled() {
+        for (enabled, expected) in [(false, false), (true, true)] {
+            let capabilities = Server::server_capabilities(PositionEncoding::UTF16, enabled);
+            let Some(types::DiagnosticServerCapabilities::Options(options)) =
+                capabilities.diagnostic_provider
+            else {
+                panic!("expected diagnostic options");
+            };
+            assert_eq!(options.workspace_diagnostics, expected);
+        }
     }
 
     #[test]

--- a/crates/shuck-server/src/server/api.rs
+++ b/crates/shuck-server/src/server/api.rs
@@ -110,6 +110,12 @@ pub(super) fn request(req: server::Request) -> Task {
                 BackgroundSchedule::Worker,
             )
         }
+        request::WorkspaceDiagnostic::METHOD => {
+            background_session_request_task::<request::WorkspaceDiagnostic>(
+                req,
+                BackgroundSchedule::Worker,
+            )
+        }
         lsp_types::request::Shutdown::METHOD => sync_request_task::<request::ShutdownHandler>(req),
         method => {
             let result: Result<()> = Err(Error::new(
@@ -441,7 +447,7 @@ mod tests {
         let workspace_url = Url::from_file_path(std::env::current_dir().unwrap())
             .expect("current directory should convert to a file URL");
         let workspaces = Workspaces::new(vec![Workspace::default(workspace_url)]);
-        let AllOptions { global, .. } = AllOptions::from_value(serde_json::Value::Null, client);
+        let AllOptions { global, .. } = AllOptions::from_value(serde_json::Value::Null);
         let global = global.into_settings(client.clone());
 
         Session::new(

--- a/crates/shuck-server/src/server/api/notifications/did_change_configuration.rs
+++ b/crates/shuck-server/src/server/api/notifications/did_change_configuration.rs
@@ -16,7 +16,7 @@ impl super::super::traits::SyncNotificationHandler for DidChangeConfiguration {
         client: &Client,
         params: types::DidChangeConfigurationParams,
     ) -> Result<()> {
-        let all_options = crate::session::AllOptions::from_value(params.settings, client);
+        let all_options = crate::session::AllOptions::from_value(params.settings);
         let global_settings = all_options.global.into_settings(client.clone());
         session.update_configuration(global_settings.options().clone(), all_options.workspace);
         Ok(())

--- a/crates/shuck-server/src/server/api/requests.rs
+++ b/crates/shuck-server/src/server/api/requests.rs
@@ -21,6 +21,7 @@ mod references;
 mod rename;
 mod selection_range;
 mod shutdown;
+mod workspace_diagnostic;
 mod workspace_symbol;
 
 use super::{
@@ -50,4 +51,5 @@ pub(super) use references::References;
 pub(super) use rename::Rename;
 pub(super) use selection_range::SelectionRanges;
 pub(super) use shutdown::ShutdownHandler;
+pub(super) use workspace_diagnostic::WorkspaceDiagnostic;
 pub(super) use workspace_symbol::WorkspaceSymbols;

--- a/crates/shuck-server/src/server/api/requests/workspace_diagnostic.rs
+++ b/crates/shuck-server/src/server/api/requests/workspace_diagnostic.rs
@@ -1,0 +1,31 @@
+use lsp_types::{self as types, request as req};
+
+use crate::server::Result;
+use crate::session::{Client, RequestCancellationToken, Session};
+use crate::workspace_diagnostics::{self, WorkspaceDiagnosticContext};
+
+pub(crate) struct WorkspaceDiagnostic;
+
+impl super::RequestHandler for WorkspaceDiagnostic {
+    type RequestType = req::WorkspaceDiagnosticRequest;
+}
+
+impl super::super::traits::BackgroundRequestHandler for WorkspaceDiagnostic {
+    type Snapshot = WorkspaceDiagnosticContext;
+
+    fn snapshot(
+        session: &Session,
+        _params: &types::WorkspaceDiagnosticParams,
+        cancellation: RequestCancellationToken,
+    ) -> Result<Self::Snapshot> {
+        Ok(session.workspace_diagnostic_context(cancellation))
+    }
+
+    fn run_with_snapshot(
+        snapshot: Self::Snapshot,
+        client: &Client,
+        params: types::WorkspaceDiagnosticParams,
+    ) -> Result<types::WorkspaceDiagnosticReportResult> {
+        workspace_diagnostics::workspace_diagnostics(snapshot, client, &params)
+    }
+}

--- a/crates/shuck-server/src/session.rs
+++ b/crates/shuck-server/src/session.rs
@@ -8,7 +8,7 @@ use lsp_types::{ClientCapabilities, FileEvent, Url};
 use crate::analysis::{DocumentAnalysis, DocumentAnalysisCache};
 use crate::edit::{DocumentKey, DocumentVersion};
 use crate::session::request_queue::RequestQueue;
-use crate::session::settings::{ClientSettings, GlobalClientSettings};
+use crate::session::settings::GlobalClientSettings;
 use crate::workspace::Workspaces;
 use crate::{PositionEncoding, TextDocument};
 
@@ -18,9 +18,10 @@ pub(crate) use self::index::WorkspaceSettingsSnapshot;
 pub(crate) use self::options::{AllOptions, WorkspaceOptionsMap};
 pub use self::options::{
     ClientOptions, CompletionFeatureOptions, GlobalOptions, RenameFeatureOptions,
-    WorkspaceSymbolFeatureOptions,
+    WorkspaceDiagnosticsFeatureOptions, WorkspaceSymbolFeatureOptions,
 };
 pub(crate) use self::request_queue::RequestCancellationToken;
+pub(crate) use self::settings::ClientSettings;
 pub(crate) use self::settings::ShuckSettings;
 pub use client::Client;
 
@@ -38,6 +39,7 @@ pub struct Session {
     global_settings: GlobalClientSettings,
     resolved_client_capabilities: Arc<ResolvedClientCapabilities>,
     workspace_symbols: Arc<crate::symbols::WorkspaceSymbolIndex>,
+    workspace_diagnostics: Arc<crate::workspace_diagnostics::WorkspaceDiagnosticCache>,
     analysis_cache: Arc<DocumentAnalysisCache>,
     workspace_function_index: Arc<crate::workspace_functions::WorkspaceFunctionIndexCache>,
     request_queue: RequestQueue,
@@ -50,6 +52,14 @@ pub struct DocumentSnapshot {
     resolved_client_capabilities: Arc<ResolvedClientCapabilities>,
     client_settings: Arc<ClientSettings>,
     document_ref: index::DocumentQuery,
+    position_encoding: PositionEncoding,
+    analysis_cache: Arc<DocumentAnalysisCache>,
+    analysis_settings_epoch: u64,
+}
+
+#[derive(Clone)]
+pub(crate) struct WorkspaceDocumentSnapshotFactory {
+    resolved_client_capabilities: Arc<ResolvedClientCapabilities>,
     position_encoding: PositionEncoding,
     analysis_cache: Arc<DocumentAnalysisCache>,
     analysis_settings_epoch: u64,
@@ -72,6 +82,9 @@ impl Session {
                 client_capabilities,
             )),
             workspace_symbols: Arc::new(crate::symbols::WorkspaceSymbolIndex::default()),
+            workspace_diagnostics: Arc::new(
+                crate::workspace_diagnostics::WorkspaceDiagnosticCache::default(),
+            ),
             analysis_cache: Arc::new(DocumentAnalysisCache::new()),
             workspace_function_index: Arc::new(
                 crate::workspace_functions::WorkspaceFunctionIndexCache::default(),
@@ -129,6 +142,8 @@ impl Session {
                 .update_text_document(key, content_changes, new_version, self.encoding());
         if result.is_ok() {
             self.analysis_cache.invalidate_uri(&key.clone().into_url());
+            self.workspace_diagnostics
+                .invalidate_uri(&key.clone().into_url());
             self.workspace_function_index.invalidate();
         }
         result
@@ -137,6 +152,7 @@ impl Session {
     /// Open or replace an in-memory text document.
     pub fn open_text_document(&mut self, url: Url, document: TextDocument) {
         self.analysis_cache.invalidate_uri(&url);
+        self.workspace_diagnostics.invalidate_uri(&url);
         self.workspace_function_index.invalidate();
         self.index.open_text_document(url, document);
     }
@@ -144,6 +160,8 @@ impl Session {
     pub(crate) fn close_document(&mut self, key: &DocumentKey) -> crate::Result<()> {
         self.index.close_document(key)?;
         self.analysis_cache.invalidate_uri(&key.clone().into_url());
+        self.workspace_diagnostics
+            .invalidate_uri(&key.clone().into_url());
         self.workspace_function_index.invalidate();
         self.workspace_symbols
             .invalidate_uri(&key.clone().into_url());
@@ -153,6 +171,7 @@ impl Session {
     pub(crate) fn reload_settings(&mut self, changes: &[FileEvent], client: &Client) {
         self.index.reload_settings(changes, client);
         self.analysis_cache.clear();
+        self.workspace_diagnostics.invalidate_all();
         self.workspace_function_index.invalidate();
         self.workspace_symbols.invalidate_file_events(changes);
     }
@@ -161,6 +180,7 @@ impl Session {
         self.index
             .open_workspace_folder(url, &self.global_settings, client)?;
         self.analysis_cache.clear();
+        self.workspace_diagnostics.invalidate_all();
         self.workspace_function_index.invalidate();
         self.workspace_symbols.invalidate_all();
         Ok(())
@@ -169,6 +189,7 @@ impl Session {
     pub(crate) fn close_workspace_folder(&mut self, url: &Url) -> crate::Result<()> {
         self.index.close_workspace_folder(url)?;
         self.analysis_cache.clear();
+        self.workspace_diagnostics.invalidate_all();
         self.workspace_function_index.invalidate();
         self.workspace_symbols.invalidate_all();
         Ok(())
@@ -192,6 +213,7 @@ impl Session {
 
     pub(crate) fn update_client_options(&mut self, options: ClientOptions) {
         self.analysis_cache.clear();
+        self.workspace_diagnostics.invalidate_all();
         self.workspace_function_index.invalidate();
         self.workspace_symbols.invalidate_all();
         self.global_settings.update_options(options);
@@ -204,6 +226,7 @@ impl Session {
         workspace_options: Option<WorkspaceOptionsMap>,
     ) {
         self.analysis_cache.clear();
+        self.workspace_diagnostics.invalidate_all();
         self.workspace_function_index.invalidate();
         self.workspace_symbols.invalidate_all();
         self.global_settings.update_options(options);
@@ -220,6 +243,60 @@ impl Session {
 
     pub(crate) fn workspace_roots(&self) -> &[std::path::PathBuf] {
         self.index.workspace_roots()
+    }
+
+    pub(crate) fn workspace_document_snapshot_factory(&self) -> WorkspaceDocumentSnapshotFactory {
+        WorkspaceDocumentSnapshotFactory {
+            resolved_client_capabilities: self.resolved_client_capabilities.clone(),
+            position_encoding: self.position_encoding,
+            analysis_cache: self.analysis_cache.clone(),
+            analysis_settings_epoch: self.analysis_cache.current_settings_epoch(),
+        }
+    }
+
+    pub(crate) fn workspace_diagnostic_context(
+        &self,
+        cancellation: RequestCancellationToken,
+    ) -> crate::workspace_diagnostics::WorkspaceDiagnosticContext {
+        let workspace_settings = self.index.workspace_settings_snapshot();
+        let workspace_roots = self.index.workspace_roots().to_vec();
+        let mut settings_workspace_roots = workspace_roots.clone();
+        for workspace in &workspace_settings {
+            let Some(canonical_root) = &workspace.canonical_root else {
+                continue;
+            };
+            if !settings_workspace_roots.contains(canonical_root) {
+                settings_workspace_roots.push(canonical_root.clone());
+            }
+        }
+        let open_documents = self
+            .index
+            .open_documents_snapshot()
+            .into_iter()
+            .filter_map(|document| {
+                let path = document.uri.to_file_path().ok()?;
+                let snapshot = self.take_snapshot(document.uri.clone())?;
+                Some(
+                    crate::workspace_diagnostics::WorkspaceDiagnosticOpenDocument {
+                        uri: document.uri,
+                        path,
+                        snapshot,
+                    },
+                )
+            })
+            .collect();
+        crate::workspace_diagnostics::WorkspaceDiagnosticContext {
+            options: self.global_settings.options().server.workspace_diagnostics,
+            global_options: self.global_settings.options().clone(),
+            workspace_settings,
+            workspace_roots,
+            settings_workspace_roots,
+            open_documents,
+            snapshot_factory: self.workspace_document_snapshot_factory(),
+            cache: self.workspace_diagnostics.clone(),
+            cache_generation: self.workspace_diagnostics.generation(),
+            cancellation,
+        }
     }
 
     pub(crate) fn workspace_symbol_context(&self) -> crate::symbols::WorkspaceSymbolContext {
@@ -314,6 +391,29 @@ impl DocumentSnapshot {
 
     pub(crate) fn analysis_settings_epoch(&self) -> u64 {
         self.analysis_settings_epoch
+    }
+}
+
+impl WorkspaceDocumentSnapshotFactory {
+    pub(crate) fn snapshot(
+        &self,
+        uri: Url,
+        document: Arc<TextDocument>,
+        settings: Arc<ShuckSettings>,
+        client_settings: Arc<ClientSettings>,
+    ) -> DocumentSnapshot {
+        DocumentSnapshot {
+            resolved_client_capabilities: self.resolved_client_capabilities.clone(),
+            client_settings,
+            document_ref: DocumentQuery::Text {
+                file_url: uri,
+                document,
+                settings,
+            },
+            position_encoding: self.position_encoding,
+            analysis_cache: self.analysis_cache.clone(),
+            analysis_settings_epoch: self.analysis_settings_epoch,
+        }
     }
 }
 

--- a/crates/shuck-server/src/session/client.rs
+++ b/crates/shuck-server/src/session/client.rs
@@ -105,6 +105,19 @@ impl Client {
             .map_err(|error| anyhow!("Failed to send notification {}: {error}", N::METHOD))
     }
 
+    pub(crate) fn send_notification_value(
+        &self,
+        method: &str,
+        params: serde_json::Value,
+    ) -> crate::Result<()> {
+        self.client_sender
+            .send(Message::Notification(Notification::new(
+                method.to_owned(),
+                params,
+            )))
+            .map_err(|error| anyhow!("Failed to send notification {method}: {error}"))
+    }
+
     pub(crate) fn respond<R>(
         &self,
         id: &RequestId,

--- a/crates/shuck-server/src/session/options.rs
+++ b/crates/shuck-server/src/session/options.rs
@@ -23,6 +23,10 @@ impl GlobalOptions {
     pub fn into_settings(self, client: Client) -> GlobalClientSettings {
         GlobalClientSettings::new(self.client, client)
     }
+
+    pub(crate) fn workspace_diagnostics_enabled(&self) -> bool {
+        self.client.server.workspace_diagnostics.enabled
+    }
 }
 
 /// Per-client or per-workspace Shuck options supplied through LSP settings.
@@ -70,10 +74,13 @@ pub struct ServerOptions {
     pub rename: RenameFeatureOptions,
     /// Cross-file call hierarchy configuration.
     pub call_hierarchy: CallHierarchyFeatureOptions,
+    /// Workspace-wide diagnostic pull configuration.
+    pub workspace_diagnostics: WorkspaceDiagnosticsFeatureOptions,
     workspace_symbols_overrides: WorkspaceSymbolFeatureOptionsOverrides,
     completion_overrides: CompletionFeatureOptionsOverrides,
     rename_overrides: RenameFeatureOptionsOverrides,
     call_hierarchy_overrides: CallHierarchyFeatureOptionsOverrides,
+    workspace_diagnostics_overrides: WorkspaceDiagnosticsFeatureOptionsOverrides,
 }
 
 impl ServerOptions {
@@ -125,6 +132,19 @@ impl ServerOptions {
             base
         }
     }
+
+    pub(crate) fn workspace_diagnostics_layered_over(
+        &self,
+        base: WorkspaceDiagnosticsFeatureOptions,
+    ) -> WorkspaceDiagnosticsFeatureOptions {
+        if self.workspace_diagnostics_overrides.has_overrides() {
+            self.workspace_diagnostics_overrides.apply_to(base)
+        } else if self.workspace_diagnostics != WorkspaceDiagnosticsFeatureOptions::default() {
+            self.workspace_diagnostics
+        } else {
+            base
+        }
+    }
 }
 
 impl<'de> Deserialize<'de> for ServerOptions {
@@ -143,6 +163,8 @@ impl<'de> Deserialize<'de> for ServerOptions {
             rename: RenameFeatureOptionsOverrides,
             #[serde(default)]
             call_hierarchy: CallHierarchyFeatureOptionsOverrides,
+            #[serde(default)]
+            workspace_diagnostics: WorkspaceDiagnosticsFeatureOptionsOverrides,
         }
 
         let raw = RawServerOptions::deserialize(deserializer)?;
@@ -155,10 +177,14 @@ impl<'de> Deserialize<'de> for ServerOptions {
             call_hierarchy: raw
                 .call_hierarchy
                 .apply_to(CallHierarchyFeatureOptions::default()),
+            workspace_diagnostics: raw
+                .workspace_diagnostics
+                .apply_to(WorkspaceDiagnosticsFeatureOptions::default()),
             workspace_symbols_overrides: raw.workspace_symbols,
             completion_overrides: raw.completion,
             rename_overrides: raw.rename,
             call_hierarchy_overrides: raw.call_hierarchy,
+            workspace_diagnostics_overrides: raw.workspace_diagnostics,
         })
     }
 }
@@ -323,6 +349,81 @@ fn default_call_hierarchy_max_files() -> usize {
     10_000
 }
 
+#[derive(Clone, Copy, Debug, Default, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+struct WorkspaceDiagnosticsFeatureOptionsOverrides {
+    #[serde(default)]
+    enabled: Option<bool>,
+    #[serde(default)]
+    max_files: Option<usize>,
+    #[serde(default)]
+    max_entries: Option<usize>,
+    #[serde(default)]
+    max_source_bytes: Option<usize>,
+}
+
+impl WorkspaceDiagnosticsFeatureOptionsOverrides {
+    fn has_overrides(self) -> bool {
+        self.enabled.is_some()
+            || self.max_files.is_some()
+            || self.max_entries.is_some()
+            || self.max_source_bytes.is_some()
+    }
+
+    fn apply_to(
+        self,
+        base: WorkspaceDiagnosticsFeatureOptions,
+    ) -> WorkspaceDiagnosticsFeatureOptions {
+        WorkspaceDiagnosticsFeatureOptions {
+            enabled: self.enabled.unwrap_or(base.enabled),
+            max_files: self.max_files.unwrap_or(base.max_files),
+            max_entries: self.max_entries.unwrap_or(base.max_entries),
+            max_source_bytes: self.max_source_bytes.unwrap_or(base.max_source_bytes),
+        }
+    }
+}
+
+/// Configuration for bounded `workspace/diagnostic` requests.
+#[derive(Clone, Copy, Debug, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct WorkspaceDiagnosticsFeatureOptions {
+    /// Whether workspace diagnostic requests are advertised and served.
+    #[serde(default)]
+    pub enabled: bool,
+    /// Maximum number of workspace files returned by one request.
+    #[serde(default = "default_workspace_diagnostics_max_files")]
+    pub max_files: usize,
+    /// Maximum number of filesystem entries visited by one request.
+    #[serde(default = "default_workspace_diagnostics_max_entries")]
+    pub max_entries: usize,
+    /// Maximum source bytes read and analyzed by one request.
+    #[serde(default = "default_workspace_diagnostics_max_source_bytes")]
+    pub max_source_bytes: usize,
+}
+
+impl Default for WorkspaceDiagnosticsFeatureOptions {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            max_files: default_workspace_diagnostics_max_files(),
+            max_entries: default_workspace_diagnostics_max_entries(),
+            max_source_bytes: default_workspace_diagnostics_max_source_bytes(),
+        }
+    }
+}
+
+fn default_workspace_diagnostics_max_files() -> usize {
+    1_000
+}
+
+fn default_workspace_diagnostics_max_entries() -> usize {
+    10_000
+}
+
+fn default_workspace_diagnostics_max_source_bytes() -> usize {
+    32 * 1024 * 1024
+}
+
 fn default_workspace_symbols_max_files() -> usize {
     5000
 }
@@ -358,7 +459,7 @@ struct InitializationOptions {
 }
 
 impl AllOptions {
-    pub(crate) fn from_value(value: serde_json::Value, _client: &Client) -> Self {
+    pub(crate) fn from_value(value: serde_json::Value) -> Self {
         if value
             .as_object()
             .is_some_and(|object| object.contains_key("shuck"))

--- a/crates/shuck-server/src/session/request_queue.rs
+++ b/crates/shuck-server/src/session/request_queue.rs
@@ -1,7 +1,5 @@
 use std::cell::{Cell, OnceCell, RefCell};
 use std::fmt::Formatter;
-use std::sync::Arc;
-use std::sync::atomic::AtomicBool;
 use std::time::Instant;
 
 use lsp_server::RequestId;
@@ -96,15 +94,19 @@ impl PendingRequest {
 }
 
 #[derive(Clone, Debug, Default)]
-pub(crate) struct RequestCancellationToken(Arc<AtomicBool>);
+pub(crate) struct RequestCancellationToken(shuck_discover::DiscoveryCancellationToken);
 
 impl RequestCancellationToken {
     pub(crate) fn is_cancelled(&self) -> bool {
-        self.0.load(std::sync::atomic::Ordering::Relaxed)
+        self.0.is_cancelled()
     }
 
     pub(crate) fn cancel(&self) {
-        self.0.store(true, std::sync::atomic::Ordering::Relaxed);
+        self.0.cancel();
+    }
+
+    pub(crate) fn discovery_token(&self) -> shuck_discover::DiscoveryCancellationToken {
+        self.0.clone()
     }
 }
 

--- a/crates/shuck-server/src/workspace_diagnostics.rs
+++ b/crates/shuck-server/src/workspace_diagnostics.rs
@@ -599,11 +599,22 @@ fn workspace_diagnostics_have_enabled_scope(context: &WorkspaceDiagnosticContext
 }
 
 fn path_in_workspace(context: &WorkspaceDiagnosticContext, path: &Path) -> bool {
-    workspace_settings_for_path(context, path).is_some()
+    if workspace_settings_for_path(context, path).is_some() {
+        return true;
+    }
+
+    let canonical_path = crate::workspace_functions::canonical_path(path);
+    workspace_settings_for_path(context, &canonical_path).is_some()
         || context
             .workspace_roots
             .iter()
-            .any(|root| path.starts_with(root))
+            .any(|root| path_starts_with_root(path, root))
+}
+
+fn path_starts_with_root(path: &Path, root: &Path) -> bool {
+    path.starts_with(root)
+        || crate::workspace_functions::canonical_path(path)
+            .starts_with(crate::workspace_functions::canonical_path(root))
 }
 
 fn path_owned_by_root(context: &WorkspaceDiagnosticContext, path: &Path, root: &Path) -> bool {
@@ -653,5 +664,16 @@ mod tests {
         std::fs::write(&path, vec![b'x'; 4096]).unwrap();
 
         assert!(read_source_bounded(&path, 16).unwrap().is_none());
+    }
+
+    #[test]
+    fn canonical_deleted_path_remains_under_workspace_root() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("deleted.sh");
+        std::fs::write(&path, "unused=1\n").unwrap();
+        let canonical_path = crate::workspace_functions::canonical_path(&path);
+        std::fs::remove_file(&path).unwrap();
+
+        assert!(path_starts_with_root(&canonical_path, directory.path()));
     }
 }

--- a/crates/shuck-server/src/workspace_diagnostics.rs
+++ b/crates/shuck-server/src/workspace_diagnostics.rs
@@ -1,0 +1,657 @@
+use std::collections::{BTreeMap, BTreeSet};
+use std::fmt::Write as _;
+use std::io::Read as _;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Mutex, MutexGuard};
+
+use lsp_types as types;
+use sha2::{Digest, Sha256};
+use shuck_discover::{DiscoveryOptions, FileKind, discover_files_with_status};
+
+use crate::TextDocument;
+use crate::lint::generate_diagnostics;
+use crate::server::Result;
+use crate::session::{
+    Client, ClientOptions, ClientSettings, DocumentSnapshot, RequestCancellationToken,
+    ShuckSettings, WorkspaceDiagnosticsFeatureOptions, WorkspaceDocumentSnapshotFactory,
+    WorkspaceSettingsSnapshot,
+};
+
+const PARTIAL_RESULT_BATCH_SIZE: usize = 25;
+
+#[derive(Clone)]
+pub(crate) struct WorkspaceDiagnosticContext {
+    pub(crate) options: WorkspaceDiagnosticsFeatureOptions,
+    pub(crate) global_options: ClientOptions,
+    pub(crate) workspace_settings: Vec<WorkspaceSettingsSnapshot>,
+    pub(crate) workspace_roots: Vec<PathBuf>,
+    pub(crate) settings_workspace_roots: Vec<PathBuf>,
+    pub(crate) open_documents: Vec<WorkspaceDiagnosticOpenDocument>,
+    pub(crate) snapshot_factory: WorkspaceDocumentSnapshotFactory,
+    pub(crate) cache: Arc<WorkspaceDiagnosticCache>,
+    pub(crate) cache_generation: u64,
+    pub(crate) cancellation: RequestCancellationToken,
+}
+
+#[derive(Clone)]
+pub(crate) struct WorkspaceDiagnosticOpenDocument {
+    pub(crate) uri: types::Url,
+    pub(crate) path: PathBuf,
+    pub(crate) snapshot: DocumentSnapshot,
+}
+
+#[derive(Default)]
+pub(crate) struct WorkspaceDiagnosticCache {
+    entries: Mutex<BTreeMap<String, CachedWorkspaceDiagnostic>>,
+    generation: AtomicU64,
+}
+
+#[derive(Clone)]
+struct CachedWorkspaceDiagnostic {
+    source_hash: [u8; 32],
+    result_id: String,
+    diagnostics: Vec<types::Diagnostic>,
+}
+
+struct WorkDoneGuard {
+    client: Client,
+    token: Option<types::ProgressToken>,
+}
+
+struct ReportSink<'a> {
+    client: &'a Client,
+    partial_token: Option<&'a types::ProgressToken>,
+    buffered: Vec<types::WorkspaceDocumentDiagnosticReport>,
+    completed: usize,
+}
+
+impl WorkspaceDiagnosticCache {
+    pub(crate) fn invalidate_all(&self) {
+        self.generation.fetch_add(1, Ordering::AcqRel);
+        lock_or_recover(&self.entries).clear();
+    }
+
+    pub(crate) fn invalidate_uri(&self, uri: &types::Url) {
+        self.generation.fetch_add(1, Ordering::AcqRel);
+        lock_or_recover(&self.entries).remove(uri.as_str());
+    }
+
+    pub(crate) fn generation(&self) -> u64 {
+        self.generation.load(Ordering::Acquire)
+    }
+
+    fn get(
+        &self,
+        uri: &types::Url,
+        source_hash: [u8; 32],
+        generation: u64,
+    ) -> Option<CachedWorkspaceDiagnostic> {
+        if self.generation() != generation {
+            return None;
+        }
+        let entries = lock_or_recover(&self.entries);
+        if self.generation() != generation {
+            return None;
+        }
+        entries
+            .get(uri.as_str())
+            .filter(|entry| entry.source_hash == source_hash)
+            .cloned()
+    }
+
+    fn insert(&self, uri: &types::Url, entry: CachedWorkspaceDiagnostic, generation: u64) {
+        if self.generation() != generation {
+            return;
+        }
+        let mut entries = lock_or_recover(&self.entries);
+        if self.generation() == generation {
+            entries.insert(uri.to_string(), entry);
+        }
+    }
+
+    fn retain(&self, uris: &BTreeSet<String>, generation: u64) {
+        if self.generation() != generation {
+            return;
+        }
+        let mut entries = lock_or_recover(&self.entries);
+        if self.generation() == generation {
+            entries.retain(|uri, _| uris.contains(uri));
+        }
+    }
+}
+
+impl WorkDoneGuard {
+    fn new(client: &Client, token: Option<types::ProgressToken>) -> Self {
+        if let Some(token) = token.as_ref() {
+            let _ = client.send_notification_value(
+                "$/progress",
+                serde_json::json!({
+                    "token": token,
+                    "value": {
+                        "kind": "begin",
+                        "title": "Shuck workspace diagnostics",
+                        "cancellable": true,
+                    },
+                }),
+            );
+        }
+        Self {
+            client: client.clone(),
+            token,
+        }
+    }
+
+    fn report(&self, completed: usize) {
+        let Some(token) = self.token.as_ref() else {
+            return;
+        };
+        let _ = self.client.send_notification_value(
+            "$/progress",
+            serde_json::json!({
+                "token": token,
+                "value": {
+                    "kind": "report",
+                    "cancellable": true,
+                    "message": format!("Analyzed {completed} shell files"),
+                },
+            }),
+        );
+    }
+}
+
+impl Drop for WorkDoneGuard {
+    fn drop(&mut self) {
+        let Some(token) = self.token.as_ref() else {
+            return;
+        };
+        let _ = self.client.send_notification_value(
+            "$/progress",
+            serde_json::json!({
+                "token": token,
+                "value": { "kind": "end" },
+            }),
+        );
+    }
+}
+
+impl<'a> ReportSink<'a> {
+    fn new(client: &'a Client, partial_token: Option<&'a types::ProgressToken>) -> Self {
+        Self {
+            client,
+            partial_token,
+            buffered: Vec::new(),
+            completed: 0,
+        }
+    }
+
+    fn completed(&self) -> usize {
+        self.completed
+    }
+
+    fn push(&mut self, report: types::WorkspaceDocumentDiagnosticReport) -> Result<()> {
+        self.buffered.push(report);
+        self.completed += 1;
+        if self.partial_token.is_some() && self.buffered.len() >= PARTIAL_RESULT_BATCH_SIZE {
+            self.flush_partial()?;
+        }
+        Ok(())
+    }
+
+    fn finish(mut self) -> Result<Vec<types::WorkspaceDocumentDiagnosticReport>> {
+        if self.partial_token.is_some() {
+            self.flush_partial()?;
+            return Ok(Vec::new());
+        }
+        Ok(self.buffered)
+    }
+
+    fn flush_partial(&mut self) -> Result<()> {
+        let Some(token) = self.partial_token else {
+            return Ok(());
+        };
+        if self.buffered.is_empty() {
+            return Ok(());
+        }
+        self.client.send_notification_value(
+            "$/progress",
+            serde_json::json!({
+                "token": token,
+                "value": { "items": self.buffered },
+            }),
+        )?;
+        self.buffered.clear();
+        Ok(())
+    }
+}
+
+pub(crate) fn workspace_diagnostics(
+    context: WorkspaceDiagnosticContext,
+    client: &Client,
+    params: &types::WorkspaceDiagnosticParams,
+) -> Result<types::WorkspaceDiagnosticReportResult> {
+    let progress = WorkDoneGuard::new(
+        client,
+        params.work_done_progress_params.work_done_token.clone(),
+    );
+    if !workspace_diagnostics_have_enabled_scope(&context) || context.cancellation.is_cancelled() {
+        return Ok(empty_report());
+    }
+
+    let previous = params
+        .previous_result_ids
+        .iter()
+        .map(|previous| (previous.uri.to_string(), previous.value.as_str()))
+        .collect::<BTreeMap<_, _>>();
+    let mut reports = ReportSink::new(
+        client,
+        params.partial_result_params.partial_result_token.as_ref(),
+    );
+    let mut seen = BTreeSet::new();
+    let mut open_paths = BTreeSet::new();
+    let mut source_bytes = 0usize;
+    let mut coverage_complete = true;
+
+    let mut open_documents = context.open_documents.clone();
+    open_documents.sort_by(|left, right| left.uri.as_str().cmp(right.uri.as_str()));
+    for document in open_documents {
+        if reports.completed() >= context.options.max_files {
+            coverage_complete = false;
+            break;
+        }
+        if context.cancellation.is_cancelled() {
+            coverage_complete = false;
+            break;
+        }
+        let options = workspace_diagnostic_options_for_path(&context, &document.path);
+        if !options.enabled || !path_in_workspace(&context, &document.path) {
+            continue;
+        }
+        let document_bytes = document.snapshot.query().document().contents().len();
+        if source_bytes.saturating_add(document_bytes) > context.options.max_source_bytes
+            || source_bytes.saturating_add(document_bytes) > options.max_source_bytes
+        {
+            coverage_complete = false;
+            continue;
+        }
+        source_bytes += document_bytes;
+        open_paths.insert(canonical_or_original(&document.path));
+        let diagnostics = generate_diagnostics(&document.snapshot);
+        let result_id = diagnostic_result_id(&diagnostics);
+        seen.insert(document.uri.to_string());
+        reports.push(document_report(
+            document.uri,
+            Some(i64::from(document.snapshot.query().document().version())),
+            diagnostics,
+            result_id,
+            &previous,
+        ))?;
+        progress.report(reports.completed());
+    }
+
+    let remaining = context
+        .options
+        .max_files
+        .saturating_sub(reports.completed());
+    let mut discovered = BTreeMap::new();
+    let mut discovery_entries = 0usize;
+    if remaining > 0 && !context.cancellation.is_cancelled() {
+        for root in &context.workspace_roots {
+            let options = workspace_diagnostic_options_for_path(&context, root);
+            if !options.enabled {
+                continue;
+            }
+            if discovered.len() >= remaining {
+                coverage_complete = false;
+                break;
+            }
+            let root_remaining = remaining
+                .saturating_sub(discovered.len())
+                .min(options.max_files);
+            let entry_remaining = context
+                .options
+                .max_entries
+                .saturating_sub(discovery_entries)
+                .min(options.max_entries);
+            if root_remaining == 0 || entry_remaining == 0 {
+                coverage_complete = false;
+                break;
+            }
+            let result = match discover_files_with_status(
+                std::slice::from_ref(root),
+                root,
+                &DiscoveryOptions {
+                    respect_gitignore: true,
+                    parallel: false,
+                    use_config_roots: true,
+                    max_files: Some(root_remaining),
+                    max_entries: Some(entry_remaining),
+                    cancellation: Some(context.cancellation.discovery_token()),
+                    include_embedded: false,
+                    excluded_subtrees: context
+                        .workspace_roots
+                        .iter()
+                        .filter(|other| *other != root && other.starts_with(root))
+                        .cloned()
+                        .collect(),
+                    ..DiscoveryOptions::default()
+                },
+            ) {
+                Ok(files) => files,
+                Err(error) => {
+                    tracing::warn!(
+                        "Failed to discover workspace diagnostic files in {}: {error}",
+                        root.display()
+                    );
+                    coverage_complete = false;
+                    continue;
+                }
+            };
+            discovery_entries += result.visited_entries;
+            coverage_complete &= result.complete;
+            for file in result.files {
+                if file.kind != FileKind::Shell
+                    || !path_owned_by_root(&context, &file.absolute_path, root)
+                    || open_paths.contains(&canonical_or_original(&file.absolute_path))
+                {
+                    continue;
+                }
+                discovered.entry(file.absolute_path.clone()).or_insert(file);
+            }
+        }
+    } else if !context.workspace_roots.is_empty() {
+        coverage_complete = false;
+    }
+
+    for file in discovered.values() {
+        if reports.completed() >= context.options.max_files {
+            coverage_complete = false;
+            break;
+        }
+        if context.cancellation.is_cancelled() {
+            coverage_complete = false;
+            break;
+        }
+        let options = workspace_diagnostic_options_for_path(&context, &file.absolute_path);
+        let remaining_source_bytes = context
+            .options
+            .max_source_bytes
+            .saturating_sub(source_bytes)
+            .min(options.max_source_bytes.saturating_sub(source_bytes));
+        let source = match read_source_bounded(&file.absolute_path, remaining_source_bytes) {
+            Ok(Some(source)) => source,
+            Ok(None) => {
+                coverage_complete = false;
+                continue;
+            }
+            Err(error) => {
+                tracing::warn!(
+                    "Failed to read workspace diagnostic file {}: {error}",
+                    file.absolute_path.display()
+                );
+                coverage_complete = false;
+                continue;
+            }
+        };
+        source_bytes += source.len();
+        let Ok(uri) = types::Url::from_file_path(&file.absolute_path) else {
+            continue;
+        };
+        let source_hash: [u8; 32] = Sha256::digest(source.as_bytes()).into();
+        let cached = context
+            .cache
+            .get(&uri, source_hash, context.cache_generation);
+        let (diagnostics, result_id) = if let Some(cached) = cached {
+            (cached.diagnostics, cached.result_id)
+        } else {
+            let (settings, client_settings) = settings_for_path(&context, &file.absolute_path);
+            let document = Arc::new(TextDocument::new(source, 0));
+            let snapshot = context.snapshot_factory.snapshot(
+                uri.clone(),
+                document,
+                Arc::new(settings),
+                Arc::new(client_settings),
+            );
+            let diagnostics = generate_diagnostics(&snapshot);
+            let result_id = diagnostic_result_id(&diagnostics);
+            context.cache.insert(
+                &uri,
+                CachedWorkspaceDiagnostic {
+                    source_hash,
+                    result_id: result_id.clone(),
+                    diagnostics: diagnostics.clone(),
+                },
+                context.cache_generation,
+            );
+            (diagnostics, result_id)
+        };
+        seen.insert(uri.to_string());
+        reports.push(document_report(
+            uri,
+            None,
+            diagnostics,
+            result_id,
+            &previous,
+        ))?;
+        progress.report(reports.completed());
+    }
+
+    if coverage_complete && !context.cancellation.is_cancelled() {
+        let remaining_reports = context
+            .options
+            .max_files
+            .saturating_sub(reports.completed());
+        for previous_uri in previous
+            .keys()
+            .filter(|uri| !seen.contains(*uri))
+            .take(remaining_reports)
+        {
+            let Ok(uri) = previous_uri.parse::<types::Url>() else {
+                continue;
+            };
+            let Ok(path) = uri.to_file_path() else {
+                continue;
+            };
+            if !path_in_workspace(&context, &path) {
+                continue;
+            }
+            reports.push(document_report(
+                uri,
+                None,
+                Vec::new(),
+                diagnostic_result_id(&[]),
+                &previous,
+            ))?;
+        }
+    }
+    context.cache.retain(&seen, context.cache_generation);
+
+    let reports = reports.finish()?;
+
+    Ok(types::WorkspaceDiagnosticReportResult::Report(
+        types::WorkspaceDiagnosticReport { items: reports },
+    ))
+}
+
+fn read_source_bounded(path: &Path, max_bytes: usize) -> std::io::Result<Option<String>> {
+    let metadata = std::fs::metadata(path)?;
+    if metadata.len() > max_bytes as u64 {
+        return Ok(None);
+    }
+    let file = std::fs::File::open(path)?;
+    let limit = u64::try_from(max_bytes)
+        .unwrap_or(u64::MAX)
+        .saturating_add(1);
+    let mut source = String::new();
+    file.take(limit).read_to_string(&mut source)?;
+    if source.len() > max_bytes {
+        return Ok(None);
+    }
+    Ok(Some(source))
+}
+
+fn empty_report() -> types::WorkspaceDiagnosticReportResult {
+    types::WorkspaceDiagnosticReportResult::Report(types::WorkspaceDiagnosticReport {
+        items: Vec::new(),
+    })
+}
+
+fn document_report(
+    uri: types::Url,
+    version: Option<i64>,
+    diagnostics: Vec<types::Diagnostic>,
+    result_id: String,
+    previous: &BTreeMap<String, &str>,
+) -> types::WorkspaceDocumentDiagnosticReport {
+    if previous.get(uri.as_str()).copied() == Some(result_id.as_str()) {
+        return types::WorkspaceDocumentDiagnosticReport::Unchanged(
+            types::WorkspaceUnchangedDocumentDiagnosticReport {
+                uri,
+                version,
+                unchanged_document_diagnostic_report: types::UnchangedDocumentDiagnosticReport {
+                    result_id,
+                },
+            },
+        );
+    }
+    types::WorkspaceDocumentDiagnosticReport::Full(types::WorkspaceFullDocumentDiagnosticReport {
+        uri,
+        version,
+        full_document_diagnostic_report: types::FullDocumentDiagnosticReport {
+            result_id: Some(result_id),
+            items: diagnostics,
+        },
+    })
+}
+
+fn diagnostic_result_id(diagnostics: &[types::Diagnostic]) -> String {
+    let serialized = serde_json::to_vec(diagnostics).unwrap_or_default();
+    let digest = Sha256::digest(&serialized);
+    let mut result = String::with_capacity(32);
+    for byte in &digest[..16] {
+        let _ = write!(result, "{byte:02x}");
+    }
+    result
+}
+
+fn settings_for_path(
+    context: &WorkspaceDiagnosticContext,
+    path: &Path,
+) -> (ShuckSettings, ClientSettings) {
+    let workspace_options =
+        workspace_settings_for_path(context, path).and_then(|workspace| workspace.options.as_ref());
+    if let Some(workspace_options) = workspace_options {
+        let layers = [&context.global_options, workspace_options];
+        return (
+            ShuckSettings::resolve(path.into(), &context.settings_workspace_roots, &layers),
+            ClientSettings::from_layered_options(&layers),
+        );
+    }
+    let layers = [&context.global_options];
+    (
+        ShuckSettings::resolve(path.into(), &context.settings_workspace_roots, &layers),
+        ClientSettings::from_layered_options(&layers),
+    )
+}
+
+fn workspace_diagnostic_options_for_path(
+    context: &WorkspaceDiagnosticContext,
+    path: &Path,
+) -> WorkspaceDiagnosticsFeatureOptions {
+    workspace_settings_for_path(context, path)
+        .and_then(|workspace| workspace.options.as_ref())
+        .map(|options| {
+            options
+                .server
+                .workspace_diagnostics_layered_over(context.options)
+        })
+        .unwrap_or(context.options)
+}
+
+fn workspace_settings_for_path<'a>(
+    context: &'a WorkspaceDiagnosticContext,
+    path: &Path,
+) -> Option<&'a WorkspaceSettingsSnapshot> {
+    context
+        .workspace_settings
+        .iter()
+        .filter_map(|workspace| {
+            workspace_root_match_len(path, workspace).map(|len| (workspace, len))
+        })
+        .max_by_key(|(_, len)| *len)
+        .map(|(workspace, _)| workspace)
+}
+
+fn workspace_root_match_len(path: &Path, workspace: &WorkspaceSettingsSnapshot) -> Option<usize> {
+    [Some(&workspace.root), workspace.canonical_root.as_ref()]
+        .into_iter()
+        .flatten()
+        .filter(|root| path.starts_with(root))
+        .map(|root| root.components().count())
+        .max()
+}
+
+fn workspace_diagnostics_have_enabled_scope(context: &WorkspaceDiagnosticContext) -> bool {
+    context
+        .workspace_roots
+        .iter()
+        .any(|root| workspace_diagnostic_options_for_path(context, root).enabled)
+}
+
+fn path_in_workspace(context: &WorkspaceDiagnosticContext, path: &Path) -> bool {
+    workspace_settings_for_path(context, path).is_some()
+        || context
+            .workspace_roots
+            .iter()
+            .any(|root| path.starts_with(root))
+}
+
+fn path_owned_by_root(context: &WorkspaceDiagnosticContext, path: &Path, root: &Path) -> bool {
+    workspace_settings_for_path(context, path)
+        .map(|workspace| workspace.root == root)
+        .unwrap_or(true)
+}
+
+fn canonical_or_original(path: &Path) -> PathBuf {
+    path.canonicalize().unwrap_or_else(|_| path.to_path_buf())
+}
+
+fn lock_or_recover<T>(mutex: &Mutex<T>) -> MutexGuard<'_, T> {
+    match mutex.lock() {
+        Ok(guard) => guard,
+        Err(poisoned) => poisoned.into_inner(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn stale_request_cannot_repopulate_an_invalidated_cache() {
+        let cache = WorkspaceDiagnosticCache::default();
+        let uri = types::Url::parse("file:///workspace/script.sh").unwrap();
+        let stale_generation = cache.generation();
+        cache.invalidate_all();
+        cache.insert(
+            &uri,
+            CachedWorkspaceDiagnostic {
+                source_hash: [7; 32],
+                result_id: "stale".to_owned(),
+                diagnostics: Vec::new(),
+            },
+            stale_generation,
+        );
+
+        assert!(cache.get(&uri, [7; 32], cache.generation()).is_none());
+    }
+
+    #[test]
+    fn bounded_reader_rejects_a_file_before_loading_past_the_budget() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("large.sh");
+        std::fs::write(&path, vec![b'x'; 4096]).unwrap();
+
+        assert!(read_source_bounded(&path, 16).unwrap().is_none());
+    }
+}

--- a/crates/shuck-server/tests/manual.rs
+++ b/crates/shuck-server/tests/manual.rs
@@ -52,6 +52,40 @@ fn recv_lsp_response(connection: &Connection, id: i32) -> Response {
     }
 }
 
+fn recv_response_with_notifications(
+    connection: &Connection,
+    id: i32,
+) -> (serde_json::Value, Vec<Notification>) {
+    let mut notifications = Vec::new();
+    loop {
+        let message = connection
+            .receiver
+            .recv_timeout(Duration::from_secs(5))
+            .expect("server should respond");
+        match message {
+            Message::Response(response) if response.id == RequestId::from(id) => {
+                assert!(
+                    response.error.is_none(),
+                    "unexpected LSP error: {:?}",
+                    response.error
+                );
+                return (
+                    response.result.expect("response should carry a result"),
+                    notifications,
+                );
+            }
+            Message::Notification(notification) => notifications.push(notification),
+            Message::Request(request) => {
+                panic!(
+                    "unexpected server request during replay: {}",
+                    request.method
+                )
+            }
+            Message::Response(_) => continue,
+        }
+    }
+}
+
 fn replay_capabilities() -> ClientCapabilities {
     serde_json::from_value(serde_json::json!({
         "general": {
@@ -2077,4 +2111,349 @@ fn call_hierarchy_round_trips_same_named_definition_identity() {
         .join()
         .expect("server thread should join")
         .expect("server should exit cleanly");
+}
+
+#[test]
+fn workspace_diagnostics_are_incremental_and_shadow_open_buffers() {
+    let (server_connection, client_connection) = Connection::memory();
+    let server_thread = thread::spawn(move || shuck_server::run_connection(server_connection));
+
+    let outer = tempfile::tempdir().expect("tempdir should be created");
+    let first_root = outer.path().join("first");
+    let second_root = outer.path().join("second");
+    let outside_root = outer.path().join("outside");
+    std::fs::create_dir_all(first_root.join(".git")).unwrap();
+    std::fs::create_dir_all(&second_root).unwrap();
+    std::fs::create_dir_all(&outside_root).unwrap();
+    let malformed_path = first_root.join("malformed.sh");
+    let changed_path = first_root.join("changed.sh");
+    let shadowed_path = second_root.join("shadowed.sh");
+    std::fs::write(&malformed_path, "if true; then\n").unwrap();
+    std::fs::write(&changed_path, "unused=1\n").unwrap();
+    std::fs::write(&shadowed_path, "disk_only=1\n").unwrap();
+    std::fs::write(first_root.join(".git/ignored.sh"), "ignored=1\n").unwrap();
+    std::fs::write(outside_root.join("outside.sh"), "outside=1\n").unwrap();
+    std::fs::write(first_root.join("notes.txt"), "not shell\n").unwrap();
+
+    let first_uri = Url::from_file_path(&first_root).unwrap();
+    let second_uri = Url::from_file_path(&second_root).unwrap();
+    let malformed_uri =
+        Url::from_file_path(std::fs::canonicalize(&malformed_path).unwrap()).unwrap();
+    let changed_uri = Url::from_file_path(std::fs::canonicalize(&changed_path).unwrap()).unwrap();
+    let shadowed_uri = Url::from_file_path(&shadowed_path).unwrap();
+
+    send_request(
+        &client_connection,
+        1,
+        "initialize",
+        serde_json::json!({
+            "capabilities": replay_capabilities(),
+            "workspaceFolders": [
+                { "uri": first_uri, "name": "first" },
+                { "uri": second_uri, "name": "second" },
+            ],
+            "initializationOptions": {
+                "shuck": {
+                    "server": {
+                        "workspaceDiagnostics": {
+                            "enabled": true,
+                            "maxFiles": 10,
+                            "maxSourceBytes": 1048576,
+                        }
+                    }
+                }
+            },
+        }),
+    );
+    let initialize = recv_response(&client_connection, 1);
+    assert_eq!(
+        initialize["capabilities"]["diagnosticProvider"]["workspaceDiagnostics"],
+        true
+    );
+    client_connection
+        .sender
+        .send(Message::Notification(Notification::new(
+            "initialized".to_owned(),
+            serde_json::json!({}),
+        )))
+        .unwrap();
+    open_document(&client_connection, &shadowed_uri, "printf '%s\\n' clean\n");
+
+    send_request(
+        &client_connection,
+        2,
+        "workspace/diagnostic",
+        serde_json::json!({
+            "identifier": "shuck",
+            "previousResultIds": [],
+            "workDoneToken": "work",
+            "partialResultToken": "partial",
+        }),
+    );
+    let (first_result, notifications) = recv_response_with_notifications(&client_connection, 2);
+    assert!(first_result["items"].as_array().unwrap().is_empty());
+    let work_kinds = notifications
+        .iter()
+        .filter(|notification| {
+            notification.method == "$/progress" && notification.params["token"] == "work"
+        })
+        .filter_map(|notification| notification.params["value"]["kind"].as_str())
+        .collect::<Vec<_>>();
+    assert!(work_kinds.contains(&"begin"));
+    assert!(work_kinds.contains(&"end"));
+    let first_items = notifications
+        .iter()
+        .filter(|notification| {
+            notification.method == "$/progress" && notification.params["token"] == "partial"
+        })
+        .flat_map(|notification| {
+            notification.params["value"]["items"]
+                .as_array()
+                .into_iter()
+                .flatten()
+        })
+        .cloned()
+        .collect::<Vec<_>>();
+    assert_eq!(first_items.len(), 3);
+    let item_for = |uri: &Url| {
+        first_items
+            .iter()
+            .find(|item| item["uri"] == uri.as_str())
+            .unwrap_or_else(|| panic!("missing diagnostic report for {uri}"))
+    };
+    assert_eq!(item_for(&shadowed_uri)["version"], 1);
+    assert!(
+        item_for(&shadowed_uri)["items"]
+            .as_array()
+            .unwrap()
+            .is_empty()
+    );
+    assert!(
+        !item_for(&changed_uri)["items"]
+            .as_array()
+            .unwrap()
+            .is_empty()
+    );
+    assert!(
+        item_for(&malformed_uri)["items"]
+            .as_array()
+            .unwrap()
+            .is_empty()
+    );
+
+    let previous = first_items
+        .iter()
+        .map(|item| {
+            serde_json::json!({
+                "uri": item["uri"],
+                "value": item["resultId"],
+            })
+        })
+        .collect::<Vec<_>>();
+    send_request(
+        &client_connection,
+        3,
+        "workspace/diagnostic",
+        serde_json::json!({
+            "identifier": "shuck",
+            "previousResultIds": previous.clone(),
+        }),
+    );
+    let unchanged = recv_response(&client_connection, 3);
+    assert!(
+        unchanged["items"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .all(|item| item["kind"] == "unchanged")
+    );
+
+    client_connection
+        .sender
+        .send(Message::Notification(Notification::new(
+            "workspace/didChangeConfiguration".to_owned(),
+            serde_json::json!({
+                "settings": {
+                    "shuck": {
+                        "showSyntaxErrors": true,
+                        "server": {
+                            "workspaceDiagnostics": {
+                                "enabled": true,
+                                "maxFiles": 10,
+                                "maxSourceBytes": 1048576,
+                            }
+                        }
+                    }
+                }
+            }),
+        )))
+        .unwrap();
+    send_request(
+        &client_connection,
+        4,
+        "workspace/diagnostic",
+        serde_json::json!({
+            "identifier": "shuck",
+            "previousResultIds": previous.clone(),
+        }),
+    );
+    let configured = recv_response(&client_connection, 4);
+    let malformed = configured["items"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|item| item["uri"] == malformed_uri.as_str())
+        .unwrap();
+    assert_eq!(malformed["kind"], "full");
+    assert!(!malformed["items"].as_array().unwrap().is_empty());
+
+    std::fs::remove_file(&changed_path).unwrap();
+    client_connection
+        .sender
+        .send(Message::Notification(Notification::new(
+            "workspace/didChangeWatchedFiles".to_owned(),
+            serde_json::json!({
+                "changes": [{ "uri": changed_uri, "type": 3 }]
+            }),
+        )))
+        .unwrap();
+    send_request(
+        &client_connection,
+        5,
+        "workspace/diagnostic",
+        serde_json::json!({
+            "identifier": "shuck",
+            "previousResultIds": previous,
+        }),
+    );
+    let deleted = recv_response(&client_connection, 5);
+    let deleted_item = deleted["items"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|item| item["uri"] == changed_uri.as_str())
+        .unwrap();
+    assert_eq!(deleted_item["kind"], "full");
+    assert!(deleted_item["items"].as_array().unwrap().is_empty());
+
+    send_request(&client_connection, 99, "shutdown", serde_json::json!(null));
+    let _ = recv_response(&client_connection, 99);
+    client_connection
+        .sender
+        .send(Message::Notification(Notification::new(
+            "exit".to_owned(),
+            serde_json::json!({}),
+        )))
+        .unwrap();
+    server_thread.join().unwrap().unwrap();
+}
+
+#[test]
+fn workspace_diagnostics_enforce_the_synthetic_workspace_limit() {
+    let (server_connection, client_connection) = Connection::memory();
+    let server_thread = thread::spawn(move || shuck_server::run_connection(server_connection));
+    let workspace = tempfile::tempdir().expect("tempdir should be created");
+    for index in 0..100 {
+        std::fs::write(
+            workspace.path().join(format!("script-{index:03}.sh")),
+            format!("unused_{index}=1\n"),
+        )
+        .unwrap();
+    }
+
+    send_request(
+        &client_connection,
+        1,
+        "initialize",
+        serde_json::json!({
+            "capabilities": replay_capabilities(),
+            "rootUri": Url::from_file_path(workspace.path()).unwrap(),
+            "initializationOptions": {
+                "shuck": {
+                    "server": {
+                        "workspaceDiagnostics": {
+                            "enabled": true,
+                            "maxFiles": 3,
+                            "maxEntries": 1000,
+                            "maxSourceBytes": 1048576,
+                        }
+                    }
+                }
+            },
+        }),
+    );
+    let _ = recv_response(&client_connection, 1);
+    client_connection
+        .sender
+        .send(Message::Notification(Notification::new(
+            "initialized".to_owned(),
+            serde_json::json!({}),
+        )))
+        .unwrap();
+    send_request(
+        &client_connection,
+        2,
+        "workspace/diagnostic",
+        serde_json::json!({
+            "identifier": "shuck",
+            "previousResultIds": [{
+                "uri": Url::from_file_path(
+                    std::fs::canonicalize(workspace.path().join("script-099.sh")).unwrap()
+                ).unwrap(),
+                "value": "stale-result",
+            }],
+        }),
+    );
+    let result = recv_response(&client_connection, 2);
+    assert_eq!(result["items"].as_array().unwrap().len(), 3);
+    assert!(
+        result["items"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .all(|item| { !item["uri"].as_str().unwrap().ends_with("script-099.sh") })
+    );
+
+    client_connection
+        .sender
+        .send(Message::Notification(Notification::new(
+            "workspace/didChangeConfiguration".to_owned(),
+            serde_json::json!({
+                "settings": {
+                    "shuck": {
+                        "server": {
+                            "workspaceDiagnostics": {
+                                "enabled": true,
+                                "maxFiles": 100,
+                                "maxEntries": 1000,
+                                "maxSourceBytes": 12,
+                            }
+                        }
+                    }
+                }
+            }),
+        )))
+        .unwrap();
+    send_request(
+        &client_connection,
+        3,
+        "workspace/diagnostic",
+        serde_json::json!({
+            "identifier": "shuck",
+            "previousResultIds": [],
+        }),
+    );
+    let byte_bounded = recv_response(&client_connection, 3);
+    assert_eq!(byte_bounded["items"].as_array().unwrap().len(), 1);
+
+    send_request(&client_connection, 99, "shutdown", serde_json::json!(null));
+    let _ = recv_response(&client_connection, 99);
+    client_connection
+        .sender
+        .send(Message::Notification(Notification::new(
+            "exit".to_owned(),
+            serde_json::json!({}),
+        )))
+        .unwrap();
+    server_thread.join().unwrap().unwrap();
 }

--- a/specs/018-lsp.md
+++ b/specs/018-lsp.md
@@ -264,7 +264,7 @@ The server advertises the following on `initialize`:
 |------------|-------|
 | `positionEncoding` | Negotiated; UTF-8 preferred, UTF-16 fallback (always supported), UTF-32 lowest priority |
 | `textDocumentSync` | `INCREMENTAL`, `openClose: true` |
-| `diagnosticProvider` | `interFileDependencies: false`, `workspaceDiagnostics: false`, `identifier: "Shuck"`, work-done progress on |
+| `diagnosticProvider` | `interFileDependencies: false`, `workspaceDiagnostics` follows the opt-in server setting, `identifier: "Shuck"`, work-done progress on |
 | `documentFormattingProvider` | `true` |
 | `documentRangeFormattingProvider` | `true` |
 | `codeActionProvider` | Kinds: `quickfix`, `source.fixAll.shuck`. `resolveProvider: true` so the editor can defer the heavy edit computation to `codeAction/resolve` |
@@ -283,6 +283,7 @@ Requests fan out by method into typed handlers:
 | Method | Handler | Schedule |
 |--------|---------|----------|
 | `textDocument/diagnostic` | `DocumentDiagnostic` | Background, Worker |
+| `workspace/diagnostic` | `WorkspaceDiagnostic` | Background, Worker; opt-in, lazy, cancellable, and bounded |
 | `textDocument/codeAction` | `CodeActions` | Background, Worker |
 | `codeAction/resolve` | `CodeActionResolve` | Background, Worker |
 | `textDocument/formatting` | `Format` | Background, Fmt |

--- a/specs/023-lsp-editor-features.md
+++ b/specs/023-lsp-editor-features.md
@@ -528,6 +528,7 @@ Feature handlers use the existing scheduler:
 | Rename | Worker |
 | Folding ranges | Worker |
 | Selection range | Worker |
+| Workspace diagnostic | Worker |
 | Formatting | Fmt |
 | Range formatting | Fmt |
 
@@ -544,6 +545,7 @@ Add server-specific options under `initializationOptions` and
 #[serde(rename_all = "camelCase")]
 pub struct ServerFeatureOptions {
     pub workspace_symbols: WorkspaceSymbolOptions,
+    pub workspace_diagnostics: WorkspaceDiagnosticsOptions,
     pub completion: CompletionOptions,
     pub rename: RenameOptions,
 }
@@ -552,6 +554,14 @@ pub struct ServerFeatureOptions {
 pub struct WorkspaceSymbolOptions {
     pub enabled: bool,
     pub max_files: usize,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct WorkspaceDiagnosticsOptions {
+    pub enabled: bool,
+    pub max_files: usize,
+    pub max_entries: usize,
+    pub max_source_bytes: usize,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -569,6 +579,9 @@ pub struct RenameOptions {
 Defaults:
 
 - workspace symbols enabled, `max_files = 5000`;
+- workspace diagnostics disabled, `max_files = 1000`, `max_entries = 10000`,
+  and `max_source_bytes = 32 MiB`; enabling them advertises and serves
+  `workspace/diagnostic` without starting a background scan;
 - runtime-name and keyword completions enabled;
 - cross-file function rename disabled by default and enabled with
   `server.rename.allowCrossFile = true`.

--- a/website/content/editors/index.mdx
+++ b/website/content/editors/index.mdx
@@ -14,7 +14,7 @@ files.
 | Feature | LSP methods | Scope and limitations |
 | --- | --- | --- |
 | Document synchronization | `textDocument/didOpen`, `didChange`, `didClose` | Incremental synchronization for open shell buffers. Dialect inference uses the buffer `languageId`, shebang, and file path. |
-| Diagnostics | `textDocument/diagnostic`, `textDocument/publishDiagnostics` | Pull diagnostics when the client supports them, with push diagnostics as a fallback. Analysis is document-local; workspace diagnostics and inter-file diagnostic dependencies are not supported. |
+| Diagnostics | `textDocument/diagnostic`, `textDocument/publishDiagnostics`, opt-in `workspace/diagnostic` | Pull diagnostics when the client supports them, with push diagnostics as a fallback. Workspace pulls are disabled by default; when enabled they discover shell files lazily, honor workspace and ignore boundaries, prefer open buffers, reuse stable result IDs, report partial progress, and stop at configurable file, visited-entry, and source-byte limits. Inter-file diagnostic dependencies are not supported. |
 | Code actions | `textDocument/codeAction`, `codeAction/resolve` | Quick fixes, disable-this-line actions, and `source.fixAll.shuck` for the active document. |
 | Completion | `textDocument/completion`, `completionItem/resolve` | Variables, declaration names, runtime names, builtins, shell keywords, and functions visible in the active document or through unconditional static `source`/`.` edges. Literal paths, valid source hints, configured source paths, and unsaved open buffers participate; dynamic or unresolved sources do not. Command-specific option completion is not supported. |
 | Hover | `textDocument/hover` | Semantic symbol information plus help for suppression codes in `# shuck:` and `# shellcheck` directives. Function calls can resolve through the same exact static source graph as go-to-definition, including source hints, configured source paths, and open buffers. Dynamic or ambiguous sources are not guessed, and Shuck does not fetch command manuals. |
@@ -40,9 +40,30 @@ Editor formatting uses the same parser-backed formatter as [`shuck format`](/doc
 ### Not currently planned
 
 Shuck does not currently advertise semantic tokens, inlay hints, signature
-help, notebook documents, or workspace-wide diagnostics. These are not
-permanent prohibitions, but there is no accepted implementation design for them
-today.
+help, or notebook documents. These are not permanent
+prohibitions, but there is no accepted implementation design for them today.
+
+Enable bounded workspace pulls through initialization options:
+
+```json
+{
+  "shuck": {
+    "server": {
+      "workspaceDiagnostics": {
+        "enabled": true,
+        "maxFiles": 1000,
+        "maxEntries": 10000,
+        "maxSourceBytes": 33554432
+      }
+    }
+  }
+}
+```
+
+Shuck does not scan a workspace at startup. Each request performs a cancellable
+bounded discovery, and embedded host documents remain excluded until their
+diagnostic position mapping is available. Once advertised, dynamic
+configuration can change the limits or disable subsequent workspace pulls.
 
 This page is the user-facing support contract. The repository's
 [design specs](https://github.com/ewhauser/shuck/tree/main/specs) record the


### PR DESCRIPTION
## Summary

- add opt-in `workspace/diagnostic` capability and worker-scheduled request handling
- lazily discover eligible shell files across workspace roots while honoring ignore rules, nested-root ownership, open-buffer shadowing, cancellation, and configurable file, visited-entry, and source-byte bounds
- reuse cached closed-file diagnostics with generation-safe invalidation, stable result IDs, unchanged reports, and proven deletion clearing
- stream partial results and work-done progress without scanning at server startup
- extend shared discovery with cancellable bounded traversal and completion status
- document configuration and support boundaries

## Validation

- `cargo test -q -p shuck-discover -p shuck-server --no-fail-fast`
- `cargo clippy -q -p shuck-discover -p shuck-server --all-targets --no-deps -- -D warnings`
- `git diff --check`
- dedicated review agent; five boundedness/cache/protocol findings fixed and final follow-up review clean

Closes #1217