### PR TITLE
docs: correct Homebrew install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Shuck parses, analyzes, formats, and powers editor feedback for shell scripts. I
 ### Homebrew
 
 ```sh
-brew install ewhauser/tap/shuck
+brew install ewhauser/tap/shuck-cli
 ```
 
 ### PyPI


### PR DESCRIPTION
## Summary

- correct the README Homebrew formula name from `shuck` to `shuck-cli`
- align the documented command with the formula generated and published to `ewhauser/homebrew-tap`

## Root cause

The README used the CLI binary name (`shuck`) as the Homebrew formula name, but cargo-dist publishes `Formula/shuck-cli.rb` from the `shuck-cli` package.

## Validation

- `git diff --check`
- `brew info --formula ewhauser/tap/shuck-cli` (resolves stable 0.1.1 from `ewhauser/tap`)
- verified `Cargo.toml` tap configuration and the repository-owned `ewhauser/homebrew-tap/Formula/shuck-cli.rb`

The repository does not have a README/Markdown command regression-test mechanism; this one-line documentation fix does not change executable code.

Closes #1253