### PR TITLE
feat(api)!: harden public analysis APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -438,6 +438,12 @@ Override the cache root with `--cache-dir` or `SHUCK_CACHE_DIR`.
 
 Disable caching with `--no-cache` or remove a project's cache entries with `shuck clean [PATH]`.
 
+## Rust API
+
+Shuck's parser and analysis crates are published for embedders. Their supported pre-1.0
+integration path and selective compatibility guarantees are documented in
+[Rust API compatibility](docs/rust-api-compatibility.md).
+
 ## Acknowledgements
 
 Shuck builds on ideas and inspiration from several excellent open-source projects. This section is a thank-you to those communities — it does not imply endorsement, affiliation, or any formal relationship between shuck and these projects.

--- a/crates/shuck-ast/README.md
+++ b/crates/shuck-ast/README.md
@@ -7,4 +7,6 @@ Use this crate when you need to inspect or transform parsed shell syntax. In mos
 `shuck-parser` is the crate that produces these types, while `shuck-indexer`, `shuck-linter`,
 and `shuck-formatter` consume them.
 
-The API is pre-1.0 and may evolve between `0.x` releases.
+The API is pre-1.0 and may evolve between `0.x` releases. Public AST types are not blanket-marked
+as stable or non-exhaustive; structural changes remain possible and will be handled explicitly.
+See [`docs/rust-api-compatibility.md`](../../docs/rust-api-compatibility.md).

