### PR TITLE
feat(formatter): support per-file shell configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -375,11 +375,11 @@ Use the `[check]` section to control embedded-script extraction:
 # Default: true
 embedded = true
 
-[lint]
-# Override shell dialect inference for matching files.
-per-file-shell = { "scripts/bash/**" = "bash", "vendor/**/*.sh" = "sh" }
-# Add shell overrides on top of earlier config or CLI layers.
-extend-per-file-shell = { "tools/**/*.zsh" = "zsh" }
+[per-file-shell]
+# Override shell dialect inference for matching files in check, format, and LSP.
+"scripts/bash/**" = "bash"
+"vendor/**/*.sh" = "sh"
+"dot_z*" = "zsh"
 
 [format]
 # Configure `shuck format` and editor formatting.
@@ -399,7 +399,18 @@ whole-document or range formatting requested through the language server. This
 makes it suitable for generated files that must remain untouched even when an
 editor has format-on-save enabled.
 
-Formatter dialect is inferred from the file name or shebang. For stdin or one-off formatting runs, use `shuck format --dialect bash|posix|mksh|zsh`.
+`per-file-shell` patterns are resolved relative to the project root and apply to
+`shuck check`, direct and stdin formatting, and editor analysis/formatting.
+Supported values are `sh`, `bash`, `dash`, `ksh`, `mksh`, and `zsh`; generic
+`ksh` mappings remain available to the linter but cannot be used by the
+formatter. Overlapping patterns may select the same dialect, but selecting
+different dialects for one file is an error. Existing
+`[lint].per-file-shell` and `[lint].extend-per-file-shell` settings remain
+supported as compatibility aliases.
+
+An explicit `shuck format --dialect bash|posix|mksh|zsh` override takes
+precedence over `per-file-shell`. Unmatched files continue to infer their
+dialect from the file name, shebang, and source.
 
 ## File discovery
 

