### PR TITLE
feat(server): enable workspace diagnostics by default

### DIFF
--- a/crates/shuck-server/src/server.rs
+++ b/crates/shuck-server/src/server.rs
@@ -51,14 +51,10 @@ impl Server {
             workspace_folders,
             ..
         } = init_params;
-        let AllOptions { global, workspace } =
+        let all_options =
             AllOptions::from_value(initialization_options.unwrap_or(serde_json::Value::Null));
-        let workspace_diagnostics_enabled = global.workspace_diagnostics_enabled()
-            || workspace.as_ref().is_some_and(|workspaces| {
-                workspaces
-                    .values()
-                    .any(|options| options.server.workspace_diagnostics.enabled)
-            });
+        let workspace_diagnostics_enabled = all_options.workspace_diagnostics_enabled();
+        let AllOptions { global, workspace } = all_options;
         let server_capabilities =
             Self::server_capabilities(position_encoding, workspace_diagnostics_enabled);
         let connection = connection.initialize_finish(

--- a/crates/shuck-server/src/session/options.rs
+++ b/crates/shuck-server/src/session/options.rs
@@ -23,10 +23,6 @@ impl GlobalOptions {
     pub fn into_settings(self, client: Client) -> GlobalClientSettings {
         GlobalClientSettings::new(self.client, client)
     }
-
-    pub(crate) fn workspace_diagnostics_enabled(&self) -> bool {
-        self.client.server.workspace_diagnostics.enabled
-    }
 }
 
 /// Per-client or per-workspace Shuck options supplied through LSP settings.
@@ -388,7 +384,7 @@ impl WorkspaceDiagnosticsFeatureOptionsOverrides {
 #[serde(rename_all = "camelCase")]
 pub struct WorkspaceDiagnosticsFeatureOptions {
     /// Whether workspace diagnostic requests are advertised and served.
-    #[serde(default)]
+    #[serde(default = "default_workspace_diagnostics_enabled")]
     pub enabled: bool,
     /// Maximum number of workspace files returned by one request.
     #[serde(default = "default_workspace_diagnostics_max_files")]
@@ -404,12 +400,16 @@ pub struct WorkspaceDiagnosticsFeatureOptions {
 impl Default for WorkspaceDiagnosticsFeatureOptions {
     fn default() -> Self {
         Self {
-            enabled: false,
+            enabled: default_workspace_diagnostics_enabled(),
             max_files: default_workspace_diagnostics_max_files(),
             max_entries: default_workspace_diagnostics_max_entries(),
             max_source_bytes: default_workspace_diagnostics_max_source_bytes(),
         }
     }
+}
+
+fn default_workspace_diagnostics_enabled() -> bool {
+    true
 }
 
 fn default_workspace_diagnostics_max_files() -> usize {
@@ -477,5 +477,79 @@ impl AllOptions {
             global,
             workspace: None,
         }
+    }
+
+    pub(crate) fn workspace_diagnostics_enabled(&self) -> bool {
+        let global = self.global.client.server.workspace_diagnostics;
+        global.enabled
+            || self.workspace.as_ref().is_some_and(|workspaces| {
+                workspaces.values().any(|options| {
+                    options
+                        .server
+                        .workspace_diagnostics_layered_over(global)
+                        .enabled
+                })
+            })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::AllOptions;
+
+    #[test]
+    fn workspace_diagnostics_are_enabled_by_default_and_can_be_disabled() {
+        let defaults = AllOptions::from_value(serde_json::json!({}));
+        assert!(defaults.workspace_diagnostics_enabled());
+
+        let disabled = AllOptions::from_value(serde_json::json!({
+            "shuck": {
+                "server": {
+                    "workspaceDiagnostics": {
+                        "enabled": false
+                    }
+                }
+            }
+        }));
+        assert!(!disabled.workspace_diagnostics_enabled());
+    }
+
+    #[test]
+    fn unrelated_workspace_options_preserve_the_global_diagnostic_opt_out() {
+        let disabled = AllOptions::from_value(serde_json::json!({
+            "shuck": {
+                "server": {
+                    "workspaceDiagnostics": {
+                        "enabled": false
+                    }
+                }
+            },
+            "workspace": {
+                "file:///workspace": {
+                    "showSyntaxErrors": true
+                }
+            }
+        }));
+        assert!(!disabled.workspace_diagnostics_enabled());
+
+        let enabled_for_workspace = AllOptions::from_value(serde_json::json!({
+            "shuck": {
+                "server": {
+                    "workspaceDiagnostics": {
+                        "enabled": false
+                    }
+                }
+            },
+            "workspace": {
+                "file:///workspace": {
+                    "server": {
+                        "workspaceDiagnostics": {
+                            "enabled": true
+                        }
+                    }
+                }
+            }
+        }));
+        assert!(enabled_for_workspace.workspace_diagnostics_enabled());
     }
 }

--- a/crates/shuck-server/tests/manual.rs
+++ b/crates/shuck-server/tests/manual.rs
@@ -2156,7 +2156,6 @@ fn workspace_diagnostics_are_incremental_and_shadow_open_buffers() {
                 "shuck": {
                     "server": {
                         "workspaceDiagnostics": {
-                            "enabled": true,
                             "maxFiles": 10,
                             "maxSourceBytes": 1048576,
                         }

--- a/specs/018-lsp.md
+++ b/specs/018-lsp.md
@@ -264,7 +264,7 @@ The server advertises the following on `initialize`:
 |------------|-------|
 | `positionEncoding` | Negotiated; UTF-8 preferred, UTF-16 fallback (always supported), UTF-32 lowest priority |
 | `textDocumentSync` | `INCREMENTAL`, `openClose: true` |
-| `diagnosticProvider` | `interFileDependencies: false`, `workspaceDiagnostics` follows the opt-in server setting, `identifier: "Shuck"`, work-done progress on |
+| `diagnosticProvider` | `interFileDependencies: false`, `workspaceDiagnostics` is enabled by default and can be disabled through server settings, `identifier: "Shuck"`, work-done progress on |
 | `documentFormattingProvider` | `true` |
 | `documentRangeFormattingProvider` | `true` |
 | `codeActionProvider` | Kinds: `quickfix`, `source.fixAll.shuck`. `resolveProvider: true` so the editor can defer the heavy edit computation to `codeAction/resolve` |
@@ -283,7 +283,7 @@ Requests fan out by method into typed handlers:
 | Method | Handler | Schedule |
 |--------|---------|----------|
 | `textDocument/diagnostic` | `DocumentDiagnostic` | Background, Worker |
-| `workspace/diagnostic` | `WorkspaceDiagnostic` | Background, Worker; opt-in, lazy, cancellable, and bounded |
+| `workspace/diagnostic` | `WorkspaceDiagnostic` | Background, Worker; lazy, cancellable, bounded, and configurable |
 | `textDocument/codeAction` | `CodeActions` | Background, Worker |
 | `codeAction/resolve` | `CodeActionResolve` | Background, Worker |
 | `textDocument/formatting` | `Format` | Background, Fmt |

--- a/specs/023-lsp-editor-features.md
+++ b/specs/023-lsp-editor-features.md
@@ -579,9 +579,10 @@ pub struct RenameOptions {
 Defaults:
 
 - workspace symbols enabled, `max_files = 5000`;
-- workspace diagnostics disabled, `max_files = 1000`, `max_entries = 10000`,
-  and `max_source_bytes = 32 MiB`; enabling them advertises and serves
-  `workspace/diagnostic` without starting a background scan;
+- workspace diagnostics enabled, `max_files = 1000`, `max_entries = 10000`,
+  and `max_source_bytes = 32 MiB`; they advertise and serve
+  `workspace/diagnostic` without starting a background scan and can be disabled
+  with `server.workspaceDiagnostics.enabled = false`;
 - runtime-name and keyword completions enabled;
 - cross-file function rename disabled by default and enabled with
   `server.rename.allowCrossFile = true`.

--- a/website/content/editors/index.mdx
+++ b/website/content/editors/index.mdx
@@ -14,7 +14,7 @@ files.
 | Feature | LSP methods | Scope and limitations |
 | --- | --- | --- |
 | Document synchronization | `textDocument/didOpen`, `didChange`, `didClose` | Incremental synchronization for open shell buffers. Dialect inference uses the buffer `languageId`, shebang, and file path. |
-| Diagnostics | `textDocument/diagnostic`, `textDocument/publishDiagnostics`, opt-in `workspace/diagnostic` | Pull diagnostics when the client supports them, with push diagnostics as a fallback. Workspace pulls are disabled by default; when enabled they discover shell files lazily, honor workspace and ignore boundaries, prefer open buffers, reuse stable result IDs, report partial progress, and stop at configurable file, visited-entry, and source-byte limits. Inter-file diagnostic dependencies are not supported. |
+| Diagnostics | `textDocument/diagnostic`, `textDocument/publishDiagnostics`, `workspace/diagnostic` | Pull diagnostics when the client supports them, with push diagnostics as a fallback. Workspace pulls are enabled by default and discover shell files lazily, honor workspace and ignore boundaries, prefer open buffers, reuse stable result IDs, report partial progress, and stop at configurable file, visited-entry, and source-byte limits. Inter-file diagnostic dependencies are not supported. |
 | Code actions | `textDocument/codeAction`, `codeAction/resolve` | Quick fixes, disable-this-line actions, and `source.fixAll.shuck` for the active document. |
 | Completion | `textDocument/completion`, `completionItem/resolve` | Variables, declaration names, runtime names, builtins, shell keywords, and functions visible in the active document or through unconditional static `source`/`.` edges. Literal paths, valid source hints, configured source paths, and unsaved open buffers participate; dynamic or unresolved sources do not. Command-specific option completion is not supported. |
 | Hover | `textDocument/hover` | Semantic symbol information plus help for suppression codes in `# shuck:` and `# shellcheck` directives. Function calls can resolve through the same exact static source graph as go-to-definition, including source hints, configured source paths, and open buffers. Dynamic or ambiguous sources are not guessed, and Shuck does not fetch command manuals. |
@@ -43,17 +43,15 @@ Shuck does not currently advertise semantic tokens, inlay hints, signature
 help, or notebook documents. These are not permanent
 prohibitions, but there is no accepted implementation design for them today.
 
-Enable bounded workspace pulls through initialization options:
+Workspace pulls are enabled by default. Disable them through initialization
+options if an editor should only request diagnostics for open documents:
 
 ```json
 {
   "shuck": {
     "server": {
       "workspaceDiagnostics": {
-        "enabled": true,
-        "maxFiles": 1000,
-        "maxEntries": 10000,
-        "maxSourceBytes": 33554432
+        "enabled": false
       }
     }
   }
@@ -61,9 +59,10 @@ Enable bounded workspace pulls through initialization options:
 ```
 
 Shuck does not scan a workspace at startup. Each request performs a cancellable
-bounded discovery, and embedded host documents remain excluded until their
-diagnostic position mapping is available. Once advertised, dynamic
-configuration can change the limits or disable subsequent workspace pulls.
+bounded discovery with defaults of 1,000 files, 10,000 visited entries, and 32
+MiB of source text. Embedded host documents remain excluded until their
+diagnostic position mapping is available. Dynamic configuration can change the
+limits or disable subsequent workspace pulls.
 
 This page is the user-facing support contract. The repository's
 [design specs](https://github.com/ewhauser/shuck/tree/main/specs) record the


### PR DESCRIPTION
## Summary

- advertise and serve bounded workspace diagnostics by default
- preserve explicit global and per-workspace opt-outs
- document the default limits and opt-out configuration

## Why

Workspace diagnostics are lazy, cancellable, and bounded by file count, visited entries, and source bytes. Those safeguards make the feature safe to expose without requiring every editor integration to opt in explicitly.

The capability aggregation now layers per-workspace settings over the global option, preventing unrelated workspace settings from overriding a global opt-out.

## Validation

- `cargo test -p shuck-server`
- `cargo clippy -p shuck-server --all-targets --no-deps -- -D warnings`
- `cargo fmt --check`
- focused default, opt-out, workspace-layering, and manual workspace-diagnostic tests
- code-review subagent pass with no remaining findings
