### PR TITLE
perf(linter): reduce repeated fact construction work

### DIFF
--- a/crates/shuck-indexer/src/region_index.rs
+++ b/crates/shuck-indexer/src/region_index.rs
@@ -57,6 +57,8 @@ pub struct IndexedHeredoc {
 /// logic at the call site.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct RegionIndex {
+    // Disjoint union for boolean quote queries; original ranges retain nesting.
+    quoted_coverage: Vec<TextRange>,
     single_quoted: Vec<TextRange>,
     double_quoted: Vec<TextRange>,
     heredocs: Vec<TextRange>,
@@ -151,9 +153,10 @@ impl RegionIndex {
     /// This includes single quotes, double quotes, and bodies of heredocs whose
     /// delimiter was quoted.
     pub fn is_quoted(&self, offset: TextSize) -> bool {
-        contains_any(&self.single_quoted, offset)
-            || contains_any(&self.double_quoted, offset)
-            || contains_any(&self.quoted_heredocs, offset)
+        let index = self
+            .quoted_coverage
+            .partition_point(|range| range.start() <= offset);
+        index > 0 && contains(self.quoted_coverage[index - 1], offset)
     }
 
     /// Return whether `offset` falls inside any heredoc body.
@@ -385,7 +388,29 @@ impl<'a> RegionCollector<'a> {
             (region.range.start().to_u32(), region.range.end().to_u32())
         });
 
+        let mut quoted_coverage = self
+            .single_quoted
+            .iter()
+            .chain(&self.double_quoted)
+            .chain(&self.quoted_heredocs)
+            .copied()
+            .collect::<Vec<_>>();
+        sort_ranges(&mut quoted_coverage);
+        let mut merged = 0usize;
+        for index in 0..quoted_coverage.len() {
+            let range = quoted_coverage[index];
+            if merged > 0 && range.start() <= quoted_coverage[merged - 1].end() {
+                let previous = &mut quoted_coverage[merged - 1];
+                *previous = TextRange::new(previous.start(), previous.end().max(range.end()));
+            } else {
+                quoted_coverage[merged] = range;
+                merged += 1;
+            }
+        }
+        quoted_coverage.truncate(merged);
+
         RegionIndex {
+            quoted_coverage,
             single_quoted: self.single_quoted,
             double_quoted: self.double_quoted,
             heredocs: self.heredocs,
@@ -1622,6 +1647,27 @@ mod tests {
     fn regions_with_source_layout_indexes(source: &str) -> RegionIndex {
         let output = Parser::new(source).parse().unwrap();
         RegionIndex::with_source_layout_indexes(source, &output.file)
+    }
+
+    #[test]
+    fn quote_coverage_matches_nested_ranges_at_every_byte() {
+        for source in [
+            "echo 'plain' \"outer $(echo 'inner') end\" tail\n",
+            "cat <<'EOF'\nquoted $text\nEOF\necho \"tail\"\n",
+            "echo \"é $(printf \"%s\" \"nested\")\" '' outside\n",
+        ] {
+            let index = regions(source);
+            for byte in 0..=source.len() {
+                let offset = TextSize::new(byte as u32);
+                let expected = index
+                    .single_quoted
+                    .iter()
+                    .chain(&index.double_quoted)
+                    .chain(&index.quoted_heredocs)
+                    .any(|range| contains(*range, offset));
+                assert_eq!(index.is_quoted(offset), expected, "{source:?} at {byte}");
+            }
+        }
     }
 
     #[test]

--- a/crates/shuck-linter/src/ambient_contracts/signals.rs
+++ b/crates/shuck-linter/src/ambient_contracts/signals.rs
@@ -10,24 +10,28 @@
 use std::collections::BTreeSet;
 use std::path::Path;
 use std::path::PathBuf;
+use std::sync::OnceLock;
 
 use super::source_scan::{code_before_shell_comment, parse_shell_name_at};
 
 pub(super) struct AmbientSignals<'a> {
-    source: SourceSignals<'a>,
+    source: &'a str,
+    source_signals: OnceLock<SourceSignals<'a>>,
     path: Option<PathSignals>,
 }
 
 impl<'a> AmbientSignals<'a> {
     pub(super) fn new(source: &'a str, path: Option<&Path>) -> Self {
         Self {
-            source: SourceSignals::new(source),
+            source,
+            source_signals: OnceLock::new(),
             path: path.map(PathSignals::new),
         }
     }
 
     pub(super) fn source(&self) -> &SourceSignals<'a> {
-        &self.source
+        self.source_signals
+            .get_or_init(|| SourceSignals::new(self.source))
     }
 
     pub(super) fn path(&self) -> Option<&PathSignals> {

--- a/crates/shuck-linter/src/facts/arithmetic.rs
+++ b/crates/shuck-linter/src/facts/arithmetic.rs
@@ -1503,14 +1503,14 @@ pub(crate) fn collect_arithmetic_update_operator_spans_in_assignment(
         source,
         spans,
     );
-    let target_is_contextual_assoc =
-        var_ref_name_has_visible_assoc_binding_at(&assignment.target, semantic, scope);
 
     match &assignment.value {
         AssignmentValue::Scalar(word) => {
             collect_arithmetic_update_operator_spans_in_word(word, semantic, source, spans);
         }
         AssignmentValue::Compound(array) => {
+            let target_is_contextual_assoc = array.kind == ArrayKind::Contextual
+                && var_ref_name_has_visible_assoc_binding_at(&assignment.target, semantic, scope);
             for element in &array.elements {
                 match element {
                     ArrayElem::Sequential(word) => {

--- a/crates/shuck-linter/src/facts/builder.rs
+++ b/crates/shuck-linter/src/facts/builder.rs
@@ -221,6 +221,7 @@ impl<'a, 'analysis> LinterFactsBuilder<'a, 'analysis> {
         let mut word_nodes = Vec::with_capacity(capacity.word_nodes);
         let mut word_spans = ListArena::with_capacity(capacity.word_nodes.saturating_mul(2));
         let mut word_span_scratch = Vec::new();
+        let mut traversal_span_scratch = DerivedWordTraversalSpans::default();
         let mut word_node_ids_by_span =
             FxHashMap::with_capacity_and_hasher(capacity.word_nodes, Default::default());
         let mut word_occurrences = Vec::with_capacity(capacity.word_occurrences);
@@ -273,7 +274,7 @@ impl<'a, 'analysis> LinterFactsBuilder<'a, 'analysis> {
             else {
                 continue;
             };
-            let key = FactSpan::new(command_span(visit.command));
+            let key = FactSpan::new(context.syntax_span());
             debug_assert_eq!(context.syntax_span(), command_span(visit.command));
             debug_assert_eq!(
                 context.kind(),
@@ -323,7 +324,7 @@ impl<'a, 'analysis> LinterFactsBuilder<'a, 'analysis> {
                 &mut ifs_literal_backslash_assignment_value_spans,
             );
             let normalized = command::normalize_command(visit.command, self.source);
-            let command_start_offset = command_span(visit.command).start.offset();
+            let command_start_offset = context.syntax_span().start.offset();
             let scope = context.scope();
             let command_shell_behavior =
                 effective_command_shell_behavior(self.semantic, command_start_offset, &normalized);
@@ -350,6 +351,7 @@ impl<'a, 'analysis> LinterFactsBuilder<'a, 'analysis> {
                     word_nodes: &mut word_nodes,
                     word_spans: &mut word_spans,
                     word_span_scratch: &mut word_span_scratch,
+                    traversal_span_scratch: &mut traversal_span_scratch,
                     word_node_ids_by_span: &mut word_node_ids_by_span,
                     word_occurrences: &mut word_occurrences,
                     pending_arithmetic_word_occurrences: &mut pending_arithmetic_word_occurrences,
@@ -446,10 +448,11 @@ impl<'a, 'analysis> LinterFactsBuilder<'a, 'analysis> {
             let simple_test = build_simple_test_fact(visit.command, self.source);
             let conditional_expression_visits = self
                 .semantic_artifacts
-                .conditional_expression_visits(command_span(visit.command));
+                .conditional_expression_visits(context.syntax_span());
             let conditional = build_conditional_fact(conditional_expression_visits, self.source);
             let enclosing_function_scope = self.semantic.enclosing_function_scope(scope);
             let command_fact = CommandFact {
+                span: context.syntax_span(),
                 id,
                 visit,
                 nested_word_command,

--- a/crates/shuck-linter/src/facts/case_patterns.rs
+++ b/crates/shuck-linter/src/facts/case_patterns.rs
@@ -290,6 +290,66 @@ pub(crate) struct ReachableCasePattern {
     matcher: StaticCasePatternMatcher,
 }
 
+/// A short literal-prefix index avoids comparing unrelated option patterns.
+/// Candidate streams are merged in insertion order so diagnostics still select
+/// the same first shadowing pattern as an exhaustive scan.
+#[derive(Default)]
+struct ReachableCasePatterns {
+    patterns: Vec<ReachableCasePattern>,
+    by_prefix: FxHashMap<(usize, [char; 4]), Vec<usize>>,
+}
+
+impl ReachableCasePatterns {
+    fn push(&mut self, pattern: ReachableCasePattern) {
+        let len = pattern.matcher.literal_prefix.len().min(4);
+        let mut prefix = ['\0'; 4];
+        prefix[..len].copy_from_slice(&pattern.matcher.literal_prefix[..len]);
+        self.by_prefix
+            .entry((len, prefix))
+            .or_default()
+            .push(self.patterns.len());
+        self.patterns.push(pattern);
+    }
+
+    fn append(&mut self, other: &mut Self) {
+        for pattern in other.patterns.drain(..) {
+            self.push(pattern);
+        }
+        other.by_prefix.clear();
+    }
+
+    fn clear(&mut self) {
+        self.patterns.clear();
+        self.by_prefix.clear();
+    }
+
+    fn candidates<'a>(
+        &'a self,
+        matcher: &StaticCasePatternMatcher,
+    ) -> impl Iterator<Item = &'a ReachableCasePattern> {
+        let mut streams: [&[usize]; 5] = std::array::from_fn(|len| -> &[usize] {
+            if len > matcher.literal_prefix.len() {
+                return &[];
+            }
+            let mut prefix = ['\0'; 4];
+            prefix[..len].copy_from_slice(&matcher.literal_prefix[..len]);
+            self.by_prefix
+                .get(&(len, prefix))
+                .map(Vec::as_slice)
+                .unwrap_or_default()
+        });
+        std::iter::from_fn(move || {
+            let (stream, index) = streams
+                .iter()
+                .enumerate()
+                .filter_map(|(stream, indices)| indices.first().map(|index| (stream, *index)))
+                .min_by_key(|(_, index)| *index)?;
+            streams[stream] = &streams[stream][1..];
+            Some(&self.patterns[index])
+        })
+    }
+}
+
 impl StaticCasePatternMatcher {
     fn from_pattern(
         pattern: &Pattern,
@@ -1110,12 +1170,12 @@ pub(crate) fn build_case_pattern_facts(
 
         let subject_matcher = StaticCasePatternMatcher::from_case_subject(&command.word, source);
 
-        let mut prior_arm_patterns = Vec::<ReachableCasePattern>::new();
-        let mut fallthrough_arm_patterns = Vec::<ReachableCasePattern>::new();
+        let mut prior_arm_patterns = ReachableCasePatterns::default();
+        let mut fallthrough_arm_patterns = ReachableCasePatterns::default();
         let mut spent_shadowing_patterns = FxHashSet::default();
 
         for item in &command.cases {
-            let mut same_item_patterns = Vec::<ReachableCasePattern>::new();
+            let mut same_item_patterns = ReachableCasePatterns::default();
 
             for pattern in &item.patterns {
                 let Some(matcher) =
@@ -1131,9 +1191,9 @@ pub(crate) fn build_case_pattern_facts(
                 }
 
                 for previous in prior_arm_patterns
-                    .iter()
-                    .chain(fallthrough_arm_patterns.iter())
-                    .chain(same_item_patterns.iter())
+                    .candidates(&matcher)
+                    .chain(fallthrough_arm_patterns.candidates(&matcher))
+                    .chain(same_item_patterns.candidates(&matcher))
                 {
                     if spent_shadowing_patterns.contains(&FactSpan::new(previous.span)) {
                         continue;
@@ -1158,10 +1218,10 @@ pub(crate) fn build_case_pattern_facts(
             match item.terminator {
                 CaseTerminator::Break => {
                     prior_arm_patterns.append(&mut fallthrough_arm_patterns);
-                    prior_arm_patterns.extend(same_item_patterns);
+                    prior_arm_patterns.append(&mut same_item_patterns);
                 }
                 CaseTerminator::FallThrough => {
-                    fallthrough_arm_patterns.extend(same_item_patterns);
+                    fallthrough_arm_patterns.append(&mut same_item_patterns);
                 }
                 CaseTerminator::Continue | CaseTerminator::ContinueMatching => {
                     fallthrough_arm_patterns.clear();
@@ -1485,4 +1545,95 @@ pub(crate) fn static_case_pattern_text(pattern: &Pattern, source: &str) -> Optio
 
 pub(crate) fn case_subject_variable_name(word: &Word) -> Option<&str> {
     standalone_variable_name_from_word_parts(&word.parts)
+}
+
+#[cfg(test)]
+mod candidate_index_tests {
+    use super::*;
+
+    fn matcher(text: &str) -> StaticCasePatternMatcher {
+        let mut tokens = CasePatternTokens::new();
+        assert!(collect_static_case_pattern_tokens(text, &mut tokens).is_some());
+        let StaticCasePatternSummary {
+            min_len,
+            max_len,
+            literal_prefix,
+            literal_suffix,
+            literal_symbols,
+            start_states,
+        } = summarize_static_case_pattern_tokens(&tokens);
+        let bit_nfa = StaticCasePatternBitNfa::new(&tokens);
+        StaticCasePatternMatcher {
+            tokens,
+            min_len,
+            max_len,
+            literal_prefix,
+            literal_suffix,
+            literal_symbols,
+            start_states,
+            bit_nfa,
+        }
+    }
+
+    #[test]
+    fn indexed_candidates_preserve_exhaustive_match_order_after_append_and_clear() {
+        let patterns = [
+            "abc",
+            "b*",
+            "*",
+            "a*",
+            "?bc",
+            "a?c",
+            "é*",
+            "abc",
+            "*bc",
+            "",
+            "--help",
+            "--h*",
+            "--version",
+            "--*",
+            "éclair",
+            "écla*",
+        ];
+        let mut indexed = ReachableCasePatterns::default();
+        for (index, text) in patterns.iter().enumerate() {
+            let mut batch = ReachableCasePatterns::default();
+            batch.push(ReachableCasePattern {
+                span: Span::default(),
+                matcher: matcher(text),
+            });
+            indexed.append(&mut batch);
+            assert!(batch.patterns.is_empty());
+            for probe in &patterns {
+                let probe = matcher(probe);
+                let expected = indexed
+                    .patterns
+                    .iter()
+                    .enumerate()
+                    .filter(|(_, pattern)| pattern.matcher.subsumes(&probe))
+                    .map(|(i, _)| i)
+                    .collect::<Vec<_>>();
+                let actual = indexed
+                    .candidates(&probe)
+                    .filter(|pattern| pattern.matcher.subsumes(&probe))
+                    .map(|pattern| {
+                        indexed
+                            .patterns
+                            .iter()
+                            .position(|p| std::ptr::eq(p, pattern))
+                            .unwrap()
+                    })
+                    .collect::<Vec<_>>();
+                assert_eq!(actual, expected, "after pattern {index}");
+            }
+        }
+        indexed.clear();
+        assert_eq!(indexed.candidates(&matcher("abc")).count(), 0);
+        indexed.push(ReachableCasePattern {
+            span: Span::default(),
+            matcher: matcher("a*"),
+        });
+        assert_eq!(indexed.candidates(&matcher("abc")).count(), 1);
+        assert_eq!(indexed.candidates(&matcher("bcd")).count(), 0);
+    }
 }

--- a/crates/shuck-linter/src/facts/commands.rs
+++ b/crates/shuck-linter/src/facts/commands.rs
@@ -4,6 +4,7 @@ pub use super::core::CommandFactRef;
 
 #[derive(Debug, Clone)]
 pub struct CommandFact<'a> {
+    pub(crate) span: Span,
     pub(crate) id: CommandId,
     pub(crate) visit: CommandVisit<'a>,
     pub(crate) nested_word_command: bool,
@@ -69,7 +70,7 @@ impl<'a> CommandFact<'a> {
     }
 
     pub fn span(&self) -> Span {
-        command_span(self.visit.command)
+        self.span
     }
 
     pub fn span_in_source(&self, source: &str) -> Span {

--- a/crates/shuck-linter/src/facts/words/occurrence.rs
+++ b/crates/shuck-linter/src/facts/words/occurrence.rs
@@ -1345,6 +1345,7 @@ pub(crate) struct WordFactOutputs<'out, 'a> {
     pub(crate) word_nodes: &'out mut Vec<WordNode<'a>>,
     pub(crate) word_spans: &'out mut ListArena<Span>,
     pub(crate) word_span_scratch: &'out mut Vec<Span>,
+    pub(crate) traversal_span_scratch: &'out mut DerivedWordTraversalSpans,
     pub(crate) word_node_ids_by_span: &'out mut FxHashMap<FactSpan, WordNodeId>,
     pub(crate) word_occurrences: &'out mut Vec<WordOccurrence>,
     pub(crate) pending_arithmetic_word_occurrences:
@@ -1394,6 +1395,7 @@ fn derive_word_fact_data<'a>(
     shell_dialect: shuck_semantic::ShellDialect,
     span_store: &mut ListArena<Span>,
     scratch: &mut Vec<Span>,
+    traversal_spans: &mut DerivedWordTraversalSpans,
     zsh_array_fanout: Option<ZshArrayFanoutContext<'_, '_, 'a>>,
 ) -> (WordNodeDerived<'a>, bool) {
     let source = locator.source();
@@ -1402,13 +1404,14 @@ fn derive_word_fact_data<'a>(
     let may_have_command_substitution_spans = word_may_have_command_substitution_spans(word);
     let may_have_mixed_quote_spans =
         word_may_have_unquoted_literal_between_double_quoted_segments_spans(word, source);
-    let mut traversal_spans = collect_derived_word_traversal_spans(
+    collect_derived_word_traversal_spans(
         word,
         locator,
         shell_dialect,
         may_have_runtime_expansion_spans,
         may_have_command_substitution_spans,
         zsh_array_fanout,
+        traversal_spans,
     );
 
     let has_unquoted_visible_array_reference =
@@ -1524,7 +1527,7 @@ fn derive_word_fact_data<'a>(
 }
 
 #[derive(Default)]
-struct DerivedWordTraversalSpans {
+pub(crate) struct DerivedWordTraversalSpans {
     active_expansion_spans: Vec<Span>,
     scalar_expansion_spans: Vec<Span>,
     unquoted_scalar_expansion_spans: Vec<Span>,
@@ -1542,11 +1545,12 @@ fn collect_derived_word_traversal_spans<'a>(
     may_have_runtime_expansion_spans: bool,
     may_have_command_substitution_spans: bool,
     zsh_array_fanout: Option<ZshArrayFanoutContext<'_, '_, 'a>>,
-) -> DerivedWordTraversalSpans {
-    let mut spans = DerivedWordTraversalSpans::default();
+    spans: &mut DerivedWordTraversalSpans,
+) {
+    spans.has_unquoted_visible_array_reference = false;
     if may_have_runtime_expansion_spans || may_have_command_substitution_spans {
         let mut visitor = DerivedWordTraversalVisitor {
-            spans: &mut spans,
+            spans,
             collect_runtime_expansion_spans: may_have_runtime_expansion_spans,
             collect_command_substitution_spans: may_have_command_substitution_spans,
             zsh_array_fanout,
@@ -1591,7 +1595,6 @@ fn collect_derived_word_traversal_spans<'a>(
         spans.active_expansion_spans.dedup();
     }
 
-    spans
 }
 
 struct DerivedWordTraversalVisitor<'spans, 'borrow, 'analysis, 'model> {
@@ -1936,6 +1939,7 @@ pub(crate) struct WordFactCollector<'out, 'a, 'norm> {
     word_nodes: &'out mut Vec<WordNode<'a>>,
     word_spans: &'out mut ListArena<Span>,
     word_span_scratch: &'out mut Vec<Span>,
+    pub(crate) traversal_span_scratch: &'out mut DerivedWordTraversalSpans,
     word_node_ids_by_span: &'out mut FxHashMap<FactSpan, WordNodeId>,
     word_occurrences: &'out mut Vec<WordOccurrence>,
     pending_arithmetic_word_occurrences: &'out mut Vec<PendingArithmeticWordOccurrence>,
@@ -2148,6 +2152,7 @@ impl<'out, 'a, 'norm> WordFactCollector<'out, 'a, 'norm> {
             word_nodes: outputs.word_nodes,
             word_spans: outputs.word_spans,
             word_span_scratch: outputs.word_span_scratch,
+            traversal_span_scratch: outputs.traversal_span_scratch,
             word_node_ids_by_span: outputs.word_node_ids_by_span,
             word_occurrences: outputs.word_occurrences,
             pending_arithmetic_word_occurrences: outputs.pending_arithmetic_word_occurrences,
@@ -3164,6 +3169,7 @@ impl<'out, 'a, 'norm> WordFactCollector<'out, 'a, 'norm> {
             self.command_shell_behavior.shell_dialect(),
             self.word_spans,
             self.word_span_scratch,
+            self.traversal_span_scratch,
             zsh_array_fanout,
         );
         apply_zsh_array_fanout(has_unquoted_visible_array_reference, &mut analysis);
@@ -3228,13 +3234,17 @@ impl<'out, 'a, 'norm> WordFactCollector<'out, 'a, 'norm> {
             | WordFactContext::ParameterOperand => None,
         };
         self.word_span_scratch.clear();
-        collect_split_sensitive_unquoted_command_substitution_spans(
-            word,
-            self.source,
-            &self.command_shell_behavior,
-            self.word_span_scratch,
-        );
-        word_spans::normalize_command_substitution_spans(self.word_span_scratch, self.locator);
+        if !self.word_nodes[node_id.index()]
+            .derived.unquoted_command_substitution_spans.is_empty()
+        {
+            collect_split_sensitive_unquoted_command_substitution_spans(
+                word,
+                self.source,
+                &self.command_shell_behavior,
+                self.word_span_scratch,
+            );
+            word_spans::normalize_command_substitution_spans(self.word_span_scratch, self.locator);
+        }
         let split_sensitive_unquoted_command_substitution_spans =
             self.word_spans.push_many(self.word_span_scratch.drain(..));
         let id = WordOccurrenceId::new(self.word_occurrences.len());

--- a/crates/shuck-linter/src/facts/words/quote_spans.rs
+++ b/crates/shuck-linter/src/facts/words/quote_spans.rs
@@ -874,33 +874,19 @@ pub(crate) fn text_contains_shell_quoting_literals(
     text: &str,
     context: ShellQuotingLiteralTextContext,
 ) -> bool {
-    if text.contains(['"', '\'']) {
+    if text.contains('"') || text.contains('\'') {
         return true;
     }
 
-    let mut chars = text.chars().peekable();
-    while let Some(ch) = chars.next() {
-        if ch != '\\' {
-            continue;
-        }
-
-        while chars.peek().is_some_and(|next| *next == '\\') {
-            chars.next();
-        }
-
-        if chars.peek().is_some_and(|next| {
-            matches!(next, '"' | '\'')
-                || (next.is_whitespace()
-                    && (matches!(
-                        context,
-                        ShellQuotingLiteralTextContext::LiteralBackslashNewlines
-                    ) || !matches!(next, '\n' | '\r')))
-        }) {
-            return true;
-        }
-    }
-
-    false
+    // Only the character after the last backslash in a run can match.
+    // Searching for the ASCII delimiter skips ordinary UTF-8 text in bulk.
+    text.match_indices('\\').any(|(offset, _)| {
+        text[offset + 1..].chars().next().is_some_and(|next| {
+            next.is_whitespace()
+                && (matches!(context, ShellQuotingLiteralTextContext::LiteralBackslashNewlines)
+                    || !matches!(next, '\n' | '\r'))
+        })
+    })
 }
 
 

--- a/crates/shuck-linter/src/facts/words/tests.rs
+++ b/crates/shuck-linter/src/facts/words/tests.rs
@@ -7,6 +7,55 @@ mod word_classification_tests {
     }
 
     #[test]
+    fn quoting_literal_scan_preserves_backslash_runs_and_unicode_whitespace() {
+        fn reference(text: &str, literal_newlines: bool) -> bool {
+            if text.contains(['"', '\'']) { return true; }
+            let mut chars = text.chars().peekable();
+            while let Some(ch) = chars.next() {
+                if ch != '\\' { continue; }
+                while chars.peek() == Some(&'\\') { chars.next(); }
+                if chars.peek().is_some_and(|next| next.is_whitespace()
+                    && (literal_newlines || !matches!(next, '\n' | '\r'))) { return true; }
+            }
+            false
+        }
+        let atoms = ["a", "é", "\\", "\n", "\r", " ", "\t", "\u{a0}", "\"", "'"];
+        for a in atoms { for b in atoms { for c in atoms {
+            let text = format!("{a}{b}{c}");
+            for literal_newlines in [false, true] {
+                let context = if literal_newlines {
+                    ShellQuotingLiteralTextContext::LiteralBackslashNewlines
+                } else { ShellQuotingLiteralTextContext::ShellContinuationAware };
+                assert_eq!(text_contains_shell_quoting_literals(&text, context),
+                    reference(&text, literal_newlines), "{text:?}");
+            }
+        } } }
+    }
+
+    #[test]
+    fn reused_expansion_buffers_do_not_leak_between_words() {
+        let source = r#"printf "$first" literal $(date) "${array[@]}" '$quoted' $last {a,b} end"#;
+        let commands = parse_commands(source);
+        let Command::Simple(command) = &commands[0].command else { panic!("simple command"); };
+        let lines = shuck_indexer::LineIndex::new(source);
+        let locator = Locator::new(source, &lines);
+        let mut reused = DerivedWordTraversalSpans::default();
+        for word in &command.args {
+            let mut actual = ListArena::new();
+            let mut expected = ListArena::new();
+            let mut scratch = Vec::new();
+            let (actual_data, actual_array) = derive_word_fact_data(word, locator,
+                shuck_semantic::ShellDialect::Bash, &mut actual, &mut scratch, &mut reused, None);
+            let (expected_data, expected_array) = derive_word_fact_data(word, locator,
+                shuck_semantic::ShellDialect::Bash, &mut expected, &mut scratch,
+                &mut DerivedWordTraversalSpans::default(), None);
+            assert_eq!(actual.as_slice(), expected.as_slice());
+            assert_eq!(format!("{actual_data:?}"), format!("{expected_data:?}"));
+            assert_eq!(actual_array, expected_array);
+        }
+    }
+
+    #[test]
     fn detects_alias_positional_parameters_with_runtime_quote_state() {
         assert!(contains_positional_parameter_reference("echo $1"));
         assert!(contains_positional_parameter_reference("echo \"${1}\""));


### PR DESCRIPTION
## Summary

Reduce repeated structural discovery and temporary allocation during linting. On the profiled `xwmx__nb__nb` workload, complete parse-and-lint runtime falls **10.20%** versus `62738ae3`, without diagnostic changes.

## Changes

- Reuse expansion-span buffers, cache command spans, and skip substitution walks when existing facts prove they are unnecessary.
- Index case-pattern candidates by literal prefixes while preserving first-match order; use a disjoint interval index for quote membership.
- Defer ambient source analysis and avoid associative-array lookups for scalar assignments; speed up quoting-text scans.
- Add equivalence tests for buffer reuse, candidate order, quote boundaries, Unicode whitespace, and backslash runs.

## Test plan

- [x] `make hawk`: zero findings
- [x] Formatting and `git diff --check`
- [x] 4,181 linter tests and 47 indexer tests
- [x] `make test` equivalent: `cargo test -p shuck-cli -p shuck-cache` — 486 passed
- [x] Complete JSON diagnostics identical across 754 files: 3,036 diagnostics, including locations and fixes
- [x] Affected-rule corpus: C128/C129/X062, deterministic 10% sample, 3,366 supported fixtures, zero differences; zsh parsing and diagnostic baseline checks also passed
- [x] Added unit tests and manually exercised the CLI
- [ ] `make check`: blocked by a pre-existing `clippy::collapsible_match` warning at `crates/shuck-ast/src/command_resolution.rs:436`; warning-capped Clippy found no warnings on changed lines

## Notes for reviewers

Performance uses immutable optimized `profiling` binaries without an active sampler, alternating baseline/candidate order. The acceptance run contains ten pairs of 60 lint iterations per version (600 per version). The metric is the median per-pair runtime reduction. Fixture reads, parsing, indexing, semantic analysis, fact construction, linting and result disposal are timed; manifest/resolver setup is outside the reported loop.

Additional paired checks: `nvm.sh` improved 6.06%, `git-prompt.sh` improved 11.59%, and the small zsh nb launcher was effectively flat. The 10% result applies to the profiled nb workload, not every script.

<details>
<summary>Primary paired measurements</summary>

| Pair | Baseline ms/iteration | Candidate ms/iteration | Reduction |
|---:|---:|---:|---:|
| 1 | 133.373 | 119.485 | 10.41% |
| 2 | 134.363 | 120.235 | 10.51% |
| 3 | 133.652 | 120.398 | 9.92% |
| 4 | 133.350 | 119.976 | 10.03% |
| 5 | 133.697 | 120.316 | 10.01% |
| 6 | 155.352 | 120.489 | 22.44% |
| 7 | 153.660 | 137.907 | 10.25% |
| 8 | 153.270 | 136.052 | 11.23% |
| 9 | 152.355 | 137.530 | 9.73% |
| 10 | 152.212 | 136.755 | 10.15% |

The machine changed speed during pair 6. That pair remains in the data; using the paired median prevents its 22.44% result from inflating the headline improvement.

</details>

No ShellCheck source, wiki content, or diagnostic wording was used in this change.