--- a/crates/shuck-cli/src/commands/check/settings.rs
+++ b/crates/shuck-cli/src/commands/check/settings.rs
@@ -8,8 +8,8 @@ use globset::{Glob, GlobMatcher};
 use shuck_cache::{CacheKey, CacheKeyHasher};
 use shuck_config::{
     ConfigArguments, LintConfig, LintContractActivationTypeConfig, LintContractWhenConfig,
-    LintContractsConfig, LintCustomContractConfig, ZshPluginEntrypointConfig, ZshPluginLoadConfig,
-    ZshThemeLoadConfig, load_project_config,
+    LintContractsConfig, LintCustomContractConfig, ShuckConfig, ZshPluginEntrypointConfig,
+    ZshPluginLoadConfig, ZshThemeLoadConfig, load_project_config,
 };
 use shuck_linter::{
     AmbientContractActivation, AmbientContractConfig, AmbientContractEffects, AmbientContractSpec,
@@ -829,7 +829,7 @@ pub(super) fn resolve_project_check_settings(
 ) -> Result<ResolvedCheckSettings> {
     let config = load_project_config(&project_root.storage_root, config_arguments)?;
     let rule_layers = [
-        parse_lint_config_layer(&config.lint)?,
+        parse_config_rule_selection_layer(&config)?,
         parse_cli_rule_selection_layer(cli_rule_selection),
     ];
     let zsh_layers = [
@@ -1285,7 +1285,17 @@ fn ambient_contract_activation_from_config(
     }
 }
 
-fn parse_lint_config_layer(lint: &LintConfig) -> Result<RuleSelectionLayer> {
+fn parse_config_rule_selection_layer(config: &ShuckConfig) -> Result<RuleSelectionLayer> {
+    let lint = &config.lint;
+    let per_file_shell = match config.per_file_shell.as_ref() {
+        Some(patterns) => Some(parse_per_file_shell_map(patterns, "per-file-shell")?),
+        None => lint
+            .per_file_shell
+            .as_ref()
+            .map(|patterns| parse_per_file_shell_map(patterns, "lint.per-file-shell"))
+            .transpose()?,
+    };
+
     Ok(RuleSelectionLayer {
         select: lint
             .select
@@ -1315,11 +1325,7 @@ fn parse_lint_config_layer(lint: &LintConfig) -> Result<RuleSelectionLayer> {
             .map(|patterns| parse_per_file_ignore_map(patterns, "lint.extend-per-file-ignores"))
             .transpose()?
             .unwrap_or_default(),
-        per_file_shell: lint
-            .per_file_shell
-            .as_ref()
-            .map(|patterns| parse_per_file_shell_map(patterns, "lint.per-file-shell"))
-            .transpose()?,
+        per_file_shell,
         extend_per_file_shell: lint
             .extend_per_file_shell
             .as_ref()

--- a/crates/shuck-cli/src/commands/format.rs
+++ b/crates/shuck-cli/src/commands/format.rs
@@ -7,9 +7,7 @@ use rayon::prelude::*;
 use serde::{Deserialize, Serialize};
 use shuck_cache::{FileCacheKey, PackageCache};
 use shuck_config::ConfigArguments;
-use shuck_formatter::{
-    FormatError, FormattedSource, ShellFormatOptions, format_source, source_is_formatted,
-};
+use shuck_formatter::{FormatError, FormattedSource, format_source, source_is_formatted};
 use similar::TextDiff;
 
 use crate::ExitStatus;
@@ -187,7 +185,6 @@ fn run_format_with_cwd(
         run.files.retain(|file| {
             file.kind == FileKind::Shell && !run.settings.is_file_excluded(&file.absolute_path)
         });
-        let settings = run.settings.to_shell_format_options();
         let pending = run.take_pending_files(|file, cached| {
             report.cache_hits += 1;
             if let FormatCacheData::ParseError(error) = cached {
@@ -211,7 +208,7 @@ fn run_format_with_cwd(
 
             let results = batch
                 .into_par_iter()
-                .map(|pending| format_pending_file(pending, &settings, mode))
+                .map(|pending| format_pending_file(pending, &run.settings, mode))
                 .collect::<Vec<_>>();
 
             for result in results {
@@ -239,11 +236,12 @@ fn pending_format_batch_size() -> usize {
 
 fn format_pending_file(
     pending: PendingProjectFile,
-    settings: &ShellFormatOptions,
+    settings: &ResolvedFormatSettings,
     mode: FormatMode,
 ) -> Result<PendingFormatOutcome> {
     let PendingProjectFile { file, file_key } = pending;
     let source = fs::read_to_string(&file.absolute_path)?;
+    let options = settings.shell_format_options_for_path(&file.absolute_path)?;
 
     let mut outcome = PendingFormatOutcome {
         relative_path: file.relative_path,
@@ -255,7 +253,7 @@ fn format_pending_file(
     };
 
     if matches!(mode, FormatMode::Check) {
-        match source_is_formatted(&source, Some(&file.absolute_path), settings) {
+        match source_is_formatted(&source, Some(&file.absolute_path), &options) {
             Ok(true) => {
                 outcome.cached_result = Some(FormatCacheData::Unchanged);
             }
@@ -283,7 +281,7 @@ fn format_pending_file(
             Err(FormatError::Internal(message)) => return Err(anyhow!(message)),
         }
     } else {
-        match format_source(&source, Some(&file.absolute_path), settings) {
+        match format_source(&source, Some(&file.absolute_path), &options) {
             Ok(FormattedSource::Unchanged) => {
                 outcome.cached_result = Some(FormatCacheData::Unchanged);
             }

--- a/crates/shuck-cli/src/commands/format_stdin.rs
+++ b/crates/shuck-cli/src/commands/format_stdin.rs
@@ -28,8 +28,18 @@ pub(crate) fn format_stdin(
         config_arguments,
         args.format_settings_patch(),
     )?;
+    let absolute_path = path.map(|path| {
+        if path.is_absolute() {
+            path.to_path_buf()
+        } else {
+            cwd.join(path)
+        }
+    });
 
-    if path.is_some_and(|path| settings.is_file_excluded(&cwd.join(path))) {
+    if absolute_path
+        .as_deref()
+        .is_some_and(|path| settings.is_file_excluded(path))
+    {
         if mode.is_write() {
             let mut stdout = io::stdout().lock();
             stdout.write_all(source.as_bytes())?;
@@ -37,7 +47,10 @@ pub(crate) fn format_stdin(
         return Ok(ExitStatus::Success);
     }
 
-    let options = settings.to_shell_format_options();
+    let options = match absolute_path.as_deref() {
+        Some(path) => settings.shell_format_options_for_path(path)?,
+        None => settings.to_shell_format_options(),
+    };
 
     if matches!(mode, FormatMode::Check) {
         return match source_is_formatted(&source, path, &options) {

--- a/crates/shuck-cli/src/config_docs.rs
+++ b/crates/shuck-cli/src/config_docs.rs
@@ -85,6 +85,7 @@ mod tests {
 
         assert!(reference.contains("## `[check]`"));
         assert!(reference.contains("## `[format]`"));
+        assert!(reference.contains("## `[per-file-shell]`"));
         assert!(reference.contains("## `[lint]`"));
         assert!(reference.contains("### `[lint.rule-options.c001]`"));
         assert!(reference.contains("### `[[lint.contracts.custom]]`"));

--- a/crates/shuck-cli/src/format_settings.rs
+++ b/crates/shuck-cli/src/format_settings.rs
@@ -1,17 +1,29 @@
+use std::collections::BTreeMap;
 use std::path::Path;
 
 use anyhow::{Result, anyhow};
 use shuck_cache::{CacheKey, CacheKeyHasher};
-use shuck_config::{ConfigArguments, FormatExclusions, FormatSettingsPatch, load_project_config};
-use shuck_formatter::{IndentStyle, ShellDialect, ShellFormatOptions};
+use shuck_config::{
+    ConfigArguments, FormatExclusions, FormatSettingsPatch, ShuckConfig, load_project_config,
+};
+use shuck_formatter::{IndentStyle, ShellDialect as FormatDialect, ShellFormatOptions};
+use shuck_linter::{CompiledPerFileShellList, PerFileShell, ShellDialect as LinterShellDialect};
 
 const CLI_INDENT_WIDTH_ERROR: &str = "`--indent-width` must be at least 1";
 const CONFIG_INDENT_WIDTH_ERROR: &str = "`[format].indent-width` must be at least 1";
 
-#[derive(Debug, Clone, Default, PartialEq, Eq)]
+#[derive(Debug, Clone, Default)]
 pub(crate) struct ResolvedFormatSettings {
     options: ShellFormatOptions,
     exclusions: FormatExclusions,
+    per_file_shell: CompiledPerFileShellList,
+    effective_per_file_shell: Vec<EffectivePerFileShell>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct EffectivePerFileShell {
+    pattern: String,
+    shell: String,
 }
 
 impl CacheKey for ResolvedFormatSettings {
@@ -29,12 +41,31 @@ impl CacheKey for ResolvedFormatSettings {
         state.write_bool(self.options.simplify());
         state.write_bool(self.options.minify());
         self.exclusions.patterns().cache_key(state);
+        self.effective_per_file_shell.cache_key(state);
+    }
+}
+
+impl CacheKey for EffectivePerFileShell {
+    fn cache_key(&self, state: &mut CacheKeyHasher) {
+        self.pattern.cache_key(state);
+        self.shell.cache_key(state);
     }
 }
 
 impl ResolvedFormatSettings {
     pub(crate) fn to_shell_format_options(&self) -> ShellFormatOptions {
         self.options.clone()
+    }
+
+    pub(crate) fn shell_format_options_for_path(&self, path: &Path) -> Result<ShellFormatOptions> {
+        if self.options.dialect() != FormatDialect::Auto {
+            return Ok(self.options.clone());
+        }
+
+        let Some(shell) = self.per_file_shell.shell_for_path_checked(path)? else {
+            return Ok(self.options.clone());
+        };
+        Ok(self.options.clone().with_dialect(format_dialect(shell)?))
     }
 
     pub(crate) fn is_file_excluded(&self, path: &Path) -> bool {
@@ -94,9 +125,20 @@ pub(crate) fn resolve_project_format_settings(
     let config = load_project_config(project_root, config_arguments)?;
     let config_patch = config.format.to_patch()?;
     let exclusions = config.format.compile_exclusions(project_root)?;
+    let per_file_shell = parse_config_per_file_shell(&config)?;
+    let effective_per_file_shell = per_file_shell
+        .iter()
+        .map(|entry| EffectivePerFileShell {
+            pattern: entry.pattern().to_owned(),
+            shell: shell_name(entry.shell()).to_owned(),
+        })
+        .collect();
+    let per_file_shell = CompiledPerFileShellList::resolve(project_root, per_file_shell)?;
 
     let mut settings = ResolvedFormatSettings {
         exclusions,
+        per_file_shell,
+        effective_per_file_shell,
         ..ResolvedFormatSettings::default()
     };
     settings.apply_patch(config_patch, CONFIG_INDENT_WIDTH_ERROR)?;
@@ -111,13 +153,78 @@ const fn indent_style_key(style: IndentStyle) -> u8 {
     }
 }
 
-const fn shell_dialect_key(dialect: ShellDialect) -> u8 {
+const fn shell_dialect_key(dialect: FormatDialect) -> u8 {
     match dialect {
-        ShellDialect::Auto => 0,
-        ShellDialect::Bash => 1,
-        ShellDialect::Posix => 2,
-        ShellDialect::Mksh => 3,
-        ShellDialect::Zsh => 4,
+        FormatDialect::Auto => 0,
+        FormatDialect::Bash => 1,
+        FormatDialect::Posix => 2,
+        FormatDialect::Mksh => 3,
+        FormatDialect::Zsh => 4,
+    }
+}
+
+fn parse_config_per_file_shell(config: &ShuckConfig) -> Result<Vec<PerFileShell>> {
+    let mut entries = match config.per_file_shell.as_ref() {
+        Some(patterns) => parse_per_file_shell_map(patterns, "per-file-shell")?,
+        None => config
+            .lint
+            .per_file_shell
+            .as_ref()
+            .map(|patterns| parse_per_file_shell_map(patterns, "lint.per-file-shell"))
+            .transpose()?
+            .unwrap_or_default(),
+    };
+
+    if let Some(patterns) = config.lint.extend_per_file_shell.as_ref() {
+        entries.extend(parse_per_file_shell_map(
+            patterns,
+            "lint.extend-per-file-shell",
+        )?);
+    }
+
+    Ok(entries)
+}
+
+fn parse_per_file_shell_map(
+    patterns: &BTreeMap<String, String>,
+    scope: &str,
+) -> Result<Vec<PerFileShell>> {
+    patterns
+        .iter()
+        .map(|(pattern, shell_name)| {
+            let shell = LinterShellDialect::from_name(shell_name);
+            if shell == LinterShellDialect::Unknown {
+                return Err(anyhow!(
+                    "invalid {scope} shell `{shell_name}`: expected one of sh, bash, dash, ksh, mksh, zsh"
+                ));
+            }
+            Ok(PerFileShell::new(pattern.clone(), shell))
+        })
+        .collect()
+}
+
+fn format_dialect(shell: LinterShellDialect) -> Result<FormatDialect> {
+    match shell {
+        LinterShellDialect::Sh | LinterShellDialect::Dash => Ok(FormatDialect::Posix),
+        LinterShellDialect::Bash => Ok(FormatDialect::Bash),
+        LinterShellDialect::Mksh => Ok(FormatDialect::Mksh),
+        LinterShellDialect::Zsh => Ok(FormatDialect::Zsh),
+        LinterShellDialect::Ksh => Err(anyhow!(
+            "per-file shell `ksh` is not supported by the formatter; use `mksh` for mksh files"
+        )),
+        LinterShellDialect::Unknown => Err(anyhow!("unknown per-file shell dialect")),
+    }
+}
+
+const fn shell_name(shell: LinterShellDialect) -> &'static str {
+    match shell {
+        LinterShellDialect::Unknown => "unknown",
+        LinterShellDialect::Sh => "sh",
+        LinterShellDialect::Bash => "bash",
+        LinterShellDialect::Dash => "dash",
+        LinterShellDialect::Ksh => "ksh",
+        LinterShellDialect::Mksh => "mksh",
+        LinterShellDialect::Zsh => "zsh",
     }
 }
 
@@ -129,7 +236,7 @@ mod tests {
     use tempfile::tempdir;
 
     use super::*;
-    use crate::args::{FileSelectionArgs, FormatCommand};
+    use crate::args::{FileSelectionArgs, FormatCommand, FormatDialectArg};
     use shuck_config::{CONFIG_DIALECT_UNSUPPORTED_ERROR, FormatConfig};
     fn format_args() -> FormatCommand {
         FormatCommand {
@@ -188,7 +295,7 @@ mod tests {
             .unwrap();
         let options = settings.to_shell_format_options();
 
-        assert_eq!(options.dialect(), ShellDialect::Auto);
+        assert_eq!(options.dialect(), FormatDialect::Auto);
         assert_eq!(options.indent_style(), IndentStyle::Space);
         assert_eq!(options.indent_width(), 2);
         assert!(options.binary_next_line());
@@ -233,6 +340,142 @@ mod tests {
 
         let err = config.to_patch().unwrap_err();
         assert_eq!(err.to_string(), CONFIG_DIALECT_UNSUPPORTED_ERROR);
+    }
+
+    #[test]
+    fn top_level_per_file_shell_selects_formatter_dialect() {
+        let tempdir = tempdir().unwrap();
+        fs::write(
+            tempdir.path().join("shuck.toml"),
+            "[per-file-shell]\n'dot_z*' = 'zsh'\n",
+        )
+        .unwrap();
+
+        let settings = resolve_project_format_settings(
+            tempdir.path(),
+            &ConfigArguments::default(),
+            format_args().format_settings_patch(),
+        )
+        .unwrap();
+
+        assert_eq!(
+            settings
+                .shell_format_options_for_path(&tempdir.path().join("dot_zshenv"))
+                .unwrap()
+                .dialect(),
+            FormatDialect::Zsh
+        );
+        assert_eq!(
+            settings
+                .shell_format_options_for_path(&tempdir.path().join("script.sh"))
+                .unwrap()
+                .dialect(),
+            FormatDialect::Auto
+        );
+    }
+
+    #[test]
+    fn lint_per_file_shell_remains_a_formatter_compatibility_alias() {
+        let tempdir = tempdir().unwrap();
+        fs::write(
+            tempdir.path().join("shuck.toml"),
+            "[lint]\nper-file-shell = { 'dot_z*' = 'zsh' }\n",
+        )
+        .unwrap();
+
+        let settings = resolve_project_format_settings(
+            tempdir.path(),
+            &ConfigArguments::default(),
+            format_args().format_settings_patch(),
+        )
+        .unwrap();
+
+        assert_eq!(
+            settings
+                .shell_format_options_for_path(&tempdir.path().join("dot_zshenv"))
+                .unwrap()
+                .dialect(),
+            FormatDialect::Zsh
+        );
+    }
+
+    #[test]
+    fn cli_dialect_overrides_per_file_shell() {
+        let tempdir = tempdir().unwrap();
+        fs::write(
+            tempdir.path().join("shuck.toml"),
+            "[per-file-shell]\n'dot_z*' = 'zsh'\n",
+        )
+        .unwrap();
+        let mut args = format_args();
+        args.dialect = Some(FormatDialectArg::Bash);
+
+        let settings = resolve_project_format_settings(
+            tempdir.path(),
+            &ConfigArguments::default(),
+            args.format_settings_patch(),
+        )
+        .unwrap();
+
+        assert_eq!(
+            settings
+                .shell_format_options_for_path(&tempdir.path().join("dot_zshenv"))
+                .unwrap()
+                .dialect(),
+            FormatDialect::Bash
+        );
+    }
+
+    #[test]
+    fn conflicting_per_file_shell_mappings_error_for_matching_path() {
+        let tempdir = tempdir().unwrap();
+        fs::write(
+            tempdir.path().join("shuck.toml"),
+            "[per-file-shell]\n'*' = 'bash'\n'dot_z*' = 'zsh'\n",
+        )
+        .unwrap();
+
+        let settings = resolve_project_format_settings(
+            tempdir.path(),
+            &ConfigArguments::default(),
+            format_args().format_settings_patch(),
+        )
+        .unwrap();
+        let error = settings
+            .shell_format_options_for_path(&tempdir.path().join("dot_zshenv"))
+            .unwrap_err();
+
+        assert!(
+            error
+                .to_string()
+                .contains("conflicting per-file shell mappings")
+        );
+    }
+
+    #[test]
+    fn generic_ksh_mapping_is_rejected_for_formatting() {
+        let tempdir = tempdir().unwrap();
+        fs::write(
+            tempdir.path().join("shuck.toml"),
+            "[per-file-shell]\n'*.ksh' = 'ksh'\n",
+        )
+        .unwrap();
+
+        let settings = resolve_project_format_settings(
+            tempdir.path(),
+            &ConfigArguments::default(),
+            format_args().format_settings_patch(),
+        )
+        .unwrap();
+        let error = settings
+            .shell_format_options_for_path(&tempdir.path().join("script.ksh"))
+            .unwrap_err();
+
+        assert!(
+            error
+                .to_string()
+                .contains("is not supported by the formatter")
+        );
     }
 
     #[test]

--- a/crates/shuck-cli/tests/integration_test.rs
+++ b/crates/shuck-cli/tests/integration_test.rs
@@ -1925,6 +1925,23 @@ fn format_stdin_filename_infers_zsh_dialect() {
 }
 
 #[test]
+fn format_stdin_filename_uses_shared_per_file_shell_config() {
+    let tempdir = tempdir().unwrap();
+    fs::write(
+        tempdir.path().join("shuck.toml"),
+        "[per-file-shell]\n'dot_z*' = 'zsh'\n",
+    )
+    .unwrap();
+
+    let source = "(($+commands[vivid]))\n";
+    let mut cmd = Command::cargo_bin("shuck").unwrap();
+    cmd.current_dir(tempdir.path())
+        .args(["format", "--stdin-filename", "dot_zshenv", "-"])
+        .write_stdin(source);
+    cmd.assert().success().stdout(source).stderr("");
+}
+
+#[test]
 fn format_stdin_rejects_configured_dialect() {
     let tempdir = tempdir().unwrap();
     fs::write(
@@ -2088,6 +2105,27 @@ fn check_per_file_shell_reaches_explicit_extensionless_file() {
     cmd.assert()
         .code(1)
         .stdout(predicate::str::contains("--> configured:1:1"));
+}
+
+#[test]
+fn check_uses_shared_per_file_shell_config() {
+    let tempdir = tempdir().unwrap();
+    fs::write(
+        tempdir.path().join("shuck.toml"),
+        "[per-file-shell]\n'dot_z*' = 'zsh'\n",
+    )
+    .unwrap();
+    fs::write(
+        tempdir.path().join("dot_zshenv"),
+        "foo=bar\nprint ${(m)foo}\n",
+    )
+    .unwrap();
+
+    let mut cmd = Command::cargo_bin("shuck").unwrap();
+    configure_env_cache(&mut cmd, tempdir.path());
+    cmd.current_dir(tempdir.path())
+        .args(["check", "--no-cache", "dot_zshenv"]);
+    cmd.assert().success().stdout("").stderr("");
 }
 
 #[test]
@@ -2439,6 +2477,46 @@ fn format_honors_project_config_and_cli_overrides_it() {
 }
 
 #[test]
+fn format_uses_shared_per_file_shell_for_extensionless_zsh_file() {
+    let tempdir = tempdir().unwrap();
+    fs::write(
+        tempdir.path().join("shuck.toml"),
+        "[per-file-shell]\n'dot_z*' = 'zsh'\n",
+    )
+    .unwrap();
+    let script = tempdir.path().join("dot_zshenv");
+    let source = "(($+commands[vivid]))\n";
+    fs::write(&script, source).unwrap();
+
+    let mut cmd = Command::cargo_bin("shuck").unwrap();
+    configure_env_cache(&mut cmd, tempdir.path());
+    cmd.current_dir(tempdir.path())
+        .args(["format", "dot_zshenv"]);
+    cmd.assert().success().stdout("").stderr("");
+
+    assert_eq!(fs::read_to_string(script).unwrap(), source);
+}
+
+#[test]
+fn format_rejects_conflicting_per_file_shell_mappings() {
+    let tempdir = tempdir().unwrap();
+    fs::write(
+        tempdir.path().join("shuck.toml"),
+        "[per-file-shell]\n'*' = 'bash'\n'dot_z*' = 'zsh'\n",
+    )
+    .unwrap();
+    fs::write(tempdir.path().join("dot_zshenv"), "(($+commands[vivid]))\n").unwrap();
+
+    let mut cmd = Command::cargo_bin("shuck").unwrap();
+    configure_env_cache(&mut cmd, tempdir.path());
+    cmd.current_dir(tempdir.path())
+        .args(["format", "dot_zshenv"]);
+    cmd.assert().code(2).stderr(predicate::str::contains(
+        "conflicting per-file shell mappings",
+    ));
+}
+
+#[test]
 fn format_honors_explicit_global_config_file() {
     let tempdir = tempdir().unwrap();
     let config_path = tempdir.path().join("override.toml");
@@ -2554,6 +2632,31 @@ fn format_cache_invalidates_when_formatter_options_change() {
         .current_dir(tempdir.path())
         .args(["format", "--check", "--function-next-line"]);
     check.assert().code(1).stdout("");
+}
+
+#[test]
+fn format_cache_invalidates_when_per_file_shell_changes() {
+    let tempdir = tempdir().unwrap();
+    let config = tempdir.path().join("shuck.toml");
+    fs::write(&config, "[per-file-shell]\n'dot_z*' = 'zsh'\n").unwrap();
+    let script = tempdir.path().join("dot_zshenv");
+    fs::write(&script, "(($+commands[vivid]))\n").unwrap();
+
+    let mut initial = Command::cargo_bin("shuck").unwrap();
+    configure_env_cache(&mut initial, tempdir.path());
+    initial
+        .current_dir(tempdir.path())
+        .args(["format", "dot_zshenv"]);
+    initial.assert().success().stdout("").stderr("");
+
+    fs::write(&config, "[per-file-shell]\n'dot_z*' = 'bash'\n").unwrap();
+
+    let mut changed = Command::cargo_bin("shuck").unwrap();
+    configure_env_cache(&mut changed, tempdir.path());
+    changed
+        .current_dir(tempdir.path())
+        .args(["format", "--check", "dot_zshenv"]);
+    changed.assert().code(1).stdout("").stderr("");
 }
 
 #[test]

--- a/crates/shuck-config/src/lib.rs
+++ b/crates/shuck-config/src/lib.rs
@@ -28,8 +28,8 @@ const CONFIG_FILENAMES: [&str; 2] = [".shuck.toml", "shuck.toml"];
 /// for global configuration.
 const GLOBAL_CONFIG_DIR_ENV: &str = "SHUCK_CONFIG_HOME";
 /// Error shown when users try to set formatter dialect in a config file.
-pub const CONFIG_DIALECT_UNSUPPORTED_ERROR: &str = "`[format].dialect` is not supported; formatter dialect is auto-discovered from the file name or shebang. Use `--dialect` for a per-run override";
-const CONFIG_OVERRIDE_ROOT_KEYS: &[&str] = &["check", "format", "lint", "run"];
+pub const CONFIG_DIALECT_UNSUPPORTED_ERROR: &str = "`[format].dialect` is not supported; use `[per-file-shell]` for project mappings or `--dialect` for a per-run override";
+const CONFIG_OVERRIDE_ROOT_KEYS: &[&str] = &["check", "format", "lint", "per-file-shell", "run"];
 const CONFIG_OVERRIDE_CHECK_KEYS: &[&str] = &["embedded"];
 const CONFIG_OVERRIDE_FORMAT_KEYS: &[&str] = &[
     "dialect",
@@ -117,6 +117,9 @@ pub struct ShuckConfig {
     pub format: FormatConfig,
     /// Linter rule selection, contracts, and analysis options.
     pub lint: LintConfig,
+    /// Shared per-file shell dialect overrides keyed by glob pattern.
+    #[serde(rename = "per-file-shell")]
+    pub per_file_shell: Option<BTreeMap<String, String>>,
     /// Runtime shell resolution options for `shuck run`.
     pub run: RunConfig,
 }
@@ -885,7 +888,7 @@ pub fn configuration_metadata() -> &'static [ConfigSectionMetadata] {
     &CONFIGURATION_METADATA
 }
 
-const CONFIGURATION_METADATA: [ConfigSectionMetadata; 4] = [
+const CONFIGURATION_METADATA: [ConfigSectionMetadata; 5] = [
     ConfigSectionMetadata {
         key: "check",
         docs: "File-level analysis behavior for `shuck check`.",
@@ -966,6 +969,12 @@ const CONFIGURATION_METADATA: [ConfigSectionMetadata; 4] = [
                 example: "switch-case-indent = true",
             },
         ],
+        sections: &[],
+    },
+    ConfigSectionMetadata {
+        key: "per-file-shell",
+        docs: "Select the shell dialect used to parse matching files in `shuck check`, `shuck format`, and the language server. Patterns are resolved relative to the project root, and overlapping patterns cannot select different dialects for one file. Supported values are `sh`, `bash`, `dash`, `ksh`, `mksh`, and `zsh`; generic `ksh` is linter-only because the formatter has no corresponding grammar. An explicit `shuck format --dialect` override takes precedence.\n\n```toml\n[per-file-shell]\n\"dot_z*\" = \"zsh\"\n\"scripts/**/*.sh\" = \"bash\"\n```",
+        fields: &[],
         sections: &[],
     },
     ConfigSectionMetadata {
@@ -1781,6 +1790,9 @@ impl ShuckConfig {
         self.check.apply_overrides(overrides.check);
         self.format.apply_overrides(overrides.format);
         self.lint.apply_overrides(overrides.lint);
+        if overrides.per_file_shell.is_some() {
+            self.per_file_shell = overrides.per_file_shell;
+        }
         apply_run_overrides(&mut self.run, overrides.run);
     }
 }
@@ -2601,6 +2613,19 @@ mod tests {
     fn inline_config_overrides_accept_format_exclusions() {
         let config = parse_config_override("format.exclude = ['generated/**']").unwrap();
         assert_eq!(config.format.exclude, Some(vec!["generated/**".to_owned()]));
+    }
+
+    #[test]
+    fn inline_config_overrides_accept_shared_per_file_shell() {
+        let config = parse_config_override("per-file-shell.'dot_z*' = 'zsh'").unwrap();
+        assert_eq!(
+            config
+                .per_file_shell
+                .as_ref()
+                .and_then(|entries| entries.get("dot_z*"))
+                .map(String::as_str),
+            Some("zsh")
+        );
     }
 
     #[test]

--- a/crates/shuck-config/tests/public_api.rs
+++ b/crates/shuck-config/tests/public_api.rs
@@ -38,6 +38,27 @@ fn public_api_layers_discovered_config_and_inline_overrides() {
 }
 
 #[test]
+fn public_api_loads_shared_per_file_shell_config() {
+    let tempdir = tempdir().unwrap();
+    fs::write(
+        tempdir.path().join("shuck.toml"),
+        "[per-file-shell]\n'dot_z*' = 'zsh'\n",
+    )
+    .unwrap();
+
+    let loaded = load_project_config(tempdir.path(), &ConfigArguments::default()).unwrap();
+
+    assert_eq!(
+        loaded
+            .per_file_shell
+            .as_ref()
+            .and_then(|entries| entries.get("dot_z*"))
+            .map(String::as_str),
+        Some("zsh")
+    );
+}
+
+#[test]
 fn public_api_prefers_explicit_config_file_over_discovered_file() {
     let tempdir = tempdir().unwrap();
     fs::write(

--- a/crates/shuck-linter/src/settings.rs
+++ b/crates/shuck-linter/src/settings.rs
@@ -403,6 +403,7 @@ pub struct CompiledPerFileShellList {
 
 #[derive(Debug, Clone)]
 struct CompiledPerFileShell {
+    pattern: String,
     basename_matcher: GlobMatcher,
     relative_matcher: GlobMatcher,
     absolute_matcher: GlobMatcher,
@@ -725,12 +726,14 @@ impl CompiledPerFileShellList {
             .into_iter()
             .map(|per_file_shell| {
                 let mut pattern = per_file_shell.pattern;
+                let configured_pattern = pattern.clone();
                 let negated = pattern.starts_with('!');
                 if negated {
                     pattern.drain(..1);
                 }
 
                 Ok(CompiledPerFileShell {
+                    pattern: configured_pattern,
                     basename_matcher: Glob::new(&pattern)
                         .map_err(|err| anyhow!("invalid glob {pattern:?}: {err}"))?
                         .compile_matcher(),
@@ -760,13 +763,52 @@ impl CompiledPerFileShellList {
         let file_name = relative_path.file_name().or_else(|| path.file_name())?;
 
         self.entries.iter().fold(None, |shell, entry| {
-            let matches = entry.basename_matcher.is_match(file_name)
-                || entry.relative_matcher.is_match(relative_path)
-                || matches_absolute_shell_path(&entry.absolute_matcher, path);
-            let applies = if entry.negated { !matches } else { matches };
-
-            if applies { Some(entry.shell) } else { shell }
+            if entry.applies(path, relative_path, file_name) {
+                Some(entry.shell)
+            } else {
+                shell
+            }
         })
+    }
+
+    /// Returns the shell selected for `path`, rejecting overlapping mappings
+    /// that select different dialects.
+    pub fn shell_for_path_checked(&self, path: &Path) -> Result<Option<ShellDialect>> {
+        let relative_path = path.strip_prefix(&self.project_root).unwrap_or(path);
+        let Some(file_name) = relative_path.file_name().or_else(|| path.file_name()) else {
+            return Ok(None);
+        };
+        let mut selected = None::<(&str, ShellDialect)>;
+
+        for entry in &self.entries {
+            if !entry.applies(path, relative_path, file_name) {
+                continue;
+            }
+            if let Some((selected_pattern, selected_shell)) = selected
+                && selected_shell != entry.shell
+            {
+                return Err(anyhow!(
+                    "conflicting per-file shell mappings for {}: {:?} selects {:?}, but {:?} selects {:?}",
+                    path.display(),
+                    selected_pattern,
+                    selected_shell,
+                    entry.pattern,
+                    entry.shell
+                ));
+            }
+            selected = Some((&entry.pattern, entry.shell));
+        }
+
+        Ok(selected.map(|(_, shell)| shell))
+    }
+}
+
+impl CompiledPerFileShell {
+    fn applies(&self, path: &Path, relative_path: &Path, file_name: &std::ffi::OsStr) -> bool {
+        let matches = self.basename_matcher.is_match(file_name)
+            || self.relative_matcher.is_match(relative_path)
+            || matches_absolute_shell_path(&self.absolute_matcher, path);
+        if self.negated { !matches } else { matches }
     }
 }
 
@@ -932,6 +974,33 @@ mod tests {
         assert_eq!(
             per_file_shell.shell_for_path(&project_root.join("README.md")),
             None
+        );
+    }
+
+    #[test]
+    fn checked_per_file_shell_rejects_conflicting_dialects() {
+        let project_root = PathBuf::from("/workspace");
+        let per_file_shell = CompiledPerFileShellList::resolve(
+            &project_root,
+            [
+                PerFileShell::new("*.sh", ShellDialect::Sh),
+                PerFileShell::new("scripts/*.sh", ShellDialect::Bash),
+            ],
+        )
+        .unwrap();
+
+        assert!(
+            per_file_shell
+                .shell_for_path_checked(&project_root.join("scripts/tool.sh"))
+                .unwrap_err()
+                .to_string()
+                .contains("conflicting per-file shell mappings")
+        );
+        assert_eq!(
+            per_file_shell
+                .shell_for_path_checked(&project_root.join("top.sh"))
+                .unwrap(),
+            Some(ShellDialect::Sh)
         );
     }
 

--- a/crates/shuck-server/src/format.rs
+++ b/crates/shuck-server/src/format.rs
@@ -21,6 +21,9 @@ pub(crate) fn format_document(
     {
         return Ok(None);
     }
+    if let Some(error) = snapshot.shuck_settings().format_dialect_error() {
+        return Err(Error::msg(error.to_owned()).into());
+    }
     let source = query.document().contents();
     let formatted = shuck_formatter::format_source(
         source,
@@ -53,6 +56,9 @@ pub(crate) fn format_range(
         .is_format_excluded(file_path.as_deref())
     {
         return Ok(None);
+    }
+    if let Some(error) = snapshot.shuck_settings().format_dialect_error() {
+        return Err(Error::msg(error.to_owned()).into());
     }
     let Some(analysis) = snapshot.analysis() else {
         return Ok(None);
@@ -260,6 +266,58 @@ mod tests {
         assert_eq!(edits[0].range.start, types::Position::new(1, 0));
         assert_eq!(edits[0].range.end, types::Position::new(1, 0));
         assert_eq!(edits[0].new_text, "\t");
+    }
+
+    #[test]
+    fn document_formatting_uses_shared_per_file_shell_config() {
+        let tempdir = tempfile::tempdir().expect("workspace should be created");
+        std::fs::write(
+            tempdir.path().join("shuck.toml"),
+            "[per-file-shell]\n'dot_z*' = 'zsh'\n",
+        )
+        .expect("config should be written");
+        let source = "(($+commands[vivid]))\n";
+        let file_path = tempdir.path().join("dot_zshenv");
+        std::fs::write(&file_path, source).expect("source should be written");
+
+        let (main_loop_sender, _main_loop_receiver) = channel::unbounded();
+        let (client_sender, _client_receiver) = channel::unbounded();
+        let client = Client::new(main_loop_sender, client_sender);
+        let workspace_uri =
+            Url::from_file_path(tempdir.path()).expect("workspace path should convert to a URL");
+        let workspaces = Workspaces::new(vec![Workspace::default(workspace_uri)]);
+        let global = GlobalOptions::default().into_settings(client.clone());
+        let mut session = Session::new(
+            &ClientCapabilities::default(),
+            PositionEncoding::UTF16,
+            global,
+            &workspaces,
+            &client,
+        )
+        .expect("test session should initialize");
+
+        let uri = Url::from_file_path(file_path).expect("script path should convert to a URL");
+        session.open_text_document(
+            uri.clone(),
+            TextDocument::new(source.to_owned(), 1).with_language_id("shellscript"),
+        );
+        let snapshot = session
+            .take_snapshot(uri.clone())
+            .expect("test document should produce a snapshot");
+
+        let edits = format_document(
+            snapshot,
+            &client,
+            types::DocumentFormattingParams {
+                text_document: types::TextDocumentIdentifier { uri },
+                options: types::FormattingOptions::default(),
+                work_done_progress_params: types::WorkDoneProgressParams::default(),
+            },
+        )
+        .expect("document formatting should succeed")
+        .expect("document formatting should return an edit list");
+
+        assert!(edits.is_empty());
     }
 
     #[test]

--- a/crates/shuck-server/src/session/options.rs
+++ b/crates/shuck-server/src/session/options.rs
@@ -1,3 +1,5 @@
+use std::collections::BTreeMap;
+
 use lsp_types::Url;
 use rustc_hash::FxHashMap;
 use serde::{Deserialize, Deserializer};
@@ -30,6 +32,9 @@ impl GlobalOptions {
 #[serde(rename_all = "camelCase")]
 pub struct ClientOptions {
     #[serde(default)]
+    /// Shared per-file shell dialect overrides.
+    pub per_file_shell: Option<BTreeMap<String, String>>,
+    #[serde(default)]
     /// Lint configuration overrides.
     pub lint: Option<LintConfig>,
     #[serde(default)]
@@ -52,6 +57,7 @@ pub struct ClientOptions {
 impl ClientOptions {
     pub(crate) fn to_config_overrides(&self) -> ShuckConfig {
         ShuckConfig {
+            per_file_shell: self.per_file_shell.clone(),
             lint: self.lint.clone().unwrap_or_default(),
             format: self.format.clone().unwrap_or_default(),
             ..ShuckConfig::default()

--- a/crates/shuck-server/src/session/settings.rs
+++ b/crates/shuck-server/src/session/settings.rs
@@ -30,6 +30,7 @@ pub(crate) struct ClientSettings {
 pub struct ShuckSettings {
     linter: LinterSettings,
     formatter: ShellFormatOptions,
+    format_dialect_error: Option<String>,
     format_exclusions: FormatExclusions,
     fixable_rules: RuleSet,
     project_root: Option<PathBuf>,
@@ -138,6 +139,10 @@ impl ShuckSettings {
         &self.formatter
     }
 
+    pub(crate) fn format_dialect_error(&self) -> Option<&str> {
+        self.format_dialect_error.as_deref()
+    }
+
     pub(crate) fn is_format_excluded(&self, path: Option<&Path>) -> bool {
         path.is_some_and(|path| self.format_exclusions.is_excluded(path))
     }
@@ -156,6 +161,7 @@ impl Default for ShuckSettings {
         Self {
             linter: LinterSettings::default(),
             formatter: ShellFormatOptions::default(),
+            format_dialect_error: None,
             format_exclusions: FormatExclusions::default(),
             fixable_rules: RuleSet::all(),
             project_root: None,
@@ -234,21 +240,55 @@ impl ResolvedProjectSettings {
     }
 
     pub(crate) fn for_file(&self, file_path: Option<&Path>) -> ShuckSettings {
+        let (formatter, format_dialect_error) = self.formatter_for_file(file_path);
         ShuckSettings {
             linter: self.linter.for_file(file_path),
-            formatter: self.formatter.clone(),
+            formatter,
+            format_dialect_error,
             format_exclusions: self.format_exclusions.clone(),
             fixable_rules: self.fixable_rules,
             project_root: self.project_root.clone(),
         }
     }
+
+    fn formatter_for_file(&self, file_path: Option<&Path>) -> (ShellFormatOptions, Option<String>) {
+        if self.formatter.dialect() != FormatDialect::Auto {
+            return (self.formatter.clone(), None);
+        }
+
+        let Some(file_path) = file_path else {
+            return (self.formatter.clone(), None);
+        };
+        let shell = match self.linter.per_file_shell.shell_for_path_checked(file_path) {
+            Ok(shell) => shell,
+            Err(error) => return (self.formatter.clone(), Some(error.to_string())),
+        };
+        let Some(shell) = shell else {
+            return (self.formatter.clone(), None);
+        };
+        let Some(dialect) = format_dialect(shell) else {
+            return (
+                self.formatter.clone(),
+                Some(format!(
+                    "per-file shell `{}` is not supported by the formatter",
+                    shell_name(shell)
+                )),
+            );
+        };
+
+        (self.formatter.clone().with_dialect(dialect), None)
+    }
 }
 
 impl ResolvedLinterSettings {
+    fn shell_for_file(&self, file_path: Option<&Path>) -> Option<LinterShellDialect> {
+        file_path.and_then(|file_path| self.per_file_shell.shell_for_path(file_path))
+    }
+
     fn for_file(&self, file_path: Option<&Path>) -> LinterSettings {
         let mut linter = self.base.clone();
-        linter.shell = file_path
-            .and_then(|file_path| self.per_file_shell.shell_for_path(file_path))
+        linter.shell = self
+            .shell_for_file(file_path)
             .unwrap_or(LinterShellDialect::Unknown);
         linter
     }
@@ -317,15 +357,11 @@ fn lint_layers<'a>(
     project_config: &'a ShuckConfig,
     option_layers: &'a [&'a ClientOptions],
 ) -> impl Iterator<Item = RuleSelectionLayer> + 'a {
-    std::iter::once(parse_lint_config_layer(&project_config.lint)).chain(option_layers.iter().map(
-        |options| {
-            options
-                .lint
-                .as_ref()
-                .map(parse_lint_config_layer)
-                .unwrap_or_default()
-        },
-    ))
+    std::iter::once(parse_config_rule_selection_layer(project_config)).chain(
+        option_layers
+            .iter()
+            .map(|options| parse_client_rule_selection_layer(options)),
+    )
 }
 
 fn resolved_linter_settings_for_layers(
@@ -448,6 +484,28 @@ fn formatter_settings_for_config(config: &shuck_config::FormatConfig) -> ShellFo
     options
 }
 
+const fn format_dialect(shell: LinterShellDialect) -> Option<FormatDialect> {
+    match shell {
+        LinterShellDialect::Sh | LinterShellDialect::Dash => Some(FormatDialect::Posix),
+        LinterShellDialect::Bash => Some(FormatDialect::Bash),
+        LinterShellDialect::Mksh => Some(FormatDialect::Mksh),
+        LinterShellDialect::Zsh => Some(FormatDialect::Zsh),
+        LinterShellDialect::Unknown | LinterShellDialect::Ksh => None,
+    }
+}
+
+const fn shell_name(shell: LinterShellDialect) -> &'static str {
+    match shell {
+        LinterShellDialect::Unknown => "unknown",
+        LinterShellDialect::Sh => "sh",
+        LinterShellDialect::Bash => "bash",
+        LinterShellDialect::Dash => "dash",
+        LinterShellDialect::Ksh => "ksh",
+        LinterShellDialect::Mksh => "mksh",
+        LinterShellDialect::Zsh => "zsh",
+    }
+}
+
 fn fixable_rules_for_layers(
     project_config: &ShuckConfig,
     option_layers: &[&ClientOptions],
@@ -502,6 +560,26 @@ fn parse_lint_config_layer(lint: &LintConfig) -> RuleSelectionLayer {
         extend_fixable: parse_selector_list(lint.extend_fixable.as_deref(), "lint.extend-fixable")
             .unwrap_or_default(),
     }
+}
+
+fn parse_config_rule_selection_layer(config: &ShuckConfig) -> RuleSelectionLayer {
+    let mut layer = parse_lint_config_layer(&config.lint);
+    if let Some(entries) = config.per_file_shell.as_ref() {
+        layer.per_file_shell = Some(parse_per_file_shell_map(entries, "per-file-shell"));
+    }
+    layer
+}
+
+fn parse_client_rule_selection_layer(options: &ClientOptions) -> RuleSelectionLayer {
+    let mut layer = options
+        .lint
+        .as_ref()
+        .map(parse_lint_config_layer)
+        .unwrap_or_default();
+    if let Some(entries) = options.per_file_shell.as_ref() {
+        layer.per_file_shell = Some(parse_per_file_shell_map(entries, "perFileShell"));
+    }
+    layer
 }
 
 fn parse_per_file_ignore_specs(
@@ -803,6 +881,56 @@ mod tests {
         );
 
         assert_eq!(settings.linter().shell, LinterShellDialect::Zsh);
+    }
+
+    #[test]
+    fn shared_per_file_shell_applies_to_linter_and_formatter() {
+        let options = ClientOptions::default();
+        let tempdir = tempfile::tempdir().expect("tempdir should be created");
+        std::fs::write(
+            tempdir.path().join(".shuck.toml"),
+            "[per-file-shell]\n'dot_z*' = 'zsh'\n",
+        )
+        .expect("config should be written");
+
+        let file_path = tempdir.path().join("dot_zshenv");
+        std::fs::write(&file_path, "(($+commands[vivid]))\n").expect("source should be written");
+
+        let settings = ShuckSettings::resolve(
+            Some(&file_path),
+            &[tempdir.path().to_path_buf()],
+            &[&options],
+        );
+
+        assert_eq!(settings.linter().shell, LinterShellDialect::Zsh);
+        assert_eq!(settings.formatter().dialect(), FormatDialect::Zsh);
+        assert_eq!(settings.format_dialect_error(), None);
+    }
+
+    #[test]
+    fn shared_per_file_shell_conflicts_block_formatter_settings() {
+        let options = ClientOptions::default();
+        let tempdir = tempfile::tempdir().expect("tempdir should be created");
+        std::fs::write(
+            tempdir.path().join(".shuck.toml"),
+            "[per-file-shell]\n'*' = 'bash'\n'dot_z*' = 'zsh'\n",
+        )
+        .expect("config should be written");
+
+        let file_path = tempdir.path().join("dot_zshenv");
+        std::fs::write(&file_path, "(($+commands[vivid]))\n").expect("source should be written");
+
+        let settings = ShuckSettings::resolve(
+            Some(&file_path),
+            &[tempdir.path().to_path_buf()],
+            &[&options],
+        );
+
+        assert!(
+            settings
+                .format_dialect_error()
+                .is_some_and(|error| error.contains("conflicting per-file shell mappings"))
+        );
     }
 
     #[test]

--- a/docs/archive/formatter.md
+++ b/docs/archive/formatter.md
@@ -29,6 +29,10 @@ shuck format --minify script.sh
 ## Config file
 
 ```toml
+[per-file-shell]
+"dot_z*" = "zsh"
+"scripts/**/*.sh" = "bash"
+
 [format]
 indent-style = "space"     # tab | space
 indent-width = 4           # 1-255, used when indent-style = "space"
@@ -40,9 +44,11 @@ function-next-line = false # opening brace on its own line
 never-split = false        # compact single-line layouts
 ```
 
-Formatter dialect is auto-discovered from the filename or shebang. Use
-`shuck format --dialect <shell>` when you need an explicit override,
-especially for stdin input.
+The shared `per-file-shell` table selects a dialect for matching files in the
+formatter, linter, and language server, including stdin with
+`--stdin-filename`. An explicit `shuck format --dialect <shell>` takes
+precedence; unmatched files continue to infer the dialect from their filename,
+shebang, and source.
 
 ## Website copy
 

--- a/website/content/configuration/index.mdx
+++ b/website/content/configuration/index.mdx
@@ -205,6 +205,26 @@ examples, and when to prefer Contracts over more source resolution. The
 [Settings Reference](/docs/settings) includes the exact `[lint.contracts]`
 syntax.
 
+## Per-file shell selection
+
+Use the shared top-level `[per-file-shell]` table when filenames and shebangs
+do not identify the correct shell dialect:
+
+```toml
+[per-file-shell]
+"dot_z*" = "zsh"
+"scripts/**/*.sh" = "bash"
+```
+
+The mapping applies consistently to checking, direct and stdin formatting, and
+language-server analysis and formatting. Patterns are project-root-relative.
+An explicit `shuck format --dialect ...` flag wins; unmatched files retain
+normal inference. Overlapping patterns must not select different dialects for
+the same file.
+
+Existing `[lint].per-file-shell` and `[lint].extend-per-file-shell` entries are
+accepted as compatibility aliases.
+
 ## Format settings
 
 The formatter reads style options from `[format]`.
@@ -223,7 +243,7 @@ never-split = false
 
 Formatter config follows the same discovery and override rules as the rest of Shuck config. CLI flags passed to `shuck format` override `[format]` for that invocation.
 
-Dialect is the exception: `[format].dialect` is rejected so projects do not accidentally force one parser mode for every file. Use file names, shebangs, or `shuck format --dialect ...` for a one-off override.
+Dialect is the exception: `[format].dialect` is rejected so projects do not accidentally force one parser mode for every file. Use the shared `[per-file-shell]` table for project mappings or `shuck format --dialect ...` for a one-off override.
 
 See the dedicated [Formatting guide](/docs/formatting) for command examples, stdin behavior, `--check`, `--diff`, `--simplify`, and `--minify`.
 

--- a/website/content/formatting/index.mdx
+++ b/website/content/formatting/index.mdx
@@ -69,7 +69,16 @@ shuck format --no-function-next-line .
 
 ## Dialect selection
 
-By default, the formatter infers dialect from the source text, shebang, and file path. Use `--dialect` for a one-off override:
+By default, the formatter infers dialect from the source text, shebang, and file path. Use the shared top-level table for files whose names cannot be inferred:
+
+```toml
+[per-file-shell]
+"dot_z*" = "zsh"
+"scripts/**/*.sh" = "bash"
+```
+
+The mapping applies to direct files, stdin with `--stdin-filename`, and LSP
+formatting. Use `--dialect` for a one-off override:
 
 ```bash
 shuck format --dialect bash script
@@ -78,7 +87,9 @@ shuck format --dialect zsh .zshrc
 
 Accepted values are `bash`, `posix`, `mksh`, and `zsh`.
 
-`[format].dialect` is intentionally not supported in config files. Use file names, shebangs, or the per-run `--dialect` flag instead.
+`[format].dialect` is intentionally not supported in config files. The per-run
+`--dialect` flag takes precedence over `[per-file-shell]`; unmatched files
+continue to use normal inference.
 
 ## Simplify and minify
 

--- a/website/content/settings/index.mdx
+++ b/website/content/settings/index.mdx
@@ -29,7 +29,7 @@ embedded = false
 
 ## `[format]`
 
-Formatter style options for `shuck format`.
+Formatter file-selection and style options for `shuck format` and editor formatting.
 
 #### `binary-next-line`
 
@@ -44,6 +44,23 @@ Place binary list and pipeline operators at the start of continuation lines when
 ```toml
 [format]
 binary-next-line = true
+```
+
+---
+
+#### `exclude`
+
+Do not format files matching these project-relative glob patterns.
+
+**Default value**: `[]`
+
+**Type**: `list[str]`
+
+**Example usage**:
+
+```toml
+[format]
+exclude = ["generated/**"]
 ```
 
 ---
@@ -166,6 +183,16 @@ switch-case-indent = true
 ```
 
 ---
+
+## `[per-file-shell]`
+
+Select the shell dialect used to parse matching files in `shuck check`, `shuck format`, and the language server. Patterns are resolved relative to the project root, and overlapping patterns cannot select different dialects for one file. Supported values are `sh`, `bash`, `dash`, `ksh`, `mksh`, and `zsh`; generic `ksh` is linter-only because the formatter has no corresponding grammar. An explicit `shuck format --dialect` override takes precedence.
+
+```toml
+[per-file-shell]
+"dot_z*" = "zsh"
+"scripts/**/*.sh" = "bash"
+```
 
 ## `[lint]`
 


### PR DESCRIPTION
## Summary

- add a shared top-level `[per-file-shell]` configuration table for checking, formatting, and the language server
- resolve formatter dialects per path for direct files and `--stdin-filename`, while keeping `--dialect` as the highest-precedence override
- retain `[lint].per-file-shell` and `[lint].extend-per-file-shell` as compatibility inputs
- reject overlapping mappings that select different dialects and report unsupported generic `ksh` formatting clearly
- include the effective mapping in formatter cache keys and document the new configuration

## Why

Extensionless shell files such as chezmoi's `dot_zshenv` cannot be identified reliably from their filename or shebang. Falling back to the wrong dialect can make formatting change valid Zsh into invalid syntax.

This completes the second slice built on #1257 and preserves `(($+commands[vivid]))` when a matching file is configured as Zsh.

Closes #1250.

## Validation

- `cargo test -p shuck-config -p shuck-linter -p shuck-cli -p shuck-server`
- `cargo fmt --all -- --check`
- `cargo clippy -p shuck-config -p shuck-cli -p shuck-server --all-targets --no-deps -- -D warnings`
- `cargo clippy -p shuck-linter --all-targets --no-deps -- -D warnings -A clippy::unneeded-wildcard-pattern -A clippy::some-filter -A clippy::while-let-loop -A clippy::question-mark`
- `pnpm test` in `website/`