### PR TITLE
fix(formatter): respect exclusions for stdin filenames

### DIFF
--- a/crates/shuck-cli/src/commands/format_stdin.rs
+++ b/crates/shuck-cli/src/commands/format_stdin.rs
@@ -23,12 +23,21 @@ pub(crate) fn format_stdin(
     let display_path = display_path(path);
     let cwd = std::env::current_dir()?;
     let project_root = stdin_project_root(path, &cwd, config_arguments.use_config_roots())?;
-    let options = resolve_project_format_settings(
+    let settings = resolve_project_format_settings(
         &project_root,
         config_arguments,
         args.format_settings_patch(),
-    )?
-    .to_shell_format_options();
+    )?;
+
+    if path.is_some_and(|path| settings.is_file_excluded(&cwd.join(path))) {
+        if mode.is_write() {
+            let mut stdout = io::stdout().lock();
+            stdout.write_all(source.as_bytes())?;
+        }
+        return Ok(ExitStatus::Success);
+    }
+
+    let options = settings.to_shell_format_options();
 
     if matches!(mode, FormatMode::Check) {
         return match source_is_formatted(&source, path, &options) {

--- a/crates/shuck-cli/tests/integration_test.rs
+++ b/crates/shuck-cli/tests/integration_test.rs
@@ -1854,6 +1854,49 @@ fn format_stdin_uses_current_project_config() {
 }
 
 #[test]
+fn format_stdin_filename_respects_project_config_exclude() {
+    let tempdir = tempdir().unwrap();
+    let generated = tempdir.path().join("generated");
+    fs::create_dir_all(&generated).unwrap();
+    fs::write(
+        tempdir.path().join("shuck.toml"),
+        "[format]\nexclude = ['generated/**']\n",
+    )
+    .unwrap();
+
+    let source = "foo(){\necho hi\n}\n";
+    let excluded = generated.join("ignored.sh");
+    let excluded = excluded.to_str().unwrap();
+
+    let mut check = Command::cargo_bin("shuck").unwrap();
+    check
+        .current_dir(tempdir.path())
+        .args(["format", "--check", "--stdin-filename", excluded, "-"])
+        .write_stdin(source);
+    check.assert().success().stdout("").stderr("");
+
+    let mut write = Command::cargo_bin("shuck").unwrap();
+    write
+        .current_dir(tempdir.path())
+        .args(["format", "--stdin-filename", excluded, "-"])
+        .write_stdin(source);
+    write.assert().success().stdout(source).stderr("");
+
+    let regular = tempdir.path().join("regular.sh");
+    let regular = regular.to_str().unwrap();
+    let mut included = Command::cargo_bin("shuck").unwrap();
+    included
+        .current_dir(tempdir.path())
+        .args(["format", "--stdin-filename", regular, "-"])
+        .write_stdin(source);
+    included
+        .assert()
+        .success()
+        .stdout("foo() {\n\techo hi\n}\n")
+        .stderr("");
+}
+
+#[test]
 fn format_stdin_filename_enforces_inferred_posix_dialect() {
     let mut cmd = Command::cargo_bin("shuck").unwrap();
     cmd.args(["format", "--stdin-filename", "script.sh"])


### PR DESCRIPTION
## Summary

- apply resolved project `[format].exclude` matchers to `--stdin-filename`
- pass excluded stdin through unchanged in write mode while returning success for check/diff modes
- cover project-root-relative absolute filename matching, unchanged excluded output, and normal non-excluded formatting

## Root cause

The stdin formatter resolved the correct project configuration, then immediately converted `ResolvedFormatSettings` into formatter options. That conversion discarded the compiled exclusion matcher before the logical stdin filename was checked.

## Validation

- `cargo test -p shuck-cli --test integration_test format_stdin_filename_respects_project_config_exclude -- --exact`
- `cargo test -p shuck-cli`
- `cargo fmt --all -- --check`
- `cargo clippy -p shuck-cli --all-targets --no-deps -- -D warnings`
- black-box reproduction: explicit path and stdin filename both exit `0` when excluded

The dependency-inclusive clippy invocation remains blocked by the existing `shuck-ast` `collapsible_match` warning in `command_resolution.rs`; the changed CLI crate passes warnings-as-errors clippy.

Closes #1249