--- a/crates/shuck-benchmark/benches/linter.rs
+++ b/crates/shuck-benchmark/benches/linter.rs
@@ -99,10 +99,7 @@ fn bench_linter_facts(c: &mut Criterion) {
 
 fn bench_linter(c: &mut Criterion) {
     let mut group = c.benchmark_group("linter");
-    let settings = LinterSettings {
-        rules: RuleSet::all(),
-        ..LinterSettings::default()
-    };
+    let settings = LinterSettings::for_rules(RuleSet::all().iter());
     let shellcheck_map = ShellCheckCodeMap::default();
 
     for case in benchmark_cases() {

--- a/crates/shuck-cli/src/commands/check/settings.rs
+++ b/crates/shuck-cli/src/commands/check/settings.rs
@@ -923,15 +923,13 @@ pub(super) fn resolve_project_check_settings(
         lint_sources,
         embedded_enabled,
     );
+    let mut linter_settings = LinterSettings::for_rules(enabled_rules.iter());
+    linter_settings.ambient_contracts = Arc::clone(&ambient_contracts);
+    linter_settings.per_file_ignores = Arc::new(compiled_per_file_ignores);
+    linter_settings.rule_options = rule_options;
 
     Ok(ResolvedCheckSettings {
-        linter_settings: LinterSettings {
-            rules: enabled_rules,
-            ambient_contracts: Arc::clone(&ambient_contracts),
-            per_file_ignores: Arc::new(compiled_per_file_ignores),
-            rule_options,
-            ..LinterSettings::default()
-        },
+        linter_settings,
         per_file_shell: Arc::new(compiled_per_file_shell),
         zsh_plugins: Arc::new(resolved_zsh_plugins),
         fixable_rules,

--- a/crates/shuck-cli/src/shellcheck_compat/mod.rs
+++ b/crates/shuck-cli/src/shellcheck_compat/mod.rs
@@ -939,18 +939,11 @@ fn lint_with_context(
     };
     let mut rule_options = shuck_linter::LinterRuleOptions::default();
     rule_options.c063.report_unreached_nested_definitions = true;
-    let settings = LinterSettings {
-        rules: options.enabled_rules,
-        severity_overrides: Default::default(),
-        shell,
-        ambient_shell_options: Default::default(),
-        ambient_contracts: Default::default(),
-        analyzed_paths: Some(Arc::new(explicit.into_iter().collect())),
-        per_file_ignores: Default::default(),
-        report_environment_style_names: options.report_environment_style_names,
-        resolve_source_closure: options.external_sources,
-        rule_options,
-    };
+    let mut settings = LinterSettings::for_rules(options.enabled_rules.iter()).with_shell(shell);
+    settings.analyzed_paths = Some(Arc::new(explicit.into_iter().collect()));
+    settings.report_environment_style_names = options.report_environment_style_names;
+    settings.resolve_source_closure = options.external_sources;
+    settings.rule_options = rule_options;
 
     let analysis =
         shuck_linter::AnalysisRequest::from_parse_result(&parse_result, source, &settings)

--- a/crates/shuck-indexer/README.md
+++ b/crates/shuck-indexer/README.md
@@ -5,3 +5,7 @@
 It sits between parsing and higher-level analysis by providing efficient lookups for lines,
 comments, quoted regions, heredocs, command substitutions, and continuation lines. The crate is
 published for downstream integrations but is still pre-1.0.
+
+Index query APIs are available to embedders, but the public index and fact graph is not yet a
+blanket stable contract. See
+[`docs/rust-api-compatibility.md`](../../docs/rust-api-compatibility.md).

--- a/crates/shuck-linter/README.md
+++ b/crates/shuck-linter/README.md
@@ -5,3 +5,8 @@
 It combines parser output, positional indexes, semantic analysis, suppressions, fixes, and rule
 selection into a diagnostics pipeline for shell scripts. The crate is public because it is part
 of the published Shuck toolchain, but its Rust API is still pre-1.0 and actively evolving.
+
+Use `LinterSettings` constructors plus `AnalysisRequest` as the supported embedding path. Settings
+and result fields remain readable, while non-exhaustive types protect routine field and rule
+growth. Match `Rule` with a fallback. The workspace documents the full boundary in
+[`docs/rust-api-compatibility.md`](../../docs/rust-api-compatibility.md).

--- a/crates/shuck-linter/src/diagnostic.rs
+++ b/crates/shuck-linter/src/diagnostic.rs
@@ -19,7 +19,25 @@ impl Severity {
     }
 }
 
+/// A diagnostic produced by Shuck analysis.
+///
+/// Fields remain public for downstream inspection, but consumers should not construct
+/// diagnostics with struct literals.
+///
+/// ```compile_fail
+/// use shuck_linter::{Diagnostic, Rule, Severity};
+///
+/// let _ = Diagnostic {
+///     rule: Rule::UnusedAssignment,
+///     message: String::new(),
+///     severity: Severity::Warning,
+///     span: todo!(),
+///     fix: None,
+///     fix_title: None,
+/// };
+/// ```
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
 pub struct Diagnostic {
     pub rule: Rule,
     pub message: String,

--- a/crates/shuck-linter/src/lib.rs
+++ b/crates/shuck-linter/src/lib.rs
@@ -5,6 +5,26 @@
 //!
 //! This crate combines parser output, semantic analysis, suppressions, and rule metadata into a
 //! diagnostics pipeline used by `shuck check`.
+//!
+//! Construct settings through [`LinterSettings::default`], [`LinterSettings::for_rule`],
+//! [`LinterSettings::for_rules`], or [`LinterSettings::from_selectors`]. Public fields remain
+//! available for inspection and customization after construction. [`Rule`] can grow as new rules
+//! are implemented, so downstream matches need a fallback arm.
+//!
+//! ```
+//! use shuck_linter::{LinterSettings, Rule, Severity};
+//!
+//! let mut settings = LinterSettings::for_rule(Rule::UnusedAssignment);
+//! settings
+//!     .severity_overrides
+//!     .insert(Rule::UnusedAssignment, Severity::Hint);
+//!
+//! let is_assignment_rule = match Rule::UnusedAssignment {
+//!     Rule::UnusedAssignment | Rule::AssignmentSpacing => true,
+//!     _ => false,
+//! };
+//! assert!(is_assignment_rule);
+//! ```
 mod ambient_contracts;
 #[allow(missing_docs)]
 mod checker;
@@ -148,6 +168,18 @@ use crate::suppression::{
 };
 
 /// Combined semantic model and diagnostic output for a file analysis pass.
+///
+/// This is a producer-owned result. Its fields remain public for ergonomic inspection.
+///
+/// ```compile_fail
+/// use shuck_linter::AnalysisResult;
+///
+/// let _ = AnalysisResult {
+///     semantic: todo!(),
+///     diagnostics: Vec::new(),
+/// };
+/// ```
+#[non_exhaustive]
 pub struct AnalysisResult {
     /// Semantic model built for the analyzed file.
     pub semantic: SemanticModel,
@@ -1155,7 +1187,7 @@ mod tests {
     use shuck_ast::{Command, Position, Span, StmtSeq, WordPart, WordPartNode};
     use shuck_parser::Error as ParseError;
     use shuck_parser::parser::{
-        ParseDiagnostic, ParseStatus, Parser, ShellDialect as ParseDialect, SyntaxFacts,
+        ParseDiagnostic, ParseStatus, Parser, ShellDialect as ParseDialect,
     };
     use shuck_semantic::{
         FileContract, PluginFramework, PluginRequest, PluginRequestKind, PluginResolution,
@@ -1452,18 +1484,14 @@ mod tests {
 
     #[test]
     fn parse_error_position_falls_back_to_first_diagnostic_span() {
-        let file = Parser::new("#!/bin/bash\n").parse().unwrap().file;
         let diagnostic_start = Position::at(3, 2, 14);
-        let parse_result = ParseResult {
-            file,
-            diagnostics: vec![ParseDiagnostic {
-                message: "expected command".to_owned(),
-                span: Span::at(diagnostic_start),
-            }],
-            status: ParseStatus::Recovered,
-            terminal_error: Some(ParseError::parse("expected command")),
-            syntax_facts: SyntaxFacts::default(),
-        };
+        let mut parse_result = Parser::new("#!/bin/bash\n").parse().unwrap();
+        parse_result.diagnostics.push(ParseDiagnostic {
+            message: "expected command".to_owned(),
+            span: Span::at(diagnostic_start),
+        });
+        parse_result.status = ParseStatus::Recovered;
+        parse_result.terminal_error = Some(ParseError::parse("expected command"));
 
         assert_eq!(parse_error_position(&parse_result), Some((3, 2)));
     }

--- a/crates/shuck-linter/src/registry.rs
+++ b/crates/shuck-linter/src/registry.rs
@@ -32,7 +32,12 @@ macro_rules! declare_rules {
     ($(
         ($code:literal, $category:expr, $severity:expr, $name:ident),
     )+) => {
+        /// Identifier for a registered lint rule.
+        ///
+        /// New rules are added routinely. Downstream matches must include a fallback arm; use
+        /// [`Rule::code`] for a stable persisted identity and [`Rule::iter`] to discover rules.
         #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+        #[non_exhaustive]
         #[repr(u16)]
         pub enum Rule {
             $($name,)*

--- a/crates/shuck-linter/src/settings.rs
+++ b/crates/shuck-linter/src/settings.rs
@@ -301,7 +301,24 @@ impl Default for C161RuleOptions {
     }
 }
 
+/// Configuration for a linter analysis pass.
+///
+/// Start with [`LinterSettings::default`], [`LinterSettings::for_rule`],
+/// [`LinterSettings::for_rules`], or [`LinterSettings::from_selectors`]. Fields remain public so
+/// embedders can inspect and customize settings after construction.
+///
+/// Direct struct construction is intentionally unsupported so future settings can be added
+/// without invalidating downstream struct literals:
+///
+/// ```compile_fail
+/// use shuck_linter::LinterSettings;
+///
+/// let _ = LinterSettings {
+///     ..LinterSettings::default()
+/// };
+/// ```
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
 pub struct LinterSettings {
     pub rules: RuleSet,
     pub severity_overrides: FxHashMap<Rule, Severity>,

--- a/crates/shuck-linter/tests/public_api.rs
+++ b/crates/shuck-linter/tests/public_api.rs
@@ -1,0 +1,37 @@
+use shuck_linter::{AnalysisRequest, Diagnostic, LinterSettings, Rule, Severity};
+use shuck_parser::parser::{ParseResult, ParseStatus, Parser};
+
+fn inspect_parse_result(result: &ParseResult) -> (&shuck_ast::File, usize, ParseStatus) {
+    (&result.file, result.diagnostics.len(), result.status)
+}
+
+fn inspect_diagnostic(diagnostic: &Diagnostic) -> (&str, Rule, Severity) {
+    (&diagnostic.message, diagnostic.rule, diagnostic.severity)
+}
+
+fn is_selected_rule(rule: Rule) -> bool {
+    matches!(rule, Rule::UnusedAssignment | Rule::UndefinedVariable)
+}
+
+#[test]
+fn downstream_construction_and_inspection_path_stays_ergonomic() {
+    let source = "echo hello\n";
+    let parsed = Parser::new(source).parse();
+    let (_, diagnostic_count, status) = inspect_parse_result(&parsed);
+    assert_eq!(status, ParseStatus::Clean);
+    assert_eq!(diagnostic_count, 0);
+
+    let mut settings = LinterSettings::for_rules([Rule::UnusedAssignment]);
+    settings
+        .severity_overrides
+        .insert(Rule::UnusedAssignment, Severity::Hint);
+    settings.report_environment_style_names = true;
+
+    let analysis = AnalysisRequest::from_parse_result(&parsed, source, &settings).analyze();
+    let _semantic = &analysis.semantic;
+    for diagnostic in &analysis.diagnostics {
+        let _ = inspect_diagnostic(diagnostic);
+    }
+
+    assert!(is_selected_rule(Rule::UnusedAssignment));
+}

--- a/crates/shuck-parser/README.md
+++ b/crates/shuck-parser/README.md
@@ -5,3 +5,7 @@
 It turns shell source into `shuck-ast` syntax trees, exposes source-backed lexical tokens, and
 lets callers choose shell dialects and zsh option profiles. The crate is pre-1.0 and may change
 between `0.x` releases.
+
+`ParseResult` is a producer-owned, non-exhaustive result with public fields for inspection.
+`ParseStatus` and shell dialects remain deliberately exhaustive. See
+[`docs/rust-api-compatibility.md`](../../docs/rust-api-compatibility.md) for the supported boundary.

--- a/crates/shuck-parser/src/lib.rs
+++ b/crates/shuck-parser/src/lib.rs
@@ -4,6 +4,21 @@
 //!
 //! `shuck-parser` turns shell source text into `shuck-ast` syntax trees and also exposes a
 //! source-backed lexer for lower-level tooling.
+//!
+//! [`parser::ParseResult`] is produced by [`parser::Parser::parse`] and keeps its fields public for
+//! inspection. It is non-exhaustive so parser-owned output can gain fields without invalidating
+//! downstream code. [`parser::ParseStatus`] and shell dialects remain exhaustive semantic sets.
+//!
+//! ```
+//! use shuck_parser::parser::{ParseStatus, Parser};
+//!
+//! let result = Parser::new("echo hello\n").parse();
+//! match result.status {
+//!     ParseStatus::Clean => assert!(result.diagnostics.is_empty()),
+//!     ParseStatus::Recovered | ParseStatus::Fatal => {}
+//! }
+//! let _file = &result.file;
+//! ```
 
 mod error;
 /// Parsing entrypoints, lexer types, and shell-profile configuration.

--- a/crates/shuck-parser/src/parser/result.rs
+++ b/crates/shuck-parser/src/parser/result.rs
@@ -60,7 +60,23 @@ pub struct ParseDiagnostic {
 /// `ParseResult` always carries the best AST the parser produced. Inspect
 /// [`ParseResult::status`] or [`ParseResult::is_ok`] before assuming it was a
 /// clean parse.
+///
+/// This is a parser-owned output type. Its fields remain public for inspection, but consumers
+/// should obtain it from [`crate::parser::Parser::parse`] instead of using a struct literal.
+///
+/// ```compile_fail
+/// use shuck_parser::parser::{ParseResult, ParseStatus, SyntaxFacts};
+///
+/// let _ = ParseResult {
+///     file: todo!(),
+///     diagnostics: Vec::new(),
+///     status: ParseStatus::Clean,
+///     terminal_error: None,
+///     syntax_facts: SyntaxFacts::default(),
+/// };
+/// ```
 #[derive(Debug, Clone)]
+#[non_exhaustive]
 pub struct ParseResult {
     /// Parsed syntax tree for the file.
     pub file: File,

--- a/crates/shuck-semantic/README.md
+++ b/crates/shuck-semantic/README.md
@@ -5,3 +5,7 @@
 It tracks scopes, bindings, references, control-flow, source references, and selected dataflow
 facts so higher-level tooling can reason about shell behavior. The crate is published as part of
 the Shuck workspace and is still pre-1.0.
+
+Semantic query APIs are available to embedders, but semantic facts are not blanket-marked as
+stable or non-exhaustive. See
+[`docs/rust-api-compatibility.md`](../../docs/rust-api-compatibility.md).

--- a/crates/shuck-server/src/session/settings.rs
+++ b/crates/shuck-server/src/session/settings.rs
@@ -410,14 +410,13 @@ fn resolved_linter_settings_for_layers(
                 CompiledPerFileShellList::default()
             });
 
+    let mut base = LinterSettings::for_rules(rules.iter());
+    base.shell = LinterShellDialect::Unknown;
+    base.per_file_ignores = Arc::new(compiled_per_file_ignores);
+    base.rule_options = rule_options;
+
     ResolvedLinterSettings {
-        base: LinterSettings {
-            rules,
-            shell: LinterShellDialect::Unknown,
-            per_file_ignores: Arc::new(compiled_per_file_ignores),
-            rule_options,
-            ..LinterSettings::default()
-        },
+        base,
         per_file_shell: compiled_per_file_shell,
     }
 }

--- a/docs/rust-api-compatibility.md
+++ b/docs/rust-api-compatibility.md
@@ -1,0 +1,84 @@
+# Rust API compatibility
+
+Shuck publishes its analysis crates so tools can embed the parser and linter. Those crates are
+still versioned `0.0.x`, and the entire public type graph is not yet a stable compatibility
+contract. The supported integration path is intentionally narrower than everything that Rust
+visibility makes reachable today.
+
+## Supported integration path
+
+For lint integrations, prefer these root-level APIs from `shuck-linter`:
+
+- construct `LinterSettings` with `Default`, `for_rule`, `for_rules`, or `from_selectors`;
+- create an `AnalysisRequest` from a parser result or AST;
+- call `analyze` or `lint`;
+- inspect `AnalysisResult` and `Diagnostic` fields;
+- identify rules with `Rule::code`, `code_to_rule`, and `Rule::iter`.
+
+For parser integrations, construct a `shuck_parser::parser::Parser`, call `parse`, and inspect the
+public fields on `ParseResult`.
+
+`LinterSettings`, `Diagnostic`, `AnalysisResult`, and `ParseResult` are non-exhaustive structs.
+Their fields remain public for ergonomic inspection and, for settings, mutation. Downstream code
+should not construct producer-owned result types with struct literals.
+
+```rust
+use shuck_linter::{LinterSettings, Rule, Severity};
+
+let mut settings = LinterSettings::for_rules([
+    Rule::UnusedAssignment,
+    Rule::UndefinedVariable,
+]);
+settings
+    .severity_overrides
+    .insert(Rule::UnusedAssignment, Severity::Hint);
+settings.report_environment_style_names = true;
+```
+
+`Rule` is a non-exhaustive enum because adding rules is routine. Match selected rules with a
+fallback, or use rule codes when persisting an identity outside the process. Numeric enum
+discriminants are an implementation detail.
+
+```rust
+use shuck_linter::Rule;
+
+fn is_assignment_rule(rule: Rule) -> bool {
+    match rule {
+        Rule::UnusedAssignment | Rule::AssignmentSpacing => true,
+        _ => false,
+    }
+}
+```
+
+## Intentional exhaustive sets
+
+`Severity` and `ParseStatus` remain exhaustive. Their variants are deliberately closed semantic
+sets, and downstream exhaustive matches are useful compiler checks. The parser and linter shell
+dialect enums also remain exhaustive; adding a dialect is expected to require deliberate updates
+throughout consumers rather than silently falling into a catch-all branch.
+
+## Current inventory and boundary
+
+| Crate | Downstream-facing role | Compatibility decision |
+| --- | --- | --- |
+| `shuck-linter` | Settings, analysis requests/results, diagnostics, rules, metadata, and selected facts | Protect routine rule growth and top-level configuration/output structs. Keep closed enums exhaustive. |
+| `shuck-parser` | Parser entrypoints, profiles, parse output, lexer, and diagnostics | Protect `ParseResult` field growth. Keep `ParseStatus` and dialects exhaustive. |
+| `shuck-ast` | Shared syntax tree, spans, tokens, and operators | Public and inspectable, but still structurally unstable; no blanket non-exhaustive annotations. |
+| `shuck-indexer` | Positional and structural indexes | Public query APIs remain pre-1.0; no blanket annotations on index facts. |
+| `shuck-semantic` | Semantic model, source closure, call graph, CFG, dataflow, and analysis facts | Public query APIs remain pre-1.0; no blanket annotations on semantic facts. |
+
+Opaque types that already use private fields and accessors do not need `#[non_exhaustive]` to
+prevent external construction. Public AST and fact records remain directly constructible where
+they are currently part of cross-crate assembly inside the workspace.
+
+## Compatibility intent
+
+Within this supported path, Shuck can add a `Rule` variant or a field to one of the protected
+configuration/output structs without forcing downstream exhaustive matches or struct literals to
+change. Existing public fields remain readable, and `LinterSettings` remains customizable after
+supported construction.
+
+This is not a promise that every public AST, index, semantic fact, or rule implementation module
+is stable. Those surfaces may change during the pre-1.0 period. Changes should be called out in
+release notes, and consumers should prefer the root-level parser and linter entrypoints above over
+depending on implementation-shaped modules.


### PR DESCRIPTION
## Summary

- mark routine-growth `Rule` and producer-owned `Diagnostic`, `AnalysisResult`, and `ParseResult` as non-exhaustive while keeping result fields readable
- make `LinterSettings` non-exhaustive after preserving supported construction through `Default`, focused constructors, fluent options, and public field mutation; migrate every in-workspace struct literal
- document the selective pre-1.0 compatibility boundary, leaving `Severity`, `ParseStatus`, dialects, AST/index/semantic enums, and fact structs unchanged
- add external-context API coverage plus compile-pass and compile-fail rustdoc examples for construction, inspection, and matching patterns

## Compatibility impact

This is an intentional pre-1.0 breaking cleanup. Downstream `LinterSettings`, `Diagnostic`, `AnalysisResult`, and `ParseResult` struct literals must move to supported constructors or producer APIs. Exhaustive `Rule` matches must add a fallback arm. Existing public fields remain available for inspection and settings customization.

## Verification

- `cargo fmt --all --check`
- `cargo check --workspace --all-targets`
- `cargo test --workspace`
- pinned Rust 1.94.1: `cargo clippy --workspace --all-targets -- -D warnings`
- pinned Rust 1.94.1: `RUSTDOCFLAGS='-D warnings' cargo doc --workspace --no-deps`
- `git diff --check`
