### PR TITLE
fix(api): expose transitive rustdoc types

### DIFF
--- a/crates/shuck-ast/README.md
+++ b/crates/shuck-ast/README.md
@@ -7,6 +7,9 @@ Use this crate when you need to inspect or transform parsed shell syntax. In mos
 `shuck-parser` is the crate that produces these types, while `shuck-indexer`, `shuck-linter`,
 and `shuck-formatter` consume them.
 
+AST node documentation is available from the crate root. Start with `File`, then traverse
+`File::body` through `Stmt` and `Command`.
+
 The API is pre-1.0 and may evolve between `0.x` releases. Public AST types are not blanket-marked
 as stable or non-exhaustive; structural changes remain possible and will be handled explicitly.
 See [`docs/rust-api-compatibility.md`](../../docs/rust-api-compatibility.md).

--- a/crates/shuck-ast/src/ast.rs
+++ b/crates/shuck-ast/src/ast.rs
@@ -157,12 +157,14 @@ impl PartialEq<&str> for LiteralText {
 /// source: `comment.range.slice(source)`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Comment {
+    /// Byte range covering the comment in the original source.
     pub range: TextRange,
 }
 
 /// A complete bash source file.
 #[derive(Debug, Clone)]
 pub struct File {
+    /// Top-level statements and comments in source order.
     pub body: StmtSeq,
     /// Source span of the entire file.
     pub span: Span,

--- a/crates/shuck-ast/src/lib.rs
+++ b/crates/shuck-ast/src/lib.rs
@@ -5,6 +5,10 @@
 //!
 //! `shuck-parser` produces these data structures, while crates such as `shuck-indexer`,
 //! `shuck-linter`, `shuck-semantic`, and `shuck-formatter` consume them.
+//!
+//! Parser consumers normally start at [`File`], traverse [`File::body`], and then inspect
+//! [`Stmt`] and [`Command`]. Syntax node types are re-exported at this crate root even though
+//! their implementation module is private.
 
 #[doc(hidden)]
 mod arena;
@@ -22,7 +26,6 @@ mod tokens;
 
 /// Compact typed arena index and list storage utilities.
 pub use arena::{IdRange, Idx, ListArena};
-#[doc(hidden)]
 pub use ast::*;
 #[doc(hidden)]
 pub use command_resolution::*;

--- a/crates/shuck-linter/README.md
+++ b/crates/shuck-linter/README.md
@@ -10,3 +10,7 @@ Use `LinterSettings` constructors plus `AnalysisRequest` as the supported embedd
 and result fields remain readable, while non-exhaustive types protect routine field and rule
 growth. Match `Rule` with a fallback. The workspace documents the full boundary in
 [`docs/rust-api-compatibility.md`](../../docs/rust-api-compatibility.md).
+
+Analysis results expose types owned by `shuck-ast`, `shuck-indexer`, and `shuck-semantic`; add
+direct dependencies when traversing those APIs. Resolver traits and their companion types are
+re-exported from `shuck-linter` because they configure `AnalysisRequest` directly.

--- a/crates/shuck-linter/src/diagnostic.rs
+++ b/crates/shuck-linter/src/diagnostic.rs
@@ -4,12 +4,16 @@ use crate::{Fix, Rule, Violation};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum Severity {
+    /// Advisory diagnostic that does not indicate likely incorrect behavior.
     Hint,
+    /// Potential problem that warrants review.
     Warning,
+    /// Definite error or invalid shell construct.
     Error,
 }
 
 impl Severity {
+    /// Returns the lowercase name used by Shuck report formats.
     pub const fn as_str(self) -> &'static str {
         match self {
             Self::Hint => "hint",
@@ -39,15 +43,24 @@ impl Severity {
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive]
 pub struct Diagnostic {
+    /// Rule that emitted this diagnostic.
     pub rule: Rule,
+    /// Human-readable explanation of the violation.
     pub message: String,
+    /// Effective severity after applying configuration overrides.
     pub severity: Severity,
+    /// Source span attributed to the diagnostic.
+    ///
+    /// Spans are defined by the `shuck-ast` crate and use byte offsets into the analyzed source.
     pub span: Span,
+    /// Optional edit set that can correct the violation.
     pub fix: Option<Fix>,
+    /// Optional human-readable label for the fix.
     pub fix_title: Option<String>,
 }
 
 impl Diagnostic {
+    /// Creates a diagnostic from a rule-specific violation and source span.
     pub fn new<V: Violation>(violation: V, span: Span) -> Self {
         Self {
             rule: V::rule(),
@@ -59,10 +72,12 @@ impl Diagnostic {
         }
     }
 
+    /// Returns the stable rule code for this diagnostic.
     pub const fn code(&self) -> &'static str {
         self.rule.code()
     }
 
+    /// Attaches an autofix to this diagnostic.
     pub fn with_fix(mut self, fix: Fix) -> Self {
         self.fix = Some(fix);
         self

--- a/crates/shuck-linter/src/fix.rs
+++ b/crates/shuck-linter/src/fix.rs
@@ -5,13 +5,17 @@ use shuck_ast::{Span, TextRange, TextSize};
 
 use crate::Diagnostic;
 
+/// Confidence level required before an edit may be applied automatically.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum Applicability {
+    /// Apply only edits designed to preserve program behavior.
     Safe,
+    /// Allow edits that may change behavior and require review.
     Unsafe,
 }
 
 impl Applicability {
+    /// Returns whether this threshold includes an edit with `applicability`.
     pub const fn includes(self, applicability: Self) -> bool {
         match self {
             Self::Safe => matches!(applicability, Self::Safe),
@@ -20,13 +24,18 @@ impl Applicability {
     }
 }
 
+/// Whether a rule can provide an autofix.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum FixAvailability {
+    /// The rule does not provide fixes.
     None,
+    /// The rule provides fixes for some diagnostics.
     Sometimes,
+    /// Every diagnostic from the rule has a fix.
     Always,
 }
 
+/// One source replacement within a [`Fix`].
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Edit {
     range: TextRange,
@@ -34,18 +43,22 @@ pub struct Edit {
 }
 
 impl Edit {
+    /// Creates an edit that deletes `span`.
     pub fn deletion(span: Span) -> Self {
         Self::deletion_at(span.start.offset(), span.end.offset())
     }
 
+    /// Creates an edit that deletes the byte range `start..end`.
     pub fn deletion_at(start: usize, end: usize) -> Self {
         Self::replacement_at(start, end, CompactString::default())
     }
 
+    /// Creates an edit that replaces `span` with `content`.
     pub fn replacement(content: impl Into<CompactString>, span: Span) -> Self {
         Self::replacement_at(span.start.offset(), span.end.offset(), content)
     }
 
+    /// Creates an edit that replaces byte range `start..end` with `content`.
     pub fn replacement_at(start: usize, end: usize, content: impl Into<CompactString>) -> Self {
         let (start, end) = ordered_offsets(start, end);
         Self {
@@ -54,14 +67,17 @@ impl Edit {
         }
     }
 
+    /// Creates an edit that inserts `content` at the byte offset.
     pub fn insertion(offset: usize, content: impl Into<CompactString>) -> Self {
         Self::replacement_at(offset, offset, content)
     }
 
+    /// Returns the source byte range replaced by this edit.
     pub const fn range(&self) -> TextRange {
         self.range
     }
 
+    /// Returns the replacement text.
     pub fn content(&self) -> &str {
         &self.content
     }
@@ -79,6 +95,7 @@ impl Edit {
     }
 }
 
+/// A non-empty set of source edits and its applicability level.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Fix {
     edits: Box<[Edit]>,
@@ -86,6 +103,7 @@ pub struct Fix {
 }
 
 impl Fix {
+    /// Creates a fix from an applicability level and source edits.
     pub fn new(applicability: Applicability, edits: impl IntoIterator<Item = Edit>) -> Self {
         let edits = edits.into_iter().collect::<Vec<_>>().into_boxed_slice();
         debug_assert!(!edits.is_empty(), "fixes should contain at least one edit");
@@ -95,34 +113,43 @@ impl Fix {
         }
     }
 
+    /// Creates a safe fix containing one edit.
     pub fn safe_edit(edit: Edit) -> Self {
         Self::safe_edits([edit])
     }
 
+    /// Creates a safe fix containing the supplied edits.
     pub fn safe_edits(edits: impl IntoIterator<Item = Edit>) -> Self {
         Self::new(Applicability::Safe, edits)
     }
 
+    /// Creates an unsafe fix containing one edit.
     pub fn unsafe_edit(edit: Edit) -> Self {
         Self::unsafe_edits([edit])
     }
 
+    /// Creates an unsafe fix containing the supplied edits.
     pub fn unsafe_edits(edits: impl IntoIterator<Item = Edit>) -> Self {
         Self::new(Applicability::Unsafe, edits)
     }
 
+    /// Returns the edits in this fix.
     pub fn edits(&self) -> &[Edit] {
         &self.edits
     }
 
+    /// Returns the applicability level of this fix.
     pub const fn applicability(&self) -> Applicability {
         self.applicability
     }
 }
 
+/// Source text and count produced by [`apply_fixes`].
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct AppliedFixes {
+    /// Source text after applying all compatible edits.
     pub code: String,
+    /// Number of diagnostic fixes applied.
     pub fixes_applied: usize,
 }
 
@@ -131,6 +158,7 @@ struct CandidateFix {
     edits: Vec<Edit>,
 }
 
+/// Applies non-conflicting diagnostic fixes at or below `applicability`.
 pub fn apply_fixes(
     source: &str,
     diagnostics: &[Diagnostic],

--- a/crates/shuck-linter/src/lib.rs
+++ b/crates/shuck-linter/src/lib.rs
@@ -11,6 +11,11 @@
 //! available for inspection and customization after construction. [`Rule`] can grow as new rules
 //! are implemented, so downstream matches need a fallback arm.
 //!
+//! Public entrypoints intentionally expose parser, AST, indexer, and semantic model types. Add
+//! direct dependencies on `shuck-parser`, `shuck-ast`, `shuck-indexer`, or `shuck-semantic` when
+//! naming or traversing types owned by those crates. Resolver traits used to configure
+//! [`AnalysisRequest`] are re-exported here for convenience.
+//!
 //! ```
 //! use shuck_linter::{LinterSettings, Rule, Severity};
 //!
@@ -140,6 +145,14 @@ pub use shuck_semantic::{
     GlobPatternBehavior, PathnameExpansionBehavior, PatternOperatorBehavior,
     SubscriptIndexBehavior,
 };
+/// Semantic resolver extension points and their request/response types.
+///
+/// These types are defined by `shuck-semantic` and re-exported here because they appear directly
+/// in [`AnalysisRequest`] resolver methods.
+pub use shuck_semantic::{
+    FileContract, PluginFramework, PluginRequest, PluginRequestKind, PluginResolution,
+    PluginResolver, SourcePathResolver,
+};
 /// Suppression directives, shellcheck mappings, and rewrite helpers.
 pub use suppression::{
     AddIgnoreParseError, AddIgnoreResult, ShellCheckCodeMap, SuppressionAction,
@@ -155,9 +168,8 @@ use shuck_indexer::Indexer;
 
 use shuck_parser::parser::ParseResult;
 use shuck_semantic::{
-    CommandKind, CompoundCommandKind, FlowContext, PluginResolver, ScopeId, SemanticBuildOptions,
-    SemanticCommandContext, SemanticModel, SourcePathResolver, TraversalObserver,
-    build_with_observer_with_options,
+    CommandKind, CompoundCommandKind, FlowContext, ScopeId, SemanticBuildOptions,
+    SemanticCommandContext, SemanticModel, TraversalObserver, build_with_observer_with_options,
 };
 use std::ops::Deref;
 use std::path::Path;
@@ -169,7 +181,9 @@ use crate::suppression::{
 
 /// Combined semantic model and diagnostic output for a file analysis pass.
 ///
-/// This is a producer-owned result. Its fields remain public for ergonomic inspection.
+/// This is a producer-owned result. Its fields remain public for ergonomic inspection. The
+/// semantic model is defined by the `shuck-semantic` crate; consumers that call its query methods
+/// should depend on that crate directly.
 ///
 /// ```compile_fail
 /// use shuck_linter::AnalysisResult;
@@ -182,6 +196,9 @@ use crate::suppression::{
 #[non_exhaustive]
 pub struct AnalysisResult {
     /// Semantic model built for the analyzed file.
+    ///
+    /// The concrete type is [`shuck_semantic::SemanticModel`]. Its query methods return additional
+    /// semantic types from that crate.
     pub semantic: SemanticModel,
     /// Diagnostics emitted by linter rules and parse checks.
     pub diagnostics: Vec<Diagnostic>,
@@ -192,6 +209,11 @@ pub struct AnalysisResult {
 /// Build one from a [`ParseResult`] when lint output should include parse-aware diagnostics and
 /// inline suppression directives. Build one from a parsed [`File`] only when the caller already
 /// owns parse diagnostics and wants rule diagnostics for that AST.
+///
+/// The constructors cross crate boundaries intentionally: parser results come from
+/// `shuck-parser`, AST nodes from `shuck-ast`, positional indexes from `shuck-indexer`, and
+/// semantic resolvers from `shuck-semantic`. Add direct dependencies on the first three crates
+/// when traversing or naming their returned types. Resolver traits are re-exported from this crate.
 pub struct AnalysisRequest<'a> {
     input: AnalysisInput<'a>,
     source: &'a str,
@@ -218,6 +240,9 @@ enum SuppressionRequest<'a> {
 impl<'a> AnalysisRequest<'a> {
     /// Creates a request from a parsed shell file.
     ///
+    /// `file` is a [`shuck_ast::File`]. Consumers that inspect its statements, commands, or words
+    /// should depend on `shuck-ast` directly.
+    ///
     /// This form runs rule analysis over the provided AST without parse diagnostics or
     /// directive-derived suppressions. Use [`AnalysisRequest::from_parse_result`] for the normal
     /// linting path where parser diagnostics and inline suppressions should be honored.
@@ -235,6 +260,9 @@ impl<'a> AnalysisRequest<'a> {
     }
 
     /// Creates a request from a parser result.
+    ///
+    /// `parse_result` is produced by [`shuck_parser::parser::Parser::parse`]. Consumers should
+    /// depend on `shuck-parser` directly to construct it.
     ///
     /// This form lets [`analyze`] and [`lint`] include parse-aware diagnostics from the supplied
     /// parser result.
@@ -267,7 +295,7 @@ impl<'a> AnalysisRequest<'a> {
         self
     }
 
-    /// Sets a resolver for shell sources reached from the analyzed file.
+    /// Sets a [`SourcePathResolver`] for shell sources reached from the analyzed file.
     pub fn with_source_path_resolver(
         mut self,
         source_path_resolver: &'a (dyn SourcePathResolver + Send + Sync),
@@ -276,7 +304,7 @@ impl<'a> AnalysisRequest<'a> {
         self
     }
 
-    /// Sets an optional resolver for shell sources reached from the analyzed file.
+    /// Sets an optional [`SourcePathResolver`] for shell sources reached from the analyzed file.
     pub fn with_optional_source_path_resolver(
         mut self,
         source_path_resolver: Option<&'a (dyn SourcePathResolver + Send + Sync)>,
@@ -285,7 +313,7 @@ impl<'a> AnalysisRequest<'a> {
         self
     }
 
-    /// Sets a plugin resolver used while building semantic facts.
+    /// Sets a [`PluginResolver`] used while building semantic facts.
     pub fn with_plugin_resolver(
         mut self,
         plugin_resolver: &'a (dyn PluginResolver + Send + Sync),
@@ -294,7 +322,7 @@ impl<'a> AnalysisRequest<'a> {
         self
     }
 
-    /// Sets an optional plugin resolver used while building semantic facts.
+    /// Sets an optional [`PluginResolver`] used while building semantic facts.
     pub fn with_optional_plugin_resolver(
         mut self,
         plugin_resolver: Option<&'a (dyn PluginResolver + Send + Sync)>,
@@ -332,6 +360,9 @@ impl<'a> AnalysisRequest<'a> {
     }
 
     /// Returns the positional index built for this request's source and AST.
+    ///
+    /// The concrete type is [`shuck_indexer::Indexer`]. Consumers that query its component indexes
+    /// should depend on `shuck-indexer` directly.
     pub fn indexer(&self) -> &Indexer {
         &self.indexer
     }
@@ -372,6 +403,9 @@ struct LinterAnalysisResult<'a> {
 }
 
 /// Semantic model plus linter-private traversal artifacts needed to build facts.
+///
+/// This lower-level API crosses into `shuck-ast`, `shuck-indexer`, and `shuck-semantic` directly.
+/// Consumers using it should declare direct dependencies on those crates.
 pub struct LinterSemanticArtifacts<'a> {
     semantic: SemanticModel,
     command_visits_by_id: Vec<Option<facts::CommandVisit<'a>>>,
@@ -383,12 +417,14 @@ pub struct LinterSemanticArtifacts<'a> {
 }
 
 impl<'a> LinterSemanticArtifacts<'a> {
-    /// Builds semantic analysis artifacts for linter fact construction.
+    /// Builds semantic analysis artifacts for linter fact construction from a
+    /// [`shuck_ast::File`] and [`shuck_indexer::Indexer`].
     pub fn build(file: &'a File, source: &'a str, indexer: &Indexer) -> Self {
         Self::build_with_options(file, source, indexer, SemanticBuildOptions::default())
     }
 
-    /// Builds semantic analysis artifacts for linter fact construction with custom options.
+    /// Builds semantic analysis artifacts for linter fact construction with custom
+    /// [`shuck_semantic::SemanticBuildOptions`].
     pub fn build_with_options(
         file: &'a File,
         source: &'a str,
@@ -421,12 +457,13 @@ impl<'a> LinterSemanticArtifacts<'a> {
         }
     }
 
-    /// Returns the semantic model built for this file.
+    /// Returns the [`shuck_semantic::SemanticModel`] built for this file.
     pub fn semantic(&self) -> &SemanticModel {
         &self.semantic
     }
 
-    /// Converts this linter semantic model into the underlying semantic model.
+    /// Converts this linter semantic model into the underlying
+    /// [`shuck_semantic::SemanticModel`].
     pub fn into_semantic(self) -> SemanticModel {
         self.semantic
     }

--- a/crates/shuck-linter/src/settings.rs
+++ b/crates/shuck-linter/src/settings.rs
@@ -171,17 +171,23 @@ impl Default for S082RuleOptions {
 /// Which functions require a leading documentation comment for `S083`.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub enum S083FunctionDocRequirement {
+    /// Require documentation for every function.
     All,
+    /// Require documentation only for exported functions.
     Exported,
+    /// Require documentation for functions at or above the configured line threshold.
     #[default]
     Long,
+    /// Require documentation only for functions that accept arguments.
     Parameterized,
 }
 
 /// Behavior overrides for `S083` missing function documentation.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct S083RuleOptions {
+    /// Function classification that determines when documentation is required.
     pub require_for: S083FunctionDocRequirement,
+    /// Minimum function length used when [`S083FunctionDocRequirement::Long`] is selected.
     pub long_function_line_threshold: usize,
 }
 
@@ -197,9 +203,13 @@ impl Default for S083RuleOptions {
 /// Behavior overrides for `S084` function documentation content.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct S084RuleOptions {
+    /// Whether documentation must describe referenced global variables.
     pub require_globals: bool,
+    /// Whether documentation must describe function arguments.
     pub require_arguments: bool,
+    /// Whether documentation must describe output written by the function.
     pub require_outputs: bool,
+    /// Whether documentation must describe the function's return status.
     pub require_returns: bool,
 }
 
@@ -320,21 +330,34 @@ impl Default for C161RuleOptions {
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive]
 pub struct LinterSettings {
+    /// Rules enabled for this analysis pass.
     pub rules: RuleSet,
+    /// Per-rule severity overrides applied to emitted diagnostics.
     pub severity_overrides: FxHashMap<Rule, Severity>,
+    /// Shell dialect used when the parser did not determine one more specifically.
     pub shell: ShellDialect,
+    /// Shell options assumed to be active before the analyzed source begins.
     pub ambient_shell_options: AmbientShellOptions,
+    /// Pre-resolved declarations and effects supplied by the host environment.
     pub ambient_contracts: Arc<ResolvedAmbientContracts>,
+    /// Canonicalized paths included in the current analysis scope, when bounded.
     pub analyzed_paths: Option<Arc<FxHashSet<PathBuf>>>,
+    /// Compiled path-specific rule exclusions.
     pub per_file_ignores: Arc<CompiledPerFileIgnoreList>,
+    /// Whether style diagnostics should name environment variables in their messages.
     pub report_environment_style_names: bool,
+    /// Whether semantic analysis should follow resolvable `source` commands.
     pub resolve_source_closure: bool,
+    /// Rule-specific behavior overrides.
     pub rule_options: LinterRuleOptions,
 }
 
+/// Shell options assumed to be enabled before the analyzed source runs.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub struct AmbientShellOptions {
+    /// Assume `errexit` (`set -e`) behavior is active.
     pub errexit: bool,
+    /// Assume `pipefail` behavior is active.
     pub pipefail: bool,
 }
 
@@ -355,6 +378,7 @@ impl Default for LinterSettings {
     }
 }
 
+/// A glob pattern paired with the rules ignored for matching files.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PerFileIgnore {
     pattern: String,
@@ -362,6 +386,7 @@ pub struct PerFileIgnore {
 }
 
 impl PerFileIgnore {
+    /// Creates a path-specific rule exclusion.
     pub fn new(pattern: impl Into<String>, rules: RuleSet) -> Self {
         Self {
             pattern: pattern.into(),
@@ -369,15 +394,18 @@ impl PerFileIgnore {
         }
     }
 
+    /// Returns the configured glob pattern.
     pub fn pattern(&self) -> &str {
         &self.pattern
     }
 
+    /// Returns the rules excluded by this entry.
     pub const fn rules(&self) -> RuleSet {
         self.rules
     }
 }
 
+/// Compiled per-file rule exclusions resolved relative to one project root.
 #[derive(Debug, Clone, Default)]
 pub struct CompiledPerFileIgnoreList {
     project_root: PathBuf,
@@ -455,6 +483,7 @@ impl PartialEq for CompiledPerFileIgnore {
 impl Eq for CompiledPerFileIgnore {}
 
 impl LinterSettings {
+    /// Creates settings with only `rule` enabled.
     pub fn for_rule(rule: Rule) -> Self {
         Self {
             rules: RuleSet::from_iter([rule]),
@@ -462,6 +491,7 @@ impl LinterSettings {
         }
     }
 
+    /// Creates settings with only the supplied rules enabled.
     pub fn for_rules(rules: impl IntoIterator<Item = Rule>) -> Self {
         Self {
             rules: rules.into_iter().collect(),
@@ -469,6 +499,7 @@ impl LinterSettings {
         }
     }
 
+    /// Returns the default non-style rule set.
     pub fn default_rules() -> RuleSet {
         Rule::iter()
             .filter(|rule| !matches!(rule.category(), Category::Style))
@@ -476,6 +507,7 @@ impl LinterSettings {
             .subtract(&default_disabled_non_style_rules())
     }
 
+    /// Creates settings from ordered rule selectors and exclusions.
     pub fn from_selectors(select: &[RuleSelector], ignore: &[RuleSelector]) -> Self {
         let mut rules = RuleSet::EMPTY;
         for selector in select {
@@ -491,11 +523,13 @@ impl LinterSettings {
         }
     }
 
+    /// Sets the fallback shell dialect.
     pub fn with_shell(mut self, shell: ShellDialect) -> Self {
         self.shell = shell;
         self
     }
 
+    /// Sets shell options assumed to be active before analysis.
     pub fn with_ambient_shell_options(
         mut self,
         ambient_shell_options: AmbientShellOptions,
@@ -504,6 +538,7 @@ impl LinterSettings {
         self
     }
 
+    /// Canonicalizes paths where possible and collects them into a shared analysis set.
     pub fn analyzed_path_set(paths: impl IntoIterator<Item = PathBuf>) -> Arc<FxHashSet<PathBuf>> {
         Arc::new(
             paths
@@ -513,15 +548,18 @@ impl LinterSettings {
         )
     }
 
+    /// Sets a precomputed set of paths included in the analysis scope.
     pub fn with_analyzed_path_set(mut self, paths: Arc<FxHashSet<PathBuf>>) -> Self {
         self.analyzed_paths = Some(paths);
         self
     }
 
+    /// Canonicalizes and sets the paths included in the analysis scope.
     pub fn with_analyzed_paths(self, paths: impl IntoIterator<Item = PathBuf>) -> Self {
         self.with_analyzed_path_set(Self::analyzed_path_set(paths))
     }
 
+    /// Configures whether `C001` treats scalar indirect-expansion targets as uses.
     pub fn with_c001_treat_indirect_expansion_targets_as_used(mut self, value: bool) -> Self {
         self.rule_options
             .c001
@@ -529,81 +567,97 @@ impl LinterSettings {
         self
     }
 
+    /// Configures whether semantic analysis follows resolvable `source` commands.
     pub fn with_resolve_source_closure(mut self, value: bool) -> Self {
         self.resolve_source_closure = value;
         self
     }
 
+    /// Configures whether `C063` reports unreachable nested function definitions.
     pub fn with_c063_report_unreached_nested_definitions(mut self, value: bool) -> Self {
         self.rule_options.c063.report_unreached_nested_definitions = value;
         self
     }
 
+    /// Sets the maximum accepted line count for `S080`.
     pub fn with_s080_max_lines(mut self, value: usize) -> Self {
         self.rule_options.s080.max_lines = value;
         self
     }
 
+    /// Sets the line-counting mode for `S080`.
     pub fn with_s080_count(mut self, value: impl Into<String>) -> Self {
         self.rule_options.s080.count = value.into();
         self
     }
 
+    /// Configures whether `S081` ignores files containing only a shebang.
     pub fn with_s081_ignore_shebang_only_files(mut self, value: bool) -> Self {
         self.rule_options.s081.ignore_shebang_only_files = value;
         self
     }
 
+    /// Sets the comment markers checked by `S082`.
     pub fn with_s082_kinds(mut self, kinds: impl IntoIterator<Item = String>) -> Self {
         self.rule_options.s082.kinds = kinds.into_iter().collect();
         self
     }
 
+    /// Configures whether `S082` requires an owner after a comment marker.
     pub fn with_s082_require_owner(mut self, value: bool) -> Self {
         self.rule_options.s082.require_owner = value;
         self
     }
 
+    /// Configures whether `S082` requires explanatory text after a comment marker.
     pub fn with_s082_require_message(mut self, value: bool) -> Self {
         self.rule_options.s082.require_message = value;
         self
     }
 
+    /// Sets the function classification checked by `S083`.
     pub fn with_s083_require_for(mut self, value: S083FunctionDocRequirement) -> Self {
         self.rule_options.s083.require_for = value;
         self
     }
 
+    /// Sets the minimum function length checked by `S083` in long-function mode.
     pub fn with_s083_long_function_line_threshold(mut self, value: usize) -> Self {
         self.rule_options.s083.long_function_line_threshold = value;
         self
     }
 
+    /// Configures whether `S084` requires function output documentation.
     pub fn with_s084_require_outputs(mut self, value: bool) -> Self {
         self.rule_options.s084.require_outputs = value;
         self
     }
 
+    /// Configures whether `S084` requires return-status documentation.
     pub fn with_s084_require_returns(mut self, value: bool) -> Self {
         self.rule_options.s084.require_returns = value;
         self
     }
 
+    /// Sets the minimum script length checked by `S085`.
     pub fn with_s085_non_trivial_line_threshold(mut self, value: usize) -> Self {
         self.rule_options.s085.non_trivial_line_threshold = value;
         self
     }
 
+    /// Sets the minimum function count checked by `S085`.
     pub fn with_s085_non_trivial_function_count(mut self, value: usize) -> Self {
         self.rule_options.s085.non_trivial_function_count = value;
         self
     }
 
+    /// Sets the expected entrypoint function name for `S085`.
     pub fn with_s085_main_name(mut self, value: impl Into<String>) -> Self {
         self.rule_options.s085.main_name = value.into();
         self
     }
 
+    /// Sets the interpreter names accepted by `S078`.
     pub fn with_s078_allowed_shells(
         mut self,
         allowed_shells: impl IntoIterator<Item = impl Into<String>>,
@@ -613,21 +667,25 @@ impl LinterSettings {
         self
     }
 
+    /// Configures whether `C158` treats top-level readonly declarations as documented globals.
     pub fn with_c158_treat_readonly_as_documented(mut self, value: bool) -> Self {
         self.rule_options.c158.treat_readonly_as_documented = value;
         self
     }
 
+    /// Configures whether `C158` treats exported bindings as intentional globals.
     pub fn with_c158_treat_export_as_intentional(mut self, value: bool) -> Self {
         self.rule_options.c158.treat_export_as_intentional = value;
         self
     }
 
+    /// Configures whether `C159` permits self-referential default initializers.
     pub fn with_c159_allow_conditional_init(mut self, value: bool) -> Self {
         self.rule_options.c159.allow_conditional_init = value;
         self
     }
 
+    /// Sets the source-path anchors accepted by `C160`.
     pub fn with_c160_allowed_anchors<I, S>(mut self, anchors: I) -> Self
     where
         I: IntoIterator<Item = S>,
@@ -637,11 +695,13 @@ impl LinterSettings {
         self
     }
 
+    /// Configures whether `C161` ignores calls after a `source` command.
     pub fn with_c161_ignore_after_source(mut self, value: bool) -> Self {
         self.rule_options.c161.ignore_after_source = value;
         self
     }
 
+    /// Sets the shebang invocation forms accepted by `S079`.
     pub fn with_s079_allowed_forms(
         mut self,
         allowed_forms: impl IntoIterator<Item = impl Into<String>>,
@@ -650,6 +710,7 @@ impl LinterSettings {
         self
     }
 
+    /// Sets exact shebang invocation strings accepted by `S079`.
     pub fn with_s079_allowed_paths(
         mut self,
         allowed_paths: impl IntoIterator<Item = impl Into<String>>,
@@ -658,6 +719,7 @@ impl LinterSettings {
         self
     }
 
+    /// Returns the rules ignored for `path` by the compiled per-file configuration.
     pub fn per_file_ignored_rules(&self, path: Option<&Path>) -> RuleSet {
         path.map_or(RuleSet::EMPTY, |path| {
             self.per_file_ignores.ignored_rules(path)
@@ -670,6 +732,7 @@ fn default_disabled_non_style_rules() -> RuleSet {
 }
 
 impl CompiledPerFileIgnoreList {
+    /// Compiles per-file exclusions for paths under `project_root`.
     pub fn resolve(
         project_root: impl Into<PathBuf>,
         per_file_ignores: impl IntoIterator<Item = PerFileIgnore>,
@@ -711,6 +774,7 @@ impl CompiledPerFileIgnoreList {
         })
     }
 
+    /// Returns the rules ignored for `path`.
     pub fn ignored_rules(&self, path: &Path) -> RuleSet {
         let relative_path = path.strip_prefix(&self.project_root).unwrap_or(path);
         let file_name = relative_path.file_name().or_else(|| path.file_name());

--- a/crates/shuck-linter/src/violation.rs
+++ b/crates/shuck-linter/src/violation.rs
@@ -1,12 +1,17 @@
 use crate::{FixAvailability, Rule};
 
+/// Rule-specific payload used to create a [`crate::Diagnostic`].
 pub trait Violation: Sized {
+    /// Whether diagnostics created from this violation type can offer fixes.
     const FIX_AVAILABILITY: FixAvailability = FixAvailability::None;
 
+    /// Returns the rule associated with this violation type.
     fn rule() -> Rule;
 
+    /// Formats the diagnostic message for this violation.
     fn message(&self) -> String;
 
+    /// Returns a human-readable fix label when the violation supports one.
     fn fix_title(&self) -> Option<String> {
         None
     }

--- a/crates/shuck-linter/tests/public_api.rs
+++ b/crates/shuck-linter/tests/public_api.rs
@@ -1,5 +1,24 @@
-use shuck_linter::{AnalysisRequest, Diagnostic, LinterSettings, Rule, Severity};
+use std::path::{Path, PathBuf};
+
+use shuck_linter::{
+    AnalysisRequest, Diagnostic, FileContract, LinterSettings, PluginFramework, PluginRequest,
+    PluginRequestKind, PluginResolution, PluginResolver, Rule, Severity, SourcePathResolver,
+};
 use shuck_parser::parser::{ParseResult, ParseStatus, Parser};
+
+struct EmptyPluginResolver;
+
+impl PluginResolver for EmptyPluginResolver {
+    fn resolve_plugin_request(
+        &self,
+        _source_path: &Path,
+        _request: &PluginRequest,
+    ) -> PluginResolution {
+        PluginResolution::default()
+    }
+}
+
+fn accepts_source_path_resolver(_resolver: &(dyn SourcePathResolver + Send + Sync)) {}
 
 fn inspect_parse_result(result: &ParseResult) -> (&shuck_ast::File, usize, ParseStatus) {
     (&result.file, result.diagnostics.len(), result.status)
@@ -27,11 +46,22 @@ fn downstream_construction_and_inspection_path_stays_ergonomic() {
         .insert(Rule::UnusedAssignment, Severity::Hint);
     settings.report_environment_style_names = true;
 
-    let analysis = AnalysisRequest::from_parse_result(&parsed, source, &settings).analyze();
+    let source_path_resolver = |_: &Path, _: &str| Vec::<PathBuf>::new();
+    accepts_source_path_resolver(&source_path_resolver);
+    let plugin_resolver = EmptyPluginResolver;
+    let analysis = AnalysisRequest::from_parse_result(&parsed, source, &settings)
+        .with_source_path_resolver(&source_path_resolver)
+        .with_plugin_resolver(&plugin_resolver)
+        .analyze();
     let _semantic = &analysis.semantic;
     for diagnostic in &analysis.diagnostics {
         let _ = inspect_diagnostic(diagnostic);
     }
 
     assert!(is_selected_rule(Rule::UnusedAssignment));
+    let _resolver_companion_types = (
+        PluginFramework::Other("custom".to_owned()),
+        PluginRequestKind::Plugin,
+        FileContract::default(),
+    );
 }

--- a/crates/shuck-parser/README.md
+++ b/crates/shuck-parser/README.md
@@ -7,5 +7,6 @@ lets callers choose shell dialects and zsh option profiles. The crate is pre-1.0
 between `0.x` releases.
 
 `ParseResult` is a producer-owned, non-exhaustive result with public fields for inspection.
-`ParseStatus` and shell dialects remain deliberately exhaustive. See
+Its `file` field is a `shuck_ast::File`; add `shuck-ast` as a direct dependency when traversing
+syntax nodes. `ParseStatus` and shell dialects remain deliberately exhaustive. See
 [`docs/rust-api-compatibility.md`](../../docs/rust-api-compatibility.md) for the supported boundary.

--- a/crates/shuck-parser/src/lib.rs
+++ b/crates/shuck-parser/src/lib.rs
@@ -8,6 +8,8 @@
 //! [`parser::ParseResult`] is produced by [`parser::Parser::parse`] and keeps its fields public for
 //! inspection. It is non-exhaustive so parser-owned output can gain fields without invalidating
 //! downstream code. [`parser::ParseStatus`] and shell dialects remain exhaustive semantic sets.
+//! The returned syntax tree is a [`shuck_ast::File`]; consumers that traverse AST nodes should add
+//! `shuck-ast` as a direct dependency.
 //!
 //! ```
 //! use shuck_parser::parser::{ParseStatus, Parser};

--- a/crates/shuck-parser/src/parser/result.rs
+++ b/crates/shuck-parser/src/parser/result.rs
@@ -79,6 +79,9 @@ pub struct ParseDiagnostic {
 #[non_exhaustive]
 pub struct ParseResult {
     /// Parsed syntax tree for the file.
+    ///
+    /// The concrete type is [`shuck_ast::File`]. Traverse its statement and command nodes through
+    /// a direct dependency on `shuck-ast`.
     pub file: File,
     /// Recovery diagnostics emitted while producing the AST.
     pub diagnostics: Vec<ParseDiagnostic>,

--- a/crates/shuck-semantic/src/lib.rs
+++ b/crates/shuck-semantic/src/lib.rs
@@ -511,8 +511,15 @@ pub struct NoopTraversalObserver;
 
 impl<'a> TraversalObserver<'a> for NoopTraversalObserver {}
 
-#[doc(hidden)]
+/// Resolves a static shell source candidate relative to the file that contains it.
+///
+/// Implement this trait when source files can be found through project-specific search roots or
+/// virtual filesystem rules. A closure with the same signature also implements this trait.
 pub trait SourcePathResolver {
+    /// Returns candidate paths for `candidate` as referenced from `source_path`.
+    ///
+    /// Returning an empty vector leaves the source unresolved. Candidates are evaluated by the
+    /// semantic source-closure builder in the order returned.
     fn resolve_candidate_paths(&self, source_path: &Path, candidate: &str) -> Vec<PathBuf>;
 }
 

--- a/docs/rust-api-compatibility.md
+++ b/docs/rust-api-compatibility.md
@@ -1,9 +1,9 @@
 # Rust API compatibility
 
 Shuck publishes its analysis crates so tools can embed the parser and linter. Those crates are
-still versioned `0.0.x`, and the entire public type graph is not yet a stable compatibility
-contract. The supported integration path is intentionally narrower than everything that Rust
-visibility makes reachable today.
+still pre-1.0, and the entire public type graph is not yet a stable compatibility contract. The
+supported integration path is intentionally narrower than everything that Rust visibility makes
+reachable today.
 
 ## Supported integration path
 
@@ -17,6 +17,21 @@ For lint integrations, prefer these root-level APIs from `shuck-linter`:
 
 For parser integrations, construct a `shuck_parser::parser::Parser`, call `parse`, and inspect the
 public fields on `ParseResult`.
+
+## Returned type and dependency graph
+
+Supported entrypoints intentionally cross crate boundaries. Add a direct dependency on the crate
+that owns a returned type when traversing it or naming it in your own public API.
+
+| Supported API | Exposed type | Consumer dependency |
+| --- | --- | --- |
+| `shuck_parser::parser::ParseResult` | `shuck_ast::File`, plus `Span` values in parser diagnostics and syntax facts | Depend on `shuck-ast` to traverse the syntax tree or work with source ranges. |
+| `shuck_linter::AnalysisRequest` | `shuck_parser::parser::ParseResult`, `shuck_ast::File`, `shuck_indexer::Indexer`, and semantic resolver traits | Depend directly on the parser, AST, or indexer crate when using those types. `SourcePathResolver`, `PluginResolver`, and plugin request/response types are re-exported by `shuck-linter`. |
+| `shuck_linter::AnalysisResult` | `shuck_semantic::SemanticModel` | Depend on `shuck-semantic` when naming the model or traversing its semantic query results. |
+| `shuck_linter::Diagnostic` | `shuck_ast::Span` | Depend on `shuck-ast` for position, span, and byte-range operations. |
+
+The `shuck-ast` crate documents syntax nodes at its root, beginning with `File`, `Stmt`, and
+`Command`. Internal traversal and semantic-build helpers remain hidden.
 
 `LinterSettings`, `Diagnostic`, `AnalysisResult`, and `ParseResult` are non-exhaustive structs.
 Their fields remain public for ergonomic inspection and, for settings, mutation. Downstream code


### PR DESCRIPTION
Stacked on #1268. This follow-up keeps the selective compatibility changes separate from the rustdoc and transitive-type cleanup.

## Summary

- expose public AST node re-exports in generated rustdoc while keeping internal traversal and build helpers hidden
- document parser and linter return-type ownership and direct dependency requirements
- re-export semantic resolver extension points and companion request/response types from shuck-linter
- add field and method documentation across the supported result, settings, diagnostic, and fix paths
- add a compact returned type and dependency graph plus a compile-time downstream API regression

## Testing

- cargo fmt --all -- --check
- cargo test -p shuck-linter --test public_api
- cargo test --workspace
- cargo clippy --workspace --all-targets --all-features -- -D warnings
- RUSTDOCFLAGS=-D warnings cargo doc --workspace --no-deps
- verified expected generated AST/parser/linter/indexer/semantic pages and 108 local links across the supported API pages