### PR TITLE
fix(server): preserve local function definitions

### DIFF
--- a/crates/shuck-server/src/server/api/requests/definition.rs
+++ b/crates/shuck-server/src/server/api/requests/definition.rs
@@ -88,6 +88,12 @@ fn definition(
     let workspace_variable = variable_target(analysis.semantic(), &target);
     match target {
         EditorSymbolTarget::FunctionCall(call) => {
+            // Without a source operation, the document-local semantic answer is
+            // exact. Avoid letting unrelated dynamic command dispatch make the
+            // more conservative workspace call graph discard that answer.
+            if analysis.semantic().source_refs().is_empty() {
+                return editor_features::definition(snapshot, client, params);
+            }
             let Some(index) = workspace_function_index(&workspace) else {
                 return Ok(None);
             };

--- a/crates/shuck-server/tests/manual.rs
+++ b/crates/shuck-server/tests/manual.rs
@@ -968,6 +968,67 @@ fn document_links_follow_sources_with_utf32_positions() {
 }
 
 #[test]
+fn local_function_definition_survives_unrelated_dynamic_command_dispatch() {
+    let (server_connection, client_connection) = Connection::memory();
+    let server_thread = thread::spawn(move || shuck_server::run_connection(server_connection));
+
+    let workspace = tempfile::tempdir().expect("tempdir should be created");
+    let script_path = workspace.path().join("script.sh");
+    let source = "#!/bin/sh\n\n# shellcheck shell=bash\n# execute script with bash (shebang line is /bin/sh for portability)\n\nGIT_PROGRAM=git\n\nfunction alt() {\n    [ \"$(config --bool yadm.alt-copy)\" == \"true\" ] && echo true\n}\n\nfunction config() {\n    \"$GIT_PROGRAM\" config\n}\n";
+    std::fs::write(&script_path, source).unwrap();
+    let script_uri = Url::from_file_path(&script_path).unwrap();
+
+    send_request(
+        &client_connection,
+        1,
+        "initialize",
+        serde_json::json!({
+            "capabilities": replay_capabilities(),
+            "rootUri": Url::from_file_path(workspace.path()).unwrap(),
+        }),
+    );
+    let _ = recv_response(&client_connection, 1);
+    client_connection
+        .sender
+        .send(Message::Notification(Notification::new(
+            "initialized".to_owned(),
+            serde_json::json!({}),
+        )))
+        .expect("initialized should send");
+    open_document(&client_connection, &script_uri, source);
+
+    send_request(
+        &client_connection,
+        2,
+        "textDocument/definition",
+        serde_json::json!({
+            "textDocument": { "uri": script_uri },
+            "position": { "line": 8, "character": 10 },
+        }),
+    );
+    let definition = recv_response(&client_connection, 2);
+    assert_eq!(definition["uri"], serde_json::json!(script_uri));
+    assert_eq!(
+        definition["range"]["start"],
+        serde_json::json!({ "line": 11, "character": 0 })
+    );
+
+    send_request(&client_connection, 99, "shutdown", serde_json::json!(null));
+    let _ = recv_response(&client_connection, 99);
+    client_connection
+        .sender
+        .send(Message::Notification(Notification::new(
+            "exit".to_owned(),
+            serde_json::json!({}),
+        )))
+        .expect("exit notification should send");
+    server_thread
+        .join()
+        .expect("server thread should join")
+        .expect("server should exit cleanly");
+}
+
+#[test]
 fn cross_file_definition_uses_exact_workspace_binding_and_open_buffers() {
     let (server_connection, client_connection) = Connection::memory();
     let server_thread = thread::spawn(move || shuck_server::run_connection(server_connection));


### PR DESCRIPTION
## Summary

Fix go-to-definition for locally resolved function calls when an unrelated dynamically named command appears elsewhere in the file.

Fixes #1281.

## Changes

- use the document-local semantic definition when the file has no source operations, matching hover behavior
- add an LSP regression test using the issue reproduction

## Test plan

- [ ] `make check` (fmt + clippy + cargo-shear)
- [ ] `make hawk` (workspace dead public API)
- [ ] `make test`
- [ ] `make test-large-corpus` (for rule changes that affect conformance)
- [x] Added or updated unit / integration / insta snapshot tests
- [ ] Manually exercised the CLI where relevant

Commands run:

- `cargo test -p shuck-server`
- `cargo test -p shuck-server --test manual local_function_definition_survives_unrelated_dynamic_command_dispatch -- --exact`
- `cargo clippy -p shuck-server --all-targets -- -D warnings` with the repository-pinned Rust 1.94.1 toolchain
- `cargo fmt --check`
- `git diff --check origin/main...HEAD`

## Notes for reviewers

The workspace call graph deliberately fails closed around dynamic dispatch because sourced functions may mutate the active function environment. Files without source operations do not need that conservative cross-file path; the existing hover handler already uses the document-local semantic answer in this case.