### PR TITLE
refactor(linter): share per-file shell resolution

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1957,7 +1957,6 @@ version = "0.1.1"
 dependencies = [
  "anyhow",
  "crossbeam",
- "globset",
  "lsp-server",
  "lsp-types",
  "rustc-hash 2.1.2",

--- a/crates/shuck-cli/src/commands/check/settings.rs
+++ b/crates/shuck-cli/src/commands/check/settings.rs
@@ -16,6 +16,7 @@ use shuck_linter::{
     AmbientFunctionContractSpec, CompiledPerFileIgnoreList, LinterSettings, PerFileIgnore,
     ResolvedAmbientContracts, Rule, RuleSelector, RuleSet, ShellDialect,
 };
+pub(super) use shuck_linter::{CompiledPerFileShellList, PerFileShell};
 use shuck_semantic::{
     PluginFramework, PluginRequest, PluginRequestKind, PluginResolution, PluginResolver,
     resolve_zsh_plugin_entrypoint, resolve_zsh_plugin_source_paths, zsh_plugin_framework_from_name,
@@ -149,8 +150,8 @@ impl EffectiveCheckSettings {
         let per_file_shell = per_file_shell
             .iter()
             .map(|shell| EffectivePerFileShell {
-                pattern: shell.pattern.clone(),
-                shell: shell_name(shell.shell).to_owned(),
+                pattern: shell.pattern().to_owned(),
+                shell: shell_name(shell.shell()).to_owned(),
             })
             .collect::<Vec<_>>();
 
@@ -407,27 +408,6 @@ impl PerFileIgnoreSpec {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub(super) struct PerFileShell {
-    pub(super) pattern: String,
-    pub(super) shell: ShellDialect,
-}
-
-#[derive(Debug, Clone)]
-pub(super) struct CompiledPerFileShellList {
-    project_root: PathBuf,
-    entries: Vec<CompiledPerFileShell>,
-}
-
-#[derive(Debug, Clone)]
-struct CompiledPerFileShell {
-    basename_matcher: GlobMatcher,
-    relative_matcher: GlobMatcher,
-    absolute_matcher: GlobMatcher,
-    negated: bool,
-    shell: ShellDialect,
-}
-
 #[derive(Debug, Clone)]
 pub(super) struct ResolvedZshPluginSettings {
     enabled: bool,
@@ -466,57 +446,6 @@ struct CompiledPathMatcher {
     relative_matcher: GlobMatcher,
     absolute_matcher: GlobMatcher,
     negated: bool,
-}
-
-impl CompiledPerFileShellList {
-    pub(super) fn resolve(
-        project_root: impl Into<PathBuf>,
-        per_file_shell: impl IntoIterator<Item = PerFileShell>,
-    ) -> Result<Self> {
-        let entries = per_file_shell
-            .into_iter()
-            .map(|per_file_shell| {
-                let mut pattern = per_file_shell.pattern;
-                let negated = pattern.starts_with('!');
-                if negated {
-                    pattern.drain(..1);
-                }
-
-                Ok(CompiledPerFileShell {
-                    basename_matcher: Glob::new(&pattern)
-                        .map_err(|err| anyhow!("invalid glob {pattern:?}: {err}"))?
-                        .compile_matcher(),
-                    relative_matcher: Glob::new(&pattern)
-                        .map_err(|err| anyhow!("invalid glob {pattern:?}: {err}"))?
-                        .compile_matcher(),
-                    absolute_matcher: Glob::new(&pattern)
-                        .map_err(|err| anyhow!("invalid glob {pattern:?}: {err}"))?
-                        .compile_matcher(),
-                    negated,
-                    shell: per_file_shell.shell,
-                })
-            })
-            .collect::<Result<Vec<_>>>()?;
-
-        Ok(Self {
-            project_root: project_root.into(),
-            entries,
-        })
-    }
-
-    pub(super) fn shell_for_path(&self, path: &Path) -> Option<ShellDialect> {
-        let relative_path = path.strip_prefix(&self.project_root).unwrap_or(path);
-        let file_name = relative_path.file_name().or_else(|| path.file_name())?;
-
-        self.entries.iter().fold(None, |shell, entry| {
-            let matches = entry.basename_matcher.is_match(file_name)
-                || entry.relative_matcher.is_match(relative_path)
-                || per_file_shell_absolute_match(&entry.absolute_matcher, path);
-            let applies = if entry.negated { !matches } else { matches };
-
-            if applies { Some(entry.shell) } else { shell }
-        })
-    }
 }
 
 impl ResolvedZshPluginSettings {
@@ -1617,10 +1546,7 @@ fn parse_per_file_shell_map(
         .map(|(pattern, shell)| {
             let shell = parse_shell_dialect(shell)
                 .map_err(|err| anyhow!("invalid {scope} shell `{shell}`: {err}"))?;
-            Ok(PerFileShell {
-                pattern: pattern.clone(),
-                shell,
-            })
+            Ok(PerFileShell::new(pattern.clone(), shell))
         })
         .collect()
 }
@@ -1641,10 +1567,7 @@ fn group_per_file_ignore_pairs(pairs: &[PatternRuleSelectorPair]) -> Vec<PerFile
 }
 
 fn per_file_shell_from_pair(pair: &PatternShellPair) -> PerFileShell {
-    PerFileShell {
-        pattern: pair.pattern.clone(),
-        shell: pair.shell,
-    }
+    PerFileShell::new(pair.pattern.clone(), pair.shell)
 }
 
 fn parse_shell_dialect(value: &str) -> Result<ShellDialect> {
@@ -2191,24 +2114,6 @@ mod tests {
         .unwrap();
 
         assert!(report.diagnostics.is_empty());
-    }
-
-    #[test]
-    fn per_file_shell_matches_normalized_windows_verbatim_paths() {
-        let path = Path::new(r"\\?\C:\repo\nested\script.sh");
-        let per_file_shell = CompiledPerFileShellList::resolve(
-            PathBuf::from(r"C:\repo"),
-            [PerFileShell {
-                pattern: "C:/repo/nested/*.sh".to_owned(),
-                shell: ShellDialect::Bash,
-            }],
-        )
-        .unwrap();
-
-        assert_eq!(
-            per_file_shell.shell_for_path(path),
-            Some(ShellDialect::Bash)
-        );
     }
 
     #[test]

--- a/crates/shuck-linter/src/lib.rs
+++ b/crates/shuck-linter/src/lib.rs
@@ -104,12 +104,13 @@ pub use rule_selector::{RuleSelector, SelectorParseError};
 pub use rule_set::RuleSet;
 #[allow(unused_imports)]
 pub(crate) use rules::common::word::conditional_binary_op_is_string_match;
-/// Linter configuration and per-file ignore types.
+/// Linter configuration and per-file selection types.
 pub use settings::{
     AmbientShellOptions, C001RuleOptions, C063RuleOptions, C158RuleOptions, C159RuleOptions,
-    C160RuleOptions, C161RuleOptions, CompiledPerFileIgnoreList, LinterRuleOptions, LinterSettings,
-    PerFileIgnore, S078RuleOptions, S079RuleOptions, S080RuleOptions, S081RuleOptions,
-    S082RuleOptions, S083FunctionDocRequirement, S083RuleOptions, S084RuleOptions, S085RuleOptions,
+    C160RuleOptions, C161RuleOptions, CompiledPerFileIgnoreList, CompiledPerFileShellList,
+    LinterRuleOptions, LinterSettings, PerFileIgnore, PerFileShell, S078RuleOptions,
+    S079RuleOptions, S080RuleOptions, S081RuleOptions, S082RuleOptions, S083FunctionDocRequirement,
+    S083RuleOptions, S084RuleOptions, S085RuleOptions,
 };
 /// Shell dialect selection used by the linter.
 pub use shell::ShellDialect;

--- a/crates/shuck-linter/src/settings.rs
+++ b/crates/shuck-linter/src/settings.rs
@@ -2,7 +2,7 @@ use std::path::Path;
 use std::path::PathBuf;
 use std::sync::Arc;
 
-use anyhow::{Context, Result};
+use anyhow::{Context, Result, anyhow};
 use globset::{Glob, GlobMatcher};
 use rustc_hash::FxHashMap;
 use rustc_hash::FxHashSet;
@@ -367,6 +367,49 @@ pub struct CompiledPerFileIgnoreList {
     entries: Vec<CompiledPerFileIgnore>,
 }
 
+/// A glob pattern paired with the shell dialect selected for matching files.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PerFileShell {
+    pattern: String,
+    shell: ShellDialect,
+}
+
+impl PerFileShell {
+    /// Creates a per-file shell mapping.
+    pub fn new(pattern: impl Into<String>, shell: ShellDialect) -> Self {
+        Self {
+            pattern: pattern.into(),
+            shell,
+        }
+    }
+
+    /// Returns the configured glob pattern.
+    pub fn pattern(&self) -> &str {
+        &self.pattern
+    }
+
+    /// Returns the shell dialect selected by the mapping.
+    pub const fn shell(&self) -> ShellDialect {
+        self.shell
+    }
+}
+
+/// Compiled per-file shell mappings resolved relative to one project root.
+#[derive(Debug, Clone, Default)]
+pub struct CompiledPerFileShellList {
+    project_root: PathBuf,
+    entries: Vec<CompiledPerFileShell>,
+}
+
+#[derive(Debug, Clone)]
+struct CompiledPerFileShell {
+    basename_matcher: GlobMatcher,
+    relative_matcher: GlobMatcher,
+    absolute_matcher: GlobMatcher,
+    negated: bool,
+    shell: ShellDialect,
+}
+
 impl PartialEq for CompiledPerFileIgnoreList {
     fn eq(&self, other: &Self) -> bool {
         self.project_root == other.project_root && self.entries == other.entries
@@ -672,11 +715,92 @@ impl CompiledPerFileIgnoreList {
     }
 }
 
+impl CompiledPerFileShellList {
+    /// Compiles per-file shell mappings for paths under `project_root`.
+    pub fn resolve(
+        project_root: impl Into<PathBuf>,
+        per_file_shell: impl IntoIterator<Item = PerFileShell>,
+    ) -> Result<Self> {
+        let entries = per_file_shell
+            .into_iter()
+            .map(|per_file_shell| {
+                let mut pattern = per_file_shell.pattern;
+                let negated = pattern.starts_with('!');
+                if negated {
+                    pattern.drain(..1);
+                }
+
+                Ok(CompiledPerFileShell {
+                    basename_matcher: Glob::new(&pattern)
+                        .map_err(|err| anyhow!("invalid glob {pattern:?}: {err}"))?
+                        .compile_matcher(),
+                    relative_matcher: Glob::new(&pattern)
+                        .map_err(|err| anyhow!("invalid glob {pattern:?}: {err}"))?
+                        .compile_matcher(),
+                    absolute_matcher: Glob::new(&pattern)
+                        .map_err(|err| anyhow!("invalid glob {pattern:?}: {err}"))?
+                        .compile_matcher(),
+                    negated,
+                    shell: per_file_shell.shell,
+                })
+            })
+            .collect::<Result<Vec<_>>>()?;
+
+        Ok(Self {
+            project_root: project_root.into(),
+            entries,
+        })
+    }
+
+    /// Returns the shell selected for `path`, if any mapping applies.
+    ///
+    /// Mappings are evaluated in order and the last matching entry wins.
+    pub fn shell_for_path(&self, path: &Path) -> Option<ShellDialect> {
+        let relative_path = path.strip_prefix(&self.project_root).unwrap_or(path);
+        let file_name = relative_path.file_name().or_else(|| path.file_name())?;
+
+        self.entries.iter().fold(None, |shell, entry| {
+            let matches = entry.basename_matcher.is_match(file_name)
+                || entry.relative_matcher.is_match(relative_path)
+                || matches_absolute_shell_path(&entry.absolute_matcher, path);
+            let applies = if entry.negated { !matches } else { matches };
+
+            if applies { Some(entry.shell) } else { shell }
+        })
+    }
+}
+
 fn matches_absolute_path(matcher: &GlobMatcher, path: &Path) -> bool {
     matcher.is_match(path)
         || normalized_absolute_match_path(path)
             .as_deref()
             .is_some_and(|normalized| matcher.is_match(normalized))
+}
+
+fn matches_absolute_shell_path(matcher: &GlobMatcher, path: &Path) -> bool {
+    matcher.is_match(path)
+        || matcher.is_match(normalize_path(path))
+        || slash_normalized_match_path(path)
+            .as_deref()
+            .is_some_and(|normalized| matcher.is_match(normalized))
+        || normalized_absolute_match_path(path)
+            .as_ref()
+            .is_some_and(|normalized| {
+                matcher.is_match(normalized)
+                    || slash_normalized_match_path(normalized)
+                        .as_deref()
+                        .is_some_and(|slash_normalized| matcher.is_match(slash_normalized))
+            })
+}
+
+fn normalize_path(path: &Path) -> PathBuf {
+    path.components().collect()
+}
+
+fn slash_normalized_match_path(path: &Path) -> Option<PathBuf> {
+    let path = path.to_string_lossy();
+    path.contains('\\')
+        .then(|| PathBuf::from(path.replace('\\', "/")))
 }
 
 fn normalized_absolute_match_path(path: &Path) -> Option<PathBuf> {
@@ -778,6 +902,71 @@ mod tests {
         let ignored_rules = per_file_ignores.ignored_rules(&script_path);
 
         assert!(ignored_rules.contains(Rule::UnusedAssignment));
+    }
+
+    #[test]
+    fn per_file_shell_matches_paths_and_uses_the_last_match() {
+        let project_root = PathBuf::from("/workspace");
+        let per_file_shell = CompiledPerFileShellList::resolve(
+            &project_root,
+            [
+                PerFileShell::new("*.sh", ShellDialect::Sh),
+                PerFileShell::new("scripts/*.sh", ShellDialect::Bash),
+                PerFileShell::new("/workspace/scripts/special.sh", ShellDialect::Zsh),
+            ],
+        )
+        .unwrap();
+
+        assert_eq!(
+            per_file_shell.shell_for_path(&project_root.join("top.sh")),
+            Some(ShellDialect::Sh)
+        );
+        assert_eq!(
+            per_file_shell.shell_for_path(&project_root.join("scripts/tool.sh")),
+            Some(ShellDialect::Bash)
+        );
+        assert_eq!(
+            per_file_shell.shell_for_path(&project_root.join("scripts/special.sh")),
+            Some(ShellDialect::Zsh)
+        );
+        assert_eq!(
+            per_file_shell.shell_for_path(&project_root.join("README.md")),
+            None
+        );
+    }
+
+    #[test]
+    fn per_file_shell_preserves_negated_pattern_semantics() {
+        let project_root = PathBuf::from("/workspace");
+        let per_file_shell = CompiledPerFileShellList::resolve(
+            &project_root,
+            [PerFileShell::new("!vendor/*.sh", ShellDialect::Bash)],
+        )
+        .unwrap();
+
+        assert_eq!(
+            per_file_shell.shell_for_path(&project_root.join("scripts/tool.sh")),
+            Some(ShellDialect::Bash)
+        );
+        assert_eq!(
+            per_file_shell.shell_for_path(&project_root.join("vendor/tool.sh")),
+            None
+        );
+    }
+
+    #[test]
+    fn per_file_shell_matches_normalized_windows_verbatim_paths() {
+        let path = Path::new(r"\\?\C:\repo\nested\script.sh");
+        let per_file_shell = CompiledPerFileShellList::resolve(
+            PathBuf::from(r"C:\repo"),
+            [PerFileShell::new("C:/repo/nested/*.sh", ShellDialect::Bash)],
+        )
+        .unwrap();
+
+        assert_eq!(
+            per_file_shell.shell_for_path(path),
+            Some(ShellDialect::Bash)
+        );
     }
 
     #[test]

--- a/crates/shuck-server/Cargo.toml
+++ b/crates/shuck-server/Cargo.toml
@@ -14,7 +14,6 @@ fuzzing = []
 [dependencies]
 anyhow = { workspace = true }
 crossbeam = { workspace = true }
-globset = { workspace = true }
 lsp-server = { workspace = true }
 lsp-types = { workspace = true }
 rustc-hash = { workspace = true }

--- a/crates/shuck-server/src/session/settings.rs
+++ b/crates/shuck-server/src/session/settings.rs
@@ -3,15 +3,14 @@ use std::path::{Path, PathBuf};
 use std::str::FromStr;
 use std::sync::Arc;
 
-use globset::{Glob, GlobMatcher};
 use shuck_config::{
     ConfigArguments, FormatExclusions, FormatSettingsPatch, LintConfig, ShuckConfig,
     apply_config_overrides, load_project_config, resolve_project_root_for_file,
 };
 use shuck_formatter::{ShellDialect as FormatDialect, ShellFormatOptions};
 use shuck_linter::{
-    CompiledPerFileIgnoreList, LinterRuleOptions, LinterSettings, PerFileIgnore, RuleSelector,
-    RuleSet, ShellDialect as LinterShellDialect,
+    CompiledPerFileIgnoreList, CompiledPerFileShellList, LinterRuleOptions, LinterSettings,
+    PerFileIgnore, PerFileShell, RuleSelector, RuleSet, ShellDialect as LinterShellDialect,
 };
 
 use crate::session::{
@@ -677,79 +676,6 @@ fn apply_linter_rule_options_for_lint_config(
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
-struct PerFileShell {
-    pattern: String,
-    shell: LinterShellDialect,
-}
-
-#[derive(Debug, Clone, Default)]
-struct CompiledPerFileShellList {
-    project_root: PathBuf,
-    entries: Vec<CompiledPerFileShell>,
-}
-
-#[derive(Debug, Clone)]
-struct CompiledPerFileShell {
-    basename_matcher: GlobMatcher,
-    relative_matcher: GlobMatcher,
-    absolute_matcher: GlobMatcher,
-    negated: bool,
-    shell: LinterShellDialect,
-}
-
-impl CompiledPerFileShellList {
-    fn resolve(project_root: PathBuf, per_file_shell: Vec<PerFileShell>) -> anyhow::Result<Self> {
-        let entries = per_file_shell
-            .into_iter()
-            .map(|per_file_shell| {
-                let mut pattern = per_file_shell.pattern;
-                let negated = pattern.starts_with('!');
-                if negated {
-                    pattern.drain(..1);
-                }
-
-                let basename_matcher = Glob::new(&pattern)
-                    .map_err(|err| anyhow::anyhow!("invalid glob {pattern:?}: {err}"))?
-                    .compile_matcher();
-                let relative_matcher = Glob::new(&pattern)
-                    .map_err(|err| anyhow::anyhow!("invalid glob {pattern:?}: {err}"))?
-                    .compile_matcher();
-                let absolute_matcher = Glob::new(&pattern)
-                    .map_err(|err| anyhow::anyhow!("invalid glob {pattern:?}: {err}"))?
-                    .compile_matcher();
-
-                Ok(CompiledPerFileShell {
-                    basename_matcher,
-                    relative_matcher,
-                    absolute_matcher,
-                    negated,
-                    shell: per_file_shell.shell,
-                })
-            })
-            .collect::<anyhow::Result<Vec<_>>>()?;
-
-        Ok(Self {
-            project_root,
-            entries,
-        })
-    }
-
-    fn shell_for_path(&self, path: &Path) -> Option<LinterShellDialect> {
-        let relative_path = path.strip_prefix(&self.project_root).unwrap_or(path);
-        let file_name = relative_path.file_name().or_else(|| path.file_name())?;
-
-        self.entries.iter().fold(None, |shell, entry| {
-            let matches = entry.basename_matcher.is_match(file_name)
-                || entry.relative_matcher.is_match(relative_path)
-                || matches_absolute_path(&entry.absolute_matcher, path);
-            let applies = if entry.negated { !matches } else { matches };
-
-            if applies { Some(entry.shell) } else { shell }
-        })
-    }
-}
-
 fn parse_per_file_shell_map(entries: &BTreeMap<String, String>, scope: &str) -> Vec<PerFileShell> {
     entries
         .iter()
@@ -760,10 +686,7 @@ fn parse_per_file_shell_map(entries: &BTreeMap<String, String>, scope: &str) -> 
                 return None;
             }
 
-            Some(PerFileShell {
-                pattern: pattern.clone(),
-                shell,
-            })
+            Some(PerFileShell::new(pattern.clone(), shell))
         })
         .collect()
 }
@@ -776,42 +699,6 @@ fn apply_per_file_shell_layer(
     let mut per_file_shell = per_file_shell.unwrap_or(current);
     per_file_shell.extend(extend_per_file_shell);
     per_file_shell
-}
-
-fn matches_absolute_path(matcher: &GlobMatcher, path: &Path) -> bool {
-    matcher.is_match(path)
-        || matcher.is_match(normalize_path(path))
-        || slash_normalized_match_path(path)
-            .as_deref()
-            .is_some_and(|normalized| matcher.is_match(normalized))
-        || normalized_absolute_match_path(path)
-            .as_ref()
-            .is_some_and(|normalized| {
-                matcher.is_match(normalized)
-                    || slash_normalized_match_path(normalized)
-                        .as_deref()
-                        .is_some_and(|slash_normalized| matcher.is_match(slash_normalized))
-            })
-}
-
-fn normalize_path(path: &Path) -> PathBuf {
-    path.components().collect()
-}
-
-fn normalized_absolute_match_path(path: &Path) -> Option<PathBuf> {
-    let path = path.to_string_lossy();
-
-    if let Some(stripped) = path.strip_prefix(r"\\?\UNC\") {
-        return Some(PathBuf::from(format!(r"\\{stripped}")));
-    }
-
-    path.strip_prefix(r"\\?\").map(PathBuf::from)
-}
-
-fn slash_normalized_match_path(path: &Path) -> Option<PathBuf> {
-    let path = path.to_string_lossy();
-    path.contains('\\')
-        .then(|| PathBuf::from(path.replace('\\', "/")))
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

- move per-file shell glob compilation and path resolution into `shuck-linter`
- make the CLI checker and language server share the same resolver
- remove `shuck-server`'s direct `globset` dependency

## Why

This is the behavior-preserving first slice of #1250. Sharing the resolver first reduces semantic drift before formatter and configuration support are added in follow-up work.

This PR does not change formatter behavior or the public configuration shape.

## Validation

- `cargo test -p shuck-linter -p shuck-server -p shuck-cli`
- `cargo fmt --all -- --check`
- `cargo clippy -p shuck-server -p shuck-cli --all-targets --no-deps -- -D warnings`
- `cargo clippy -p shuck-linter --all-targets --no-deps -- -D warnings -A clippy::unneeded-wildcard-pattern -A clippy::some-filter -A clippy::while-let-loop -A clippy::question-mark`