### PR TITLE
fix(formatter): preserve multiline literal indentation

### DIFF
--- a/crates/shuck-formatter/src/word/command_substitution.rs
+++ b/crates/shuck-formatter/src/word/command_substitution.rs
@@ -691,7 +691,7 @@ pub(super) fn render_command_substitution(
         }
         CommandSubstitutionLayout::Block => {
             rendered.push_str("$(\n");
-            push_indented_rendered_block(rendered, trimmed, options, 1);
+            push_indented_command_substitution_block(rendered, trimmed, options, 1);
             rendered.push_str("\n)");
         }
     }
@@ -1127,7 +1127,7 @@ pub(super) fn push_inline_raw_command_substitution_as_block(
 
     let nested = normalize_inline_raw_command_substitution_body(body_source, options);
     target.push_str("$(\n");
-    push_indented_rendered_block(target, &nested, options, 1);
+    push_indented_command_substitution_block(target, &nested, options, 1);
     target.push_str("\n)");
     true
 }
@@ -1496,6 +1496,27 @@ pub(super) fn push_indented_rendered_block(
     options: &ResolvedShellFormatOptions,
     levels: usize,
 ) {
+    push_indented_rendered_block_with_literal_policy(target, rendered, options, levels, false);
+}
+
+pub(super) fn push_indented_command_substitution_block(
+    target: &mut String,
+    rendered: &str,
+    options: &ResolvedShellFormatOptions,
+    levels: usize,
+) {
+    push_indented_rendered_block_with_literal_policy(target, rendered, options, levels, true);
+}
+
+fn push_indented_rendered_block_with_literal_policy(
+    target: &mut String,
+    rendered: &str,
+    options: &ResolvedShellFormatOptions,
+    levels: usize,
+    preserve_multiline_single_quoted_lines: bool,
+) {
+    let preserve_multiline_single_quoted_lines = preserve_multiline_single_quoted_lines
+        && matches!(options.indent_style(), IndentStyle::Space);
     let prefix = options.indent_prefix(levels);
     let normalized_literal_continuations =
         normalize_literal_continuation_indent_for_block(rendered);
@@ -1505,6 +1526,7 @@ pub(super) fn push_indented_rendered_block(
     let common_source_indent = common_rendered_block_indent(rendered, options);
 
     let mut active_heredoc: Option<CommandSubstitutionHeredocIndent> = None;
+    let mut quote = QuoteState::default();
     for (index, line) in rendered.lines().enumerate() {
         if index > 0 {
             target.push('\n');
@@ -1531,11 +1553,16 @@ pub(super) fn push_indented_rendered_block(
             continue;
         }
 
+        let line_starts_in_single_quotes =
+            preserve_multiline_single_quoted_lines && quote.in_single_quotes();
         let line = strip_common_rendered_block_indent(line, &common_source_indent);
-        if line_needs_command_substitution_indent(line, options) {
+        if !line_starts_in_single_quotes && line_needs_command_substitution_indent(line, options) {
             target.push_str(&prefix);
         }
         target.push_str(line);
+        if preserve_multiline_single_quoted_lines {
+            quote.scan_line(line);
+        }
         active_heredoc = command_substitution_heredoc_indent(line);
     }
 }

--- a/crates/shuck-formatter/src/word/raw_rewrites.rs
+++ b/crates/shuck-formatter/src/word/raw_rewrites.rs
@@ -639,7 +639,7 @@ pub(super) fn render_inline_raw_command_substitution_as_block(
         rendered.push(')');
     } else {
         rendered.push_str("$(\n");
-        push_indented_rendered_block(&mut rendered, trimmed, options, 1);
+        push_indented_command_substitution_block(&mut rendered, trimmed, options, 1);
         rendered.push_str("\n)");
     }
     Some(rendered)

--- a/crates/shuck-formatter/tests/format_cases.rs
+++ b/crates/shuck-formatter/tests/format_cases.rs
@@ -2298,12 +2298,31 @@ echo "$foobar"
 }
 
 format_cases_with_options! {
+    space_indented_block_command_substitution_formats_shell_around_multiline_literal:
+        ShellFormatOptions::default()
+            .with_dialect(ShellDialect::Bash)
+            .with_indent_style(IndentStyle::Space)
+            .with_indent_width(2),
+        "value=\"$(\n    printf x |\n    python3 -c '\nprint(\"ok\")\n' <<< \"$payload\"\n)\"\n",
+        => "value=\"$(\n  printf x |\n    python3 -c '\nprint(\"ok\")\n' <<<\"$payload\"\n)\"\n";
+}
+
+format_cases_with_options! {
     space_indented_command_substitution_normalizes_with_spaces:
         ShellFormatOptions::default()
             .with_indent_style(IndentStyle::Space)
             .with_indent_width(4),
         "foobar=$(ls -al \\\n    | grep \"$USER\" \\\n    | grep -i \"jul\")\n",
         => "foobar=$(ls -al |\n    grep \"$USER\" |\n    grep -i \"jul\")\n";
+}
+
+unchanged_cases_with_options! {
+    space_indented_block_command_substitution_preserves_multiline_literal_payload:
+        ShellFormatOptions::default()
+            .with_dialect(ShellDialect::Bash)
+            .with_indent_style(IndentStyle::Space)
+            .with_indent_width(2),
+        "value=\"$(\n  python3 -c '\nprint(\"ok\")\n'\n)\"\n";
 }
 
 format_cases_with_options! {


### PR DESCRIPTION
## Summary

- detect multiline single-quoted payloads inside block command substitutions
- route those blocks through the source-preserving formatter while still normalizing surrounding shell indentation
- add regression coverage for the reported two-space Bash formatting case

## Validation

- `cargo fmt --check`
- `cargo test -p shuck-formatter`
- `make test`
- reproduced both direct and pipeline cases and executed the formatted script successfully

Closes #1259